### PR TITLE
chore(flake/freminal): `785dace2` -> `eb286779`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,14 +513,15 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "precommit": "precommit_3"
+        "precommit": "precommit_3",
+        "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1776223814,
-        "narHash": "sha256-ffHCcIdNLHGh7TNcrjB01bhnA7YuAfGSWrll+DkSjFM=",
+        "lastModified": 1776438868,
+        "narHash": "sha256-olSO/R4m14Nivp9aw59bkm3neSCMAqr8b9maGcXBB80=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "785dace2b85f34209f0bb259fb78af2c8e732a99",
+        "rev": "eb286779f2939779ebe51d78a27465235c590bbd",
         "type": "github"
       },
       "original": {
@@ -1283,11 +1284,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -1409,7 +1410,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_4"
+        "rust-overlay": "rust-overlay_5"
       },
       "locked": {
         "lastModified": 1776356478,
@@ -1457,11 +1458,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1776180412,
-        "narHash": "sha256-i/rUOrl2y7f1pHjkKC2VZlltHEpyj76osI6Ad5xaINc=",
+        "lastModified": 1776356478,
+        "narHash": "sha256-F8tgeptiO/pEewoVR94GGQCCoaEUKTCin5XHITqkwgM=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "d48771750f19b0b0b74d6d1029cacb073c84f3d9",
+        "rev": "bd6364c9469a46d993e3877ee847f091cbe0916a",
         "type": "github"
       },
       "original": {
@@ -1535,11 +1536,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1776136407,
-        "narHash": "sha256-Cp8XrVLGruSDBTRs8L4LmvaEcd76tHHU9esLk7Ysa4E=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "753568957a87312ed599cba5699e67126eded6c0",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {
@@ -1549,6 +1550,27 @@
       }
     },
     "rust-overlay_4": {
+      "inputs": {
+        "nixpkgs": [
+          "freminal",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776395632,
+        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_5": {
       "inputs": {
         "nixpkgs": "nixpkgs_12"
       },


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`eb286779`](https://github.com/fredsystems/freminal/commit/eb286779f2939779ebe51d78a27465235c590bbd) | `` fix: use rust-overlay for package build to satisfy MSRV 1.95 ``                                      |
| [`b83575e1`](https://github.com/fredsystems/freminal/commit/b83575e13e2c1c481fdd8afb22287b63d6f40cff) | `` cargo version bump ``                                                                                |
| [`fdcbe1b6`](https://github.com/fredsystems/freminal/commit/fdcbe1b627e9af5bb2aa18c8a864694cb609e15c) | `` bump version ``                                                                                      |
| [`02d54dcf`](https://github.com/fredsystems/freminal/commit/02d54dcf7457c9713e7c6053c47c692b4b575de5) | `` fix: scope settings modal to the window that opened it ``                                            |
| [`8093eed1`](https://github.com/fredsystems/freminal/commit/8093eed1ff1024e8c9ae1a98e4bfe284f02f51b8) | `` fix: apply window icon to winit windows ``                                                           |
| [`9eb76f52`](https://github.com/fredsystems/freminal/commit/9eb76f52dac46076f5184515bb763a87b94c46ff) | `` fix: correct InputEvent::Resize args and clamp initial size to >= 1 ``                               |
| [`56d8a691`](https://github.com/fredsystems/freminal/commit/56d8a691d85c4f01ea9b7450761d5b566aa528b5) | `` fix: 67 — pass actual window size to PTY on spawn instead of 100x100 ``                              |
| [`a9ce7ebf`](https://github.com/fredsystems/freminal/commit/a9ce7ebfc80e58bf372c83550b690127f8dcf9a3) | `` docs: mark Tasks 65 and 66 complete in plan documents ``                                             |
| [`8b0311ff`](https://github.com/fredsystems/freminal/commit/8b0311ff5b29808557354b69fddac6f730188ce1) | `` feat: 65 + 66 — remove eframe dependency, clean up stale references ``                               |
| [`399c9005`](https://github.com/fredsystems/freminal/commit/399c90053bcc3a4f040cac5aeb4f0275625a2392) | `` docs: add Task 67 (window spawn truncation diagnostic), defer from Task 64 ``                        |
| [`ccbac276`](https://github.com/fredsystems/freminal/commit/ccbac276ba279f04fed67e2b54894ed922dfbf18) | `` fix: make GL context current before rendering each window ``                                         |
| [`640ddcfb`](https://github.com/fredsystems/freminal/commit/640ddcfb69581fc28131d1e53d99f0ce138a3645) | `` docs: mark Task 64 complete in plan documents ``                                                     |
| [`63b9a68e`](https://github.com/fredsystems/freminal/commit/63b9a68e4418a5c0752c006c08134c80049e89c9) | `` feat: 64 — multi-window parity with per-window state split ``                                        |
| [`8c380589`](https://github.com/fredsystems/freminal/commit/8c3805891f8e26f0bae40a7b75fe0d07a7d6b7e5) | `` feat: 63 — migrate freminal from eframe to freminal-windowing ``                                     |
| [`b147b963`](https://github.com/fredsystems/freminal/commit/b147b9631fd6205e4e3ba4960a2caafe2ac1a869) | `` feat: 62 — add freminal-windowing crate with winit + glutin + egui integration ``                    |
| [`d1137344`](https://github.com/fredsystems/freminal/commit/d11373445a873e068d03ba55deb469391ca68fd2) | `` docs: renumber v0.6.0 (Foundation) and v0.7.0 (Replay & Layouts) ``                                  |
| [`4defb5a0`](https://github.com/fredsystems/freminal/commit/4defb5a019690006a5be32af5174f93676e6f088) | `` docs: swap v0.7.0 before v0.6.0, add child window spawn bug note to Task 64 ``                       |
| [`024924fb`](https://github.com/fredsystems/freminal/commit/024924fb89dc808265d0ef09ebe539d314ca56f8) | `` fix: remap cursor through reflow + repaint child viewports on root frame ``                          |
| [`d82c2e8c`](https://github.com/fredsystems/freminal/commit/d82c2e8c5d7c6d0b63857c665462d11047b31349) | `` refactor: bump MSRV to 1.95.0, fix new clippy lints, adopt if-let guards ``                          |
| [`2fb4062f`](https://github.com/fredsystems/freminal/commit/2fb4062f296fe4a48a97fdedd3d3a8ee7db4d8b7) | `` update flake ``                                                                                      |
| [`1d435d28`](https://github.com/fredsystems/freminal/commit/1d435d2849d504a4164a8b13d1502c21dcd5a721) | `` fix: merge duplicate permissions blocks in ci.yml ``                                                 |
| [`b2ca6b42`](https://github.com/fredsystems/freminal/commit/b2ca6b42a7e22883ccd441573a453507edf00c23) | `` docs: add v0.7.0 to MASTER_PLAN.md — tasks 62-66, dependency graph, execution order ``               |
| [`d8dcf5ee`](https://github.com/fredsystems/freminal/commit/d8dcf5ee56f483e2dda36674de9bb59d23b8330c) | `` fix: address PR review — remove unused param, merge racy tests, fix axis swap ``                     |
| [`1bf0e7cf`](https://github.com/fredsystems/freminal/commit/1bf0e7cf5de0faac93202e9e96e3692501c4aeaa) | `` docs: mark Task 53 (Multiple Windows) complete in plan documents ``                                  |
| [`b5952ef9`](https://github.com/fredsystems/freminal/commit/b5952ef96376cea9f67c88a7344434443009a2d6) | `` fix: replace broken root-hidden coordinator with close-all confirmation dialog ``                    |
| [`5d79c17c`](https://github.com/fredsystems/freminal/commit/5d79c17ccb7c62ddac2a9bfac4e0401f312a6e1e) | `` refactor: split gui/mod.rs into focused submodules (actions, menu, rendering, hot_reload, window) `` |
| [`53f8a206`](https://github.com/fredsystems/freminal/commit/53f8a206c44cec1cb3a1ffaa8e5bb1ff7dec370b) | `` fix: multi-window bug fixes — shaders, bg images, opacity, close behavior ``                         |
| [`18773ecb`](https://github.com/fredsystems/freminal/commit/18773ecbee01831b9e50c887d4bcce5f7d6b16f2) | `` feat: 53.1 + 53.3–53.7 — multiple OS windows via egui deferred viewports ``                          |
| [`113cbc7c`](https://github.com/fredsystems/freminal/commit/113cbc7cfae64701acf10a9eee7317a29ee70fc9) | `` Configure Dependabot for Cargo package updates ``                                                    |
| [`fcb3bb9d`](https://github.com/fredsystems/freminal/commit/fcb3bb9d10477b759c8bff2303fe46014b05dc68) | `` chore(deps): update softprops/action-gh-release action to v3 ``                                      |
| [`7c38d1ca`](https://github.com/fredsystems/freminal/commit/7c38d1cae4d6b32dc430066efb7a5e7127353a43) | `` Potential fix for code scanning alert no. 24: Workflow does not contain permissions ``               |
| [`35b2cba6`](https://github.com/fredsystems/freminal/commit/35b2cba68235280342117efd9dd43a6189c50b2a) | `` Potential fix for code scanning alert no. 16: Workflow does not contain permissions ``               |
| [`081dabf3`](https://github.com/fredsystems/freminal/commit/081dabf30ec20c02efd94774e67c5ad41dd478f2) | `` chore(deps): update taiki-e/install-action action to v2.75.14 ``                                     |
| [`c0da6cd9`](https://github.com/fredsystems/freminal/commit/c0da6cd9984b3f3077be436aef770fd405e75527) | `` chore(deps): update softprops/action-gh-release digest to 3bb1273 ``                                 |
| [`1ee344ae`](https://github.com/fredsystems/freminal/commit/1ee344ae0e21f962b970547b1ace996bbbae7d8e) | `` chore(deps): update actions/cache digest to 27d5ce7 ``                                               |