### PR TITLE
chore(flake/niri): `cf9d440b` -> `7d67b9d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1034,11 +1034,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1776278082,
-        "narHash": "sha256-6/S3eqSEcZ26ii5W6+w9UfYgwsmFlJr61/25XZB+tcA=",
+        "lastModified": 1776368615,
+        "narHash": "sha256-JGGdvn645wseAbRzwT/Zz2Y0na7v2FZ7FogIyKIFkk8=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "cf9d440b4dd24ebf1e3b69b6144f1ae17a9224b2",
+        "rev": "7d67b9d0857c7efc7a6f9fc70982bdcb1e3d9a88",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1776252914,
-        "narHash": "sha256-251qX0g75KcVtwCckXiOiqc+4VleJBDfiHiZ9v1c8Ro=",
+        "lastModified": 1776363469,
+        "narHash": "sha256-MH7ieeYawsCAjGkoHFZfUDZXplEOiFgSpx2pGr5RK3c=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "4d214891017fa7b893df1140d24f76defba0eb88",
+        "rev": "82d4c7569e731379284e0653dcdadb8f17cceec7",
         "type": "github"
       },
       "original": {
@@ -1139,11 +1139,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1776067740,
-        "narHash": "sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ=",
+        "lastModified": 1776221942,
+        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e495b747b51f95ae15e74377c5ce1fe69c1765f",
+        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`7d67b9d0`](https://github.com/sodiboo/niri-flake/commit/7d67b9d0857c7efc7a6f9fc70982bdcb1e3d9a88) | `` Update flake.lock `` |
| [`3b04bfc7`](https://github.com/sodiboo/niri-flake/commit/3b04bfc7457cf40a212ae9de02b972e95f83d920) | `` Update flake.lock `` |
| [`f273e140`](https://github.com/sodiboo/niri-flake/commit/f273e1406713b729e02e419d31c48200a285fac1) | `` Update flake.lock `` |
| [`3877b9fd`](https://github.com/sodiboo/niri-flake/commit/3877b9fd1f78e831b3ea223f9e992c758d13df0f) | `` Update flake.lock `` |
| [`086715f2`](https://github.com/sodiboo/niri-flake/commit/086715f219fdcf2420f39f76f9a38aac04dd5348) | `` Update flake.lock `` |
| [`e64a8f7f`](https://github.com/sodiboo/niri-flake/commit/e64a8f7f8f904f8371a3b925037bf2b0f9f9cb82) | `` Update flake.lock `` |