### PR TITLE
chore(flake/sops-nix-stable): `d2e8438d` -> `31ac5fe5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1698,11 +1698,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775682595,
-        "narHash": "sha256-0E9PohY/VuESLq0LR4doaH7hTag513sDDW5n5qmHd1Q=",
+        "lastModified": 1775971308,
+        "narHash": "sha256-VKp9bhVSm0bT6JWctFy06ocqxGGnWHi1NfoE90IgIcY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d2e8438d5886e92bc5e7c40c035ab6cae0c41f76",
+        "rev": "31ac5fe5d015f76b54058c69fcaebb66a55871a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`5f684839`](https://github.com/Mic92/sops-nix/commit/5f6848398c9f4505b5d5f2690e83694afa0008a3) | `` [create-pull-request] automated change `` |