### PR TITLE
chore(flake/sops-nix): `31ac5fe5` -> `d4971dd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1678,11 +1678,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775971308,
-        "narHash": "sha256-VKp9bhVSm0bT6JWctFy06ocqxGGnWHi1NfoE90IgIcY=",
+        "lastModified": 1776119890,
+        "narHash": "sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "31ac5fe5d015f76b54058c69fcaebb66a55871a4",
+        "rev": "d4971dd58c6627bfee52a1ad4237637c0a2fb0cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                              |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`7f637c27`](https://github.com/Mic92/sops-nix/commit/7f637c27cf35ad94960f5de8565fea384aa7e580) | `` update vendorHash ``                              |
| [`462a352d`](https://github.com/Mic92/sops-nix/commit/462a352d32c75d5ffcd116776087d3bcc311bf60) | `` Bump golang.org/x/crypto from 0.49.0 to 0.50.0 `` |