### PR TITLE
chore(flake/nixos-cosmic): `bf3d41b9` -> `ad225743`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741432127,
-        "narHash": "sha256-JrN9MWJLVVEjVYINDX0NHI2U91/7qSywm6m6mGKwB0E=",
+        "lastModified": 1741519386,
+        "narHash": "sha256-ihmi/TpQK49D/bXCWaV7G5W+H5VOSSnDFfSfqWBw2n8=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "bf3d41b9fc89883823ce9fadbec1b44f2cdd1fac",
+        "rev": "ad2257430e16a120c3b27c499122b632ed496509",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                           |
| ------------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`ad225743`](https://github.com/lilyinstarlight/nixos-cosmic/commit/ad2257430e16a120c3b27c499122b632ed496509) | `` flake: update inputs (#701) `` |