### PR TITLE
chore(flake/nixpkgs): `95600680` -> `cdd2ef00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741724370,
-        "narHash": "sha256-WsD+8uodhl58jzKKcPH4jH9dLTLFWZpVmGq4W1XDVF4=",
+        "lastModified": 1741862977,
+        "narHash": "sha256-prZ0M8vE/ghRGGZcflvxCu40ObKaB+ikn74/xQoNrGQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "95600680c021743fd87b3e2fe13be7c290e1cac4",
+        "rev": "cdd2ef009676ac92b715ff26630164bb88fec4e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`cdd2ef00`](https://github.com/NixOS/nixpkgs/commit/cdd2ef009676ac92b715ff26630164bb88fec4e0) | `` gitlab: 17.9.1 -> 17.9.2 ``                                            |
| [`151c7b88`](https://github.com/NixOS/nixpkgs/commit/151c7b884a0f502fbf68cd9fba58490483232596) | `` fetchFromGitHub: use of the API endpoint only when fetching tarball `` |
| [`80b53fdb`](https://github.com/NixOS/nixpkgs/commit/80b53fdb4f883238807ced86db41be809d60f3b5) | `` [Backport release-24.11] exegol: 4.3.9 -> 4.3.10 (#389424) ``          |
| [`ee349bfb`](https://github.com/NixOS/nixpkgs/commit/ee349bfb8c8c6d773f336011cf51867c5487e740) | `` electron-source.electron_34: init at 34.3.2 ``                         |
| [`bf39d837`](https://github.com/NixOS/nixpkgs/commit/bf39d8372c08a57f2415aa19f50dba1b36494431) | `` electron-source: fix update script for electron >= 34 ``               |
| [`ebe0d46a`](https://github.com/NixOS/nixpkgs/commit/ebe0d46a5c0eda4ee705459f3cbff3007c88ab14) | `` whatsie: Add desktop entry and install icons ``                        |
| [`5b2e6d05`](https://github.com/NixOS/nixpkgs/commit/5b2e6d050cb29f5d6851d8dac04f94eac2c63890) | `` tandoor-recipes: 1.5.19 -> 1.5.31 ``                                   |
| [`a9d8c093`](https://github.com/NixOS/nixpkgs/commit/a9d8c09317ca272904fbb511f174ed4df2363c4b) | `` tandoor-recipes: fix build ``                                          |
| [`9f2e39e6`](https://github.com/NixOS/nixpkgs/commit/9f2e39e66a5a399916652f72b1ba4ca86be0696d) | `` linux_xanmod_latest: 6.13.5 -> 6.13.6 ``                               |
| [`bff19d1f`](https://github.com/NixOS/nixpkgs/commit/bff19d1f239da633447299e3ad3ad534158a1d0f) | `` linux_xanmod: 6.12.17 -> 6.12.18 ``                                    |
| [`af6300d5`](https://github.com/NixOS/nixpkgs/commit/af6300d5789a7f887f79dceca5ac5f15d3807704) | `` redmine: 5.1.5 -> 5.1.6 ``                                             |
| [`1ec44c63`](https://github.com/NixOS/nixpkgs/commit/1ec44c63225436c7def5b72920d3769c89ebac26) | `` nuget-to-json: fix missing tool packages ``                            |
| [`8baeb6c8`](https://github.com/NixOS/nixpkgs/commit/8baeb6c8cbb67e1ef9a95111553e28c3957a1186) | `` linux-firmware: 20250211 -> 20250311, fetch from cdn.kernel.org ``     |