### PR TITLE
chore(flake/home-manager): `0f5908da` -> `b5e29565`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743788974,
-        "narHash": "sha256-2LeVyQZI2wTkSzMLvnN/kJjXVWp4HCVUoq17Bv8TNTk=",
+        "lastModified": 1743860185,
+        "narHash": "sha256-TkhfJ+vH+iGxLQL6RJLObMmldAQpysVJ+p1WnnKyIeQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0f5908daf890c3d7e7052bef1d6deb0f2710aaa1",
+        "rev": "b5e29565131802cc8adee7dccede794226da8614",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`b5e29565`](https://github.com/nix-community/home-manager/commit/b5e29565131802cc8adee7dccede794226da8614) | `` redshift/gammastep: add tray tests ``             |
| [`46f93825`](https://github.com/nix-community/home-manager/commit/46f93825af684a094950ae66ba5ef24a4b10c49f) | `` redshift/gammastep: fix tray.target dependency `` |