### PR TITLE
chore(flake/home-manager): `0afad8f0` -> `f4d9d1e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743519130,
-        "narHash": "sha256-Nw6sLnuwDPW7pBJ5jIvFFMqBfeK31xcp7/w1oYH1Q7U=",
+        "lastModified": 1743527271,
+        "narHash": "sha256-EuanEW1qqXZ2h0zJnq7uz8BoHbsgHgUrqWkCZHwZ9FA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0afad8f08014c992c832466c1d46a0aa96ca2563",
+        "rev": "f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`f4d9d1e2`](https://github.com/nix-community/home-manager/commit/f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9) | `` broot: get rid of IFDs (#6723) `` |