### PR TITLE
chore(flake/home-manager): `1efd2503` -> `71703001`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743136572,
-        "narHash": "sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54=",
+        "lastModified": 1743295846,
+        "narHash": "sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1efd2503172016a6742c87b47b43ca2c8145607d",
+        "rev": "717030011980e9eb31eb8ce011261dd532bce92c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`71703001`](https://github.com/nix-community/home-manager/commit/717030011980e9eb31eb8ce011261dd532bce92c) | `` podman: fix service name in generated manifest (#6710) `` |
| [`b4314965`](https://github.com/nix-community/home-manager/commit/b431496538b0e294fbe44a1441b24ae8195c63f0) | `` launchd: refactor setupLaunchAgents ``                    |
| [`86d2e3b0`](https://github.com/nix-community/home-manager/commit/86d2e3b00561a166f8c31ff9ec6a947ca0992ec5) | `` launchd: remove checkLaunchAgents ``                      |
| [`ef8f8987`](https://github.com/nix-community/home-manager/commit/ef8f898727d174b16a154b29e8c0f82d39cbac21) | `` launchd: add khaneliman maintainer ``                     |
| [`a710f337`](https://github.com/nix-community/home-manager/commit/a710f337d6f541f5ba50bc2d5daa6c34e9ee5834) | `` launchd: remove with lib ``                               |
| [`f1d4acaa`](https://github.com/nix-community/home-manager/commit/f1d4acaa1085930f76165e99db356db9f9f9fda6) | `` treewide: use mkPackageOption (#6727) ``                  |
| [`1f679ed2`](https://github.com/nix-community/home-manager/commit/1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68) | `` zsh-abbr: Add global abbreviations (#6720) ``             |
| [`3527c8c7`](https://github.com/nix-community/home-manager/commit/3527c8c7785d1855ccf9da0e8436a0e769190b18) | `` sesh: add module (#5789) ``                               |