### PR TITLE
chore(flake/home-manager): `cfa196c7` -> `ac3c1f4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744570807,
-        "narHash": "sha256-g07PYyZCIHVDLzRo8fllZRES7Nf9R8+xZwNJ7t0gt5s=",
+        "lastModified": 1744584414,
+        "narHash": "sha256-uk9NgZvkTkHEuTdnZ2GGO/Y4q4sbHdAMzPPoASpIpWo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cfa196c705a896372319249d757085876ab62448",
+        "rev": "ac3c1f4fa40497b07f1f3ea3c4f644ce5dbcd2a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`ac3c1f4f`](https://github.com/nix-community/home-manager/commit/ac3c1f4fa40497b07f1f3ea3c4f644ce5dbcd2a4) | `` foot: enable duplicate key-bindings (#6815) `` |
| [`14229249`](https://github.com/nix-community/home-manager/commit/1422924908881faf59722810884addf109ebea07) | `` Translate using Weblate (Czech) (#6813) ``     |