### PR TITLE
chore(flake/nixvim): `2e008bb9` -> `a587a96a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -1188,11 +1188,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1770380644,
-        "narHash": "sha256-P7dWMHRUWG5m4G+06jDyThXO7kwSk46C1kgjEWcybkE=",
+        "lastModified": 1774701658,
+        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae67888ff7ef9dff69b3cf0cc0fbfbcd3a722abe",
+        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
         "type": "github"
       },
       "original": {
@@ -1353,11 +1353,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1775307257,
-        "narHash": "sha256-y9hEecHH4ennFwIcw1n480YCGh73DkEmizmQnyXuvgg=",
+        "lastModified": 1775837497,
+        "narHash": "sha256-L17VI03w/wVXvc1SK7EI1muLqHxD3+esYPPzgQvvdOE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e008bb941f72379d5b935d5bfe70ed8b7c793ff",
+        "rev": "a587a96a48c705609bfd2ad23f9ae5961eb0d373",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`a587a96a`](https://github.com/nix-community/nixvim/commit/a587a96a48c705609bfd2ad23f9ae5961eb0d373) | `` plugins/treesitter-textobjects: keymaps update ``                   |
| [`8f634488`](https://github.com/nix-community/nixvim/commit/8f634488bcc052064d2619a782c34a915bd7fe33) | `` plugins/sidekick: don't bundle providers default ``                 |
| [`8e608496`](https://github.com/nix-community/nixvim/commit/8e608496d9294b0b0bf75ac92f84e9312b3e54dd) | `` plugins/dap: add configuration examples to docs ``                  |
| [`47844a7f`](https://github.com/nix-community/nixvim/commit/47844a7f6b4b3fd6ac11390c61731d715669e711) | `` plugins/treesitter: recommend configured package ``                 |
| [`37e43d80`](https://github.com/nix-community/nixvim/commit/37e43d800387d3a387e29109b2673a9bd72d8b7c) | `` Fix manpages name ``                                                |
| [`cfd9affc`](https://github.com/nix-community/nixvim/commit/cfd9affcf97ea2007988a0aca2379fec5f24acc5) | `` tests/all-package-defaults: disable flow and fstar on darwin ``     |
| [`c050ddce`](https://github.com/nix-community/nixvim/commit/c050ddce2980e54a5483e419f09e2016c4b6b0ff) | `` tests/all-package-defaults: disable fortitude on darwin ``          |
| [`61876f39`](https://github.com/nix-community/nixvim/commit/61876f3936fa25d6520dbc95c4595e38c2d649a0) | `` tests/nvim-surround: drop removed keymaps setting ``                |
| [`e5393a55`](https://github.com/nix-community/nixvim/commit/e5393a55e9b107a317d2eb64d5313a5859471c10) | `` tests/pylsp: skip broken memestra build on python3.13 ``            |
| [`5690a3ea`](https://github.com/nix-community/nixvim/commit/5690a3ea1fc45727e3ed7ff3f540feb73edc98ba) | `` plugins/mkdnflow: update examples for upstream config changes ``    |
| [`0d5e1973`](https://github.com/nix-community/nixvim/commit/0d5e1973f85bca0a83acc5cb7fb04a74a2cb74ef) | `` tests/minuet: update deprecated lsp completion keys ``              |
| [`2ef7a4a8`](https://github.com/nix-community/nixvim/commit/2ef7a4a82a6c8de70e8235d59b0fbe19ecce3acc) | `` tests/kitty-navigator: skip runtime execution without kitty ``      |
| [`cdcfe3f2`](https://github.com/nix-community/nixvim/commit/cdcfe3f2ff4a814e49387f0b7c8ab4e50fe40a62) | `` tests/origami: update renamed foldtext padding key ``               |
| [`9db4ae75`](https://github.com/nix-community/nixvim/commit/9db4ae75fc633d3111267b9fcb7f94ab2fbf901e) | `` modules/performance: preserve lua deps in combined plugin pack ``   |
| [`3056067b`](https://github.com/nix-community/nixvim/commit/3056067b5518cc092bc551e0bf86f3e656e561c1) | `` plugins/rhubarb: update maintainer attr ``                          |
| [`1e05ad24`](https://github.com/nix-community/nixvim/commit/1e05ad24e005a12e0d285adc24f9f2fd6ec314d8) | `` plugins/rest: add temporary docs URL workaround ``                  |
| [`989b3633`](https://github.com/nix-community/nixvim/commit/989b3633d9d7fd38dcb02fdbda7531a21e8caf53) | `` plugins/colorizer: enable termguicolors by default ``               |
| [`b0d5d932`](https://github.com/nix-community/nixvim/commit/b0d5d9320d04d5dc33c7c4e0247dfe5f3669d6b7) | `` modules/lsp/servers: declare new generated server entries ``        |
| [`637f4ef8`](https://github.com/nix-community/nixvim/commit/637f4ef832a1fbd6bd4ac295230835f87d52f2d0) | `` colorschemes/modus: replace deprecated variant option ``            |
| [`4825cfe6`](https://github.com/nix-community/nixvim/commit/4825cfe6563e48d2e2610c0a9bf45b3a24b9e5f8) | `` tests/modules/output: adapt provider checks to upstream changes ``  |
| [`9722058c`](https://github.com/nix-community/nixvim/commit/9722058ce16e50bf2b2fa5215bad7a564e85ce86) | `` modules/output: adapt to upstream changes in provider generation `` |
| [`1b1e1aed`](https://github.com/nix-community/nixvim/commit/1b1e1aed53370ce2fc6c5e4a5c6c02235b5d3b99) | `` plugins/{efmls-configs,none-ls}/packages: remove alex ``            |
| [`18324d8f`](https://github.com/nix-community/nixvim/commit/18324d8f9efd1059e2fd1cae6bf24831dc2fa4c6) | `` tests/plugins/mkdnflow: adapt test cases to upstream changes ``     |
| [`00a38f08`](https://github.com/nix-community/nixvim/commit/00a38f089bbfd2f36583b1e6578a76c7c6bfae6d) | `` generated: Update ``                                                |
| [`6d7c8ab4`](https://github.com/nix-community/nixvim/commit/6d7c8ab427fe820f2c4727b0371f9752f35b6786) | `` flake: Update ``                                                    |
| [`f6636ce7`](https://github.com/nix-community/nixvim/commit/f6636ce710266750ea5696adf735e04b5799ae55) | `` ci: bump actions/deploy-pages from 4 to 5 ``                        |
| [`1b5fbbd8`](https://github.com/nix-community/nixvim/commit/1b5fbbd8103d2c002f9ba17c2c43d69cf64f4a1d) | `` ci: bump actions/checkout from 5 to 6 ``                            |
| [`54a60652`](https://github.com/nix-community/nixvim/commit/54a60652997832a88088531225e6ccd2c7c88c27) | `` ci: bump actions/create-github-app-token from 2 to 3 ``             |
| [`14702778`](https://github.com/nix-community/nixvim/commit/14702778ef8bc800b38ec92bd6145fb0f12575d2) | `` plugins/none-ls: fix prettier formatting source default package ``  |