### PR TITLE
chore(flake/home-manager): `def0dbbc` -> `486b0660`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741174782,
-        "narHash": "sha256-dYRebJk58/d5Ej1G6xTOadTfG6tU5zFgXYrLsRJlrgw=",
+        "lastModified": 1741217763,
+        "narHash": "sha256-g/TrltIjFHIjtzKY5CJpoPANfHQWDD43G5U1a/v5oVg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "def0dbbcea715d4514ca343ab4d6d7f3a1742da0",
+        "rev": "486b066025dccd8af7fbe5dd2cc79e46b88c80da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`486b0660`](https://github.com/nix-community/home-manager/commit/486b066025dccd8af7fbe5dd2cc79e46b88c80da) | `` specialisation: escape specialisation name `` |
| [`f6ac8a34`](https://github.com/nix-community/home-manager/commit/f6ac8a3414181cb7e97fb76973a14bd661e9492f) | `` flake.lock: Update ``                         |