### PR TITLE
chore(flake/nixpkgs-stable): `54170c54` -> `7e495b74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1155,11 +1155,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1775811116,
-        "narHash": "sha256-t+HZK42pB6N+i5RGbuy7Xluez/VvWbembBdvzsc23Ss=",
+        "lastModified": 1776067740,
+        "narHash": "sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "54170c54449ea4d6725efd30d719c5e505f1c10e",
+        "rev": "7e495b747b51f95ae15e74377c5ce1fe69c1765f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`c5675628`](https://github.com/NixOS/nixpkgs/commit/c5675628ce6716ff9b9cad436b30fbe1599e89b7) | `` radarr: 6.0.4.10291 -> 6.1.1.10360 ``                              |
| [`fafc4e3d`](https://github.com/NixOS/nixpkgs/commit/fafc4e3d7f6d7f50aec88225e715b5912ad3fbbf) | `` filebrowser: 2.62.2 -> 2.63.2 ``                                   |
| [`55153c15`](https://github.com/NixOS/nixpkgs/commit/55153c15441ccfeefc9eea6af0708ea9723b18b0) | `` open5gs: 2.7.6 -> 2.7.7 ``                                         |
| [`f7dd528f`](https://github.com/NixOS/nixpkgs/commit/f7dd528fc15391950f927a16754226188fe4e631) | `` prismlauncher: 11.0.0 -> 11.0.1 ``                                 |
| [`6e73f249`](https://github.com/NixOS/nixpkgs/commit/6e73f249315da0f5579559474e20067ed6df363f) | `` perlPackages.NetCIDRLite: 0.22 -> 0.23 ``                          |
| [`e2edbd86`](https://github.com/NixOS/nixpkgs/commit/e2edbd867f0ee07b6b3026868118d0a418a22624) | `` weechat-unwrapped: 4.8.2 -> 4.9.0 ``                               |
| [`16502454`](https://github.com/NixOS/nixpkgs/commit/165024545999d9a12ae1ee0d66e48b4b824423e2) | `` weechat: 4.8.1 -> 4.8.2 ``                                         |
| [`a95d50a6`](https://github.com/NixOS/nixpkgs/commit/a95d50a60b9a879a2c20da4b53d824a140715f44) | `` wechat: 4.1.8.29-36603 -> 4.1.8.106-37335 for darwin ``            |
| [`24063a2c`](https://github.com/NixOS/nixpkgs/commit/24063a2c73b05d248c2837dfc470f0a584f20945) | `` linux_xanmod_latest: 6.19.11 -> 6.19.12 ``                         |
| [`0e0f21aa`](https://github.com/NixOS/nixpkgs/commit/0e0f21aad64462eee02407fc2d0cffeae566033d) | `` linux_xanmod: 6.18.21 -> 6.18.22 ``                                |
| [`c21ac045`](https://github.com/NixOS/nixpkgs/commit/c21ac045c15c09fc4ceb94984e96f446195830f8) | `` flatpak: 1.16.4 -> 1.16.6 ``                                       |
| [`6410119f`](https://github.com/NixOS/nixpkgs/commit/6410119f5fc25f6c8819fce9f28dd63485aa7592) | `` maintainers/github-teams.json: sync from master manually ``        |
| [`6c2cd357`](https://github.com/NixOS/nixpkgs/commit/6c2cd3571bd6c2821ba7824b83b1c85067178698) | `` tandoor-recipes: 2.6.4 -> 2.6.6 ``                                 |
| [`e6f048af`](https://github.com/NixOS/nixpkgs/commit/e6f048af99eff505d005f9b2035eb1d6f47c4349) | `` prowlarr: 2.3.0.5236 -> 2.3.5.5327 ``                              |
| [`ce3aa1fb`](https://github.com/NixOS/nixpkgs/commit/ce3aa1fbc930732283551a626de9b13022aacd3a) | `` linux_6_1: 6.1.167 -> 6.1.168 ``                                   |
| [`0a63d9dc`](https://github.com/NixOS/nixpkgs/commit/0a63d9dc149b3d9e5885ad2a987c6a1b9b15aaae) | `` linux_6_6: 6.6.132 -> 6.6.134 ``                                   |
| [`dfc6cc87`](https://github.com/NixOS/nixpkgs/commit/dfc6cc872c1e0a9087325578b1c3996f7f7cce2f) | `` linux_6_12: 6.12.80 -> 6.12.81 ``                                  |
| [`b6dd5514`](https://github.com/NixOS/nixpkgs/commit/b6dd55149b7c17fcc2eee310cf130bb55099a000) | `` linux_6_18: 6.18.21 -> 6.18.22 ``                                  |
| [`7f2f54af`](https://github.com/NixOS/nixpkgs/commit/7f2f54af298e926cc910e3620965224c5e4f0208) | `` linux_6_19: 6.19.11 -> 6.19.12 ``                                  |
| [`c5079f99`](https://github.com/NixOS/nixpkgs/commit/c5079f99fd23a086a6496283df7041edddb4e5fa) | `` linux_testing: 7.0-rc6 -> 7.0-rc7 ``                               |
| [`5195448f`](https://github.com/NixOS/nixpkgs/commit/5195448f9a6ce3d4ad4782e3ceb245e2e0e8219d) | `` nixos/cockpit: disable LoginTo by default ``                       |
| [`6c7c0207`](https://github.com/NixOS/nixpkgs/commit/6c7c020718400edd02f5e0c09a37f605b372f6a7) | `` turbo-unwrapped: 2.8.15 -> 2.9.6 ``                                |
| [`63168fce`](https://github.com/NixOS/nixpkgs/commit/63168fce58edd63c20b789a8388fe68fb2aaa675) | `` turbo-unwrapped: fix passthru.updateScript ``                      |
| [`8240cfb0`](https://github.com/NixOS/nixpkgs/commit/8240cfb0c92fd98df8e7ade337d58468b1683e93) | `` vikunja: 2.2.2 -> 2.3.0 ``                                         |
| [`f29c0bf1`](https://github.com/NixOS/nixpkgs/commit/f29c0bf161056ff3d4cf28422769e2a2b71e2514) | `` dprint: 0.53.2 -> 0.54.0 ``                                        |
| [`8db80f3c`](https://github.com/NixOS/nixpkgs/commit/8db80f3c63c6071a4d48239fb0879c27d6325789) | `` rgx: enable PCRE2 engine ``                                        |
| [`8297893f`](https://github.com/NixOS/nixpkgs/commit/8297893f4369cf3e0a7a5544568c2c4173c4b4fd) | `` rgx: 0.9.0 -> 0.10.1 ``                                            |
| [`d728ba25`](https://github.com/NixOS/nixpkgs/commit/d728ba250445a1fb2530519af61ee6aa5156f6df) | `` brave: 1.88.138 -> 1.89.132 ``                                     |
| [`5ca24ae1`](https://github.com/NixOS/nixpkgs/commit/5ca24ae1328cc4a763356502ed99627ff357dc5c) | `` linux-firmware: 20260309 -> 20260410 ``                            |
| [`f92ab68a`](https://github.com/NixOS/nixpkgs/commit/f92ab68a867848413e52df2de4d4726efbe124a1) | `` necesse-server: 1.1.1-21292486 -> 1.2.0-22728942 ``                |
| [`7adb88af`](https://github.com/NixOS/nixpkgs/commit/7adb88af246b6765c38ff3adb0c84ca3ddbefe2c) | `` immich: 2.7.3 -> 2.7.4 ``                                          |
| [`c9076b41`](https://github.com/NixOS/nixpkgs/commit/c9076b413ef443e1e1cce923d646d7035a35de4c) | `` obs-studio-plugins.obs-color-monitor: 0.9.3 -> 0.9.6 ``            |
| [`a3cd6013`](https://github.com/NixOS/nixpkgs/commit/a3cd60134792d599b348e892f8420e00b40fd2e1) | `` prismlauncher: 10.0.5 -> 11.0.0 ``                                 |
| [`ea0b551e`](https://github.com/NixOS/nixpkgs/commit/ea0b551e318cb77f8cd1fb51518191a3aa19563e) | `` forgejo-lts: 11.0.11 -> 11.0.12 ``                                 |
| [`3d431bc7`](https://github.com/NixOS/nixpkgs/commit/3d431bc7ccbe18e58181120591695eac02c9b91c) | `` forgejo: 14.0.3 -> 14.0.4 ``                                       |
| [`9a01ca36`](https://github.com/NixOS/nixpkgs/commit/9a01ca3602bd9fb673a2191a974f40312b2a6cb3) | `` kyverno: 1.16.2 -> 1.17.1 ``                                       |
| [`e484dff4`](https://github.com/NixOS/nixpkgs/commit/e484dff4b406d0e41e849b2f715d2de604443fe1) | `` kyverno: 1.15.2 -> 1.16.2 ``                                       |
| [`7cb9d3b0`](https://github.com/NixOS/nixpkgs/commit/7cb9d3b004acdcaa6a80805b79d52db1df1df17a) | `` .github: Bump actions/github-script from 8.0.0 to 9.0.0 ``         |
| [`c2a857e1`](https://github.com/NixOS/nixpkgs/commit/c2a857e18160277fe4f5bca421c2ee43835a7800) | `` .github: Bump cachix/install-nix-action from 31.10.3 to 31.10.4 `` |
| [`aa98fdb2`](https://github.com/NixOS/nixpkgs/commit/aa98fdb26911601a39f7f13e30b959c7b9079858) | `` thunderbird-esr-bin-unwrapped: 140.9.0esr -> 140.9.1esr ``         |
| [`4bb3dd63`](https://github.com/NixOS/nixpkgs/commit/4bb3dd633e90f6c71a89296f049b9c8f40ac3e2b) | `` ci: update pinned ``                                               |
| [`5520696b`](https://github.com/NixOS/nixpkgs/commit/5520696bb8bc26dd44b5c49cfb379fc4e83471fe) | `` immich: 2.7.2 -> 2.7.3 ``                                          |
| [`f29ef850`](https://github.com/NixOS/nixpkgs/commit/f29ef850eee30b59feccc1e7bf86c44d63311df0) | `` treewide: remove executable bit from .nix files ``                 |
| [`a6fd90be`](https://github.com/NixOS/nixpkgs/commit/a6fd90bea9521756c8e47711ffe268c1f2c92769) | `` qbz: 1.2.3 -> 1.2.4 ``                                             |
| [`2a628c5f`](https://github.com/NixOS/nixpkgs/commit/2a628c5fa6146f6a5ddb5349c1198c851471935b) | `` palemoon-bin: 34.1.0 -> 34.2.0 ``                                  |
| [`ad2f30ef`](https://github.com/NixOS/nixpkgs/commit/ad2f30efd93674b68d3c324dc550521e843c771c) | `` electron_40: fix build ``                                          |
| [`ee19b8aa`](https://github.com/NixOS/nixpkgs/commit/ee19b8aa16c8b6cfe8d62f45762556dae8df7110) | `` electron_41: remove no longer needed patch ``                      |
| [`21675f52`](https://github.com/NixOS/nixpkgs/commit/21675f5213674ab08ab9b6423b2c49b31c24c373) | `` electron-source.electron_41: 41.0.2 -> 41.2.0 ``                   |
| [`45e7a1cd`](https://github.com/NixOS/nixpkgs/commit/45e7a1cd34cdbb053b6aaee750dd4da16e21e5dc) | `` electron-source.electron_40: 40.8.2 -> 40.8.5 ``                   |
| [`ba693165`](https://github.com/NixOS/nixpkgs/commit/ba693165264aebdc8417c3731736f058a3388521) | `` electron-source.electron_39: 39.8.2 -> 39.8.7 ``                   |
| [`5894fc32`](https://github.com/NixOS/nixpkgs/commit/5894fc32a415a93284fbead9bcbd48d3dd03cc7e) | `` electron-chromedriver_41: 41.0.2 -> 41.2.0 ``                      |
| [`455d50f9`](https://github.com/NixOS/nixpkgs/commit/455d50f9730693c0ec9e8d2cd1c956696027a6e0) | `` electron_41-bin: 41.0.2 -> 41.2.0 ``                               |
| [`0a06a719`](https://github.com/NixOS/nixpkgs/commit/0a06a719df65390bfa05620aa839ff7428b02197) | `` electron-chromedriver_40: 40.8.2 -> 40.8.5 ``                      |
| [`ec9b0ebd`](https://github.com/NixOS/nixpkgs/commit/ec9b0ebd45e45a489ce5847cc9494abdac72d1dc) | `` electron_40-bin: 40.8.2 -> 40.8.5 ``                               |
| [`82ed7ad5`](https://github.com/NixOS/nixpkgs/commit/82ed7ad568699e059c252befe488a494b235e8dd) | `` electron-chromedriver_39: 39.8.2 -> 39.8.7 ``                      |
| [`6f2197fd`](https://github.com/NixOS/nixpkgs/commit/6f2197fd4c89a629f1828d5772be935b2326b4c9) | `` electron_39-bin: 39.8.2 -> 39.8.7 ``                               |
| [`baad2040`](https://github.com/NixOS/nixpkgs/commit/baad204015f309ce8f4987d1399687408c0a1c4f) | `` hmcl: 3.12.2 -> 3.12.4 ``                                          |
| [`61197896`](https://github.com/NixOS/nixpkgs/commit/61197896899291d0a5767fa103a61b21ff889cda) | `` docker: 29.3.1 -> 29.4.0 ``                                        |
| [`63e95132`](https://github.com/NixOS/nixpkgs/commit/63e95132ae2aace85e780cc7c767cd42f1b95979) | `` signal-desktop: 8.4.1 -> 8.6.0 ``                                  |
| [`f6d001ed`](https://github.com/NixOS/nixpkgs/commit/f6d001edce43f7b9b044ea0aaee921cf193631c9) | `` lockbook: 26.1.31 -> 26.4.8 ``                                     |
| [`a0a40400`](https://github.com/NixOS/nixpkgs/commit/a0a40400659b0fc7b8f4907e90ae4f29eed4ff4c) | `` lockbook-desktop: 26.1.31 -> 26.4.9 ``                             |
| [`76cecf08`](https://github.com/NixOS/nixpkgs/commit/76cecf087fbb4f3e291915d2d15402dfff6d6471) | `` oxidized: 0.35.0 -> 0.36.0 ``                                      |
| [`44d2c52b`](https://github.com/NixOS/nixpkgs/commit/44d2c52bb5f3634971f32015be374bc2ffb795a9) | `` mattermost-desktop: 6.1.0 -> 6.1.1 ``                              |
| [`279e208a`](https://github.com/NixOS/nixpkgs/commit/279e208a6a6f27e4132442bdd3df6ae5b1360123) | `` tor-browser: 15.0.8 -> 15.0.9 ``                                   |
| [`aa4bb947`](https://github.com/NixOS/nixpkgs/commit/aa4bb94794d0d87f8024320a9fcc91187b1d421a) | `` go_1_26: 1.26.1 -> 1.26.2 ``                                       |
| [`76e69c1b`](https://github.com/NixOS/nixpkgs/commit/76e69c1b514c38be39260d95666e4088f45f1af1) | `` flatpak: 1.16.3 -> 1.16.4 ``                                       |
| [`3f902967`](https://github.com/NixOS/nixpkgs/commit/3f9029675609640e9530edf50fb4b04694f4fe02) | `` flatpak: 1.16.2 -> 1.16.3 ``                                       |
| [`e9594123`](https://github.com/NixOS/nixpkgs/commit/e9594123fbb8f4b46a0ab96692dd1711337e309e) | `` fflogs: 9.0.24 -> 9.0.33 ``                                        |
| [`239fcf9c`](https://github.com/NixOS/nixpkgs/commit/239fcf9c4553a84feb72200798961f8e63593ad9) | `` fflogs: 8.20.113 -> 9.0.24 ``                                      |
| [`67c5ff2d`](https://github.com/NixOS/nixpkgs/commit/67c5ff2d08211bf826d50ecbed3b4abe3e6e4b8d) | `` fflogs: 8.20.36 -> 8.20.113 ``                                     |
| [`623601ac`](https://github.com/NixOS/nixpkgs/commit/623601ac2f4ea0f789ed8a8cd33a226d80018018) | `` fflogs: 8.20.17 -> 8.20.36 ``                                      |
| [`473eaa98`](https://github.com/NixOS/nixpkgs/commit/473eaa988d1c2dedc9d2393e08d33e32c5db487d) | `` fflogs: 8.19.70 -> 8.20.17 ``                                      |
| [`a478387d`](https://github.com/NixOS/nixpkgs/commit/a478387d254d9ec434641af45c919b9572c31219) | `` fflogs: 8.19.39 -> 8.19.70 ``                                      |
| [`ec578431`](https://github.com/NixOS/nixpkgs/commit/ec57843158599091e16886a9496a44d906f0c4ae) | `` fflogs: 8.17.115 -> 8.19.39 ``                                     |
| [`236d98e2`](https://github.com/NixOS/nixpkgs/commit/236d98e2f91e4fa0a4eaeb1e73b112bf3adab554) | `` fflogs: 8.17.101 -> 8.17.115 ``                                    |
| [`0cc75810`](https://github.com/NixOS/nixpkgs/commit/0cc75810a1b5585fa2fa193ae4aaa4b9cf15f45e) | `` navidrome: 0.60.3 -> 0.61.1 ``                                     |
| [`53c956c1`](https://github.com/NixOS/nixpkgs/commit/53c956c1ecdb0ffd6a68ddf664e8d6c693ee2e25) | `` opensc: 0.26.1 -> 0.27.1 ``                                        |
| [`4afdb13a`](https://github.com/NixOS/nixpkgs/commit/4afdb13a6e9a59a5d6a3a698692c3840a0f90227) | `` knot-dns: 3.5.3 -> 3.5.4 ``                                        |
| [`1e5c9c2a`](https://github.com/NixOS/nixpkgs/commit/1e5c9c2aec73bcbd3c8f52d75ae73d36d395f8a9) | `` xbyak: 7.35.3 -> 7.35.4 ``                                         |
| [`c7a8187f`](https://github.com/NixOS/nixpkgs/commit/c7a8187f6149785759a717bf0b6213470f4e5fa0) | `` discord: 0.0.128 -> 0.0.130 ``                                     |
| [`b9927b68`](https://github.com/NixOS/nixpkgs/commit/b9927b68ea411277a612871277529d8955d7ce49) | `` discord: 0.0.127 -> 0.0.128 ``                                     |
| [`d80b7547`](https://github.com/NixOS/nixpkgs/commit/d80b754725c571659984ada796037d1665c448d6) | `` wl-clipboard: 2.2.1 -> 2.3.0 ``                                    |
| [`bf101482`](https://github.com/NixOS/nixpkgs/commit/bf1014820f2c79e4277ec201709ee11958f50b48) | `` irpf: 2025-1.7 -> 2026-1.0 ``                                      |
| [`9d4b29eb`](https://github.com/NixOS/nixpkgs/commit/9d4b29eb1135719fbab825922ffd5d71944aac19) | `` irpf: move icon to spec-compliant location ``                      |
| [`4cd3a17a`](https://github.com/NixOS/nixpkgs/commit/4cd3a17abf019bf9ea2c09bd2d7c18c4363965a8) | `` xbyak: 7.34.1 -> 7.35.3 ``                                         |
| [`dea4557d`](https://github.com/NixOS/nixpkgs/commit/dea4557d750365650c9064638e2fc47b46395526) | `` xbyak: 7.33.3 -> 7.34.1 ``                                         |
| [`8ea98271`](https://github.com/NixOS/nixpkgs/commit/8ea98271b2e6d5b6c9884fdad17d8509e4c63794) | `` xbyak: 7.31 -> 7.33.3 ``                                           |
| [`405db0f8`](https://github.com/NixOS/nixpkgs/commit/405db0f8aa5608d2cf2b705f32180f83d486f796) | `` xbyak: 7.30 -> 7.31 ``                                             |
| [`04f936ea`](https://github.com/NixOS/nixpkgs/commit/04f936ea42b133c7717a29c4eb21a93b0094bd78) | `` winbox4: 4.0rc3 -> 4.0.1 ``                                        |
| [`27595b6b`](https://github.com/NixOS/nixpkgs/commit/27595b6b5297e2890758af3ccb33b1c1f464bd6f) | `` bookstack: 25.12.1 -> 25.12.3 ``                                   |
| [`086d51f7`](https://github.com/NixOS/nixpkgs/commit/086d51f79cab1a1b664781299adaf18e4a21e5ca) | `` bookstack: 25.11.6 -> 25.12.1 ``                                   |
| [`d0281407`](https://github.com/NixOS/nixpkgs/commit/d02814078a4f93d68ab6403854816367c4a517c4) | `` bookstack: update `vendorHash` ``                                  |