### PR TITLE
chore(flake/home-manager): `543caa31` -> `f1ffd097`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744316889,
-        "narHash": "sha256-qS0BhvsL9J7gt4cOpBZdzT0EqylGPKyKnU9v/6SJvFI=",
+        "lastModified": 1744343724,
+        "narHash": "sha256-DkiOZlkXbdf6f09pSulJPE0IaaJi1p7sqia/G2kqNKI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "543caa313abe45b56520efdaa35d379703f79e3a",
+        "rev": "f1ffd097e717a8d1b441577b8d23f9d2c96e0657",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`f1ffd097`](https://github.com/nix-community/home-manager/commit/f1ffd097e717a8d1b441577b8d23f9d2c96e0657) | `` hyprsunset: support multiple commands to IPC ``                       |
| [`cf6314f8`](https://github.com/nix-community/home-manager/commit/cf6314f8e173e208882e32ed85158f78bf74d085) | `` hyprsunset: init ``                                                   |
| [`47eb2d80`](https://github.com/nix-community/home-manager/commit/47eb2d80f943521ec88fe92899925c5f444c8a5c) | `` accounts/contact: add sensible defaults to the localModule (#6799) `` |