### PR TITLE
chore(flake/home-manager): `760eed59` -> `542efdf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744138333,
-        "narHash": "sha256-l0Vjq1EZoYTfWImVmwsvMEuIdasrBRRCoNTV0rNtYi0=",
+        "lastModified": 1744208565,
+        "narHash": "sha256-vG3JJOar/r8ognz7wuwMtOJ8Knu1MMlOzHB1N6R2MbY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "760eed59594f2f258db0d66b7ca4a5138681fd97",
+        "rev": "542efdf2dfac351498f534eb71671525b9bd45ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`542efdf2`](https://github.com/nix-community/home-manager/commit/542efdf2dfac351498f534eb71671525b9bd45ed) | `` flake.lock: Update (#6785) ``                          |
| [`9864a2f4`](https://github.com/nix-community/home-manager/commit/9864a2f421e859d9784b6c413ec25d1415ddfe08) | `` thunderbird: add accountsOrder option (#6310) ``       |
| [`a1036d4d`](https://github.com/nix-community/home-manager/commit/a1036d4d3e939d740149508aa68b2545c4964d37) | `` tests: stub notmuch darwin (#6788) ``                  |
| [`fcb8a2b6`](https://github.com/nix-community/home-manager/commit/fcb8a2b62b30ae054a4eadbf43c913a755f1d14c) | `` swaylock: fix path values in config file (#6786) ``    |
| [`4040c577`](https://github.com/nix-community/home-manager/commit/4040c5779ce56d36805bc7a83e072f0f894eae7d) | `` modules/programs/ssh: support identityAgent (#6783) `` |