### PR TITLE
chore(flake/nixpkgs): `4c1018da` -> `4bd9165a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1171,11 +1171,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`ea42261b`](https://github.com/NixOS/nixpkgs/commit/ea42261b90daac4abe9d40d9b43b746016304717) | `` nixpkgs/release-checks: fix url-literal warns after Nix upgrade ``                        |
| [`a39a49a0`](https://github.com/NixOS/nixpkgs/commit/a39a49a04a5191f4ec37ac6b0b0a05e641195135) | `` firefox-esr-140-unwrapped: 140.9.0esr -> 140.9.1esr ``                                    |
| [`bfb56059`](https://github.com/NixOS/nixpkgs/commit/bfb560593d0d8bd774e1c685ac9501994f2d3991) | `` lisette: 0.1.3 -> 0.1.9 ``                                                                |
| [`a75847f6`](https://github.com/NixOS/nixpkgs/commit/a75847f6eb885d84ce01dc66e28516def506f098) | `` python3Packages.pueblo: 0.0.17 -> 0.0.18 ``                                               |
| [`a5be142a`](https://github.com/NixOS/nixpkgs/commit/a5be142ac62b03e5780d770090bb51cba5087838) | `` sanbdox-runtime: fix wrapProgram ``                                                       |
| [`e76ee720`](https://github.com/NixOS/nixpkgs/commit/e76ee720676d42d427c12f6a52ed9db38124b755) | `` nixos/flood: add `AF_NETLINK` to `RestrictedAddressFamilies` ``                           |
| [`2fd0fa1a`](https://github.com/NixOS/nixpkgs/commit/2fd0fa1a77ae15e52b242cb43b985615dd2076fa) | `` piliplus: 2.0.2 -> 2.0.4 ``                                                               |
| [`1d164861`](https://github.com/NixOS/nixpkgs/commit/1d16486166a9eb27aefc7739b9c3c615bfa1345d) | `` Revert "nixos/test-driver: use log levels" ``                                             |
| [`a55848fb`](https://github.com/NixOS/nixpkgs/commit/a55848fbc380cf7d699e15cb2cfef10043ab6dbe) | `` terraform-providers.dopplerhq_doppler: 1.21.1 -> 1.21.2 ``                                |
| [`b3055b6b`](https://github.com/NixOS/nixpkgs/commit/b3055b6b3a9cc0c1f131aa127c12516988274ce7) | `` signal-desktop: 8.6.0 -> 8.6.1 ``                                                         |
| [`187cd6b8`](https://github.com/NixOS/nixpkgs/commit/187cd6b88e9738d33d686d87e7f724e46e88f960) | `` python3Packages.dtfabric: modernize ``                                                    |
| [`d5370b25`](https://github.com/NixOS/nixpkgs/commit/d5370b25d215adec0529aed379523eb74769a4f6) | `` python3Packages.smbus2: migrate to finalAttrs ``                                          |
| [`bcb5ec98`](https://github.com/NixOS/nixpkgs/commit/bcb5ec98ea019ecc2e57cbe324ef188d293a348c) | `` python3Packages.boto3-stubs: 1.42.88 -> 1.42.89 ``                                        |
| [`22343baf`](https://github.com/NixOS/nixpkgs/commit/22343baff8ae120529f227a61b8f2b8293ac9108) | `` python3Packages.mypy-boto3-securityhub: 1.42.58 -> 1.42.89 ``                             |
| [`d3d9b7b5`](https://github.com/NixOS/nixpkgs/commit/d3d9b7b5ce6dd77a4ff01982667bc0013693c709) | `` python3Packages.mypy-boto3-macie2: 1.42.3 -> 1.42.89 ``                                   |
| [`4e54536a`](https://github.com/NixOS/nixpkgs/commit/4e54536a7183ba54184ba9a0b09dc5b58bfc18f4) | `` python3Packages.mypy-boto3-glue: 1.42.70 -> 1.42.89 ``                                    |
| [`a6ec95d9`](https://github.com/NixOS/nixpkgs/commit/a6ec95d9b93fb81aceb1f20910c66d4f3735ecf8) | `` python3Packages.mypy-boto3-customer-profiles: 1.42.66 -> 1.42.89 ``                       |
| [`c02ec9a7`](https://github.com/NixOS/nixpkgs/commit/c02ec9a7c537d858bcc9809525e00532abe5e8dd) | `` python3Packages.tencentcloud-sdk-python: 3.1.76 -> 3.1.77 ``                              |
| [`09062456`](https://github.com/NixOS/nixpkgs/commit/09062456773fc944e299ed2f310207d68686dd5a) | `` python3Packages.iamdata: 0.1.202604131 -> 0.1.202604141 ``                                |
| [`d9c0977b`](https://github.com/NixOS/nixpkgs/commit/d9c0977bdebb36790a975a0ce0a26e9dfbc67e8c) | `` wpprobe: 0.11.4 -> 0.11.8 ``                                                              |
| [`67da696d`](https://github.com/NixOS/nixpkgs/commit/67da696dd262b77419efa6d9f4ae9d088814b7a2) | `` python3Packages.python-qube-heatpump: 1.8.0 -> 1.9.0 ``                                   |
| [`65ea35e6`](https://github.com/NixOS/nixpkgs/commit/65ea35e65114eec4d8d69a0ea314d0a921a94b33) | `` python3Packages.py-unifi-access: 1.1.4 -> 1.1.5 ``                                        |
| [`a60e18a6`](https://github.com/NixOS/nixpkgs/commit/a60e18a6cd653c59e331cdf6853d175b2b39591a) | `` dprint-plugins.dprint-plugin-biome: 0.12.6 -> 0.12.7 ``                                   |
| [`93a50ca3`](https://github.com/NixOS/nixpkgs/commit/93a50ca37a0550daddea5bf578cd549cec9d8bc6) | `` walker: 2.15.2 -> 2.16.0 ``                                                               |
| [`8c98ec6f`](https://github.com/NixOS/nixpkgs/commit/8c98ec6f14e16e168cf0d73a34dcf61bfa36eb2d) | `` gemini-cli: 0.37.0 -> 0.37.2 ``                                                           |
| [`8b87850e`](https://github.com/NixOS/nixpkgs/commit/8b87850e493f1d37b490aa97d672127fea4d62a6) | `` python3Packages.hueble: 2.2.0 -> 2.2.1 ``                                                 |
| [`40edea6c`](https://github.com/NixOS/nixpkgs/commit/40edea6c125318a24bea9ef16076a2f0382c1133) | `` terraform-providers.opentelekomcloud_opentelekomcloud: 1.36.62 -> 1.36.63 ``              |
| [`6e58b21d`](https://github.com/NixOS/nixpkgs/commit/6e58b21d31d30b6cad199f5a36b0b9127a21a2e3) | `` valdi: 1.0.8 -> 1.0.11 ``                                                                 |
| [`b058fbd6`](https://github.com/NixOS/nixpkgs/commit/b058fbd658fb6506327a031614dc8f30d5e46e9e) | `` fence: 0.1.42 -> 0.1.46 ``                                                                |
| [`73aca421`](https://github.com/NixOS/nixpkgs/commit/73aca4219492e1747da236e1c0f30d15aa875a9e) | `` vivaldi: 7.9.3970.47 -> 7.9.3970.50 ``                                                    |
| [`e009415a`](https://github.com/NixOS/nixpkgs/commit/e009415adbe6b3232232ec394c0e649abce441c5) | `` server-box: 1.0.1351 -> 1.0.1365 ``                                                       |
| [`b698b023`](https://github.com/NixOS/nixpkgs/commit/b698b0234a37bf8b9d352189d50320ab83927a12) | `` zashboard: init at 0.3.4 ``                                                               |
| [`975ba901`](https://github.com/NixOS/nixpkgs/commit/975ba901b0661f41a4f08f298540f2229c132f35) | `` python3Packages.django-dbbackup: 5.2.0 -> 5.3.0 ``                                        |
| [`cbb4e765`](https://github.com/NixOS/nixpkgs/commit/cbb4e7652ca49ce3aa5ff83f18939bbe63b3710c) | `` python3Packages.python-discovery: 1.2.1 -> 1.2.2 ``                                       |
| [`dcca91f8`](https://github.com/NixOS/nixpkgs/commit/dcca91f8d4805fb29d1871651f302857b3cbb3b1) | `` python3Packages.smbus2: 0.6.0 -> 0.6.1 ``                                                 |
| [`20dab280`](https://github.com/NixOS/nixpkgs/commit/20dab2803951359ff2fc5164cd3a1c7a92eca2ba) | `` fluent-reader: 1.2.0 -> 1.2.1 ``                                                          |
| [`8b985df1`](https://github.com/NixOS/nixpkgs/commit/8b985df14c7487be81796758c733ae350ffb3fa5) | `` python3Packages.dtfabric: 20251118 -> 20260411 ``                                         |
| [`0ac5766b`](https://github.com/NixOS/nixpkgs/commit/0ac5766bf8252b828d66ab621205a067abed6b8f) | `` prek: 0.3.8 -> 0.3.9 ``                                                                   |
| [`8b952759`](https://github.com/NixOS/nixpkgs/commit/8b95275958abd62abce43ea225e31dc6509e7f53) | `` lua-language-server: 3.18.0 -> 3.18.1 ``                                                  |
| [`aac0cb2e`](https://github.com/NixOS/nixpkgs/commit/aac0cb2ead1f40b5bc29c351b66c8d323c6613a7) | `` libretro.snes9x2010: 0-unstable-2026-03-31 -> 0-unstable-2026-04-09 ``                    |
| [`654e8e00`](https://github.com/NixOS/nixpkgs/commit/654e8e0099f94884efd3c6e0db051a2d1350aa3a) | `` lycheeslicer: 7.6.3 -> 7.6.4 ``                                                           |
| [`a4ca4684`](https://github.com/NixOS/nixpkgs/commit/a4ca468475ad93c5161c52642cd10ef8277cd2ef) | `` terraform-providers.auth0_auth0: 1.42.0 -> 1.43.0 ``                                      |
| [`ea2ae503`](https://github.com/NixOS/nixpkgs/commit/ea2ae503d62e9876e9e60be44c69ca4d9714899c) | `` remnote: 1.25.0 -> 1.25.7 ``                                                              |
| [`eb99ea10`](https://github.com/NixOS/nixpkgs/commit/eb99ea10a99d567233342b50b4fe71b7e5d065f3) | `` python3Packages.netutils: migrate to finalAttrs ``                                        |
| [`e19ff720`](https://github.com/NixOS/nixpkgs/commit/e19ff720495a9484b11b2438f1f0c19c42ab6d47) | `` python3Packages.pysigma-backend-qradar: migrate to finalAttrs ``                          |
| [`15fc03cd`](https://github.com/NixOS/nixpkgs/commit/15fc03cdc4081499832e75e18b5fb1e9a4bbbb05) | `` sigma-cli: 2.0.2 -> 3.0.0 ``                                                              |
| [`0f71379d`](https://github.com/NixOS/nixpkgs/commit/0f71379d10e01798537587021eb25fe8340fdd05) | `` python3Packages.pysigma-backend-qradar: disable failing test ``                           |
| [`cc2ece6a`](https://github.com/NixOS/nixpkgs/commit/cc2ece6aeea50b497d64718ce6c451f8fc1ebb04) | `` python3Packages.netutils: 1.17.1 -> 1.17.2 ``                                             |
| [`e3a64b4a`](https://github.com/NixOS/nixpkgs/commit/e3a64b4adb71ee8dff930bc907e542f065c18ddc) | `` python3Packages.pysigma: 1.2.0 -> 1.3.1 ``                                                |
| [`b1f2768c`](https://github.com/NixOS/nixpkgs/commit/b1f2768ca17c2c651dc5a2dc4eb81cbbfc471641) | `` sigsum: fix build ``                                                                      |
| [`5715c23f`](https://github.com/NixOS/nixpkgs/commit/5715c23f408af18a3b558c2106f326ea7c7af24c) | `` go-httpbin: enable tests ``                                                               |
| [`56180d95`](https://github.com/NixOS/nixpkgs/commit/56180d957ed93ed57dcf5cca117e294590cd39bf) | `` codebook: 0.3.36 -> 0.3.37 ``                                                             |
| [`c462991f`](https://github.com/NixOS/nixpkgs/commit/c462991f1a648979ade1615c0307fa05cdc829b1) | `` go-httpbin: 2.21.0 -> 2.22.0 ``                                                           |
| [`2841a229`](https://github.com/NixOS/nixpkgs/commit/2841a229e5dc0a89f29290c731e7c6c1e1a59065) | `` dopamine: 3.0.3 -> 3.0.4 ``                                                               |
| [`d77dbd93`](https://github.com/NixOS/nixpkgs/commit/d77dbd9311b548d1b0df6bcc6120d7c86548c28c) | `` firefox-beta-unwrapped: 150.0b5 -> 150.0b9 ``                                             |
| [`b2546c2c`](https://github.com/NixOS/nixpkgs/commit/b2546c2c8f909e21ce00d40139fa15b6306fbfa1) | `` open-watcom-v2-unwrapped: disable strictflexarrays1 to fix build ``                       |
| [`fcd96622`](https://github.com/NixOS/nixpkgs/commit/fcd966222373e7722954f2ae01fbdd083dcbf831) | `` servo: fix feature flag ``                                                                |
| [`01e707f7`](https://github.com/NixOS/nixpkgs/commit/01e707f7552db84d00de44d8fcedaed23382fd9f) | `` nitrotpm-tools: 1.1.0 -> 1.1.1 ``                                                         |
| [`36bddcd1`](https://github.com/NixOS/nixpkgs/commit/36bddcd1a5dcb2eea9e0731fd88138a4edd3147d) | `` chiri: fix mainProgram on non-darwin ``                                                   |
| [`7845d899`](https://github.com/NixOS/nixpkgs/commit/7845d8993662976ef4f76d5532e7d5b0664048b7) | `` terraform-providers.grafana_grafana: 4.29.0 -> 4.31.0 ``                                  |
| [`e40686a0`](https://github.com/NixOS/nixpkgs/commit/e40686a0def0601c828e45ceafb357cf2cfb6df6) | `` millisecond: 0.2.1 -> 0.2.3 ``                                                            |
| [`9309cdf3`](https://github.com/NixOS/nixpkgs/commit/9309cdf32700c43207537012f604541f7f3bc0b4) | `` avogadro2: migrate to by-name ``                                                          |
| [`207a37af`](https://github.com/NixOS/nixpkgs/commit/207a37af3d5302582d99d7b668c2257773664a40) | `` molequeue: migrate to by-name ``                                                          |
| [`defff9f3`](https://github.com/NixOS/nixpkgs/commit/defff9f32746ad847b0a170c13637d13a1fc600a) | `` avogadrolibs: migrate to by-name ``                                                       |
| [`4b065c03`](https://github.com/NixOS/nixpkgs/commit/4b065c03d8650f6e2304d58845c68d06bd0faf4a) | `` go-away: use buildGo125Module ``                                                          |
| [`8040d221`](https://github.com/NixOS/nixpkgs/commit/8040d2213e1cc6d674ac21b33af772070bf105c1) | `` formiko: migrate to by-name, switch to PEP 517, and update GTK deps ``                    |
| [`6c3c0d81`](https://github.com/NixOS/nixpkgs/commit/6c3c0d8107dc410e172723e716ca2c2bf1b05511) | `` cartero: add _0xErwin1 to maintainers ``                                                  |
| [`69a18679`](https://github.com/NixOS/nixpkgs/commit/69a1867947bceb5a9c20f573e6e1412fe29d9b1a) | `` maintainers: add _0xErwin1 ``                                                             |
| [`397ffc81`](https://github.com/NixOS/nixpkgs/commit/397ffc81e65ec8780f87579e566833d74d776562) | `` gnuplot: migrate to by-name, switch to finalAttrs, and remove Qt-specific mkDerivation `` |
| [`3cf8d643`](https://github.com/NixOS/nixpkgs/commit/3cf8d643c3a305ab9713198c14205b92dbd2baef) | `` elementsd: 23.3.2 -> 23.3.3 ``                                                            |
| [`10b8c4da`](https://github.com/NixOS/nixpkgs/commit/10b8c4da5184bc5815b79f8d27e464f79356c3e4) | `` license_finder: 7.0.1 -> 7.2.1 ``                                                         |
| [`17983e8e`](https://github.com/NixOS/nixpkgs/commit/17983e8ee9358a57ad4f64984daf077b091e7eb7) | `` license_finder: migrate to by-name ``                                                     |
| [`3dc87b0b`](https://github.com/NixOS/nixpkgs/commit/3dc87b0bbf8512be458ca6d3a8a087abfa200c13) | `` lazygit: 0.61.0 -> 0.61.1 ``                                                              |
| [`e26cc137`](https://github.com/NixOS/nixpkgs/commit/e26cc1370e3bafdf6ad05a79abc54c317f74fe8c) | `` python3Packages.switchbot-api: 2.11.0 -> 2.11.1 ``                                        |
| [`b32d62ef`](https://github.com/NixOS/nixpkgs/commit/b32d62efd7d4c63aaf4557d7b4c6461ca133666f) | `` python3Packages.rns: 1.1.4 -> 1.1.5 ``                                                    |
| [`be9140fb`](https://github.com/NixOS/nixpkgs/commit/be9140fb2c1778ccd19af040babb454840eb6d70) | `` q4wine: modernize derivation ``                                                           |
| [`bad67f4f`](https://github.com/NixOS/nixpkgs/commit/bad67f4f1ac73ad1ffab0f8828fa47cafdf9e5e0) | `` q4wine: migrate to by-name ``                                                             |
| [`29bfc9b4`](https://github.com/NixOS/nixpkgs/commit/29bfc9b4d79630c8dd1095797d0da8f901918c6b) | `` gphoto2,gphoto2fs: move gphoto2 and gphoto2fs to pkgs/by-name ``                          |
| [`bff2fb1a`](https://github.com/NixOS/nixpkgs/commit/bff2fb1a0c15eda6fd2fb913940f4116588fff08) | `` python3Packages.pyexploitdb: 0.3.21 -> 0.3.22 ``                                          |
| [`facac4e9`](https://github.com/NixOS/nixpkgs/commit/facac4e9dc6cb4f32d50717288d7ccaa319cae7c) | `` checkov: 3.2.513 -> 3.2.521 ``                                                            |
| [`9c1a21be`](https://github.com/NixOS/nixpkgs/commit/9c1a21bed3cda2f95c76860232aa9fdbb7585d32) | `` libvgm: 0-unstable-2026-03-01 -> 0-unstable-2026-04-06 ``                                 |
| [`ef9d5133`](https://github.com/NixOS/nixpkgs/commit/ef9d5133540f95b1146a895546eb87a80d5ea6ce) | `` python3Packages.dnsight: init at 1.0.1 ``                                                 |
| [`a54161ac`](https://github.com/NixOS/nixpkgs/commit/a54161acd31be8d33a465b632b9b9208f99bd38b) | `` gpg-tui: refactor ``                                                                      |
| [`b1e33c00`](https://github.com/NixOS/nixpkgs/commit/b1e33c00b6a0c3bc813b3bc7f985e7c061b972ae) | `` gpg-tui: migrate to by-name ``                                                            |
| [`f9ef591e`](https://github.com/NixOS/nixpkgs/commit/f9ef591e97d9ca6962ea97aa3263046a0e5c4356) | `` python3Packages.aioghost: 0.4.0 -> 0.4.10 ``                                              |
| [`b7cae342`](https://github.com/NixOS/nixpkgs/commit/b7cae3429d3a4b05b71eee1b73ce8abd6b2fb893) | `` postgresql: reduce duplicated postgresqlWithPackages ``                                   |
| [`2b864903`](https://github.com/NixOS/nixpkgs/commit/2b8649037b2dd039188016c5e2ddaaec2399fbd9) | `` gatekeeper: 3.22.0 -> 3.22.1 ``                                                           |
| [`c95ef668`](https://github.com/NixOS/nixpkgs/commit/c95ef668a58e3e54719705fc6e366fbd4db3535c) | `` postgresql: cleanup unused imports ``                                                     |
| [`8f697ee7`](https://github.com/NixOS/nixpkgs/commit/8f697ee7bcdb87889018f3cb76bc024952a1f529) | `` googlesans-code: 6.001 -> 7.000 ``                                                        |
| [`63cb61ae`](https://github.com/NixOS/nixpkgs/commit/63cb61ae504cfdda3a7893557b385ff3f652f7c4) | `` istioctl: 1.29.1 -> 1.29.2 ``                                                             |
| [`94466d51`](https://github.com/NixOS/nixpkgs/commit/94466d51a76f5f03cf630a3db3e85fd0af33bfe1) | `` signalbackup-tools: 20260407 -> 20260413 ``                                               |
| [`54c3dd12`](https://github.com/NixOS/nixpkgs/commit/54c3dd12b80823ae77169204b3b940d6d9002060) | `` zipline: 4.5.2 -> 4.5.3 ``                                                                |
| [`a705cf65`](https://github.com/NixOS/nixpkgs/commit/a705cf65dbb064f618db4b0f3ba3c0586c5d18af) | `` libretro.mame2003-plus: 0-unstable-2026-04-04 -> 0-unstable-2026-04-08 ``                 |
| [`aea389e0`](https://github.com/NixOS/nixpkgs/commit/aea389e00d4d8a106369d24a7eba0eb519745ff0) | `` nixos/dovecot: define options for config and storage version ``                           |
| [`d7f265e0`](https://github.com/NixOS/nixpkgs/commit/d7f265e05324fd8295fb76b9d43fe7346bfe8c58) | `` nixos/tests/machinectl: re-org configs into profiles ``                                   |
| [`2fce735e`](https://github.com/NixOS/nixpkgs/commit/2fce735eaa9483acebb8bcf2c2edd776102c8f06) | `` matlab-language-server: 1.3.9 -> 1.3.10 ``                                                |
| [`a5222257`](https://github.com/NixOS/nixpkgs/commit/a52222578b2edaca51efbbf1ef5518d32395b71a) | `` mmdbctl: 1.4.9 -> 1.4.10 ``                                                               |
| [`284288c3`](https://github.com/NixOS/nixpkgs/commit/284288c32ef782e6e28bab2756a3d4aa9315d48a) | `` nixosTests.gitlab: fixup for new dovecot module ``                                        |
| [`df663e5f`](https://github.com/NixOS/nixpkgs/commit/df663e5fb1f3f258bde0848fc0f2287eb201f2f4) | `` python3Packages.aiosonos: 0.1.11 -> 0.1.12 ``                                             |
| [`64886b11`](https://github.com/NixOS/nixpkgs/commit/64886b11dd780e2d12f5481f8d23f0a9a31845a2) | `` phpstan: 2.1.46 -> 2.1.47 ``                                                              |
| [`4491a180`](https://github.com/NixOS/nixpkgs/commit/4491a1802b80134df07530b3323edbcb80948a39) | `` regclient: 0.11.2 -> 0.11.3 ``                                                            |
| [`f8b8c5e7`](https://github.com/NixOS/nixpkgs/commit/f8b8c5e73618d47cf8509b980541f193c4c82dae) | `` sesh: 2.24.2 -> 2.25.0 ``                                                                 |
| [`fe3321fa`](https://github.com/NixOS/nixpkgs/commit/fe3321fa8240435c35a460f9380450fd9ff08184) | `` terraform-providers.hashicorp_awscc: 1.78.0 -> 1.79.0 ``                                  |
| [`efef5829`](https://github.com/NixOS/nixpkgs/commit/efef582923f8d4d2cc8668d017b04f03e362ff54) | `` python3Packages.python-melcloud: 0.1.2 -> 0.1.3 ``                                        |
| [`c010e03f`](https://github.com/NixOS/nixpkgs/commit/c010e03f8efbf8609f508974380307330ce1593a) | `` cursor-cli: 0-unstable-2026-03-30 -> 0-unstable-2026-04-08 ``                             |
| [`7efac4f5`](https://github.com/NixOS/nixpkgs/commit/7efac4f5fb84aac7ea8005d4910043d9a7d92633) | `` python3Packages.nhc: 0.7.0 -> 0.8.0 ``                                                    |
| [`33dc39b9`](https://github.com/NixOS/nixpkgs/commit/33dc39b949b8642d1542f6aa28c83b123208869d) | `` duckdb: fix build on darwin ``                                                            |
| [`7d811977`](https://github.com/NixOS/nixpkgs/commit/7d8119771239bab74343c392bde5dd67fe297f86) | `` androidStudioPackages.beta: 2025.3.3.5 -> 2025.3.4.5 ``                                   |
| [`814c2774`](https://github.com/NixOS/nixpkgs/commit/814c27744f2d8f3f2273a64b4ec5f3a163ebde89) | `` mslicer: 0.4.0 -> 0.6.0 ``                                                                |
| [`65526b3b`](https://github.com/NixOS/nixpkgs/commit/65526b3b985f570c0a49783831e5fc90b440ca1d) | `` terraform-providers.mongodb_mongodbatlas: 2.9.0 -> 2.10.0 ``                              |
| [`00083874`](https://github.com/NixOS/nixpkgs/commit/0008387437cc4d00148413ca8d4233a5cf3fe2bc) | `` home-assistant-custom-components.waste_collection_schedule: 2.15.0 -> 2.19.0 ``           |
| [`2c2a1af6`](https://github.com/NixOS/nixpkgs/commit/2c2a1af6ecd970d55154d29c8be66b6c427e9c2d) | `` python3Packages.unicode-segmentation-rs: 0.2.3 -> 0.2.4 ``                                |
| [`e392ae48`](https://github.com/NixOS/nixpkgs/commit/e392ae4881324f001f8b7cb4b8cfef15d4b7591e) | `` openafs: refactor derivation ``                                                           |
| [`6d4401e1`](https://github.com/NixOS/nixpkgs/commit/6d4401e1b6a45455d8e7198540911152c7f40f2d) | `` openafs: migrate to by-name ``                                                            |
| [`4db9cdce`](https://github.com/NixOS/nixpkgs/commit/4db9cdce834d9f2a327c967f75275cf7ad50bcac) | `` chef-cli: 5.6.21 -> 5.6.23 ``                                                             |
| [`88e17999`](https://github.com/NixOS/nixpkgs/commit/88e17999f69ba3fa0275c1344d568de83c23cacc) | `` chef-cli: add missing syslog gem ``                                                       |
| [`b645b3f3`](https://github.com/NixOS/nixpkgs/commit/b645b3f35e187537b0cba87ee69c475acc28a70a) | `` chef-cli: migrate to by-name ``                                                           |
| [`a735cae5`](https://github.com/NixOS/nixpkgs/commit/a735cae567974fcc303e96c8e9317bb90b06458d) | `` rocmPackages.rocprofiler-sdk: init at 7.2.1 ``                                            |
| [`e7c273a4`](https://github.com/NixOS/nixpkgs/commit/e7c273a44a793bb2999efc83d106448ad5d3af08) | `` taskwarrior-tui: 0.26.6 -> 0.27.0 ``                                                      |
| [`feaef5cc`](https://github.com/NixOS/nixpkgs/commit/feaef5cc96300e1c8558e7c8488a7e75defd791c) | `` nixos/tests/machinectl: add systemd-vmspawn tests ``                                      |
| [`1166aab1`](https://github.com/NixOS/nixpkgs/commit/1166aab11c9b096213b9ea5db46fdaf772bf11e0) | `` dms-shell: 1.4.4 -> 1.4.4.1 ``                                                            |
| [`98345937`](https://github.com/NixOS/nixpkgs/commit/9834593727344c72a8cca7d0a0b949e219573843) | `` umap: 3.7.1 -> 3.7.3 ``                                                                   |
| [`fd1f7efd`](https://github.com/NixOS/nixpkgs/commit/fd1f7efde060b9805af9b90ec40d6e0087f6f46f) | `` linuxPackages.bcachefs: allow kernel 7.0 ``                                               |
| [`d7b5f851`](https://github.com/NixOS/nixpkgs/commit/d7b5f85137720a9811937afaad0511296107dbc5) | `` arkade: 0.11.92 -> 0.11.93 ``                                                             |
| [`6f975340`](https://github.com/NixOS/nixpkgs/commit/6f975340c87fab1281eb9b5b67eab57fddd5ec38) | `` cargo-xwin: 0.21.4 -> 0.21.5 ``                                                           |
| [`efa0fd1f`](https://github.com/NixOS/nixpkgs/commit/efa0fd1fd07e5c40d0e7554011c423c229ae7a95) | `` cargo-wizard: 0.2.2 -> 0.2.3 ``                                                           |
| [`84171d1e`](https://github.com/NixOS/nixpkgs/commit/84171d1e33efc604058e018ae0d7ec6a3e4be547) | `` camunda-modeler: 5.45.0 -> 5.46.0 ``                                                      |
| [`72f9a5a9`](https://github.com/NixOS/nixpkgs/commit/72f9a5a94dbaf7108b883c798b577b8966462b4a) | `` servo: 0.0.6 -> 0.1.0 ``                                                                  |
| [`d0625f34`](https://github.com/NixOS/nixpkgs/commit/d0625f347ee07eb178332e7526cd9d0b2da0a70c) | `` parted: add kybe236 as maintainer ``                                                      |
| [`0f21f18c`](https://github.com/NixOS/nixpkgs/commit/0f21f18c78527405aa8db83457a634b18ea600c4) | `` parted: 3.6 -> 3.7 ``                                                                     |
| [`f75cfe70`](https://github.com/NixOS/nixpkgs/commit/f75cfe7041f1e35147b8dc50aa81fa31849dfc00) | `` python3Packages.aiodukeenergy: 1.0.0 -> 1.1.0 ``                                          |
| [`9ffd29fb`](https://github.com/NixOS/nixpkgs/commit/9ffd29fb9c554e1fa667aa96c07fb3d1b3ac0659) | `` linux_7_0: init at 7.0 ``                                                                 |
| [`5fa08ada`](https://github.com/NixOS/nixpkgs/commit/5fa08ada63593b3afdff9e25afeab79d086332fe) | `` xfr: init at 0.9.6 ``                                                                     |
| [`e1b44678`](https://github.com/NixOS/nixpkgs/commit/e1b446781e80463bb9eace382275e00552f61c94) | `` elephant: enable all providers by default ``                                              |
| [`cf431ef6`](https://github.com/NixOS/nixpkgs/commit/cf431ef62bd8d4b90819e2267b35f7255fd8e0cd) | `` nixos/dovecot: hotfix config defaults for sieve-less setups ``                            |
| [`b714c05c`](https://github.com/NixOS/nixpkgs/commit/b714c05c4a416ce498e31eb454e5251702b2d4cd) | `` netpeek: switch to finalAttrs ``                                                          |
| [`7272b6ad`](https://github.com/NixOS/nixpkgs/commit/7272b6ad4d631566ae1cfba328e881e6e092441e) | `` canokey-qemu: 0-unstable-2023-06-06 -> 0-unstable-2026-03-24 ``                           |
| [`b139eab7`](https://github.com/NixOS/nixpkgs/commit/b139eab700e8cf41ef8057caf5205f6b67aedede) | `` wine-staging: 11.5 -> 11.6 ``                                                             |
| [`fe0b8e32`](https://github.com/NixOS/nixpkgs/commit/fe0b8e32075958ea2832871b914e707b5df978e8) | `` python3Packages.python-obfuscator: 0.0.2 -> 0.1.0 ``                                      |
| [`2bb4d032`](https://github.com/NixOS/nixpkgs/commit/2bb4d0324f34d049cab2d35c93d5cf08bdb61093) | `` yara-x: 1.14.0 -> 1.15.0 ``                                                               |
| [`d7f2dfe6`](https://github.com/NixOS/nixpkgs/commit/d7f2dfe6bff0d63e361df324d526355734edc3bf) | `` ollama: 0.20.5 -> 0.20.6 ``                                                               |
| [`9a4f2cae`](https://github.com/NixOS/nixpkgs/commit/9a4f2cae89d822ccdf5d3c750f24f9d79937c601) | `` python313Packages.python-troveclient: disable failing tests ``                            |
| [`56b5f531`](https://github.com/NixOS/nixpkgs/commit/56b5f53187d19d2ec7377d3edb6ab9955bbf8dd9) | `` git-pkgs: 0.15.2 -> 0.15.3 ``                                                             |
| [`b758f062`](https://github.com/NixOS/nixpkgs/commit/b758f062ef9a529e2b4c34e1ee74dc1720f1e940) | `` openclaw: 2026.4.10 -> 2026.4.11 ``                                                       |
| [`c9dddb85`](https://github.com/NixOS/nixpkgs/commit/c9dddb8541772fd3fd4e41db4e30523c043b5064) | `` mago: 1.18.1 -> 1.19.0 ``                                                                 |
| [`fbc7b5e0`](https://github.com/NixOS/nixpkgs/commit/fbc7b5e018430ee29735ec268759d28d50090356) | `` glaze: 7.2.3 -> 7.3.3 ``                                                                  |
| [`98825dcb`](https://github.com/NixOS/nixpkgs/commit/98825dcbb6a82eb84136a796067dbd7c93001e8e) | `` canaille: 0.2.3 -> 0.2.4 ``                                                               |
| [`dd2b5675`](https://github.com/NixOS/nixpkgs/commit/dd2b5675ac29422590a3cf4fc4049f71da63af7f) | `` python3Packages.scim2-tester: 0.2.6 -> 0.2.8 ``                                           |
| [`fd194e21`](https://github.com/NixOS/nixpkgs/commit/fd194e2162da4fd4cc3df05a6c7a9818b46f890c) | `` python3Packages.scim2-models: 0.6.6 -> 0.6.11 ``                                          |
| [`80025137`](https://github.com/NixOS/nixpkgs/commit/800251373641941de2492ab37e2c669fd2873687) | `` zwave-js-ui: 11.15.1 -> 11.16.0 ``                                                        |
| [`5c4a0a54`](https://github.com/NixOS/nixpkgs/commit/5c4a0a541a060625ff74a6d877b8e5d1650969a1) | `` librepods: add Cameo007 as maintainer ``                                                  |
| [`6c19e12a`](https://github.com/NixOS/nixpkgs/commit/6c19e12a217147f2ec6c3230e0ff0f5b8268dcc7) | `` nixos/librepods: init ``                                                                  |
| [`28ede244`](https://github.com/NixOS/nixpkgs/commit/28ede2449fe109d0e3f929f4282204bd20829639) | `` python3Packages.scim2-client: 0.7.3 -> 0.7.5 ``                                           |
| [`ee41b012`](https://github.com/NixOS/nixpkgs/commit/ee41b012c4b2bab6af02dd173ba58603d7012f7c) | `` librepods: 0.1.0-unstable-2025-12-07 -> 0.2.0-alpha ``                                    |
| [`eade3ea0`](https://github.com/NixOS/nixpkgs/commit/eade3ea0a01a49a49887b02b4f6d2926e3f2dc1f) | `` bird3: switch from rev to tag for src ``                                                  |
| [`f8330c08`](https://github.com/NixOS/nixpkgs/commit/f8330c08fb82f1f84b3e6b3d826950536a6e6738) | `` bird2: 2.18 -> 2.18.1 ``                                                                  |
| [`ecc662dc`](https://github.com/NixOS/nixpkgs/commit/ecc662dc4f171f90ef85772f6235b3dce7b6a0ed) | `` vaultwarden.webvault: 2026.1.1+0 -> 2026.2.0+0 ``                                         |
| [`a958c920`](https://github.com/NixOS/nixpkgs/commit/a958c920524e4301653beaefef33b91883202a3b) | `` spire-tpm-plugin: init at 1.11.1 ``                                                       |
| [`e3c1b1e1`](https://github.com/NixOS/nixpkgs/commit/e3c1b1e1cd65cc22c21f16b2e58331a9786c43e6) | `` python3Packages.oslo-utils: 10.0.0 -> 10.0.1 ``                                           |
| [`80ebf8a3`](https://github.com/NixOS/nixpkgs/commit/80ebf8a36289d88807e60bbe4b19b6b7d0f6b775) | `` python3Packages.pytools: 2025.2.5 -> 2026.1 ``                                            |
| [`1ba5ed92`](https://github.com/NixOS/nixpkgs/commit/1ba5ed924cf6c30dea893b598d22b99b1d2d491d) | `` elephant: 2.20.3 -> 2.21.0 ``                                                             |
| [`5dae3e65`](https://github.com/NixOS/nixpkgs/commit/5dae3e65178bda2e65dfb166f5ca080d6034274c) | `` python3Packages.reconplogger: migrate to finalAttrs ``                                    |
| [`b887779f`](https://github.com/NixOS/nixpkgs/commit/b887779f249114e1448f530ad3328e58071210ce) | `` python3Packages.certihound: migrate to finalAttrs ``                                      |
| [`3e017e95`](https://github.com/NixOS/nixpkgs/commit/3e017e9576695942df00f5c3758912da8cf67190) | `` python3Packages.certihound: add build-system ``                                           |
| [`32a3e446`](https://github.com/NixOS/nixpkgs/commit/32a3e446b9fdc7673576f556e39ce7eaaf8942a3) | `` python3Packages.reconplogger: 4.18.1 -> 5.0.0 ``                                          |
| [`0b225d39`](https://github.com/NixOS/nixpkgs/commit/0b225d39b3d785427c9d221c7fc20dffeb9abdd0) | `` python3Pakcages.pynfsclient: migrate to finalAttrs ``                                     |
| [`8926c73f`](https://github.com/NixOS/nixpkgs/commit/8926c73f508a53ad64ff37b7282063c77679f68b) | `` ci/eval/compare: Expose attrdiff by kernel and platform ``                                |
| [`149201a7`](https://github.com/NixOS/nixpkgs/commit/149201a7e37c197bc090723af5c016f4f596c735) | `` nixos/test-driver: use log levels ``                                                      |
| [`a1458aa0`](https://github.com/NixOS/nixpkgs/commit/a1458aa056876683692f9595fdc75777e416473c) | `` cnspec: 13.3.3 -> 13.4.1 ``                                                               |
| [`c754ee1b`](https://github.com/NixOS/nixpkgs/commit/c754ee1b356753af364b928f6c1d41ab239ee4eb) | `` jsonschema-cli: 0.45.0 -> 0.46.0 ``                                                       |
| [`42795842`](https://github.com/NixOS/nixpkgs/commit/42795842703c774aa4614d5b28d56d3d019adc93) | `` lasuite-docs{,-frontend,-collaboration-server}: 4.8.5 -> 4.8.6 ``                         |
| [`c515a64c`](https://github.com/NixOS/nixpkgs/commit/c515a64c2478cf96e61b879c2fbfbc4eb431eb83) | `` shaka-packager: 3.7.1 -> 3.7.2 ``                                                         |
| [`939c3c57`](https://github.com/NixOS/nixpkgs/commit/939c3c57ae1f70c8829bcf1406cd9fd67af9f00a) | `` nzbhydra2: add meta.changelog ``                                                          |
| [`051da568`](https://github.com/NixOS/nixpkgs/commit/051da568320af663533b070b3affe2b775114752) | `` buildVcode: replace glibc.bin with getconf ``                                             |
| [`f0412cc8`](https://github.com/NixOS/nixpkgs/commit/f0412cc83f6fb1c3e9bd1e99d9842c3b9e9b570c) | `` python3Packages.unifi-discovery: migrate to finalAttrs ``                                 |
| [`f89111d3`](https://github.com/NixOS/nixpkgs/commit/f89111d314ec7a43f1a2c88f4e34f4bdc2777b92) | `` tcping-rs: 1.2.24 -> 1.2.26 ``                                                            |
| [`3b3ed2c2`](https://github.com/NixOS/nixpkgs/commit/3b3ed2c2f7c0aff1883095c6257e42eb3d49e00d) | `` python3Packages.unifi-discovery: 1.3.0 -> 1.4.0 ``                                        |
| [`c7b840ca`](https://github.com/NixOS/nixpkgs/commit/c7b840ca599968a0cf7b9fafc08539d9046faf96) | `` files-cli: 2.15.257 -> 2.15.264 ``                                                        |
| [`744084a6`](https://github.com/NixOS/nixpkgs/commit/744084a69e28b42259ccb5a1f57445eb6978a14c) | `` air: 1.65.0 -> 1.65.1 ``                                                                  |
| [`3a63e649`](https://github.com/NixOS/nixpkgs/commit/3a63e649ca1cc16cd149521722a3202cf2513180) | `` kiro-cli: 1.29.3 -> 1.29.8 ``                                                             |
| [`b8b939cd`](https://github.com/NixOS/nixpkgs/commit/b8b939cdcca154895f718f65c33d9abfa1add3a4) | `` fetchfossil: do not use nobody ``                                                         |
| [`1f35c7be`](https://github.com/NixOS/nixpkgs/commit/1f35c7befee1c2372b2237ab4bdbf8f9df680702) | `` povray: do not use nobody/nogroup ``                                                      |
| [`4d90b8bb`](https://github.com/NixOS/nixpkgs/commit/4d90b8bb6c1540de08f374bf9732868e3b926c51) | `` nixos/tests/wpa_supplicant: do not use nobody ``                                          |
| [`577b32b0`](https://github.com/NixOS/nixpkgs/commit/577b32b084a372c19629804835076e8446781593) | `` treewide: remove nobody/nogroup from examples ``                                          |
| [`82a11027`](https://github.com/NixOS/nixpkgs/commit/82a11027ac61cd4f5dba058f97c3bc0a261ef5e7) | `` glpi-agent: 1.16 -> 1.17 ``                                                               |
| [`4e0ae8e8`](https://github.com/NixOS/nixpkgs/commit/4e0ae8e893d257219815c7a9ec89e5bac31c2cd2) | `` python313Packages.gitpython: migrate to finalAttrs ``                                     |
| [`9704065d`](https://github.com/NixOS/nixpkgs/commit/9704065dabed871b833b5678cb86878ed60fad63) | `` python3Packages.beetcamp: 0.24.1 -> 0.24.2 ``                                             |
| [`1e645638`](https://github.com/NixOS/nixpkgs/commit/1e645638fbcb684091ee8555a3d51e67186bc179) | `` python3Packages.beets-alternatives: fix a test failing with beets 2.9.0 ``                |
| [`ec64070f`](https://github.com/NixOS/nixpkgs/commit/ec64070f7f45b81197ce245e7ca5545eb965280a) | `` python3Packages.nominatim: migrate to finalAttrs ``                                       |
| [`2975f3bf`](https://github.com/NixOS/nixpkgs/commit/2975f3bf8fa611d0a7d4ba3d407b16fecb753030) | `` python3Packages.aioopenexchangerates: migrate to finalAttrs ``                            |
| [`4efedc53`](https://github.com/NixOS/nixpkgs/commit/4efedc535c93e052e1866f27a84e4fd5fbd6f687) | `` python3Packages.aioopenexchangerates: 0.6.21 -> 0.7.0 ``                                  |
| [`1db487ee`](https://github.com/NixOS/nixpkgs/commit/1db487ee6f8e88aed3ddd611348b708b8bd48578) | `` python3Packages.claude-agent-sdk: 0.1.56 -> 0.1.58 ``                                     |
| [`10d1334e`](https://github.com/NixOS/nixpkgs/commit/10d1334ec69a21c1b0cc044c457fed728cae500f) | `` python3Packages.microsoft-kiota-abstractions: migrate to finalAttrs ``                    |
| [`ddd2d118`](https://github.com/NixOS/nixpkgs/commit/ddd2d118e9fd0444cc129fb310d1149a80f1d1c3) | `` libretro.twenty-fortyeight: 0-unstable-2026-03-31 -> 0-unstable-2026-04-10 ``             |
| [`20e1f762`](https://github.com/NixOS/nixpkgs/commit/20e1f7625b37fd1582065bdd7c8dd9a27340fd5f) | `` python3Packages.iamdata: 0.1.202604111 -> 0.1.202604131 ``                                |
| [`1b80c482`](https://github.com/NixOS/nixpkgs/commit/1b80c482c1dba8008e881de6696c579af40edc35) | `` python3Packages.iamdata: 0.1.202604101 -> 0.1.202604111 ``                                |
| [`69ad71b8`](https://github.com/NixOS/nixpkgs/commit/69ad71b86ac4d63e7e8e1846f6bfedb28081f76d) | `` python3Packages.publicsuffixlist: 1.0.2.20260411 -> 1.0.2.20260412 ``                     |
| [`8dffd3b1`](https://github.com/NixOS/nixpkgs/commit/8dffd3b19c046afa7c89792f21ecc56c5adcb6a3) | `` python3Packages.tencentcloud-sdk-python: 3.1.75 -> 3.1.76 ``                              |
| [`f243a237`](https://github.com/NixOS/nixpkgs/commit/f243a23777735602de42dfc110e4ae6c7d448294) | `` nzbhydra2: 8.5.3 -> 8.5.4 ``                                                              |
| [`2abc0a90`](https://github.com/NixOS/nixpkgs/commit/2abc0a9047617ca44724c31089ac25e4563d753e) | `` home-assistant-custom-components.mitsubishi: ignore pymitsubishi version requirement ``   |
| [`fcb8241f`](https://github.com/NixOS/nixpkgs/commit/fcb8241fade6a448634815c878dbe5043f0fa900) | `` lazyhetzner: 1.1.1 -> 1.2.0 ``                                                            |
| [`e975a929`](https://github.com/NixOS/nixpkgs/commit/e975a9293a5c983f62b1d396a4b59a0f67475fe2) | `` gauge-unwrapped: 1.6.29 -> 1.6.30 ``                                                      |
| [`b975b60b`](https://github.com/NixOS/nixpkgs/commit/b975b60bef87715638f95d25dd0570be4901d527) | `` wasmtime: 43.0.0 -> 43.0.1 ``                                                             |
| [`33241219`](https://github.com/NixOS/nixpkgs/commit/33241219884dd5a539e872b70acfa1c308ad0c27) | `` python3Packages.nominatim-api: 5.3.0 -> 5.3.1 ``                                          |
| [`3c3a7088`](https://github.com/NixOS/nixpkgs/commit/3c3a7088fb2f8faac07687c068f4e8f122d15295) | `` proton-pass-cli: 1.9.0 -> 1.10.0 ``                                                       |
| [`f9826b3c`](https://github.com/NixOS/nixpkgs/commit/f9826b3c639e5bd3fac3085e36af26f6006469ea) | `` serie: 0.7.1 -> 0.7.2 ``                                                                  |
| [`0af53ba8`](https://github.com/NixOS/nixpkgs/commit/0af53ba82da4e2b8d2f5e3838c32e59186cd6485) | `` searxng: 0-unstable-2026-04-05 -> 0-unstable-2026-04-11 ``                                |
| [`32d63f90`](https://github.com/NixOS/nixpkgs/commit/32d63f904e4ddc3573ab6874263bd76b450cc8dc) | `` grafanaPlugins.frser-sqlite-datasource: 4.0.1 -> 4.0.2 ``                                 |
| [`26c92163`](https://github.com/NixOS/nixpkgs/commit/26c921630420591a4d819b6d9fce3356bdef20fd) | `` nushell: 0.111.0 -> 0.112.1 ``                                                            |
| [`b0a385a7`](https://github.com/NixOS/nixpkgs/commit/b0a385a761fbf8acfa72097722cbfa0254b24be4) | `` tun2proxy: 0.7.19 -> 0.7.20 ``                                                            |
| [`0183d571`](https://github.com/NixOS/nixpkgs/commit/0183d57188dc3b84dd10d7856dc23c4f21bf2405) | `` stackql: 0.10.383 -> 0.10.421 ``                                                          |
| [`69923695`](https://github.com/NixOS/nixpkgs/commit/69923695368f2fb25c1676327447b0893dc13ee6) | `` llama-cpp: 8733 -> 8770 ``                                                                |
| [`cbbd7209`](https://github.com/NixOS/nixpkgs/commit/cbbd72092a3b67b0406d234adb89d2914cbaa2ca) | `` python3Packages.adlfs: 2026.2.0 -> 2026.4.0 ``                                            |
| [`f21739e2`](https://github.com/NixOS/nixpkgs/commit/f21739e2f9925d0c023238a6619e98a821aa3aae) | `` vaultwarden: 1.35.4 -> 1.35.6 ``                                                          |
| [`e547b025`](https://github.com/NixOS/nixpkgs/commit/e547b0255a656d048de6a460f9a4eb273e6976f5) | `` python3Packages.microsoft-kiota-abstractions: 1.9.10 -> 1.10.1 ``                         |
| [`8c8664e5`](https://github.com/NixOS/nixpkgs/commit/8c8664e5847a41d6a61bbf7f8749558a928a91d9) | `` cherry-studio: 1.8.4 -> 1.9.1 ``                                                          |
| [`5458dd7b`](https://github.com/NixOS/nixpkgs/commit/5458dd7b4e8efd4f16fbbf4043a11c89c4791ffd) | `` home-assistant-custom-lovelace-modules.swipe-navigation: 1.15.8 -> 1.16.0 ``              |
| [`41c38333`](https://github.com/NixOS/nixpkgs/commit/41c383338e1881994bf517b4c66aacb30a2410f7) | `` nixos/sshd: add enableRecommendedAlgorithms option ``                                     |
| [`23d7be22`](https://github.com/NixOS/nixpkgs/commit/23d7be2248a34bed2d29d9997a812c3f08ea10ce) | `` tests/openssh: move order-dependent test to top ``                                        |
| [`20268e0a`](https://github.com/NixOS/nixpkgs/commit/20268e0ada6d437056825f995b55e1300cd02af3) | `` nixos/hedgedoc: remove minio from examples ``                                             |
| [`cbe0413f`](https://github.com/NixOS/nixpkgs/commit/cbe0413f0c00be8b8b016b8d3e8259a0bf70e5d5) | `` lfe: fix install phase, make sure we get the binaries in the right place ``               |
| [`063871bb`](https://github.com/NixOS/nixpkgs/commit/063871bb06371ef85b06561026d068602dabb4ee) | `` wtfis: 0.14.0 -> 0.15.0 ``                                                                |
| [`4ba0d409`](https://github.com/NixOS/nixpkgs/commit/4ba0d409e73ec0fa15bbf9178c8c10a500ebdb14) | `` juju: 3.6.12 -> 3.6.21 ``                                                                 |
| [`421f79c3`](https://github.com/NixOS/nixpkgs/commit/421f79c3bb77c13836ebb3313b338e4d92f54e15) | `` dokieli: 0-unstable-2026-03-25 -> 0-unstable-2026-04-13 ``                                |
| [`22ea82c4`](https://github.com/NixOS/nixpkgs/commit/22ea82c45143eee8b15498dca7d4d4bc9e7a72fb) | `` blackmagic-desktop-video: 15.3.1 -> 16.0 ``                                               |
| [`e97f5124`](https://github.com/NixOS/nixpkgs/commit/e97f51246f14cd29d1638b36f1b72a2a6a72a73d) | `` terraform-providers.kreuzwerker_docker: 4.0.0 -> 4.1.0 ``                                 |
| [`f5ac9eb9`](https://github.com/NixOS/nixpkgs/commit/f5ac9eb951a99f0d78e3870a2579dead8eba01b2) | `` python3Packages.connect-box3: init at 0.2.1 ``                                            |
| [`a84374b1`](https://github.com/NixOS/nixpkgs/commit/a84374b17038bd8e1ceb8c79140e0c54efbd5030) | `` python3Packages.home-assistant-datasets: init at 0.3.0 ``                                 |
| [`bcc3b706`](https://github.com/NixOS/nixpkgs/commit/bcc3b7065c1ca1a275a498363f5857e7bdf81f85) | `` python3Packages.synthetic-home: init at 5.0.2 ``                                          |
| [`a74cedeb`](https://github.com/NixOS/nixpkgs/commit/a74cedeb0f37db012602d9a2ade1139306c00aeb) | `` libretro.vba-m: 0-unstable-2024-10-21 -> 0-unstable-2026-04-10 ``                         |
| [`0cc192e5`](https://github.com/NixOS/nixpkgs/commit/0cc192e5c28b032ddc21c2572bf1d757a5787ce8) | `` python3Packages.textual-image: modernize ``                                               |
| [`5f69fa74`](https://github.com/NixOS/nixpkgs/commit/5f69fa740a33fdc231a3b6a892959b5da5bc3bdc) | `` rocketchat-desktop: 4.13.0 -> 4.14.0 ``                                                   |
| [`99cfdd76`](https://github.com/NixOS/nixpkgs/commit/99cfdd764636e90d82d4eb9500ba7993e248da9b) | `` gleam: 1.15.2 -> 1.15.4 ``                                                                |
| [`ac4b29b9`](https://github.com/NixOS/nixpkgs/commit/ac4b29b9f4f0f85b50e5132c66edbf96810346c1) | `` copier: 9.14.1 -> 9.14.3 ``                                                               |
| [`23fcd774`](https://github.com/NixOS/nixpkgs/commit/23fcd7748c0efbf22f33a1009d1bdf16ff4dee0d) | `` terraform-providers.bpg_proxmox: 0.100.0 -> 0.101.1 ``                                    |
| [`d1935047`](https://github.com/NixOS/nixpkgs/commit/d19350471c103c7c8111c9f2fe65902e327fd284) | `` mojoshader: move env variable into env for structuredAttrs ``                             |
| [`8e55aea6`](https://github.com/NixOS/nixpkgs/commit/8e55aea6ee2ca353eedf2311aad7d92f58264ed9) | `` cuda_nvcc: fix host_defines.h __noinline__ conflict under clang ``                        |
| [`9992618b`](https://github.com/NixOS/nixpkgs/commit/9992618b854b6bf13a60daf67d13bc9239f231f2) | `` cdncheck: 1.2.30 -> 1.2.31 ``                                                             |
| [`d25d786f`](https://github.com/NixOS/nixpkgs/commit/d25d786f61615fb8376808b7ed92b7bd536222da) | `` python3Packages.slack-bolt: migrate to finalAttrs ``                                      |
| [`6caea797`](https://github.com/NixOS/nixpkgs/commit/6caea797e6e60e696c290c5633d17042579902f2) | `` minify: 2.24.11 -> 2.24.12 ``                                                             |
| [`46ffa52d`](https://github.com/NixOS/nixpkgs/commit/46ffa52dc7ed75fe0438560b1c396d15b4ed4695) | `` python3Packages.django-weasyprint: 2.4.0 -> 2.5.0 ``                                      |
| [`d85d3c67`](https://github.com/NixOS/nixpkgs/commit/d85d3c6701445f9ef6b25f595f88d38d98650010) | `` openbgpd: replace cvengler as openbgpd maintainer ``                                      |
| [`ca8f20ef`](https://github.com/NixOS/nixpkgs/commit/ca8f20ef41856d4cc98fe49569ee9556c97a5e33) | `` maintainers: add cvengler ``                                                              |
| [`6296268b`](https://github.com/NixOS/nixpkgs/commit/6296268b145058df635ce2720702ab8b75332fb8) | `` python3Packages.kagglesdk: 0.1.16 -> 0.1.18 ``                                            |
| [`0ca69b06`](https://github.com/NixOS/nixpkgs/commit/0ca69b06507c8a66ba02774b218aa2e8ccd2b59e) | `` nix: fix nix-store-tests-run for static builds ``                                         |
| [`924e5a22`](https://github.com/NixOS/nixpkgs/commit/924e5a22c732c1caebb498c2efcb3c0eecd9feee) | `` nixVersions.stable: nix_2_31 -> nix_2_34 ``                                               |
| [`3bee0d4c`](https://github.com/NixOS/nixpkgs/commit/3bee0d4c462a2a8b16b569509c024e38cf655498) | `` exploitdb: 2026-04-07 -> 2026-04-11 ``                                                    |
| [`4fb7d141`](https://github.com/NixOS/nixpkgs/commit/4fb7d14139b5412201ab8125be9b905aed2e057b) | `` python3Packages.pyworxcloud: 6.3.0 -> 6.3.2 ``                                            |
| [`21a52410`](https://github.com/NixOS/nixpkgs/commit/21a5241014422146d8bd6bda0be49336eddaa120) | `` python313Packages.pyais: 2.20.1 -> 3.0.0 ``                                               |
| [`26f20743`](https://github.com/NixOS/nixpkgs/commit/26f2074339b783fed498b3832b28cd404a428732) | `` python3Packages.slack-bolt: 1.27.0 -> 1.28.0 ``                                           |
| [`465c4687`](https://github.com/NixOS/nixpkgs/commit/465c4687aaf467ed3eac1273072de3c23b9a668d) | `` vscode-extensions.james-yu.latex-workshop: 10.13.1 -> 10.14.1 ``                          |
| [`5dc59002`](https://github.com/NixOS/nixpkgs/commit/5dc59002fdc3c6cd8bce6103f31ea88e906a3e1e) | `` python312Packages.mobi: exclude standard-imghdr to fix build ``                           |
| [`0786ca53`](https://github.com/NixOS/nixpkgs/commit/0786ca530cca0778f83ee7bc04ace3f483a75cf1) | `` qownnotes: 26.4.4 -> 26.4.11 ``                                                           |
| [`fb249ab3`](https://github.com/NixOS/nixpkgs/commit/fb249ab3909e4482502a60bc3f704b0904e0b59c) | `` flood: 4.13.0 -> 4.13.9 ``                                                                |
| [`85a50950`](https://github.com/NixOS/nixpkgs/commit/85a509502df8222c6116a333a68f6748d80bb9ea) | `` Revert #481473 "nixos/network-interfaces: remove network-setup" ``                        |
| [`219c4e5b`](https://github.com/NixOS/nixpkgs/commit/219c4e5b4a0ebe1057664fbcf5ac3fe4ca5c46bd) | `` cargo-binstall: 1.17.9 -> 1.18.0 ``                                                       |
| [`cc4c73ec`](https://github.com/NixOS/nixpkgs/commit/cc4c73ecfa36cf3beb900603b8efaafd3441af3e) | `` cargo-crev: 0.26.5 -> 0.27.1 ``                                                           |
| [`58d94653`](https://github.com/NixOS/nixpkgs/commit/58d94653f27da69eaa8a5fedf97a9c9397c821c3) | `` cloudfox: 2.0.1 -> 2.0.2 ``                                                               |
| [`77e90496`](https://github.com/NixOS/nixpkgs/commit/77e9049646721bc67ef47109fc1595d4f987daa1) | `` htop: 3.4.1 -> 3.5.0 ``                                                                   |
| [`ae519751`](https://github.com/NixOS/nixpkgs/commit/ae519751731ac34f009a68b3c7cc47e0da01d36d) | `` teams-for-linux: 2.7.13 -> 2.8.0 ``                                                       |
| [`1d4bf652`](https://github.com/NixOS/nixpkgs/commit/1d4bf652382ffd11af62d7cff944aaa255736efe) | `` neovim-unwrapped: enable treesitter tests ``                                              |
| [`ec5cd4a2`](https://github.com/NixOS/nixpkgs/commit/ec5cd4a2ce057cd7a9f34977af811eb577a9370d) | `` vscode-extensions.ms-vsliveshare.vsliveshare: 1.1.119 -> 1.1.122 ``                       |
| [`1b73d57a`](https://github.com/NixOS/nixpkgs/commit/1b73d57a6a28f91bb031fb59e1da98cc76e8b08c) | `` python3Packages.manifestoo-core: 1.15 -> 1.15.1 ``                                        |
| [`adccbb0b`](https://github.com/NixOS/nixpkgs/commit/adccbb0bcf813bf3526c9680da7373d9541b0ada) | `` flowblade: 2.24 -> 2.24.1 ``                                                              |
| [`9240373d`](https://github.com/NixOS/nixpkgs/commit/9240373d7d04c645abf7b849b00b1d4ce26ca218) | `` androidStudioPackages.canary: 2025.3.4.3 -> 2025.3.4.4 ``                                 |
| [`45f86eec`](https://github.com/NixOS/nixpkgs/commit/45f86eec6fa2d00563eb6ce7a561a8565acd3552) | `` open-policy-agent: 1.15.1 -> 1.15.2 ``                                                    |
| [`d5f00d36`](https://github.com/NixOS/nixpkgs/commit/d5f00d36a75444426aef6cac26d3fae80a57cfbe) | `` python3Packages.mwxml: 0.3.6 -> 0.3.8 ``                                                  |
| [`fc26589d`](https://github.com/NixOS/nixpkgs/commit/fc26589de9ceadf556f14baec218fc2eeb6cbdfd) | `` python3Packages.para: cleanup, disable tests on python>=3.14 ``                           |
| [`1e7184f7`](https://github.com/NixOS/nixpkgs/commit/1e7184f71ce667bc81d554ef0559975055faa1fd) | `` kubecolor: 0.5.3 -> 0.6.0 ``                                                              |
| [`97201731`](https://github.com/NixOS/nixpkgs/commit/9720173123a260bcb8b8f95e1d36f666669d2180) | `` emacs: update vendored patch for Emacs bug#77143 and bug#80744 ``                         |
| [`9d10842e`](https://github.com/NixOS/nixpkgs/commit/9d10842ede7d11dc1545467f9fcdd0381062f951) | `` emacs.pkgs.p4-16-mode: remove unneeded override ``                                        |
| [`f7afb1dc`](https://github.com/NixOS/nixpkgs/commit/f7afb1dc30fbf9ad7026a9f137eebbadc4e94ba4) | `` sdformat: init at 0.2.0 ``                                                                |
| [`1e899f19`](https://github.com/NixOS/nixpkgs/commit/1e899f1972ecada32108eed16eadce33fb39af63) | `` urxvt-tabbedex: 22.32 → 26.16.1 ``                                                        |
| [`eacf9868`](https://github.com/NixOS/nixpkgs/commit/eacf986823ddcb7069ac6f5330cc05690e553f46) | `` open5gs: 2.7.6 -> 2.7.7 ``                                                                |
| [`45417ace`](https://github.com/NixOS/nixpkgs/commit/45417ace406a30ac7a3cf08714686f1101978cd4) | `` python3Packages.fastcore: 1.12.34 -> 1.12.38 ``                                           |
| [`d8a4c4c0`](https://github.com/NixOS/nixpkgs/commit/d8a4c4c0ce208cf6d9a51324ae50bd8e668f8fd1) | `` prometheus-influxdb-exporter: 0.12.0 -> 0.12.1 ``                                         |
| [`f3916ccf`](https://github.com/NixOS/nixpkgs/commit/f3916ccf4c4140dfa1d60f22e29e57494f64daa2) | `` slidev-cli: 52.14.1 -> 52.14.2 ``                                                         |
| [`54e01739`](https://github.com/NixOS/nixpkgs/commit/54e017393240a419ba948afdc12724edb22429a8) | `` renode-unstable: 1.16.1-unstable-2026-04-03 -> 1.16.1-unstable-2026-04-12 ``              |
| [`8c4a5631`](https://github.com/NixOS/nixpkgs/commit/8c4a563166c453bb40e8055837d8518edebeea6b) | `` seconlay: 0-unstable-2026-03-31 -> 0-unstable-2026-04-10 ``                               |
| [`8bf079b9`](https://github.com/NixOS/nixpkgs/commit/8bf079b97841efde1baff697d6a7777cdd40575f) | `` alt-tab-macos: 10.4.0 -> 10.11.0 ``                                                       |
| [`556d69a1`](https://github.com/NixOS/nixpkgs/commit/556d69a161ebf5f3d7e067593f60dc9f49f83238) | `` pkgsite: 0-unstable-2026-04-02 -> 0-unstable-2026-04-10 ``                                |
| [`8ff3f614`](https://github.com/NixOS/nixpkgs/commit/8ff3f614c8d94cb3a8dc027152712bd6fef526d7) | `` python3Packages.coqpit: 0.2.4 -> 0.2.5 ``                                                 |
| [`5084388d`](https://github.com/NixOS/nixpkgs/commit/5084388d89b318442631c425514e34f93f026a57) | `` julia: build from source for aarch64-darwin ``                                            |
| [`795b04ad`](https://github.com/NixOS/nixpkgs/commit/795b04adb7cf0d3d36e80d10745ff657c5b81d58) | `` bilibili: 1.17.5-2 -> 1.17.6-1 ``                                                         |
| [`2bb029a3`](https://github.com/NixOS/nixpkgs/commit/2bb029a32db8cf23d0b3ea79e1f90ec2e44597aa) | `` golazo: Set __structuredAttrs to true ``                                                  |
| [`c475ea54`](https://github.com/NixOS/nixpkgs/commit/c475ea546779900919c3648ae2fb3e2d8c6fdf3a) | `` vimPlugins.git-dev-nvim: init at 0.11.0-unstable-2026-04-11 ``                            |
| [`693aa3b7`](https://github.com/NixOS/nixpkgs/commit/693aa3b72d216b71865977cb447297186d52a5f4) | `` grafanaPlugins.volkovlabs-variable-panel: 5.1.1 -> 5.1.2 ``                               |
| [`41f18dfe`](https://github.com/NixOS/nixpkgs/commit/41f18dfebdfb60e4e56dfbdaf9deebed17c4b707) | `` gaphor: 3.2.0 -> 3.3.0 ``                                                                 |
| [`77fe85fa`](https://github.com/NixOS/nixpkgs/commit/77fe85fa7c49a5359502372c572b9b78246b5ed8) | `` iotas: 2026.4 -> 2026.5 ``                                                                |
| [`16410a38`](https://github.com/NixOS/nixpkgs/commit/16410a38545a469d2da9d938af10d52cc094f4fc) | `` cotp: 1.9.7 -> 1.9.9 ``                                                                   |
| [`1575fffe`](https://github.com/NixOS/nixpkgs/commit/1575fffe38bf916e5d747251db663db898836091) | `` nexttrace: 1.6.1 -> 1.6.2 ``                                                              |
| [`b2cef5e3`](https://github.com/NixOS/nixpkgs/commit/b2cef5e32f0811f748d5a41dbd1652aae18638a9) | `` iio-sensor-proxy: 3.8 -> 3.9 ``                                                           |
| [`f8658cdd`](https://github.com/NixOS/nixpkgs/commit/f8658cdda3cc3bc0253adbf8cce7eda66e2315c7) | `` nixosTests.porxie: init ``                                                                |
| [`61236303`](https://github.com/NixOS/nixpkgs/commit/612363033c4f69c85a31fb7de27e472e1ef47b6d) | `` nixos/porxie: init ``                                                                     |
| [`ec42c4aa`](https://github.com/NixOS/nixpkgs/commit/ec42c4aa6f224da6c7ef89c4f8c795c7d932316f) | `` dotenvx: 1.59.1 -> 1.61.0 ``                                                              |
| [`23f0f8ca`](https://github.com/NixOS/nixpkgs/commit/23f0f8cacf3d8d6b8beb09ce7f994ed39b51d68d) | `` dockerTools: fix failing `etc` test case ``                                               |
| [`27effc2a`](https://github.com/NixOS/nixpkgs/commit/27effc2ab62a31ec6d03bc113c524dc3d48c6492) | `` easyeda2kicad: 0.8.0 -> 1.0.1 ``                                                          |
| [`df4ce0a8`](https://github.com/NixOS/nixpkgs/commit/df4ce0a827ed3d3b26fb8562668f23a9fd23f298) | `` python3Packages.textual-image: 0.8.5 -> 0.11.0 ``                                         |
| [`8682852a`](https://github.com/NixOS/nixpkgs/commit/8682852a4d931f83e433bb7af2401e553a8e7277) | `` porxie: init at 0.1.0 ``                                                                  |
| [`525c398b`](https://github.com/NixOS/nixpkgs/commit/525c398bd838b86a8f8d85767a5ee1e6cde31f4e) | `` fresh-editor: 0.2.21 -> 0.2.23 ``                                                         |
| [`11c097c1`](https://github.com/NixOS/nixpkgs/commit/11c097c1ff4b909ef04176c8405c14e6bb314107) | `` pythonPackages.certipy: relax beautifulsoup4 ``                                           |
| [`d226092c`](https://github.com/NixOS/nixpkgs/commit/d226092cf26a0672d371f91d012e7c669bf9d4db) | `` flyctl: 0.4.29 -> 0.4.33 ``                                                               |
| [`8a53f019`](https://github.com/NixOS/nixpkgs/commit/8a53f0196aebd71cc61d708702fa09c2b1a1288d) | `` vscode-extensions.teabyii.ayu: 1.1.11 -> 1.1.12 ``                                        |
| [`09d662e7`](https://github.com/NixOS/nixpkgs/commit/09d662e78e7003e9826b83ae142cc2b5898ca6ed) | `` cantus: 0.6.3 -> 0.6.4 ``                                                                 |
| [`538571f6`](https://github.com/NixOS/nixpkgs/commit/538571f67be6bd60a546859f8bdd2500fdc6de3e) | `` home-assistant-cli: 0.9.6 -> 1.0.0 ``                                                     |
| [`c9baf8b2`](https://github.com/NixOS/nixpkgs/commit/c9baf8b27b3e1114b13b6406d58e1f6c500eae30) | `` neovim.tests: test plugin lua config is loaded ``                                         |
| [`ba00f7e4`](https://github.com/NixOS/nixpkgs/commit/ba00f7e4bfad1c1eceb30556676f637088094027) | `` neovim.tests: cleanup  ``                                                                 |
| [`1d355385`](https://github.com/NixOS/nixpkgs/commit/1d3553857b9cc56a46220adc9161c94030c533a3) | `` neovim: support per plugin lua config ``                                                  |
| [`a4c8ee22`](https://github.com/NixOS/nixpkgs/commit/a4c8ee22d570d7c56075799ef2ff652374a04aab) | `` ukmm: 0.15.0 -> 0.17.0 ``                                                                 |
| [`d27ee915`](https://github.com/NixOS/nixpkgs/commit/d27ee91503f3330695c2d132a4ae40aac7cd7140) | `` lazycommit: use finalAttrs ``                                                             |
| [`8f9b1830`](https://github.com/NixOS/nixpkgs/commit/8f9b18302fd51c1e4a12be6848baeb02c3549106) | `` lazycommit: 1.4.0 -> 1.4.2 ``                                                             |
| [`d7378931`](https://github.com/NixOS/nixpkgs/commit/d73789314a326c3ef4788f443e22a22d345bd510) | `` libretro.beetle-pce: 0-unstable-2025-06-22 -> 0-unstable-2026-04-11 ``                    |
| [`8f240b05`](https://github.com/NixOS/nixpkgs/commit/8f240b059484b4a6d190cc9ef791b782e27e2930) | `` postgresqlPackages.system_stats: fix meta.changelog ``                                    |
| [`4120bb72`](https://github.com/NixOS/nixpkgs/commit/4120bb72dfc4bc33d168ead00a89f8fec205654d) | `` xpipe: 22.5 -> 22.9 ``                                                                    |
| [`2075b976`](https://github.com/NixOS/nixpkgs/commit/2075b976011c50d9e56e1933533c9f52971491f9) | `` vimPlugins.zen-nvim: init at 0-unstable-2026-04-12 ``                                     |
| [`b6391da5`](https://github.com/NixOS/nixpkgs/commit/b6391da51aab189934d4396a861792a05caeb378) | `` apidog: 2.8.23 -> 2.8.24 ``                                                               |
| [`3646f370`](https://github.com/NixOS/nixpkgs/commit/3646f370db7099968e4460db6f1607b81eda283d) | `` cliamp: 1.34.0 -> 1.35.0 ``                                                               |
| [`eff8aa55`](https://github.com/NixOS/nixpkgs/commit/eff8aa55f99b8f88ae79337e65c4398e4b466efc) | `` gnomeExtensions.systemd-manager: 19 -> 20 ``                                              |
| [`91c8e3be`](https://github.com/NixOS/nixpkgs/commit/91c8e3bebaa66e5b5ec3f00e5e04baf99d8e3b63) | `` serverpod_cli: 3.4.5 -> 3.4.6 ``                                                          |
| [`1db9b514`](https://github.com/NixOS/nixpkgs/commit/1db9b514997abd54174dab90fa40bddcebcf04c4) | `` models-dev: 0-unstable-2026-04-04 -> 0-unstable-2026-04-11 ``                             |
| [`5d62335e`](https://github.com/NixOS/nixpkgs/commit/5d62335e5a0b922263a86140e9aede76f6434182) | `` prometheus-node-exporter: 1.11.0 -> 1.11.1 ``                                             |
| [`bc38febc`](https://github.com/NixOS/nixpkgs/commit/bc38febc42278a4570f08c6f1d2467eddeb6498f) | `` linode-cli: removed deprecated terminaltables dependency ``                               |
| [`0916cfa7`](https://github.com/NixOS/nixpkgs/commit/0916cfa76520f88c3f274e19d13da4bbcb750b17) | `` nvc: 1.19.3 -> 1.20.0 ``                                                                  |
| [`199e7de1`](https://github.com/NixOS/nixpkgs/commit/199e7de1d94c195fa5c87a619c00df42c57d4e06) | `` nomore403: 1.3.0 -> 1.4.0 ``                                                              |
| [`ec750433`](https://github.com/NixOS/nixpkgs/commit/ec7504335125e698b92caf660106508e52fac8ce) | `` coc-rust-analyzer: 0-unstable-2026-04-01 -> 0-unstable-2026-04-09 ``                      |
| [`6b9de8a5`](https://github.com/NixOS/nixpkgs/commit/6b9de8a599f7e5c4849d74a25f5594b713527785) | `` engauge-digitizer: refactor derivation ``                                                 |
| [`f4d38218`](https://github.com/NixOS/nixpkgs/commit/f4d382182afdf082480c68effc51ce590249eb56) | `` engauge-digitizer: migrate to by-name ``                                                  |
| [`b6c52b0b`](https://github.com/NixOS/nixpkgs/commit/b6c52b0be225f675ac2e4a055399965b6aaa3ee0) | `` firebird-emu: switch from rev to tag ``                                                   |
| [`f1546d06`](https://github.com/NixOS/nixpkgs/commit/f1546d06900f5c3d1d74baa0e9cd112006373264) | `` firebird-emu: migrate to by-name ``                                                       |
| [`06fe5b6c`](https://github.com/NixOS/nixpkgs/commit/06fe5b6cf5d63381027614f8cdde86f8b55f7874) | `` evcc: 0.304.2 -> 0.304.3 ``                                                               |
| [`a054da44`](https://github.com/NixOS/nixpkgs/commit/a054da4484c2dfad71636bfa948a4330ff70dbcb) | `` coolreader: modernize derivation ``                                                       |
| [`7a2c5f00`](https://github.com/NixOS/nixpkgs/commit/7a2c5f004c0de9c525f50da93adfad46d4b4c61f) | `` coolreader: migrate to by-name ``                                                         |
| [`3f3c35a6`](https://github.com/NixOS/nixpkgs/commit/3f3c35a6fb2ddc57a5303cdb3afc704916061d79) | `` boomerang: modernize derivation ``                                                        |
| [`f957c839`](https://github.com/NixOS/nixpkgs/commit/f957c8396800f40b26c14c450340deb45472979f) | `` boomerang: migrate to by-name ``                                                          |
| [`48822319`](https://github.com/NixOS/nixpkgs/commit/4882231942db3d3d3c5b0157591066f96ffe62e5) | `` oxlint: 1.58.0 -> 1.59.0 ``                                                               |

*... and 1022 more commits (truncated)*