### PR TITLE
chore(flake/freminal): `1257483b` -> `785dace2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -516,11 +516,11 @@
         "precommit": "precommit_3"
       },
       "locked": {
-        "lastModified": 1776180766,
-        "narHash": "sha256-zsWCScS7ZzERsFXWixkWJ87bhXu5vuOt4zbnS7BBGtY=",
+        "lastModified": 1776223814,
+        "narHash": "sha256-ffHCcIdNLHGh7TNcrjB01bhnA7YuAfGSWrll+DkSjFM=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "1257483bde431e2ec88a6a009ff4ccb05919b128",
+        "rev": "785dace2b85f34209f0bb259fb78af2c8e732a99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`5c8a2984`](https://github.com/fredsystems/freminal/commit/5c8a298461b1b044a4cc0cf32f388161a589472c) | `` fix: address PR review feedback — typo in Display impl, env var test guard, tautological assertion `` |
| [`3bac61ad`](https://github.com/fredsystems/freminal/commit/3bac61ad59da6709473a0e947116cd3f81f203c3) | `` test: comprehensive coverage gap tests across all three library crates ``                             |
| [`9df202bc`](https://github.com/fredsystems/freminal/commit/9df202bc661ed91f910cb937f8ac3c6c7c5e365b) | `` chore: update cargo deps and fix xtask precommit to skip benchmarks ``                                |
| [`1469375a`](https://github.com/fredsystems/freminal/commit/1469375a6c421c6e5790ebe87bf351a78998992b) | `` stop running benches during pc hooks ``                                                               |