### PR TITLE
chore(flake/nixos-cosmic): `2c9c267f` -> `c62c1915`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1742845974,
-        "narHash": "sha256-NQpQ1SuRhknXa1FrywA6qIQjPCvdl3Mp6F1FTxb07mY=",
+        "lastModified": 1742847293,
+        "narHash": "sha256-2TJhcc0oczRl6ngiv42gkHB0HFMGaA50tiuDs7Ivl5A=",
         "owner": "lilyinstarlight",
         "repo": "nixos-cosmic",
-        "rev": "2c9c267ff122161a637d611b13066fd577886fba",
+        "rev": "c62c19158e4841550b8ebf614bb8b7147ef19e30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                               |
| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`c62c1915`](https://github.com/lilyinstarlight/nixos-cosmic/commit/c62c19158e4841550b8ebf614bb8b7147ef19e30) | `` nixos/cosmic-greeter: add package option (#726) `` |