### PR TITLE
chore(flake/home-manager): `5a096a88` -> `d5cdf55b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744659400,
-        "narHash": "sha256-q0wwsR/hvOjj1G8ogdudX5cU0IE/Vgvgjo9g9OpQv5U=",
+        "lastModified": 1744663884,
+        "narHash": "sha256-a6QGaZMDM1miK8VWzAITsEPOdmLk+xTPyJSTjVs3WhI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5a096a8822cb98584c5dc4f2616dcd5ed394bfd7",
+        "rev": "d5cdf55bd9f19a3debd55b6cb5d38f7831426265",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`d5cdf55b`](https://github.com/nix-community/home-manager/commit/d5cdf55bd9f19a3debd55b6cb5d38f7831426265) | `` direnv: add tests for silent option ``                      |
| [`ae5fcad7`](https://github.com/nix-community/home-manager/commit/ae5fcad746ac79ea2f791c6369089e4db7ad6bc1) | `` direnv: fix silent option after update to direnv v2.36.0 `` |