### PR TITLE
chore(flake/nixpkgs-stable): `7e495b74` -> `1766437c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1155,11 +1155,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1776067740,
-        "narHash": "sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ=",
+        "lastModified": 1776221942,
+        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7e495b747b51f95ae15e74377c5ce1fe69c1765f",
+        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`947d33a7`](https://github.com/NixOS/nixpkgs/commit/947d33a7093a7d565e34a4e5534f4e7113892f7e) | `` xbyak: 7.35.4 -> 7.36 ``                                                                     |
| [`4196f336`](https://github.com/NixOS/nixpkgs/commit/4196f336fabbb76ab52eaf2ff97fb3fc81507293) | `` nss_latest: 3.122 -> 3.122.1 ``                                                              |
| [`44218d25`](https://github.com/NixOS/nixpkgs/commit/44218d2539f50d96a36d720bdbc4943ccf33935d) | `` wivrn: add libSDL2 and libudev to library path for lighthouse driver ``                      |
| [`8e014496`](https://github.com/NixOS/nixpkgs/commit/8e01449668f7c4b68746d1b3879971873f83c484) | `` xwayland: 24.1.9 -> 24.1.10 ``                                                               |
| [`c93e2a21`](https://github.com/NixOS/nixpkgs/commit/c93e2a21af352cf490f6a53e3a50d9a7b9c6af9e) | `` immich: 2.7.4 -> 2.7.5 ``                                                                    |
| [`a35306aa`](https://github.com/NixOS/nixpkgs/commit/a35306aa91b2cd39aa42a54d5b3f8211fb709dca) | `` gitlab-runner: 18.9.0 -> 18.10.1 ``                                                          |
| [`ef26a1e7`](https://github.com/NixOS/nixpkgs/commit/ef26a1e749c463c9117edf8124efa0077bf30a4d) | `` apacheHttpdPackages.php: 8.4.19 -> 8.4.20 ``                                                 |
| [`72404a3c`](https://github.com/NixOS/nixpkgs/commit/72404a3c079c0f7267f8e8841f86372f351a5559) | `` ed-odyssey-materials-helper: disable/hide features not working in open source build ``       |
| [`fb703640`](https://github.com/NixOS/nixpkgs/commit/fb7036401fd9c1ffe3985c384bafac4adca33a7a) | `` ed-odyssey-materials-helper: 3.1.12 -> 3.6.6 ``                                              |
| [`a78b0c95`](https://github.com/NixOS/nixpkgs/commit/a78b0c95fa37d77fb9f3e6389653236dac2c7f1a) | `` forgejo: backport patch for flaky TestBleveDeleteIssue test from v15 ``                      |
| [`3be4b81f`](https://github.com/NixOS/nixpkgs/commit/3be4b81fce047243dfd75200fdefc9131c22a9b8) | `` darwin.ICU: avoid conflicts with the system libicucore ``                                    |
| [`76306e8f`](https://github.com/NixOS/nixpkgs/commit/76306e8f29326fdf780f34fc1004cd6564e28530) | `` oauth2-proxy: 7.13.0 -> 7.15.2 ``                                                            |
| [`dbc28ec0`](https://github.com/NixOS/nixpkgs/commit/dbc28ec08af9f07afb59608cb1d31084e46a0738) | `` firefox-esr-140-unwrapped: 140.9.0esr -> 140.9.1esr ``                                       |
| [`ad3c3467`](https://github.com/NixOS/nixpkgs/commit/ad3c346713a4d676a7e9a5e9e34d40b364bb6144) | `` firefox-beta-unwrapped: 150.0b5 -> 150.0b9 ``                                                |
| [`5e87d0d9`](https://github.com/NixOS/nixpkgs/commit/5e87d0d969e9200fb3ab0da8a7587779c40a7b3f) | `` firefox-beta-unwrapped: 150.0b2 -> 150.0b5 ``                                                |
| [`e6153ceb`](https://github.com/NixOS/nixpkgs/commit/e6153ceb36b455f0d901fb2bb18d3130c37a2ef7) | `` signal-desktop: 8.6.0 -> 8.6.1 ``                                                            |
| [`aaab5313`](https://github.com/NixOS/nixpkgs/commit/aaab5313fac89c166f5bd95ce3184dd790afc955) | `` dprint-plugins.dprint-plugin-biome: 0.12.6 -> 0.12.7 ``                                      |
| [`47ecb1a6`](https://github.com/NixOS/nixpkgs/commit/47ecb1a6c0c0c153f001c8f9563670157c44abc7) | `` vivaldi: 7.9.3970.47 -> 7.9.3970.50 ``                                                       |
| [`cd48bae7`](https://github.com/NixOS/nixpkgs/commit/cd48bae79473557048ed33523534f7851d9a7f1f) | `` zipline: 4.5.2 -> 4.5.3 ``                                                                   |
| [`2c88127c`](https://github.com/NixOS/nixpkgs/commit/2c88127c968c876700c2040e766fbb4437da72ba) | `` keepassxc: 2.7.11 -> 2.7.12 ``                                                               |
| [`1193f04e`](https://github.com/NixOS/nixpkgs/commit/1193f04ee25743360820d61eab260c8400c4392f) | `` bird3: switch from rev to tag for src ``                                                     |
| [`5292e669`](https://github.com/NixOS/nixpkgs/commit/5292e66992785d0bd41ce612285cbd2ad9dc0a5e) | `` bird2: 2.18 -> 2.18.1 ``                                                                     |
| [`3a18f893`](https://github.com/NixOS/nixpkgs/commit/3a18f893b939c008f8d204ed13f50646b8caf60d) | `` ci/eval/compare: Expose attrdiff by kernel and platform ``                                   |
| [`d83e39a5`](https://github.com/NixOS/nixpkgs/commit/d83e39a5b68ef7f476f602d8e0ad06eec2f10ecc) | `` mediawiki: 1.44.3 -> 1.44.5 ``                                                               |
| [`892ea1cf`](https://github.com/NixOS/nixpkgs/commit/892ea1cf8e33c2f86f1223d9784b7786829b9176) | `` gleam: 1.15.2 -> 1.15.4 ``                                                                   |
| [`8d6eb9d6`](https://github.com/NixOS/nixpkgs/commit/8d6eb9d68c84e451b0058366e80c6497276d7ac4) | `` gleam: 1.15.1 -> 1.15.2 ``                                                                   |
| [`dcf12e5f`](https://github.com/NixOS/nixpkgs/commit/dcf12e5f73947399daa8d9739015b90dd2df334c) | `` gleam: 1.15.0 -> 1.15.1 ``                                                                   |
| [`a3385c44`](https://github.com/NixOS/nixpkgs/commit/a3385c4489986afb66d494c7c92671d49392c907) | `` gleam: 1.14.0 -> 1.15.0 ``                                                                   |
| [`a97dae28`](https://github.com/NixOS/nixpkgs/commit/a97dae28d279c56bcd29c83da2d531195d658565) | `` gleam: 1.13.0 -> 1.14.0 ``                                                                   |
| [`2aabb10a`](https://github.com/NixOS/nixpkgs/commit/2aabb10ada1165ec83c918f91fd13ae936caffac) | `` .github/labeler.yml, ci/OWNERS: update and sync linux kernel paths ``                        |
| [`c0761bb9`](https://github.com/NixOS/nixpkgs/commit/c0761bb96ea105dec861d65984f1006d00d860de) | `` juju: 3.6.11 -> 3.6.12 ``                                                                    |
| [`99b3f266`](https://github.com/NixOS/nixpkgs/commit/99b3f2662798a0acabf361117f065df07e3c8853) | `` lazyhetzner: 1.1.1 -> 1.2.0 ``                                                               |
| [`e6286448`](https://github.com/NixOS/nixpkgs/commit/e6286448b7ea081cd71ea31e6a0ce68f1bd24a44) | `` teams-for-linux: 2.7.13 -> 2.8.0 ``                                                          |
| [`2cc06622`](https://github.com/NixOS/nixpkgs/commit/2cc0662227c71e16ec749a19f4c49da03f2a588b) | `` python313Packages.pymupdf: 1.27.1 -> 1.27.2 ``                                               |
| [`a0c31cec`](https://github.com/NixOS/nixpkgs/commit/a0c31cecb30bd3f79af1257767a27c03e1a163ec) | `` python3Packages.pymupdf: 1.26.7 -> 1.27.1 ``                                                 |
| [`7a28869a`](https://github.com/NixOS/nixpkgs/commit/7a28869a65a06769bf95a95d132d81bb4d7b7212) | `` python3Packages.pymupdf: 1.26.6 -> 1.26.7 ``                                                 |
| [`880dfd96`](https://github.com/NixOS/nixpkgs/commit/880dfd9675274afdad0c0c49561893ced2b6a2de) | `` thunderbird-latest-bin-unwrapped: 149.0.1 -> 149.0.2 ``                                      |
| [`fa845eff`](https://github.com/NixOS/nixpkgs/commit/fa845effc3d13a96c701af2afbdb673e8140734b) | `` lightway: 0-unstable-2026-01-02 -> 0-unstable-2026-04-10 ``                                  |
| [`72c31f9f`](https://github.com/NixOS/nixpkgs/commit/72c31f9fa5fb6737ca0c40a8df208fad1eafac5a) | `` authelia: 4.39.12 -> 4.39.18 ``                                                              |
| [`2f306c3b`](https://github.com/NixOS/nixpkgs/commit/2f306c3b82e1838ea01a440eace3c74e77401ace) | `` authelia: migrate from fetcherVersion = 1 to fetcherVersion = 3 ``                           |
| [`1bc96f5f`](https://github.com/NixOS/nixpkgs/commit/1bc96f5fb9049d53b84efd5cae42884cefd06b85) | `` authelia: use buildGo125Module ``                                                            |
| [`5f1a2f9f`](https://github.com/NixOS/nixpkgs/commit/5f1a2f9ff3de6f30ec4345478d8e9c07593b9865) | `` authelia: move to pkgs/by-name ``                                                            |
| [`dc45e721`](https://github.com/NixOS/nixpkgs/commit/dc45e721b5650a2896205098d0d5e0ce976508b7) | `` fastcap: fix build with gcc15 ``                                                             |
| [`c0c9646d`](https://github.com/NixOS/nixpkgs/commit/c0c9646d4d1d53e3698676052be83df4e38c7e64) | `` element-{web,desktop}: 1.12.10 -> 1.12.14 ``                                                 |
| [`3ba7ad4b`](https://github.com/NixOS/nixpkgs/commit/3ba7ad4bdee922e3f73bf6d7734b35ec413d85b4) | `` firefox-devedition-unwrapped: 150.0b3 -> 150.0b7 ``                                          |
| [`bb991b33`](https://github.com/NixOS/nixpkgs/commit/bb991b3311e9bf087bcee74815632f5c44eacb8b) | `` nixos/collectd: allow accessing the final package with applied plugins and minimalPackage `` |
| [`0d1612c9`](https://github.com/NixOS/nixpkgs/commit/0d1612c9b1ca30c329cd4132118c2601fac69c4c) | `` collectd: remove ... from inputs ``                                                          |
| [`26b2338b`](https://github.com/NixOS/nixpkgs/commit/26b2338b2857cc6265c387dd0b3c148d2fa361e8) | `` openasar: 0-unstable-2026-03-04 -> 0-unstable-2026-03-28 ``                                  |
| [`1b6b6370`](https://github.com/NixOS/nixpkgs/commit/1b6b63700c8526b52c6a4bd01efd24d853a0fe39) | `` victoriametrics: use buildGo126Module on release-25.11 ``                                    |
| [`621b7807`](https://github.com/NixOS/nixpkgs/commit/621b7807fa908acc39f883eefdd9c6d83c94762e) | `` victoriametrics: 1.138.0 -> 1.139.0 ``                                                       |
| [`e768a382`](https://github.com/NixOS/nixpkgs/commit/e768a382000950072a478d2f59da30fe1137a6d2) | `` firefox-beta-unwrapped: 148.0b15 -> 150.0b2 ``                                               |
| [`4cbe1b67`](https://github.com/NixOS/nixpkgs/commit/4cbe1b6776df53e3520c6ca407b96a1e9324bfaf) | `` super-slicer: pick patch to drop unused ilmbase dependency ``                                |
| [`32202615`](https://github.com/NixOS/nixpkgs/commit/32202615f608c2fe36db4aed1ec1bbcf8afa1926) | `` prusa-slicer: pick patch to drop unused ilmbase dependency ``                                |
| [`3169c900`](https://github.com/NixOS/nixpkgs/commit/3169c9000b0fdba39b3dcd1b9f4a49d952daac99) | `` orca-slicer: pick patch to remove unused ilmbase dependency ``                               |
| [`09b087d8`](https://github.com/NixOS/nixpkgs/commit/09b087d8ee4af45a8585f598d2a92528cdec539e) | `` bambu-studio: drop unused ilmbase dependency ``                                              |
| [`fa8f163d`](https://github.com/NixOS/nixpkgs/commit/fa8f163d50204115eb03ef953c652ac04af6e7a5) | `` darktable: drop unused ilmbase dependency ``                                                 |
| [`82c19893`](https://github.com/NixOS/nixpkgs/commit/82c198935670413787d11f130091ef514327f8ab) | `` color-transformation-language: drop unused ilmbase dependency ``                             |
| [`65b5ca78`](https://github.com/NixOS/nixpkgs/commit/65b5ca78c213850c5c21719f128feb622e18f42d) | `` art: drop unused ilmbase dependency ``                                                       |
| [`792d56f2`](https://github.com/NixOS/nixpkgs/commit/792d56f29c4d1d5d3c0c552ff7b7ee249822cd93) | `` krita: remove ilmbase dependency to unbreak build ``                                         |
| [`1ba6fc7b`](https://github.com/NixOS/nixpkgs/commit/1ba6fc7be0ab0d25c06387179b95523f13a3bf14) | `` gegl: Switch to openexr v3 ``                                                                |
| [`baa655d5`](https://github.com/NixOS/nixpkgs/commit/baa655d555bbd3b8ca306a5acbe9b9ff1cf25ba9) | `` ilmbase: Repalce meta.insecure with meta.knownVulnerabilities ``                             |
| [`6144762b`](https://github.com/NixOS/nixpkgs/commit/6144762b570f9c87c92963b83b2e0d7f7386283d) | `` openexr_2: Replace meta.insecure with meta.knownVulnerabilities ``                           |
| [`46df6890`](https://github.com/NixOS/nixpkgs/commit/46df6890d97d0cd4bf6886d0145977dfd1edf5d6) | `` linuxPackages.openafs: Refresh patches from upstream Gerrit ``                               |
| [`a600e695`](https://github.com/NixOS/nixpkgs/commit/a600e69588e51c4806724a1cfcce973dd1b7adf1) | `` openafs: 1.8.14 → 1.8.15 ``                                                                  |
| [`d58ec3a3`](https://github.com/NixOS/nixpkgs/commit/d58ec3a3672d3f20062d9739128f25de1d3fb39d) | `` prismlauncher: add jdk25 support ``                                                          |