### PR TITLE
chore(flake/home-manager): `da624eaa` -> `e43c6bcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744360457,
-        "narHash": "sha256-Rcd9KYFRYPkMfOsz6vzWosEfggJMGjb1/j9mnxC7q9s=",
+        "lastModified": 1744380363,
+        "narHash": "sha256-cXjAUuAfQDPSLSsckZuTioQ986iqSPTzx8D7dLAcC+Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da624eaad0fefd4dac002e1f09d300d150c20483",
+        "rev": "e43c6bcb101ba3301522439c459288c4a248f624",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`e43c6bcb`](https://github.com/nix-community/home-manager/commit/e43c6bcb101ba3301522439c459288c4a248f624) | `` anyrun: init module (#6804) ``                                   |
| [`6bccb54a`](https://github.com/nix-community/home-manager/commit/6bccb54a4f98408f22d2e45921bb401f393f2174) | `` aerospace: revert flattening on-window-detected rules (#6803) `` |
| [`f0c69ede`](https://github.com/nix-community/home-manager/commit/f0c69ede700deeef5aa0d7b8604f35a4e7d292bf) | `` way-displays: init module (#6791) ``                             |
| [`e15c4203`](https://github.com/nix-community/home-manager/commit/e15c4203ea04cd80edbd8005d0eadb53eded45ea) | `` hyprland: plugins use hyprctl from path (#6801) ``               |