### PR TITLE
chore(flake/nixvim): `a587a96a` -> `0a126932`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1352,11 +1352,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1775837497,
-        "narHash": "sha256-L17VI03w/wVXvc1SK7EI1muLqHxD3+esYPPzgQvvdOE=",
+        "lastModified": 1776128025,
+        "narHash": "sha256-spZM5zll0cBPHHSZPioZREArzCsllurKQsJME08nnXY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a587a96a48c705609bfd2ad23f9ae5961eb0d373",
+        "rev": "0a12693297d23f1b3af04ba6112b5936e2eba41b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`0a126932`](https://github.com/nix-community/nixvim/commit/0a12693297d23f1b3af04ba6112b5936e2eba41b) | `` ci: bump actions/upload-pages-artifact from 4 to 5 ``                                           |
| [`306d2772`](https://github.com/nix-community/nixvim/commit/306d2772d6647b7cde8388318042f5b95c2ce2b8) | `` maintainers: update generated/all-maintainers.nix ``                                            |
| [`3682e0dd`](https://github.com/nix-community/nixvim/commit/3682e0dde624e8e37b93ad053e567703ac33fd36) | `` plugins/gitlab: use dependencies.nodejs.path as default for code_suggestions.lsp_binary_path `` |
| [`05a8ad9f`](https://github.com/nix-community/nixvim/commit/05a8ad9f006936bf451043afb80821c204264a48) | `` ci: use prettier instead of (soon-removed) nodePackages.prettier ``                             |