### PR TITLE
chore(flake/catppuccin): `2eefec08` -> `bdf0285d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776190523,
-        "narHash": "sha256-qfZWzaWuXfbF487cXj43uT7HWtqF45A+g7g59fOPYsk=",
+        "lastModified": 1776420287,
+        "narHash": "sha256-0P2QyDM8R1FFww//TNDLTRVnVkQxVdbEVQiVuyD1SqY=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "2eefec08414e2f90824bf2b508ea38ef6f295dfa",
+        "rev": "bdf0285dc7978ebd78b76054631d7ef05680895e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`bdf0285d`](https://github.com/catppuccin/nix/commit/bdf0285dc7978ebd78b76054631d7ef05680895e) | `` chore: update flakes (#892) ``       |
| [`8d8c7c7d`](https://github.com/catppuccin/nix/commit/8d8c7c7dd833d0dad96c402b92bb1a28e09bcc00) | `` chore: update port sources (#893) `` |