### PR TITLE
chore(flake/home-manager): `8a423e44` -> `3c7524c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -766,11 +766,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776136611,
-        "narHash": "sha256-b2pu3Pb28W0bJzQVP3OJHZC5+dgOOeqjlli2WVakKEU=",
+        "lastModified": 1776184304,
+        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a423e444b17dde406097328604a64fc7429e34e",
+        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`3c7524c6`](https://github.com/nix-community/home-manager/commit/3c7524c68348ef79ce48308e0978611a050089b2) | `` treewide: set git pager for specific commands, not for core.pager `` |