### PR TITLE
chore(flake/nixpkgs): `cdd2ef00` -> `a1185f40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741862977,
-        "narHash": "sha256-prZ0M8vE/ghRGGZcflvxCu40ObKaB+ikn74/xQoNrGQ=",
+        "lastModified": 1742136038,
+        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cdd2ef009676ac92b715ff26630164bb88fec4e0",
+        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| [`f3e78005`](https://github.com/NixOS/nixpkgs/commit/f3e78005058bd5d1af420be7d26c43014d98b5fd) | `` nixos/flarum: restart on package update ``                                                                |
| [`591fdd30`](https://github.com/NixOS/nixpkgs/commit/591fdd30b22e41768f9dfe3c446d06ce3e9f29f0) | `` nixos/plasma6: add qtimageformats to the requiredPackages ``                                              |
| [`e87b96c9`](https://github.com/NixOS/nixpkgs/commit/e87b96c9e603a70ea6c91a96e043e4c0ddc63571) | `` pnpm_9: 9.15.7 -> 9.15.9 ``                                                                               |
| [`a077c6cd`](https://github.com/NixOS/nixpkgs/commit/a077c6cd59c3f8f8aef7b0b8454a5a41cbb82e55) | `` php81: 8.1.31 -> 8.1.32 ``                                                                                |
| [`43724dcb`](https://github.com/NixOS/nixpkgs/commit/43724dcb384c4cfc229a8503a2e129e7c46dc358) | `` php82: 8.2.27 -> 8.2.28 ``                                                                                |
| [`3eeded1c`](https://github.com/NixOS/nixpkgs/commit/3eeded1c5afd5ffc8edecdaa6560dd6e576ed58c) | `` php84: 8.4.4 -> 8.4.5 ``                                                                                  |
| [`d92756c5`](https://github.com/NixOS/nixpkgs/commit/d92756c5eff0ce07d43514b07979954220d0c09d) | `` php: 8.3.17 -> 8.3.19 ``                                                                                  |
| [`4b51c25e`](https://github.com/NixOS/nixpkgs/commit/4b51c25e61a08d9246fc921e8029ebe78139644a) | `` gitbutler: vendor libgit2 ``                                                                              |
| [`8a4fe187`](https://github.com/NixOS/nixpkgs/commit/8a4fe18736d36ba8648d6f096496a7072604119c) | `` kdePackages.plasma-workspace: wrap with --inherit-argv0 ``                                                |
| [`b4a6a1be`](https://github.com/NixOS/nixpkgs/commit/b4a6a1be414d7e6e265e6122127486ab8aec7ae0) | `` komikku: 1.71.0 -> 1.72.0 ``                                                                              |
| [`b5cd9877`](https://github.com/NixOS/nixpkgs/commit/b5cd98778c6c2a65b8c8e3a89d6f406ee78fc095) | `` snac2: 2.72 -> 2.73 ``                                                                                    |
| [`be8dfc08`](https://github.com/NixOS/nixpkgs/commit/be8dfc08b47afebd58364b71db931aa6bd5a4347) | `` electron-chromedriver_34: 34.3.1 -> 34.3.2 ``                                                             |
| [`18533c52`](https://github.com/NixOS/nixpkgs/commit/18533c5288259b8cec11959fe8f3c532335fac09) | `` electron_34-bin: 34.3.1 -> 34.3.2 ``                                                                      |
| [`8d908db2`](https://github.com/NixOS/nixpkgs/commit/8d908db203711582b52ce8a93d089bbd0c5f2458) | `` electron-source.electron_33: 33.4.2 -> 33.4.3 ``                                                          |
| [`9a7d2be5`](https://github.com/NixOS/nixpkgs/commit/9a7d2be5363c60a3c13cf52d4dd7a28d0d2232c3) | `` electron-chromedriver_34: 34.3.0 -> 34.3.1 ``                                                             |
| [`18e46340`](https://github.com/NixOS/nixpkgs/commit/18e46340cb9a0f3cb74642c8929aeed0496b88dd) | `` electron_34-bin: 34.3.0 -> 34.3.1 ``                                                                      |
| [`f7775717`](https://github.com/NixOS/nixpkgs/commit/f7775717e427fb86250ca1cf84d2438ea1961948) | `` electron-chromedriver_33: 33.4.2 -> 33.4.3 ``                                                             |
| [`77212596`](https://github.com/NixOS/nixpkgs/commit/77212596b757d2355de24a34046709fe1a9baee9) | `` electron_33-bin: 33.4.2 -> 33.4.3 ``                                                                      |
| [`fb43bf6f`](https://github.com/NixOS/nixpkgs/commit/fb43bf6f14622fba7e590ebba98da9e42ccd39c6) | `` _3proxy: 0.9.4 -> 0.9.5 ``                                                                                |
| [`3cbf014f`](https://github.com/NixOS/nixpkgs/commit/3cbf014f122cd718b064f2cb5f6376edeb6406c2) | `` zvbi: enable parallel building ``                                                                         |
| [`0f01cbd3`](https://github.com/NixOS/nixpkgs/commit/0f01cbd30c645ab7f42d15d05d3c5bb541291b2a) | `` zvbi: 0.2.43 -> 0.2.44 ``                                                                                 |
| [`f67d5534`](https://github.com/NixOS/nixpkgs/commit/f67d55344ebf6c3859b1906347eee975b22b26e6) | `` zvbi: fix building for musl on x86_64 ``                                                                  |
| [`daf5e7f8`](https://github.com/NixOS/nixpkgs/commit/daf5e7f84fb2f7a52cce8af41a7014b2508cbcea) | `` zvbi: 0.2.42-unstable-2024-11-29 -> 0.2.43 ``                                                             |
| [`f5c7f771`](https://github.com/NixOS/nixpkgs/commit/f5c7f771b24fcb2d9d6e53b35c9d8a63f5d08ca6) | `` zvbi: propagate libiconv and libintl ``                                                                   |
| [`664bd1dc`](https://github.com/NixOS/nixpkgs/commit/664bd1dcb38945f6e77ccd35f6186c0aae8fbe62) | `` zvbi: 0.2.42-unstable-2024-03-21 -> 0.2.42-unstable-2024-11-29 ``                                         |
| [`7ac5d1e5`](https://github.com/NixOS/nixpkgs/commit/7ac5d1e5fd1d19bd564bdbd66396ceddf7d9e2ef) | `` zvbi: 0.2.42 -> 0.2.42-unstable-2024-03-21 ``                                                             |
| [`465b8a1f`](https://github.com/NixOS/nixpkgs/commit/465b8a1fd6892508e37eda380a0f025c9f89d52b) | `` go-chromecast: 0.3.2 -> 0.3.3 ``                                                                          |
| [`2d0d1776`](https://github.com/NixOS/nixpkgs/commit/2d0d1776271ba0f5eb028bcc6458f85afef9b1cf) | `` linuxPackages.rtl8821ce: 0-unstable-2025-02-08 -> 0-unstable-2025-03-12 ``                                |
| [`16027ac4`](https://github.com/NixOS/nixpkgs/commit/16027ac46b6799e17350b69428e938288ec16d99) | `` linuxPackages.rtl8821ce: add updateScript ``                                                              |
| [`0aaf0a9a`](https://github.com/NixOS/nixpkgs/commit/0aaf0a9a31c2bde7e603c21ae83d06d98295b604) | `` brave: 1.76.73 -> 1.76.74 ``                                                                              |
| [`e1026b76`](https://github.com/NixOS/nixpkgs/commit/e1026b76acd7be6aea34255fd4de42d6355cb160) | `` beetsPackages.alternatives: 0.13.0 -> 0.13.1 ``                                                           |
| [`970f7b90`](https://github.com/NixOS/nixpkgs/commit/970f7b907930c9b46e12e0d9134829d2a833af9c) | `` beetsPackages.alternatives: modernize ``                                                                  |
| [`053988cc`](https://github.com/NixOS/nixpkgs/commit/053988ccc61903db30fddecdde3f8e368457e73d) | `` beets: disable flaky tests on darwin ``                                                                   |
| [`7295efb6`](https://github.com/NixOS/nixpkgs/commit/7295efb6e6e4ef2b49b06a7aaacfd41c0b7b0c91) | `` beets: fetch patch to fix IMBackend ``                                                                    |
| [`d29bd55f`](https://github.com/NixOS/nixpkgs/commit/d29bd55ff12474d856b697d3f75ab03ca8c3661a) | `` beets: modernize ``                                                                                       |
| [`2d46e112`](https://github.com/NixOS/nixpkgs/commit/2d46e11243816a3874dd13a3f3ae4a43fac51dde) | `` gitlab-container-registry: fix s3 test ``                                                                 |
| [`249bc152`](https://github.com/NixOS/nixpkgs/commit/249bc152cb96037d6fb448c47cd89842dc0dd7b9) | `` invidious: 2.20241110.0 -> 2.20250314.0 ``                                                                |
| [`d6ea9484`](https://github.com/NixOS/nixpkgs/commit/d6ea94841f28e292c328caac4fe82dc40e356c42) | `` electron: bump default version from 33 to 34 ``                                                           |
| [`38d13269`](https://github.com/NixOS/nixpkgs/commit/38d13269fa2ecc3facce326e50e68cb8cfd8344a) | `` pnpm: 10.6.2 -> 10.6.3 ``                                                                                 |
| [`5ec1ba64`](https://github.com/NixOS/nixpkgs/commit/5ec1ba645e4a8d2e4e79b12bde7178f81f9de362) | `` keycloak: 26.1.3 -> 26.1.4 ``                                                                             |
| [`d6bf8e25`](https://github.com/NixOS/nixpkgs/commit/d6bf8e25980197fad7e67aa7e4b1ff8d5df2285e) | `` maintainers: remove 48cf, sanana -> lzcunt (#385342) ``                                                   |
| [`2963d183`](https://github.com/NixOS/nixpkgs/commit/2963d18378949264695e398e115fa575990c4a87) | `` nixos/slskd: remove useless inotify watches ``                                                            |
| [`0d1ff1f0`](https://github.com/NixOS/nixpkgs/commit/0d1ff1f0c45288fcf5f8ef2cfdb7597b8a7463e9) | `` matrix-synapse: 1.125.0 -> 1.126.0 ``                                                                     |
| [`e8cf4aec`](https://github.com/NixOS/nixpkgs/commit/e8cf4aecc9d4e224eb11f4ba882df792fcea27c1) | `` backport jetbrains.plugins -> 24.11 (#389509) ``                                                          |
| [`19bd6527`](https://github.com/NixOS/nixpkgs/commit/19bd6527aeebaac2447b5552654c9f02d3ea0ed3) | `` ci: Update pinned Nixpkgs ``                                                                              |
| [`3954c520`](https://github.com/NixOS/nixpkgs/commit/3954c520c9b8a63d00851412c96240181473859b) | `` misskey: apply patch for CVE-2025-24896 ``                                                                |
| [`fa9009f1`](https://github.com/NixOS/nixpkgs/commit/fa9009f137210ba7274c8b0643e2aed8d77961ee) | `` redmine: 5.1.6 -> 5.1.7 ``                                                                                |
| [`4e84dc23`](https://github.com/NixOS/nixpkgs/commit/4e84dc237d58f6381e4b433ba9fc9cbd3708331e) | `` signal-desktop(darwin): 7.44.0 -> 7.46.0 ``                                                               |
| [`b57dcbc9`](https://github.com/NixOS/nixpkgs/commit/b57dcbc9199cacf335a2f89efcf6226b12132d2a) | `` signal-desktop: 7.44.0 -> 7.46.0 ``                                                                       |
| [`dc02047c`](https://github.com/NixOS/nixpkgs/commit/dc02047c3d19c92559ff50ab8cabde92363b3d17) | `` ungoogled-chromium: 134.0.6998.35-1 -> 134.0.6998.88-1 ``                                                 |
| [`42951501`](https://github.com/NixOS/nixpkgs/commit/42951501516bc47b3a4a3e5cdea815953dd6b5ee) | `` slack: 4.41.105 -> 4.42.120 ``                                                                            |
| [`f463c20d`](https://github.com/NixOS/nixpkgs/commit/f463c20dea3400e88b38c355d0f4b4a7c276be23) | `` doc/release-notes: add victorialogs ``                                                                    |
| [`ac76f0df`](https://github.com/NixOS/nixpkgs/commit/ac76f0dfc2f6ec628d94f3736d91fcb12c5919ac) | `` telegram-desktop: 5.12.1 -> 5.12.3 ``                                                                     |
| [`2ee9be53`](https://github.com/NixOS/nixpkgs/commit/2ee9be5347fbd424d80fc26f02119ed78d5aa13d) | `` telegram-desktop: 5.12.0 -> 5.12.1 ``                                                                     |
| [`639fb776`](https://github.com/NixOS/nixpkgs/commit/639fb7768927b61e559ac3a9e0af32ab1e3eaf51) | `` telegram-desktop: 5.11.1 -> 5.12.0 ``                                                                     |
| [`158f2133`](https://github.com/NixOS/nixpkgs/commit/158f2133f9e738541a528da1d0dd6690e390d242) | `` nix-builder-vm: disable `auto-optimise-store` ``                                                          |
| [`f710992c`](https://github.com/NixOS/nixpkgs/commit/f710992c14c7c86624c50081264b802e67a022c4) | `` librewolf: 136.0-2 -> 136.0.1-1 ``                                                                        |
| [`811de9da`](https://github.com/NixOS/nixpkgs/commit/811de9dab2d12a8bed83b7693d59c8ca451531ce) | `` linux_5_4: 5.4.290 -> 5.4.291 ``                                                                          |
| [`912805fb`](https://github.com/NixOS/nixpkgs/commit/912805fbe7f46d80233d710f831aa0c38f0db9c0) | `` linux_5_10: 5.10.234 -> 5.10.235 ``                                                                       |
| [`02677937`](https://github.com/NixOS/nixpkgs/commit/02677937eb9a9e52e968b3349ec0317735328a46) | `` linux_5_15: 5.15.178 -> 5.15.179 ``                                                                       |
| [`67906550`](https://github.com/NixOS/nixpkgs/commit/67906550b0f5b7909fb4691cca70bbf50ae22301) | `` linux_6_1: 6.1.130 -> 6.1.131 ``                                                                          |
| [`49fab588`](https://github.com/NixOS/nixpkgs/commit/49fab58863c455789e7503b51c76a94d8d2403ce) | `` linux_6_6: 6.6.82 -> 6.6.83 ``                                                                            |
| [`b0819d42`](https://github.com/NixOS/nixpkgs/commit/b0819d422bd52e1fcd4999db4143bddf246affb2) | `` linux_6_12: 6.12.18 -> 6.12.19 ``                                                                         |
| [`334e079f`](https://github.com/NixOS/nixpkgs/commit/334e079f528d985bb2428238e85392caaec7195f) | `` linux_6_13: 6.13.6 -> 6.13.7 ``                                                                           |
| [`6d29c0d5`](https://github.com/NixOS/nixpkgs/commit/6d29c0d59833d3381eb79bedf29fab3e9463fa55) | `` element-desktop: 1.11.91 -> 1.11.95 ``                                                                    |
| [`cd34cac2`](https://github.com/NixOS/nixpkgs/commit/cd34cac2aa70c931063fea3344fef64050e10b05) | `` element-desktop.keytar: 7.9.0 -> 7.10.0 ``                                                                |
| [`3331b403`](https://github.com/NixOS/nixpkgs/commit/3331b4035c3fb75140e20379c2c84d5988e7df5b) | `` element-desktop: use electron_34, follow upstream ``                                                      |
| [`b826fda5`](https://github.com/NixOS/nixpkgs/commit/b826fda57191bf21cc82f692cdff407b753e34b8) | `` element-web: 1.11.91 -> 1.11.95 ``                                                                        |
| [`5b17cf9d`](https://github.com/NixOS/nixpkgs/commit/5b17cf9dd09f98f57afaf955a3de9ec2625774c4) | `` playwright: 1.48.1 -> 1.50.1 ``                                                                           |
| [`1873ac4b`](https://github.com/NixOS/nixpkgs/commit/1873ac4bd8c4df6a5bd01a0f565df195f7b8581d) | `` python3Packages.playwright: 1.48.0 -> 1.49.1 ``                                                           |
| [`5eabaf57`](https://github.com/NixOS/nixpkgs/commit/5eabaf578fafb94754cdddedd37a7d607138901f) | `` playwright: 1.47.0 -> 1.48.1 ``                                                                           |
| [`80a3e9ca`](https://github.com/NixOS/nixpkgs/commit/80a3e9ca766a82fcec24648ab3a771d5dd8f9bf2) | `` playwright: download browsers for Mac OS ``                                                               |
| [`24990060`](https://github.com/NixOS/nixpkgs/commit/249900608c04a8221ddde8f458de2c57f35a46f3) | `` refine: 0.4.4 -> 0.5.2 ``                                                                                 |
| [`cb7f6002`](https://github.com/NixOS/nixpkgs/commit/cb7f600293aaaa7b8cc053c669df98b5f2512a50) | `` cargo-tauri: 2.2.7 -> 2.3.1 ``                                                                            |
| [`3ebd8c3f`](https://github.com/NixOS/nixpkgs/commit/3ebd8c3f397a62876ad32148e31007dbcf02bb1a) | `` dependency-track: 4.12.5 -> 4.12.6 ``                                                                     |
| [`baffffd6`](https://github.com/NixOS/nixpkgs/commit/baffffd6271acba41261f8ed40ecc1a53192b2a7) | `` nixos/postfixadmin: use `config.services.postgresql.settings.port` instead of old ...`postgresql.port` `` |
| [`432a5d05`](https://github.com/NixOS/nixpkgs/commit/432a5d05a1502d153de72449143d7d093d57d4b8) | `` nixos/postfixadmin: add `set -o pipefail` for `postfixadmin-postgres` script ``                           |
| [`075e0430`](https://github.com/NixOS/nixpkgs/commit/075e043000c455f329c0ae9de1bd8a4ca0fcb305) | `` nixos/postfixadmin: refactor ``                                                                           |
| [`b51bafc1`](https://github.com/NixOS/nixpkgs/commit/b51bafc1705140ee54393f54ec5edb2173c963ec) | `` nixos/postfixadmin: format with nixfmt-rfc-style ``                                                       |
| [`556063af`](https://github.com/NixOS/nixpkgs/commit/556063af3c341420f0a74cc1b904e9b886544d41) | `` nixos/victorialogs: init module ``                                                                        |
| [`09648206`](https://github.com/NixOS/nixpkgs/commit/0964820656bd6b0dc18f27dba83d6fbcd5d65cbd) | `` gitbutler: 0.14.4 -> 0.14.7 ``                                                                            |