### PR TITLE
chore(flake/nixos-cosmic): `f34eb24f` -> `b36c8d4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1741609568,
-        "narHash": "sha256-kJwImKYJq9djZ13l5lSEdqfB/Y+h43LTqUPjz5wZOec=",
+        "lastModified": 1741661081,
+        "narHash": "sha256-MO8haf9wtlFFPhWcVCVQfiHDZBiYa7NKQbwJY0v92jw=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "f34eb24fb96780df1437a201948df785d77b3b8a",
+        "rev": "b36c8d4e57e57be9eaf1c820f61f63f60cd3b876",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                  |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b36c8d4e`](https://github.com/lilyinstarlight/nixos-cosmic/commit/b36c8d4e57e57be9eaf1c820f61f63f60cd3b876) | `` ci: bump cachix/cachix-action from 15 to 16 (#706) `` |
| [`56ef4fe3`](https://github.com/lilyinstarlight/nixos-cosmic/commit/56ef4fe3b1890e9ae29f1dc8dcd38775b2c40820) | `` pkgs: update cosmic (#705) ``                         |