### PR TITLE
chore(flake/nixpkgs-stable): `4e92bbcd` -> `54170c54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1156,11 +1156,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1775595990,
-        "narHash": "sha256-OEf7YqhF9IjJFYZJyuhAypgU+VsRB5lD4DuiMws5Ltc=",
+        "lastModified": 1775811116,
+        "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4e92bbcdb030f3b4782be4751dc08e6b6cb6ccf2",
+        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`ecf622c2`](https://github.com/NixOS/nixpkgs/commit/ecf622c2d15709b03a43f31c29665b52a49b1293) | `` matrix-authentication-service: 1.14.0 -> 1.15.0 ``         |
| [`b7f6edc0`](https://github.com/NixOS/nixpkgs/commit/b7f6edc092a35a0ba645fcc2e8699c8fb5baac90) | `` dn42-registry-wizard: 0.4.19 -> 0.4.20 ``                  |
| [`2b40e625`](https://github.com/NixOS/nixpkgs/commit/2b40e62526b4ceebc63e66a8752c3057a2420ed3) | `` gitlab: 18.10.1 -> 18.10.3 ``                              |
| [`6bd442f9`](https://github.com/NixOS/nixpkgs/commit/6bd442f9189fff2726ee7a847860d8cc4e46664f) | `` zammad: 7.0.0 -> 7.0.1 ``                                  |
| [`c01c78c7`](https://github.com/NixOS/nixpkgs/commit/c01c78c7faafb1ec9b869154c3e901978495ed69) | `` nginx-sso: 0.27.6 -> 0.27.7 ``                             |
| [`b9c908c0`](https://github.com/NixOS/nixpkgs/commit/b9c908c0c2aafb478db340af11387c04a59330d2) | `` nginx-sso: 0.27.5 -> 0.27.6 ``                             |
| [`0648a6b3`](https://github.com/NixOS/nixpkgs/commit/0648a6b3063c7858fdda439254ffc1fc05af7bc9) | `` github-runner: only disable __noChroot on linux ``         |
| [`482f1934`](https://github.com/NixOS/nixpkgs/commit/482f1934c0ed2f15eac65a13cd4a9180d64b3420) | `` pyrefly: 0.58.0 -> 0.60.0 ``                               |
| [`3557c2c2`](https://github.com/NixOS/nixpkgs/commit/3557c2c20b8e97a2c052de18cddd93ccd8141201) | `` batman-adv: 2026.0 -> 2026.1 ``                            |
| [`dc34fce6`](https://github.com/NixOS/nixpkgs/commit/dc34fce6aa19ec924b5dd137467097ed8899f88a) | `` tirith: 0.2.10 -> 0.2.12 ``                                |
| [`9baecd7e`](https://github.com/NixOS/nixpkgs/commit/9baecd7e80a77f41c9c35f041158db4ca10d2510) | `` ungoogled-chromium: 146.0.7680.177-1 -> 147.0.7727.55-1 `` |
| [`6d30150d`](https://github.com/NixOS/nixpkgs/commit/6d30150da2d2d3a1ca6902ddeb2991748408fea5) | `` chromium,chromedriver: 146.0.7680.177 -> 147.0.7727.55 ``  |
| [`faaa45df`](https://github.com/NixOS/nixpkgs/commit/faaa45df6863743032bf2e3abd5ca629e61fbc5b) | `` immich: update geodata 20250818205425 -> 20260408011516 `` |
| [`d9f87a70`](https://github.com/NixOS/nixpkgs/commit/d9f87a708fa4484c9a9448ff373700dfc6829c93) | `` immich: 2.6.3 -> 2.7.2 ``                                  |
| [`5846ed8d`](https://github.com/NixOS/nixpkgs/commit/5846ed8dd9adb3b14d6fd8ee76182bf19e8776d0) | `` matrix-synapse-unwrapped: 1.150.0 -> 1.151.0 ``            |
| [`d1c83c6e`](https://github.com/NixOS/nixpkgs/commit/d1c83c6edebd1f2feed32966ddbc4853620cc298) | `` xdg-desktop-portal: 1.20.3 -> 1.20.4 ``                    |
| [`272d69d5`](https://github.com/NixOS/nixpkgs/commit/272d69d5e9ce71672866e81130c88926ce973a69) | `` importNpmLock: handle commit in resolved git url ``        |
| [`c9cce1b6`](https://github.com/NixOS/nixpkgs/commit/c9cce1b66624b804ff3ee4e98d80899599b025f5) | `` gitlab: 18.9.3 -> 18.10.1 ``                               |
| [`c8b9f03f`](https://github.com/NixOS/nixpkgs/commit/c8b9f03f673d81933ce0fb6305a502ca85f1b9fb) | `` nginx-sso: 0.27.4 -> 0.27.5 ``                             |
| [`ebd32cf9`](https://github.com/NixOS/nixpkgs/commit/ebd32cf91330975eca726f25c2a5b9c3523d5630) | `` goshs: 1.1.4 -> 2.0.0-beta.3 ``                            |
| [`2f29ceb3`](https://github.com/NixOS/nixpkgs/commit/2f29ceb3b31477f8797d44fbe225d4c67829dd73) | `` goshs: 1.1.3 -> 1.1.4 ``                                   |
| [`49125e1e`](https://github.com/NixOS/nixpkgs/commit/49125e1e48eec49caddbc37022631065cfa2a573) | `` goshs: 1.1.2 -> 1.1.3 ``                                   |
| [`304fb873`](https://github.com/NixOS/nixpkgs/commit/304fb87316d0b690228b6982d70bb252adc9fc70) | `` sub-store: 2.21.64 -> 2.21.81 ``                           |
| [`d0612268`](https://github.com/NixOS/nixpkgs/commit/d061226811b2e68becc5ea80b5d25caa85401af5) | `` sub-store-frontend: 2.16.30 -> 2.16.46 ``                  |
| [`002d0728`](https://github.com/NixOS/nixpkgs/commit/002d072890f21cbe6bd474691e84bafb5c7c483c) | `` pocket-casts: 0.12.0 -> 0.12.1 ``                          |
| [`f6ab645f`](https://github.com/NixOS/nixpkgs/commit/f6ab645f066c8ae25d545abee992a72a5bb8724b) | `` [Backport release-25.11] dnsdist: 1.9.10 -> 1.9.12 ``      |
| [`b9ce2aea`](https://github.com/NixOS/nixpkgs/commit/b9ce2aeaab29bba881a1607fcc1a0757218acd40) | `` monero-cli: 0.18.4.5 -> 0.18.4.6 ``                        |
| [`cb1ffc66`](https://github.com/NixOS/nixpkgs/commit/cb1ffc66d655704201d5547449df560841e20eaa) | `` monero-gui: 0.18.4.5 -> 0.18.4.7 ``                        |
| [`1723d995`](https://github.com/NixOS/nixpkgs/commit/1723d995c19805999e32ff9d6eefe2943a918661) | `` erlang_26: 26.2.5.18 -> 26.2.5.19 ``                       |
| [`7c70a8e5`](https://github.com/NixOS/nixpkgs/commit/7c70a8e52ff39cfb52473c9483a7735319b8049e) | `` archisteamfarm: 6.3.3.3 -> 6.3.4.2 ``                      |
| [`e54285e7`](https://github.com/NixOS/nixpkgs/commit/e54285e7717e69ce8f0023bcecafcacaee4a12d7) | `` google-chrome: 146.0.7680.177 -> 147.0.7727.55 ``          |
| [`3f2c0dcc`](https://github.com/NixOS/nixpkgs/commit/3f2c0dcca2e5f224fb95937eb00b39c5e717a406) | `` erlang_28: 28.4.1 -> 28.4.2 ``                             |
| [`23a3069f`](https://github.com/NixOS/nixpkgs/commit/23a3069f1e9d6e9d90785aa7317a2f2793311e78) | `` erlang_27: 27.3.4.9 -> 27.3.4.10 ``                        |
| [`ece9819f`](https://github.com/NixOS/nixpkgs/commit/ece9819f98671d5151c84288900fcd771ce4132d) | `` forgejo-runner: 12.7.3 -> 12.8.2 ``                        |
| [`0be3959f`](https://github.com/NixOS/nixpkgs/commit/0be3959fa13160acaf140b2234f31b9acaae004f) | `` firefox-bin-unwrapped: 149.0 -> 149.0.2 ``                 |
| [`35d6223a`](https://github.com/NixOS/nixpkgs/commit/35d6223a8d00a4499aaa6542a47e3c7fa51793c3) | `` firefox-unwrapped: 149.0 -> 149.0.2 ``                     |
| [`c2cd0d39`](https://github.com/NixOS/nixpkgs/commit/c2cd0d39bfdd806f5d4d418db798cda51d8d76b8) | `` tcl-9_0: 9.0.1 -> 9.0.3 ``                                 |
| [`8ed18042`](https://github.com/NixOS/nixpkgs/commit/8ed1804210501032631d2a7695999c8558475c75) | `` signal-cli: 0.14.1 -> 0.14.2 ``                            |
| [`95117384`](https://github.com/NixOS/nixpkgs/commit/95117384c345dac2b07bb0839de95ff8a22a3ae2) | `` signal-cli: 0.13.24 -> 0.14.1 ``                           |
| [`670522eb`](https://github.com/NixOS/nixpkgs/commit/670522ebae401381a5fe85c5e419697cf62a811e) | `` jellyfin{,-web}: 10.11.7 -> 10.11.8 ``                     |
| [`f0f23e9f`](https://github.com/NixOS/nixpkgs/commit/f0f23e9ffeb55161a111aa54726776a1e0a64c12) | `` nixos/unifi: fix stop behavior ``                          |
| [`a5c5107d`](https://github.com/NixOS/nixpkgs/commit/a5c5107daa1d8f7771b99c912ce858b76fec6947) | `` yubihsm-shell: 2.7.1 -> 2.7.2 ``                           |
| [`7578cccc`](https://github.com/NixOS/nixpkgs/commit/7578cccca715c98bd4765ea7a8f6012d8e673864) | `` protonmail-export: 1.0.5 -> 1.0.6 ``                       |
| [`2085e3a2`](https://github.com/NixOS/nixpkgs/commit/2085e3a26f7433d98317d29646a0f6f0717480e2) | `` buffer: 0.10.2 -> 2026.1 ``                                |
| [`f034183b`](https://github.com/NixOS/nixpkgs/commit/f034183bd41e214e66d7b8bf5053accb366107ce) | `` nixos/veilid: remove old defaults ``                       |
| [`81686765`](https://github.com/NixOS/nixpkgs/commit/816867652acf6ffb8d7c33e43f42e54175d09c0a) | `` nixos/veilid: node_id -> public_keys ``                    |
| [`48cf2de7`](https://github.com/NixOS/nixpkgs/commit/48cf2de7ba5b8201d20a5d21aea24b0469d69e88) | `` emblem: 1.5.0 -> 1.6.0 ``                                  |
| [`f762fea7`](https://github.com/NixOS/nixpkgs/commit/f762fea72f9d603c17f03ea7f7a35989ad4cc25c) | `` colima: 0.9.1 -> 0.10.1 ``                                 |
| [`9123aab5`](https://github.com/NixOS/nixpkgs/commit/9123aab5ae930529e58b1a1bf4b07c6701fb7aa1) | `` waywall: 0.2026.01.11 -> 0.2026.02.06 ``                   |
| [`96f56279`](https://github.com/NixOS/nixpkgs/commit/96f562798607f3e80ef45489da64b60bc1f4a97e) | `` waywall: 0.2025.12.30 -> 0.2026.01.11 ``                   |
| [`de2cd792`](https://github.com/NixOS/nixpkgs/commit/de2cd792ffe434886b2ca2c79fa5d3097342da3b) | `` waywall: switch to gcc 15 ``                               |
| [`308c6a14`](https://github.com/NixOS/nixpkgs/commit/308c6a142a456aba1c4233adc3b151dbe113bf76) | `` waywall: 0.2025.12.20 -> 0.2025.12.30 ``                   |
| [`dc519391`](https://github.com/NixOS/nixpkgs/commit/dc5193917b66e44e9b9eefc2ef10e96ce9ac2e47) | `` waywall: add update script ``                              |
| [`70ac73d9`](https://github.com/NixOS/nixpkgs/commit/70ac73d9e2716931b87afa5c93aa1daa0393a7cf) | `` waywall: add uku3lig to maintainers ``                     |
| [`dfb99f97`](https://github.com/NixOS/nixpkgs/commit/dfb99f975f79ed216b2980e818826d8a00e96d1f) | `` waywall: add wrapper with xwayland ``                      |
| [`f7300359`](https://github.com/NixOS/nixpkgs/commit/f730035955747adb1dc135db723a8e5ead28e5da) | `` waywall: 0-unstable-2025-08-03 -> 0.2025.12.20 ``          |