### PR TITLE
chore(flake/nixpkgs): `ebe2788e` -> `95600680`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741600792,
-        "narHash": "sha256-yfDy6chHcM7pXpMF4wycuuV+ILSTG486Z/vLx/Bdi6Y=",
+        "lastModified": 1741724370,
+        "narHash": "sha256-WsD+8uodhl58jzKKcPH4jH9dLTLFWZpVmGq4W1XDVF4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe2788eafd539477f83775ef93c3c7e244421d3",
+        "rev": "95600680c021743fd87b3e2fe13be7c290e1cac4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`57e601b1`](https://github.com/NixOS/nixpkgs/commit/57e601b1ac16345fefa7463bec8a3f8db4c7bb4f) | `` gotosocial: 0.18.1 -> 0.18.2 ``                                                                   |
| [`385576f6`](https://github.com/NixOS/nixpkgs/commit/385576f604dfbf37b2424f1d26fb618b6441d2a1) | `` epson-escpr2: remove with lib; from meta ``                                                       |
| [`88be5517`](https://github.com/NixOS/nixpkgs/commit/88be5517f3cd56869ef990744982b583522a9512) | `` epson-escpr2: 1.2.26 -> 1.2.27 ``                                                                 |
| [`30b3f73c`](https://github.com/NixOS/nixpkgs/commit/30b3f73c10af66439fdd731049e5added086ac90) | `` firefox-bin-unwrapped: 136.0 -> 136.0.1 ``                                                        |
| [`55b80305`](https://github.com/NixOS/nixpkgs/commit/55b8030576d0edbd2c9f7b3c5ca475a461acbf13) | `` firefox-unwrapped: 136.0 -> 136.0.1 ``                                                            |
| [`97c30ee0`](https://github.com/NixOS/nixpkgs/commit/97c30ee0f4752fd706fb655eedff4013c0aa82a1) | `` firefox-{beta,devedition}-bin: 134.0b10 -> 137.0b1 ``                                             |
| [`3b878255`](https://github.com/NixOS/nixpkgs/commit/3b878255bf9a7a5e999b442443888cca6ab95c91) | `` firefox-devedition-bin-unwrapped: 133.0b1 -> 134.0b10 ``                                          |
| [`59717866`](https://github.com/NixOS/nixpkgs/commit/597178661ef37e01c6a6f26394c21f30afa8e2f0) | `` firefox-beta-bin-unwrapped: 134.0b8 -> 134.0b10 ``                                                |
| [`4cabbd89`](https://github.com/NixOS/nixpkgs/commit/4cabbd893dc2d0e294b8ba7a70bebb279055a073) | `` firefox-bin: release_sources: add linux-aarch64 ``                                                |
| [`026aadf3`](https://github.com/NixOS/nixpkgs/commit/026aadf3737c98ecab8f73a0e0c4de859785275d) | `` firefox-bin: update.nix: also update linux-aarch64 now ``                                         |
| [`c73fcd38`](https://github.com/NixOS/nixpkgs/commit/c73fcd38dda7dca1215dada9d8cb00578cb520b2) | `` firefox-bin: add linux-aarch64 to mozillaPlatforms ``                                             |
| [`461fbf8d`](https://github.com/NixOS/nixpkgs/commit/461fbf8da1eb553d15af60c6262599c0ae410427) | `` torzu: unstable-2024-12-15 -> unstable-2025-02-22 ``                                              |
| [`99d40640`](https://github.com/NixOS/nixpkgs/commit/99d40640fc3acd9a3cc4543d9a79c23a9ab669aa) | `` vscode-extensions.apollographql.vscode-apollo: 2.3.6 -> 2.5.5 ``                                  |
| [`bbcb31f9`](https://github.com/NixOS/nixpkgs/commit/bbcb31f9b02b58bcb809c5a57bf87d70389e9135) | `` imagemagick: 7.1.1-44 -> 7.1.1-45 ``                                                              |
| [`1039e50e`](https://github.com/NixOS/nixpkgs/commit/1039e50e8a4ccedf10d573e305c6f1bcff730103) | `` imagemagick: 7.1.1-43 -> 7.1.1-44 ``                                                              |
| [`8eb3844d`](https://github.com/NixOS/nixpkgs/commit/8eb3844d1fb0f6c971b8316eb634633be22b69c6) | `` qq: 3.2.15-2025.1.10 -> 3.2.16-2025.3.7 ``                                                        |
| [`28e70f7b`](https://github.com/NixOS/nixpkgs/commit/28e70f7b74cb13cddd7df89999e54bb724bef6e9) | `` chromium,chromedriver: 134.0.6998.35 -> 134.0.6998.88 ``                                          |
| [`75b69fb5`](https://github.com/NixOS/nixpkgs/commit/75b69fb55e6f5bf0ee3f13b5fa7ecf4dc16b3aac) | `` services.mysql: make sql statements consistent uppercase ``                                       |
| [`5e785bc7`](https://github.com/NixOS/nixpkgs/commit/5e785bc77086b43d775f6822f2ae17d7eae6c752) | `` services.mysql: on create initial databases add savety statement 'IF NOT EXISTS' for edgecases `` |
| [`76b620aa`](https://github.com/NixOS/nixpkgs/commit/76b620aac6ab84f0f4dff0aaac91e84ec236720d) | `` services.mysql: wait for galera cluster sync to be done ``                                        |
| [`f68d5a32`](https://github.com/NixOS/nixpkgs/commit/f68d5a32d23093fd3f8e82bc605599aee65c3220) | `` nginxModules.modsecurity: v1.0.3 -> 0b4f0cf (unstable) ``                                         |
| [`af7a7a76`](https://github.com/NixOS/nixpkgs/commit/af7a7a760a395037cbbe7b463c479d1100c83e08) | `` libmodsecurity: 3.0.13 -> 3.0.14 ``                                                               |
| [`a7eae75e`](https://github.com/NixOS/nixpkgs/commit/a7eae75ed4e4c14f27deee26de7750f8a6f10bc3) | `` [Backport release-24.11] freeipa: Cleanup obsolete patches (#388755) ``                           |
| [`1ee5d49f`](https://github.com/NixOS/nixpkgs/commit/1ee5d49f14c064c3ff2794fbf4f6117e45b7e8a3) | `` nixos/postgresql: fix merging of shared_preload_libraries option ``                               |
| [`92fefbf2`](https://github.com/NixOS/nixpkgs/commit/92fefbf27772239ae3ed398c915b12fc11dd9f94) | `` python312Packages.deal: 4.24.4 -> 4.24.5 ``                                                       |
| [`1cbcf830`](https://github.com/NixOS/nixpkgs/commit/1cbcf830c3e2e60e855aa90ee1971c0338fbe729) | `` bundlerUpdateScript: format `gemset.nix` with nixfmt ``                                           |
| [`fc4c2e0f`](https://github.com/NixOS/nixpkgs/commit/fc4c2e0fc79e14c794d4014a61df698600adb75b) | `` finamp: 0.9.13-beta -> 0.9.14-beta ``                                                             |
| [`87d6dda6`](https://github.com/NixOS/nixpkgs/commit/87d6dda6bd13163f59661d8e9428322c2e016a85) | `` nixos/gitlab: do not set default http(s) port number of gitlab registry explicitly ``             |
| [`07ab6ae8`](https://github.com/NixOS/nixpkgs/commit/07ab6ae874ba6937e3c714602f15a8c3d38c3111) | `` nixos/gitlab: Fix registry port ``                                                                |
| [`8f23b830`](https://github.com/NixOS/nixpkgs/commit/8f23b8302ced3aaf37b87e0c315ef4b22c68beb9) | `` nixos/iosched: exclude loop devices by default ``                                                 |
| [`cda045d7`](https://github.com/NixOS/nixpkgs/commit/cda045d71b1c49ed3e5bfa91903033a4bd662770) | `` cinny-desktop: 4.5.0 -> 4.5.1 ``                                                                  |
| [`a13e7c11`](https://github.com/NixOS/nixpkgs/commit/a13e7c117a8acf51b760a66643a73a56ff05e288) | `` cinny-unwrapped: 4.5.0 -> 4.5.1 ``                                                                |
| [`bdd6a8c6`](https://github.com/NixOS/nixpkgs/commit/bdd6a8c6ee4d4e91715d90b90955913ab500ae44) | `` mopidy-jellyfin: 1.0.5 -> 1.0.6 (#385274) ``                                                      |
| [`1a8b93ec`](https://github.com/NixOS/nixpkgs/commit/1a8b93ecace62e7d26b2981fa1bde69dda052541) | `` firefox-beta-unwrapped: 135.0b9 -> 137.0b2 ``                                                     |
| [`4a6ecb68`](https://github.com/NixOS/nixpkgs/commit/4a6ecb68c5d8e7a86ceb7c4243d4ad6891f886a4) | `` firefox-devedition-unwrapped: 135.0b9 -> 137.0b2 ``                                               |
| [`eae51087`](https://github.com/NixOS/nixpkgs/commit/eae5108719392d43e41c7e3139f229328cd792b5) | `` ungoogled-chromium: 133.0.6943.141-1 -> 134.0.6998.35-1 ``                                        |
| [`c358ef51`](https://github.com/NixOS/nixpkgs/commit/c358ef5198d77f6e75844855a41e7c8f474b4147) | `` typora: 1.9.3 -> 1.10.8 ``                                                                        |
| [`2597f9aa`](https://github.com/NixOS/nixpkgs/commit/2597f9aa0c27fbd18895f64c4065c418b948ded1) | `` tailscale: 1.80.2 -> 1.80.3 ``                                                                    |
| [`37ed8c67`](https://github.com/NixOS/nixpkgs/commit/37ed8c671f5b428f0b7f4d6ca7e73dc943a3487d) | `` tailscale: fix darwin build ``                                                                    |
| [`9444026e`](https://github.com/NixOS/nixpkgs/commit/9444026eb289ecac3c463b358bdcec89d1274110) | `` kanidm_1_4: mark EOL ``                                                                           |
| [`6c884b39`](https://github.com/NixOS/nixpkgs/commit/6c884b39e1c5fe492881093c33ec616284aca0cb) | `` beam26Packages.elixir: 1.18.2 -> 1.18.3 ``                                                        |
| [`46c01529`](https://github.com/NixOS/nixpkgs/commit/46c01529bc26772d4bb6a0d5dbbc3dbacd9a55fa) | `` beam26Packages.elixir: 1.18.1 -> 1.18.2 ``                                                        |
| [`aed656d7`](https://github.com/NixOS/nixpkgs/commit/aed656d7f9e96e260fa3a5eb9c4f7aac44f71091) | `` tailscale: add lsof dependency on darwin ``                                                       |
| [`fe8be737`](https://github.com/NixOS/nixpkgs/commit/fe8be73725161b4719a56cad0cf1c5781999636f) | `` rcu: 2025.001r -> 2025.001s ``                                                                    |
| [`1f7fa63f`](https://github.com/NixOS/nixpkgs/commit/1f7fa63ff05bfc6c8b378a6f16cdeded948b4a3f) | `` cinny-desktop: 4.3.2 -> 4.5.0 ``                                                                  |
| [`9d63f5df`](https://github.com/NixOS/nixpkgs/commit/9d63f5dfeb8c10ca35c732db8911e17327b13767) | `` cinny: 4.3.2 -> 4.5.0 ``                                                                          |
| [`b9c2555b`](https://github.com/NixOS/nixpkgs/commit/b9c2555bf8fb7c47820f463fa60fd9c74aca1783) | `` cinny-desktop: 4.3.1 -> 4.3.2 ``                                                                  |
| [`b0fb646a`](https://github.com/NixOS/nixpkgs/commit/b0fb646a4b2b662a79895cc3f44c640ec935ff8f) | `` cinny: 4.3.0 -> 4.3.2 ``                                                                          |
| [`3e875cac`](https://github.com/NixOS/nixpkgs/commit/3e875cac7da6750bf552fde97248c6cd1054c7cd) | `` cinny-{unwrapped,desktop}: 4.2.3 -> 4.3.0 ``                                                      |
| [`47cdb55e`](https://github.com/NixOS/nixpkgs/commit/47cdb55e564d3eb4455df13a004dcf151e0a3c9c) | `` tailscale: re-enable tests ``                                                                     |
| [`e5cf6280`](https://github.com/NixOS/nixpkgs/commit/e5cf6280886fb2e30822796bacd72174823d8454) | `` tailscale-nginx-auth: move back to buildGoModule ``                                               |
| [`05c68807`](https://github.com/NixOS/nixpkgs/commit/05c68807262c0e315755836c5aea96992717df76) | `` tailscale: move back to buildGoModule ``                                                          |