### PR TITLE
chore(flake/apple-fonts): `f8dad87c` -> `ecb84305`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "sf-pro": "sf-pro"
       },
       "locked": {
-        "lastModified": 1772251183,
-        "narHash": "sha256-Zfr9trB8LaesfpupugDgXPqC4F25MO18kyMyb9b2PkM=",
+        "lastModified": 1775780043,
+        "narHash": "sha256-gjSmzLF1WaxZ1128suHgT5lp6qbjv+qy4NIuE8dEUXM=",
         "owner": "Lyndeno",
         "repo": "apple-fonts.nix",
-        "rev": "f8dad87c2cb956695d18c1f36360322d8a0b7d63",
+        "rev": "ecb843051893bdf34fd4f9c0ec664e356e2251a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                              |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`ecb84305`](https://github.com/Lyndeno/apple-fonts.nix/commit/ecb843051893bdf34fd4f9c0ec664e356e2251a6) | `` hydra: Reduce kept derivations `` |