### PR TITLE
chore(flake/nixos-cosmic): `216557e6` -> `2c9c267f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742641703,
-        "narHash": "sha256-hoN8blvJco8OSZmPj8izwQaQUdydVi+5FO4/nWd1MNU=",
+        "lastModified": 1742845974,
+        "narHash": "sha256-NQpQ1SuRhknXa1FrywA6qIQjPCvdl3Mp6F1FTxb07mY=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "216557e6cd229dbe7d73a497c227824a3c579cd7",
+        "rev": "2c9c267ff122161a637d611b13066fd577886fba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                                                 |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`2c9c267f`](https://github.com/lilyinstarlight/nixos-cosmic/commit/2c9c267ff122161a637d611b13066fd577886fba) | `` cosmic-session: override `cargo-target-dir` with just flag (#727) `` |
| [`98a0228c`](https://github.com/lilyinstarlight/nixos-cosmic/commit/98a0228c8324b8094423640939586daf14109c25) | `` cosmic-ext-applet-caffeine: init (#694) ``                           |