### PR TITLE
chore(flake/home-manager): `f1ffd097` -> `da624eaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744343724,
-        "narHash": "sha256-DkiOZlkXbdf6f09pSulJPE0IaaJi1p7sqia/G2kqNKI=",
+        "lastModified": 1744360457,
+        "narHash": "sha256-Rcd9KYFRYPkMfOsz6vzWosEfggJMGjb1/j9mnxC7q9s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f1ffd097e717a8d1b441577b8d23f9d2c96e0657",
+        "rev": "da624eaad0fefd4dac002e1f09d300d150c20483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`da624eaa`](https://github.com/nix-community/home-manager/commit/da624eaad0fefd4dac002e1f09d300d150c20483) | `` jujutsu: evaluate the settings after merging with other options (#6775) `` |