### PR TITLE
chore(flake/home-manager): `f4d9d1e2` -> `e355ae93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743527271,
-        "narHash": "sha256-EuanEW1qqXZ2h0zJnq7uz8BoHbsgHgUrqWkCZHwZ9FA=",
+        "lastModified": 1743552362,
+        "narHash": "sha256-enHrqjpK3/wJ7m0QCxci/PDSSa7ScHXF9GMRK5ELaSQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9",
+        "rev": "e355ae93a3cdaff64a3152c78b944ef36a85e8ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e355ae93`](https://github.com/nix-community/home-manager/commit/e355ae93a3cdaff64a3152c78b944ef36a85e8ce) | `` docs: add docs for mkOutOfStoreSymlink (#6660) `` |
| [`89279a66`](https://github.com/nix-community/home-manager/commit/89279a66f4c6c32ea39940a6af63171dae75aafd) | `` fcitx5: set SDL_IM_MODULE (#6742) ``              |