### PR TITLE
chore(flake/home-manager): `9d3d080a` -> `f6af7280`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739757849,
-        "narHash": "sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA=",
+        "lastModified": 1742234739,
+        "narHash": "sha256-zFL6zsf/5OztR1NSNQF33dvS1fL/BzVUjabZq4qrtY4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9d3d080aec2a35e05a15cedd281c2384767c2cfe",
+        "rev": "f6af7280a3390e65c2ad8fd059cdc303426cbd59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`f6af7280`](https://github.com/nix-community/home-manager/commit/f6af7280a3390e65c2ad8fd059cdc303426cbd59) | `` ci: bump cachix/cachix-action from 15 to 16 (#6646) ``      |
| [`7fbde08e`](https://github.com/nix-community/home-manager/commit/7fbde08ea24460216cacddbf5c4f839baa98b02e) | `` ci: bump cachix/install-nix-action from 30 to 31 (#6645) `` |