### PR TITLE
chore(flake/nixos-cosmic): `8522280e` -> `5be89641`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741306001,
-        "narHash": "sha256-m0/bgjXbUg9ficrlsX6FFezsnuJjbcCk4ye49Wh1s+M=",
+        "lastModified": 1741360124,
+        "narHash": "sha256-x9eHurxh8AhCmVplugQiYTyfz+NNU4DGRRLq1UqQ8g0=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "8522280e59847b06610d8585fb53e73b87e5f688",
+        "rev": "5be89641d8b9190460af05d59f6dbe4cb8695399",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1741048562,
-        "narHash": "sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4+fai1Sk=",
+        "lastModified": 1741196730,
+        "narHash": "sha256-0Sj6ZKjCpQMfWnN0NURqRCQn2ob7YtXTAOTwCuz7fkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6af28b834daca767a7ef99f8a7defa957d0ade6f",
+        "rev": "48913d8f9127ea6530a2a2f1bd4daa1b8685d8a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                     |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`5be89641`](https://github.com/lilyinstarlight/nixos-cosmic/commit/5be89641d8b9190460af05d59f6dbe4cb8695399) | `` cosmic-files: re-enable checks (#693) `` |
| [`c7b55dc5`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c7b55dc5e0e010e28b01d61e5b261160dcf01f5a) | `` flake: update inputs (#697) ``           |