### PR TITLE
chore(flake/freminal): `e72ca4ff` -> `a26512cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         "precommit": "precommit_3"
       },
       "locked": {
-        "lastModified": 1775752219,
-        "narHash": "sha256-HNj/euwlYZpOpaN0mOOEfz15D0bZYqed2VaVh+/8ZLo=",
+        "lastModified": 1775759095,
+        "narHash": "sha256-niMhbuKKe3wR/LJnebMTqvZPjMazt9uVzEP2Dep5nyE=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "e72ca4ff2b34099dc69bd71e57618dd4d439a25c",
+        "rev": "a26512cb4322ac7fe68bca5642615f3b28123d3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`86cddeb1`](https://github.com/fredsystems/freminal/commit/86cddeb1ce5cace2356e045d0d89e77cb720ca31) | `` chore(deps): update taiki-e/install-action action to v2.75.3 ``                    |
| [`b8d922e9`](https://github.com/fredsystems/freminal/commit/b8d922e9f1fcbfbbf2dacf46c87b812ef8dfabe0) | `` chore(deps): update actions/upload-artifact action to v7 ``                        |
| [`f800fb54`](https://github.com/fredsystems/freminal/commit/f800fb54c15d596775e1ed96021f22e7fd0a2e45) | `` chore(deps): update actions/cache action to v5 ``                                  |
| [`5ce39f9e`](https://github.com/fredsystems/freminal/commit/5ce39f9e91efcf296edcea1fc6df2727b223c0de) | `` chore(deps): update fredsystems/flake-update-action action to v3.0.4 ``            |
| [`bcf30d1a`](https://github.com/fredsystems/freminal/commit/bcf30d1ae4ffe96ae67755e84444c3eaad5e629c) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 32cb6a5 `` |
| [`1d62b9ac`](https://github.com/fredsystems/freminal/commit/1d62b9ac6df69dd39b35966470950f987dd91719) | `` fix hm info for logging ``                                                         |
| [`e48ce221`](https://github.com/fredsystems/freminal/commit/e48ce22180d19dd94f667e1c6c561e7916febb96) | `` docs: mark Task 57 subtasks 57.1–57.5 as complete ``                               |
| [`3e032d61`](https://github.com/fredsystems/freminal/commit/3e032d6149cf9b25e84222345492689119d847f7) | `` docs: add Task 58 (Built-in Multiplexer / Split Panes) to v0.5.0 plan ``           |