### PR TITLE
chore(flake/freminal): `ba200fb6` -> `1257483b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -516,11 +516,11 @@
         "precommit": "precommit_3"
       },
       "locked": {
-        "lastModified": 1775955910,
-        "narHash": "sha256-fawB51yPNU/2QAf/3rirterTum/EidowQkQrYkJA4i4=",
+        "lastModified": 1776180766,
+        "narHash": "sha256-zsWCScS7ZzERsFXWixkWJ87bhXu5vuOt4zbnS7BBGtY=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "ba200fb61db7a5ad4282e25a9bd7bd87bf24a6fd",
+        "rev": "1257483bde431e2ec88a6a009ff4ccb05919b128",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -1283,11 +1283,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -1457,11 +1457,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1775320680,
-        "narHash": "sha256-nw3uNIw3DrBVyrTUkQlVGFEd7Fqn+YyTad8dUp/DTTE=",
+        "lastModified": 1776180412,
+        "narHash": "sha256-i/rUOrl2y7f1pHjkKC2VZlltHEpyj76osI6Ad5xaINc=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "6d12f2a02b764b7f202613cb1447dd6aba71dd4b",
+        "rev": "d48771750f19b0b0b74d6d1029cacb073c84f3d9",
         "type": "github"
       },
       "original": {
@@ -1535,11 +1535,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1775272153,
-        "narHash": "sha256-FwYb64ysv8J2TxaqsYYcDyHAHBUEaQlriPMWPMi1K7M=",
+        "lastModified": 1776136407,
+        "narHash": "sha256-Cp8XrVLGruSDBTRs8L4LmvaEcd76tHHU9esLk7Ysa4E=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "740fb0203b2852917b909a72b948d34d0b171ec0",
+        "rev": "753568957a87312ed599cba5699e67126eded6c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`1257483b`](https://github.com/fredsystems/freminal/commit/1257483bde431e2ec88a6a009ff4ccb05919b128) | `` stop running benches during pc hooks ``                                                              |
| [`ebef59fc`](https://github.com/fredsystems/freminal/commit/ebef59fc540d7cfde1a1c3fb8de2696dbe7bfd59) | `` docs: fix garbled doc comments on pointer_shape_to_cursor_icon and handle_osc_pointer_shape ``       |
| [`5f7c5004`](https://github.com/fredsystems/freminal/commit/5f7c50041a62ff84714cb479467bb078104210cd) | `` fix: preserve scrollback during soft-wrap in full-screen primary buffer ``                           |
| [`80cfd130`](https://github.com/fredsystems/freminal/commit/80cfd13058cd0422cb9dc70128ca536c98027988) | `` fix: set cursor icon unconditionally every frame for OSC 22 ``                                       |
| [`a2f47b05`](https://github.com/fredsystems/freminal/commit/a2f47b0591e7fe8b8d3e45520702201fa8fb7337) | `` feat: implement OSC 22 pointer shape — PointerShape enum, snapshot field, GUI cursor icon mapping `` |
| [`9c053f4b`](https://github.com/fredsystems/freminal/commit/9c053f4be1a0e9ece28ff6865b15d13e677b020d) | `` fix: silence spurious warnings for known OSC sequences and DEC 2031 theming ``                       |
| [`1c2b8132`](https://github.com/fredsystems/freminal/commit/1c2b81321fcf19696b6fbca6205b7995148f5567) | `` fix: remove incorrect cursor clamp in primary buffer resize_height ``                                |
| [`ba40339b`](https://github.com/fredsystems/freminal/commit/ba40339b7b9a878d524a0eca33a55a8883e903de) | `` fix: address PR review — Fit mode tests, frame-1 timing, shader read error ``                        |
| [`99a31a3a`](https://github.com/fredsystems/freminal/commit/99a31a3adfe94be6fb48bf75d1fd6d2ae48e32ce) | `` feat: 54 + 55 — background images and custom post-process shaders ``                                 |