### PR TITLE
chore(flake/home-manager): `33754144` -> `5a096a88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744637364,
-        "narHash": "sha256-ZVINTNMJS6W3fqPYV549DSmjYQW5I9ceKBl83FwPP7k=",
+        "lastModified": 1744659400,
+        "narHash": "sha256-q0wwsR/hvOjj1G8ogdudX5cU0IE/Vgvgjo9g9OpQv5U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "337541447773985f825512afd0f9821a975186be",
+        "rev": "5a096a8822cb98584c5dc4f2616dcd5ed394bfd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`5a096a88`](https://github.com/nix-community/home-manager/commit/5a096a8822cb98584c5dc4f2616dcd5ed394bfd7) | `` superfile: initial support (#6610) `` |
| [`273ad32f`](https://github.com/nix-community/home-manager/commit/273ad32fbb4769ac56e15caccdbdaad2c2e6b88a) | `` tests/nh: init tests (#6819) ``       |