### PR TITLE
chore(flake/home-manager): `71703001` -> `1d2ed9c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743295846,
-        "narHash": "sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ=",
+        "lastModified": 1743346616,
+        "narHash": "sha256-AB/ve2el1TB7k4iyogHGCVlWVkrhp3+4FKKMr1W5iKQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "717030011980e9eb31eb8ce011261dd532bce92c",
+        "rev": "1d2ed9c503cf41ca7f3db091edc8519dcdcd8b41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`1d2ed9c5`](https://github.com/nix-community/home-manager/commit/1d2ed9c503cf41ca7f3db091edc8519dcdcd8b41) | `` flake.lock: Update (#6730) ``                                                  |
| [`802653e5`](https://github.com/nix-community/home-manager/commit/802653e5d1f654ac67c045ca6eea8c8cfa8fc052) | `` auto-upgrade: unbreak on unattended, loginctl enable-linger systems (#6719) `` |
| [`8ce84337`](https://github.com/nix-community/home-manager/commit/8ce84337430492b984a7ddd73371773e8d19ad73) | `` granted: Add override for package (#6722) ``                                   |
| [`2760046f`](https://github.com/nix-community/home-manager/commit/2760046f34780cc72f67e06240ccf6a7a3ae3765) | `` docs: correct improper import of home.nix (#6732) ``                           |