### PR TITLE
chore(flake/home-manager): `db56335c` -> `cfa196c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744498625,
-        "narHash": "sha256-pL52uCt9CUoTTmysGG91c2FeU7XUvpB7Cep6yon2vDk=",
+        "lastModified": 1744570807,
+        "narHash": "sha256-g07PYyZCIHVDLzRo8fllZRES7Nf9R8+xZwNJ7t0gt5s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db56335ca8942d86f2200664acdbd5b9212b26ad",
+        "rev": "cfa196c705a896372319249d757085876ab62448",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`cfa196c7`](https://github.com/nix-community/home-manager/commit/cfa196c705a896372319249d757085876ab62448) | `` flake.lock: Update (#6812) ``                            |
| [`4f898f37`](https://github.com/nix-community/home-manager/commit/4f898f373d8b0bfdac635b036396c90b0ad17be8) | `` helix: add support for path and string themes (#6814) `` |