### PR TITLE
chore(flake/home-manager): `b0569dc6` -> `8a423e44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -766,11 +766,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775900011,
-        "narHash": "sha256-QUGu6CJYFQ5AWVV0n3/FsJyV+1/gj7HSDx68/SX9pwM=",
+        "lastModified": 1776136611,
+        "narHash": "sha256-b2pu3Pb28W0bJzQVP3OJHZC5+dgOOeqjlli2WVakKEU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0569dc6ec1e6e7fefd8f6897184e4c191cd768e",
+        "rev": "8a423e444b17dde406097328604a64fc7429e34e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`8a423e44`](https://github.com/nix-community/home-manager/commit/8a423e444b17dde406097328604a64fc7429e34e) | `` ci: adjust flake lock update pr titles ``                                  |
| [`78f7d3d6`](https://github.com/nix-community/home-manager/commit/78f7d3d6ab306643de47d2ba0f509e9b6ca5506f) | `` git: ignore deadnix treewide blame ``                                      |
| [`eff7ee75`](https://github.com/nix-community/home-manager/commit/eff7ee75f0881e08c500fe90d43607a0b3f923d5) | `` ci: add release branch label ``                                            |
| [`5843fa30`](https://github.com/nix-community/home-manager/commit/5843fa302bbd5028e5c2a2f9ea4b57f772a2f22d) | `` ci: migrate to Dependabot for nix flake updates ``                         |
| [`970cd853`](https://github.com/nix-community/home-manager/commit/970cd853bfb4fb97729415521389e7d71f3b4b62) | `` hyprland: use previously unused lambda parameter ``                        |
| [`5a728e43`](https://github.com/nix-community/home-manager/commit/5a728e434d12df6f2e6bfb064e918dab2460f426) | `` tests/integration: simplify `pkgs.linkFarm` usage ``                       |
| [`a93d80bc`](https://github.com/nix-community/home-manager/commit/a93d80bcec089abf80894c25ee3934b7e196bbd9) | `` treewide: remove unused attrs patterns ``                                  |
| [`71402c5d`](https://github.com/nix-community/home-manager/commit/71402c5df34df5ee7b6c10d738018f9f0c8bde2b) | `` treewide: mark unused lambda arguments ``                                  |
| [`2de7205c`](https://github.com/nix-community/home-manager/commit/2de7205ce6e10b031151033e69b7ef89708dc282) | `` maintainers: update all-maintainers.nix ``                                 |
| [`287f8484`](https://github.com/nix-community/home-manager/commit/287f84846c1eb3b72c986f5f6bebcff0bd67440d) | `` opencode: align tools directory with upstream documentation ``             |
| [`26c9d5dc`](https://github.com/nix-community/home-manager/commit/26c9d5dca1eee9556bb2b256ad2616eb39111980) | `` opencode: align agents directory with upstream documentation ``            |
| [`a5e824c8`](https://github.com/nix-community/home-manager/commit/a5e824c8626dba88fb1c627e5f220d91727c5dde) | `` opencode: align commands directory with upstream documentation ``          |
| [`49088dc2`](https://github.com/nix-community/home-manager/commit/49088dc2e7a876e338e510c5f5f60f659819c650) | `` syncthing: rewrite credential management ``                                |
| [`adc677d0`](https://github.com/nix-community/home-manager/commit/adc677d02ead017dcb2d03198209fed54cc5ee52) | `` kakoune: remove unused options ``                                          |
| [`f6196e5b`](https://github.com/nix-community/home-manager/commit/f6196e5b4d3f0168d09feab9ba678fa18ca58cbb) | `` oh-my-zsh: Fix plugins escapeShellArgs use ``                              |
| [`7832a664`](https://github.com/nix-community/home-manager/commit/7832a664c40c98a2dcf45400f60d0f70f8b6fd19) | `` feedr: fix enable option description ``                                    |
| [`30ca31c8`](https://github.com/nix-community/home-manager/commit/30ca31c87a9bfa2c1315330f977ff63356907453) | `` news: add entry about the unification of agents "context" and "skills" ``  |
| [`16e50c6f`](https://github.com/nix-community/home-manager/commit/16e50c6ffea28f1999d6cb34dcee1ad0d479d690) | `` gemini-cli: unify `context` description and let `skills` be a directory `` |
| [`d6d2468b`](https://github.com/nix-community/home-manager/commit/d6d2468b88488c141a905e22f57883fb2cb0b83b) | `` opencode: migrate `rules` to `context` ``                                  |
| [`447796d6`](https://github.com/nix-community/home-manager/commit/447796d64a9ac736b83ff348aa00167cd2c4855d) | `` codex: migrate `custom-instructions` to `context` ``                       |
| [`13df3b4e`](https://github.com/nix-community/home-manager/commit/13df3b4e44bf4784a4167d3b09198e555ef2219c) | `` claude-code: migrate `memory` to `context` & `skills{,Dir}` to `skills` `` |
| [`ffa740c0`](https://github.com/nix-community/home-manager/commit/ffa740c0dfbee917b8bc36efb1c2be46e0dde164) | `` syshud: add module ``                                                      |
| [`89b2d575`](https://github.com/nix-community/home-manager/commit/89b2d575eec0a853c236d01dcd0d2f37bc2b124c) | `` zsh/oh-my-zsh: improve escaping of shell arguments ``                      |
| [`46ecfa22`](https://github.com/nix-community/home-manager/commit/46ecfa22a61158a811c9f6569543fb7c7a2a75ac) | `` antidote: improve escaping of shell arguments & use pkgs.writeText ``      |
| [`adf6e3aa`](https://github.com/nix-community/home-manager/commit/adf6e3aafb8e0ad38051b8be41d67b2dbb2cf598) | `` feedr: add module ``                                                       |
| [`fd22058b`](https://github.com/nix-community/home-manager/commit/fd22058b436fd996825e70204b5b38853d9da1d5) | `` copyApps: fix linkApps migration ``                                        |
| [`23d85301`](https://github.com/nix-community/home-manager/commit/23d85301a5d330f4178774019027c1dc46833a31) | `` copyApps: skip check when migrating from linkApps ``                       |
| [`44111a5c`](https://github.com/nix-community/home-manager/commit/44111a5c6f78da5c024f222fec352e8ec49d1bc1) | `` jjui: Add options to configure settings in Lua including plugins ``        |
| [`0c8ef0f2`](https://github.com/nix-community/home-manager/commit/0c8ef0f2b93a769cbcbbf83724a2a7db5dbd92ef) | `` jjui: Fix default config directory path on Darwin ``                       |
| [`e0ca734f`](https://github.com/nix-community/home-manager/commit/e0ca734ffc85d25297715e98010b93303fa165c4) | `` starship: add extraPackages options ``                                     |