### PR TITLE
chore(flake/home-manager): `85dd758c` -> `33754144`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744618730,
-        "narHash": "sha256-n3gN7aHwVRnnBZI64EDoKyJnWidNYJ0xezhqQtdjH2Q=",
+        "lastModified": 1744637364,
+        "narHash": "sha256-ZVINTNMJS6W3fqPYV549DSmjYQW5I9ceKBl83FwPP7k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "85dd758c703ffbf9d97f34adcef3a898b54b4014",
+        "rev": "337541447773985f825512afd0f9821a975186be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`33754144`](https://github.com/nix-community/home-manager/commit/337541447773985f825512afd0f9821a975186be) | `` helix: fix str + path theme (#6816) `` |