### PR TITLE
chore(flake/freminal): `a26512cb` -> `e2277602`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         "precommit": "precommit_3"
       },
       "locked": {
-        "lastModified": 1775759095,
-        "narHash": "sha256-niMhbuKKe3wR/LJnebMTqvZPjMazt9uVzEP2Dep5nyE=",
+        "lastModified": 1775930485,
+        "narHash": "sha256-As+G1GbLzZKXWHbhrWnswRr+vyX6Qd6MIHm6OiO811A=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "a26512cb4322ac7fe68bca5642615f3b28123d3c",
+        "rev": "e22776023b3f0142e85897af33ac2018b7c12545",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| [`e2277602`](https://github.com/fredsystems/freminal/commit/e22776023b3f0142e85897af33ac2018b7c12545) | `` chore: update deps ``                                                                                     |
| [`dc9b110a`](https://github.com/fredsystems/freminal/commit/dc9b110a4579532f9147a64253f836f88f6b52ed) | `` fix: expand scroll region and resize saved primary on alternate buffer grow ``                            |
| [`001d77af`](https://github.com/fredsystems/freminal/commit/001d77af98e4dead1ee1db37f4babdb05112f14f) | `` fix(gui): address PR feedback on split dragging and docs ``                                               |
| [`a9c18e9b`](https://github.com/fredsystems/freminal/commit/a9c18e9b9e7cbca4d0a1159d8467c81b46a3b8ba) | `` fix: resolve CPU spike in multi-pane layouts ``                                                           |
| [`85da7147`](https://github.com/fredsystems/freminal/commit/85da7147b3de7ca110af34be8fc791be5702b32e) | `` fix: nvim resize bug by implementing DEC ?2048 In-Band Resize Notifications ``                            |
| [`8733a17f`](https://github.com/fredsystems/freminal/commit/8733a17f37b46341e35b32a66b2152624f99f7e7) | `` fix(gui): send FocusChange events on pane split, close, and PTY death ``                                  |
| [`60a5dcad`](https://github.com/fredsystems/freminal/commit/60a5dcadd63a34fb0aacff467e7b2f1778a6bd37) | `` docs: mark Task 58 complete — all 14 subtasks done ``                                                     |
| [`e1e30388`](https://github.com/fredsystems/freminal/commit/e1e30388958f4a4b8ebfa1d030e719f1dc807fee) | `` fix(gui): reset last_sent_size on pane close and zoom toggle ``                                           |
| [`9b14d6fd`](https://github.com/fredsystems/freminal/commit/9b14d6fd37ea6742b092609a5d587048af848dc4) | `` feat(gui): tmux-style half-highlighted split borders ``                                                   |
| [`58e38336`](https://github.com/fredsystems/freminal/commit/58e38336f6f985221f33dea43a862a37d75fc7c6) | `` docs: update Task 58 plan — mark 58.7–58.13 complete, renumber tests to 58.14 ``                          |
| [`85cb495f`](https://github.com/fredsystems/freminal/commit/85cb495f9b11098ba35e7a21cae30795f3e1a77a) | `` feat(gui): mouse drag-to-resize pane borders + fix Pipe keybinding (58.13) ``                             |
| [`4a762555`](https://github.com/fredsystems/freminal/commit/4a762555c0abc04262a24fd6ec472540db473a8b) | `` feat(gui): pane keybindings, close, focus, resize, zoom, menu bar, and cursor suppression (58.7-58.12) `` |
| [`8df02ea7`](https://github.com/fredsystems/freminal/commit/8df02ea7c0cd4a89879fe8906102774b4abe186e) | `` feat(gui): split pane operations (subtask 58.6) ``                                                        |
| [`6335e306`](https://github.com/fredsystems/freminal/commit/6335e3063fd900aa9682fb134c49c6e69bedceeb) | `` feat: 58.5 — input routing for split panes ``                                                             |
| [`91d2e1c0`](https://github.com/fredsystems/freminal/commit/91d2e1c07a91b8b4a4976c110c696be59991b59d) | `` docs: add mandatory sub-agent intent scoping rules to agents.md ``                                        |
| [`88d6fcf8`](https://github.com/fredsystems/freminal/commit/88d6fcf894f437a4affff2ce4598d5b3c3d2f9c2) | `` feat(gui): per-pane render state and multi-pane rendering loop (subtask 58.4) ``                          |
| [`6da0cb8a`](https://github.com/fredsystems/freminal/commit/6da0cb8a4c1e2718d35b13304e14949ccdf38bfa) | `` refactor(gui): replace Tab fields with PaneTree (subtask 58.3) ``                                         |
| [`4ec8bda1`](https://github.com/fredsystems/freminal/commit/4ec8bda1ec07d6fd27ac5d13ff33e0ca13b43916) | `` docs: mark subtask 58.2 complete ``                                                                       |
| [`333dcb4d`](https://github.com/fredsystems/freminal/commit/333dcb4d12c7d6484c43c8abcc4d7ef283e49715) | `` feat(gui): add PaneTree binary tree data structure (subtask 58.2) ``                                      |
| [`1026068d`](https://github.com/fredsystems/freminal/commit/1026068d7c04adc389531ca967d6e696ec08f11f) | `` docs: mark subtask 58.1 complete ``                                                                       |
| [`8f8fc06a`](https://github.com/fredsystems/freminal/commit/8f8fc06a081ec69e14472bc0d9e64ad943cce26f) | `` feat(gui): add PaneId and Pane struct (subtask 58.1) ``                                                   |
| [`592cac5f`](https://github.com/fredsystems/freminal/commit/592cac5fab4aa654ab1095ddd198d418aacb5892) | `` docs: add CWD inheritance and flamegraph acceptance criteria to Task 58 ``                                |