### PR TITLE
chore(flake/home-manager): `ac3c1f4f` -> `85dd758c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744584414,
-        "narHash": "sha256-uk9NgZvkTkHEuTdnZ2GGO/Y4q4sbHdAMzPPoASpIpWo=",
+        "lastModified": 1744618730,
+        "narHash": "sha256-n3gN7aHwVRnnBZI64EDoKyJnWidNYJ0xezhqQtdjH2Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ac3c1f4fa40497b07f1f3ea3c4f644ce5dbcd2a4",
+        "rev": "85dd758c703ffbf9d97f34adcef3a898b54b4014",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`85dd758c`](https://github.com/nix-community/home-manager/commit/85dd758c703ffbf9d97f34adcef3a898b54b4014) | `` yazi: remove assertions (#6817) ``          |
| [`e980d0e0`](https://github.com/nix-community/home-manager/commit/e980d0e0e216f527ea73cfd12c7b019eceffa7f1) | `` nh: support 4.0 for flake option (#6818) `` |