### PR TITLE
chore(flake/home-manager): `e355ae93` -> `5ee44bc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743552362,
-        "narHash": "sha256-enHrqjpK3/wJ7m0QCxci/PDSSa7ScHXF9GMRK5ELaSQ=",
+        "lastModified": 1743556466,
+        "narHash": "sha256-rvU79DJ6rPDxiH0sTp686Vlm+JewwAZPGcwt8OfHJbM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e355ae93a3cdaff64a3152c78b944ef36a85e8ce",
+        "rev": "5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5ee44bc7`](https://github.com/nix-community/home-manager/commit/5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0) | `` news: add services.home-manager.autoExpire entry `` |
| [`28242a60`](https://github.com/nix-community/home-manager/commit/28242a60d3cdcb6675dfe68ebbb64bf43c7be4e0) | `` home-manager-auto-expire: init ``                   |
| [`938e802b`](https://github.com/nix-community/home-manager/commit/938e802b70ee7700141b18ef8dca05ad89917a37) | `` alacritty: add `theme` option (#5238) ``            |