### PR TITLE
chore(flake/nixos-cosmic): `e4921f25` -> `fcee247f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742124080,
-        "narHash": "sha256-z5mkfJIorzstjD2uoDdlGPmnFdGN6WsE0/Rro0NGzhk=",
+        "lastModified": 1742166771,
+        "narHash": "sha256-8IuaS/sjMUEqn6wDfidZRKgCfTXBIsfK+Fxfam0EvKM=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "e4921f258a2af86245330afb914849f5b78c7bc5",
+        "rev": "fcee247f21d21acb738ac208d6ed86e65c2e7240",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                                |
| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`fcee247f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/fcee247f21d21acb738ac208d6ed86e65c2e7240) | `` cosmic-ext-tweaks: 0.1.3-unstable-2025-03-13 -> 0.1.3-unstable-2025-03-16 (#717) `` |