### PR TITLE
chore(flake/home-manager): `5ee44bc7` -> `49748c74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743556466,
-        "narHash": "sha256-rvU79DJ6rPDxiH0sTp686Vlm+JewwAZPGcwt8OfHJbM=",
+        "lastModified": 1743607567,
+        "narHash": "sha256-kTzKPDFmNzwO1cK4fiJgPB/iSw7HgBAmknRTeAPJAeI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0",
+        "rev": "49748c74cdbae03d70381f150b810f92617f23aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`49748c74`](https://github.com/nix-community/home-manager/commit/49748c74cdbae03d70381f150b810f92617f23aa) | `` tests/atuin: add nushell test ``                        |
| [`28273920`](https://github.com/nix-community/home-manager/commit/282739209a55470c8a17b821301962e8b841d265) | `` atuin: fix nushell config ``                            |
| [`53cacafd`](https://github.com/nix-community/home-manager/commit/53cacafd9be391e5ec41f688846edd1e1830c822) | `` treewide: nushell build time configs suffixed ``        |
| [`180fd43e`](https://github.com/nix-community/home-manager/commit/180fd43eea296e62ae68e079fcf56aba268b9a1a) | `` pay-respects: allow setting custom options ``           |
| [`812a12d0`](https://github.com/nix-community/home-manager/commit/812a12d014c8bca72304c68d92e057e2cdd5028b) | `` oh-my-posh: build-time nushell config generation ``     |
| [`287cbbbf`](https://github.com/nix-community/home-manager/commit/287cbbbf80d460cd07ef66e05b92565b4b1eee6e) | `` nix-your-shell: build-time nushell config generation `` |
| [`dde05a0b`](https://github.com/nix-community/home-manager/commit/dde05a0b10d7db1410c3d9641026a84707e945cd) | `` carapace: build-time nushell config generation ``       |
| [`3722855a`](https://github.com/nix-community/home-manager/commit/3722855a1cd480d4179477a21d82d5eca2e33e57) | `` atuin: build-time nushell config generation ``          |
| [`267f6ada`](https://github.com/nix-community/home-manager/commit/267f6ada1ecc1a3534023d6414a7407008140e96) | `` zoxide: build-time nushell config generation ``         |
| [`98d718b4`](https://github.com/nix-community/home-manager/commit/98d718b46d2628a3703a10028d0b51620351b0c5) | `` starship: build-time nushell config generation ``       |
| [`81f38986`](https://github.com/nix-community/home-manager/commit/81f38986a2a63ed9b1a61e60c700a9f01bd96f3f) | `` jq: add missing color option (#6734) ``                 |