### PR TITLE
chore(flake/home-manager): `7ba4ee42` -> `b0569dc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775683737,
-        "narHash": "sha256-oBYyowo6yfgb95Z78s3uTnAd9KkpJpwzjJbfnpLaM2Y=",
+        "lastModified": 1775900011,
+        "narHash": "sha256-QUGu6CJYFQ5AWVV0n3/FsJyV+1/gj7HSDx68/SX9pwM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7ba4ee4228ed36123c7cb75d50524b43514ef992",
+        "rev": "b0569dc6ec1e6e7fefd8f6897184e4c191cd768e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`b0569dc6`](https://github.com/nix-community/home-manager/commit/b0569dc6ec1e6e7fefd8f6897184e4c191cd768e) | `` fresh-editor: add defaultEditor option ``                             |
| [`fb821d64`](https://github.com/nix-community/home-manager/commit/fb821d642253f830d4ccff100b020ab08e191c34) | `` fresh-editor: add extra packages option ``                            |
| [`f899c5d6`](https://github.com/nix-community/home-manager/commit/f899c5d6f3aee046fd7cc33acc690ad51da7d87c) | `` pipewire: add module ``                                               |
| [`f7f6a559`](https://github.com/nix-community/home-manager/commit/f7f6a559c21dfe5e63108ded0d036ae15e6e9d57) | `` xdg: add support for local bin path ``                                |
| [`e35c39fc`](https://github.com/nix-community/home-manager/commit/e35c39fca04fee829cecdf839a50eb9b54d8a701) | `` tmux: reduce default escapeTime ``                                    |
| [`0eddb2cc`](https://github.com/nix-community/home-manager/commit/0eddb2cc1abc5692935308c5efb4035c023bddc7) | `` neovim: use improved submodule deprecation detection ``               |
| [`fbc97e23`](https://github.com/nix-community/home-manager/commit/fbc97e23f6a7440de1ed6d54759a3e29ecea04ea) | `` lib/deprecations: improve submodule warning support ``                |
| [`7f6c5834`](https://github.com/nix-community/home-manager/commit/7f6c5834caef6a289d3515cff09d8537a7157e93) | `` neovim: change the plugin default type from viml -> lua ``            |
| [`a91f37ef`](https://github.com/nix-community/home-manager/commit/a91f37efbaa4572d1e855581be5cc5077a316778) | `` services.darkman: add unified scripts option ``                       |
| [`5c663d57`](https://github.com/nix-community/home-manager/commit/5c663d57811fb584182c65c4bb84d63771c98d4f) | `` gemini-cli: add option for integration with `programs.mcp.servers` `` |
| [`5ef2b986`](https://github.com/nix-community/home-manager/commit/5ef2b9862f34e3a65b212fd6295224b91d664141) | `` gemini-cli: add skills option ``                                      |
| [`0f9090a7`](https://github.com/nix-community/home-manager/commit/0f9090a77c7af9eafcc79394ac3d258a438f722d) | `` aerc: encode username in account URLs ``                              |
| [`505e91f8`](https://github.com/nix-community/home-manager/commit/505e91f877dab9754c9d4197bc92927342c4c31e) | `` glance: add darwin support ``                                         |
| [`c975a66a`](https://github.com/nix-community/home-manager/commit/c975a66a56306b38eaa3108f54bbc11e213f42f6) | `` niriswitcher: remove module ``                                        |
| [`2877554a`](https://github.com/nix-community/home-manager/commit/2877554a72fed1a1ca8bc805e494bfe3f8b144c9) | `` programs.nheko: link to upstream issue in description for settings `` |