### PR TITLE
chore(flake/nixvim): `0a126932` -> `4f759924`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1187,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1774701658,
-        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
@@ -1352,11 +1352,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1776128025,
-        "narHash": "sha256-spZM5zll0cBPHHSZPioZREArzCsllurKQsJME08nnXY=",
+        "lastModified": 1776350339,
+        "narHash": "sha256-Rl+tnpvdpf66e/3m+LPNzUoebV3jpiJz7oMxas8FB3I=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0a12693297d23f1b3af04ba6112b5936e2eba41b",
+        "rev": "4f75992439d3d554a3681880510e4b645ca2d15b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`4f759924`](https://github.com/nix-community/nixvim/commit/4f75992439d3d554a3681880510e4b645ca2d15b) | `` tests/all-package-defaults: skip nushell on darwin (build failure) ``  |
| [`9ce71c12`](https://github.com/nix-community/nixvim/commit/9ce71c12c108c07248e406b265fd3c8e1268e63b) | `` tests/platforms: explicitly set fsType ``                              |
| [`cfd83c77`](https://github.com/nix-community/nixvim/commit/cfd83c774bc4c2e70f363d4c4eda556832763277) | `` lsp/servers: mark csskit as unpackaged ``                              |
| [`f3a77183`](https://github.com/nix-community/nixvim/commit/f3a771830d6a7a70e55868171dbd37d4721f17e2) | `` tests/colorschemes/palette: disable test.runNvim ``                    |
| [`8d55155d`](https://github.com/nix-community/nixvim/commit/8d55155d8246741bceb90ee369a0058a29c24091) | `` tests/plugins/llm: disable test.runNvim ``                             |
| [`fbe196f0`](https://github.com/nix-community/nixvim/commit/fbe196f0267c3fb6b5cdb329dd312b7e98013a52) | `` tests/plugins/sg: disable test.runNvim as an auth token is required `` |
| [`e306ab3a`](https://github.com/nix-community/nixvim/commit/e306ab3ad484aae37688c2838b8ae905caee96ab) | `` flake/dev: lock nuscht-search version ``                               |
| [`9336455b`](https://github.com/nix-community/nixvim/commit/9336455b20bcdabbb76292f86bf994e1b7c54ced) | `` treewide: migrate away from removed nodePackages ``                    |
| [`c12d3867`](https://github.com/nix-community/nixvim/commit/c12d3867715c3e7042ae4273a62f1dea469bd3a4) | `` generated: Updated lspconfig-servers.json ``                           |
| [`3e62b906`](https://github.com/nix-community/nixvim/commit/3e62b9064f3ab0ee6aeb18782e78458994105828) | `` flake: Update ``                                                       |