### PR TITLE
feat(darwin): self-hosted runners, attic cache, cross-platform CI

### DIFF
--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -292,11 +292,9 @@ jobs:
             substituters = http://192.168.31.14/fred https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0=
 
-      - name: Enable Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
-        with:
-          use-flakehub: false
-          use-gha-cache: false
+      # Magic Nix Cache is NOT used here — multiple self-hosted runners
+      # on the same machine fight over port 41239.  We push to Attic
+      # explicitly instead.
 
       - name: Build Darwin system
         shell: bash

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -44,22 +44,168 @@ jobs:
           fi
 
   # =====================================================================
-  # Discover Darwin systems
+  # Discover Darwin systems and detect what changed
   # =====================================================================
   find-darwin:
     name: Find Darwin systems
     runs-on: ubuntu-latest
     needs: [skip-if-clean]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }} # <-- works reliably now
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
 
     outputs:
       systems: ${{ steps.out.outputs.systems }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      # Detect which paths changed so we can scope builds to affected
+      # systems only.  Uses the same git-diff approach as ci-linux.yaml.
+      #
+      # When flake.lock changes, we parse the diff to determine which
+      # inputs actually changed and map them to darwin CI categories.
+      #
+      # Darwin input categories:
+      #   darwin       — rebuilds all darwin hosts
+      #   skip         — no darwin rebuild needed
+      #
+      # Any input used by darwin builds maps to "darwin" (rebuild all).
+      # Inputs only used by Linux (stable channel, niri, solaar, etc.)
+      # map to "skip".
+      - name: Detect changed paths
+        id: changes
+        if: github.event_name != 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          else
+            base_sha="${{ github.event.merge_group.base_sha }}"
+          fi
+
+          echo "Comparing ${base_sha}..HEAD"
+          changed_files=$(git diff --name-only "$base_sha" HEAD)
+          echo "Changed files:"
+          echo "$changed_files"
+
+          global=false
+          flake_lock_changed=false
+          machine_files_arr=()
+
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              flake.nix)
+                global=true ;;
+              flake.lock)
+                flake_lock_changed=true ;;
+              modules/*|profiles/*|home-profiles/*|dotfiles/*|overlays/*)
+                global=true ;;
+              features/*)
+                global=true ;;
+              .github/renovate.json5)
+                ;; # excluded
+              .github/workflows/ci-darwin.yaml)
+                global=true ;;
+              .github/*)
+                ;; # other CI/GH files don't affect darwin builds
+              hosts/darwin/*)
+                machine_files_arr+=("$file") ;;
+              hosts/linux/*|firmware.nix)
+                ;; # linux-only, skip
+            esac
+          done <<< "$changed_files"
+
+          # ----------------------------------------------------------------
+          # Input-aware flake.lock filtering for darwin
+          #
+          # Map each changed input to a darwin CI category.  Inputs used by
+          # darwin builds trigger a full rebuild; linux-only inputs are
+          # skipped.  Unknown inputs default to "darwin" (safe over-build).
+          # ----------------------------------------------------------------
+          if [ "$flake_lock_changed" = "true" ] && [ "$global" = "false" ]; then
+            echo ""
+            echo "flake.lock changed — parsing input diff..."
+
+            old_lock=$(git show "${base_sha}:flake.lock" 2>/dev/null || echo '{}')
+            new_lock=$(cat flake.lock)
+
+            # Associative array: input name → darwin CI category
+            declare -A input_category=(
+              [nixpkgs]="darwin"
+              [home-manager]="darwin"
+              [catppuccin]="darwin"
+              [sops-nix]="darwin"
+              [nixvim]="darwin"
+              [darwin]="darwin"
+              [freminal]="darwin"
+              [apple-fonts]="darwin"
+              [nixpkgs-stable]="skip"
+              [home-manager-stable]="skip"
+              [catppuccin-stable]="skip"
+              [sops-nix-stable]="skip"
+              [niri]="skip"
+              [fredbar]="skip"
+              [solaar]="skip"
+              [walls-catppuccin]="skip"
+              [nixos-needsreboot]="skip"
+              [colmena]="skip"
+              [flake-utils]="skip"
+              [precommit-base]="skip"
+            )
+
+            root_inputs=$(echo "$new_lock" | jq -r '.nodes.root.inputs | keys[]')
+
+            for input in $root_inputs; do
+              node_name=$(echo "$new_lock" | jq -r ".nodes.root.inputs.\"$input\"")
+              old_rev=$(echo "$old_lock" | jq -r ".nodes.\"$node_name\".locked.rev // .nodes.\"$node_name\".locked.narHash // empty" 2>/dev/null)
+              new_rev=$(echo "$new_lock" | jq -r ".nodes.\"$node_name\".locked.rev // .nodes.\"$node_name\".locked.narHash // empty")
+
+              if [ "$old_rev" != "$new_rev" ]; then
+                category="${input_category[$input]:-darwin}"
+                echo "  Input changed: $input → category: $category"
+
+                case "$category" in
+                  darwin)
+                    global=true ;;
+                  skip)
+                    echo "    (skipped — no darwin rebuild needed)" ;;
+                esac
+              fi
+
+              # Short-circuit
+              if [ "$global" = "true" ]; then
+                echo "  global=true — skipping remaining inputs"
+                break
+              fi
+            done
+          elif [ "$flake_lock_changed" = "true" ] && [ "$global" = "true" ]; then
+            echo ""
+            echo "flake.lock changed but global already set — skipping input parsing"
+          fi
+
+          if [ ${#machine_files_arr[@]} -eq 0 ]; then
+            machine_files="[]"
+          else
+            machine_files=$(printf '%s\n' "${machine_files_arr[@]}" | jq -R . | jq -cs .)
+          fi
+
+          echo "global=$global" >> "$GITHUB_OUTPUT"
+          echo "machine_files=$machine_files" >> "$GITHUB_OUTPUT"
+
+          echo ""
+          echo "Change detection results:"
+          echo "  global=$global"
+          echo "  machine_files=$machine_files"
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
 
       - name: Enable Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
@@ -68,36 +214,83 @@ jobs:
           use-gha-cache: false
 
       - id: out
+        shell: bash
         run: |
           echo "Evaluating darwinConfigurations..."
-          systems=$(nix eval --json .#darwinConfigurations --apply builtins.attrNames)
-          echo "Darwin systems: $systems"
-          echo "systems=$systems" >> "$GITHUB_OUTPUT"
+
+          all_systems=$(nix eval --json .#darwinConfigurations --apply builtins.attrNames)
+          echo "All darwin systems: $all_systems"
+
+          event="${{ github.event_name }}"
+
+          # Gather change-detection outputs (the step is skipped for
+          # workflow_dispatch, so fall back to building everything).
+          if [ "$event" = "workflow_dispatch" ]; then
+            global_changed="true"
+            machine_files="[]"
+          else
+            global_changed="${{ steps.changes.outputs.global }}"
+            machine_files='${{ steps.changes.outputs.machine_files }}'
+          fi
+
+          if [ "$global_changed" = "true" ]; then
+            echo "Building ALL darwin systems (event=$event, global_changed=$global_changed)"
+            systems_json="$all_systems"
+          else
+            echo "Filtering to affected machines only (event=$event)"
+
+            # Extract the third path segment (the machine dir name)
+            # from every changed path under hosts/darwin/**.
+            changed_machines=$(echo "$machine_files" \
+              | jq -r '.[] | split("/")[2]' \
+              | sort -u)
+
+            echo "Changed machine dirs: $(echo "$changed_machines" | tr '\n' ' ')"
+
+            filtered=()
+            for sys in $(jq -r '.[]' <<< "$all_systems"); do
+              if echo "$changed_machines" | grep -qx "$sys"; then
+                filtered+=("$sys")
+              fi
+            done
+
+            if [ ${#filtered[@]} -eq 0 ]; then
+              systems_json="[]"
+            else
+              systems_json=$(printf '%s\n' "${filtered[@]}" | jq -R . | jq -cs .)
+            fi
+          fi
+
+          echo "systems=$systems_json" >> "$GITHUB_OUTPUT"
+          echo "Darwin systems to build: $systems_json"
 
   # =====================================================================
   # Build Darwin systems (matrix)
   # =====================================================================
   build-darwin:
     name: Build Darwin systems
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS]
     needs: [skip-if-clean, find-darwin]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }} # <-- same tidy logic
-
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-darwin.outputs.systems != '[]' }}
+    permissions:
+      id-token: "write"
+      contents: "read"
     strategy:
       fail-fast: false
       matrix:
         system: ${{ fromJson(needs.find-darwin.outputs.systems) }}
 
     steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo docker image prune --all --force || true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          trust-runner-user: true
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+            substituters = http://192.168.31.14/fred https://cache.nixos.org/
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0=
 
       - name: Enable Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
@@ -106,11 +299,44 @@ jobs:
           use-gha-cache: false
 
       - name: Build Darwin system
+        shell: bash
         run: |
-          echo "Skipping build for now (placeholder)"
-          # Uncomment when ready:
-          # echo "Building Darwin system: ${{ matrix.system }}"
-          # nix build ".#darwinConfigurations.${{ matrix.system }}.system"
+          set -euo pipefail
+
+          error=0
+
+          echo "Logging in..."
+          nix shell nixpkgs#attic-client --command attic login fred http://192.168.31.14:8080 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIxNDgyMzMyODksIm5iZiI6MTc2OTU0MjA4OSwic3ViIjoiZnJlZCIsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJmcmVkIjp7InIiOjEsInciOjEsImNjIjoxfX19fQ.WhR5ixdW0j-wV77Tl8VubJPEyEvgQ8nQWYbgJxI8pPiLJN6v4DVaqKPu15mcY0N0B0zKnq9-njG5EOn2Z2-4dMgfx9ttTA-lltxrvPf5nKR9zAXg6hgPYsnGQuRFBvAFzlfPCpcIU2rgEVzMajzjipQgfUnVPDuto9uPU1VG25fncVRYz5dUhOXTfvN_WWpzcgQ7HDHQufbui5IoG-nmFMFWcNkxTCw7XVNs1PYFpadMGn6zAeh9Hi6epYYllr1aTcmTCx6ut3-fbFdQaxGG_HsCyxFiIf9r6GNSQvZOeHbeLcE21RQ6qNrkKZuQiVoOAcQr7ngpQ2jjcWnajw_hCPi6rqByZxdZy8IAbPQ83nm9o5UlfKg99sr6YSV-6ZTBvsOm-ioUX9hSktWm3O7cdH74ygmbUC_QL-os6aYNhbyQjSEMgiOpS65VnFURG58gnnvVHncMvohyDKwZqcWVtiaQApNeL3_LEATtX_zdqlaWdCVXO3t3QlD0ebYVhb4rn2KEg0GOZHGpWPqJnszRSMwXgWM1fG37OF117Qz6O9280BoEMdjLvITr5Cq0kQqS0PzapLdI5maU6ZluyqvAvgqdHzwjey4hDDq3FjITA_JMUStRlH7sMwtaSGTiTTOHQPe7WT9PImqfm4G8Q3urOsHMBE_Au1dqnUz4Lq-yU4M
+
+          : > build.stderr
+
+          echo "Building Darwin system: ${{ matrix.system }}"
+          nix build ".#darwinConfigurations.${{ matrix.system }}.config.system.build.toplevel" 2> >(tee build.stderr >&2)
+
+          if grep -qE "evaluation warning:" build.stderr; then
+            error=1
+          fi
+
+          echo "Pushing system result..."
+          nix shell nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+
+          : > build.stderr
+          echo "Building home-manager for: ${{ matrix.system }}"
+          nix build ".#darwinConfigurations.${{ matrix.system }}.config.home-manager.users.fred.home.activationPackage" 2> >(tee build.stderr >&2)
+
+          if grep -qE "evaluation warning:" build.stderr; then
+            error=1
+          fi
+
+          echo "Pushing home-manager result..."
+          nix shell nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+
+          if [ "$error" -ne 0 ]; then
+            echo "One or more warnings were detected during the build."
+
+            echo "::error::Nix evaluation warnings detected"
+            exit 1
+          fi
 
   # =====================================================================
   # Required Check Summary
@@ -144,5 +370,5 @@ jobs:
             exit 1
           fi
 
-          echo "All Darwin builds succeeded."
+          echo "✅ All in-scope Darwin systems built successfully (skipped systems were not affected by this PR)."
           exit 0

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -357,7 +357,7 @@ jobs:
   # =====================================================================
   build-servers:
     name: Build server systems
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux]
     needs: [skip-if-clean, find-systems]
     if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-systems.outputs.servers != '[]' }}
     permissions:
@@ -429,7 +429,7 @@ jobs:
   # =====================================================================
   build-desktops:
     name: Build desktop systems
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux]
     needs: [skip-if-clean, find-systems]
     if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-systems.outputs.desktops != '[]' }}
     permissions:

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -385,12 +385,6 @@ jobs:
             substituters = http://192.168.31.14/fred https://niri.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964=
 
-      - name: Enable Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
-        with:
-          use-flakehub: false
-          use-gha-cache: false
-
       - name: Build server system
         shell: bash
         run: |
@@ -457,12 +451,6 @@ jobs:
             access-tokens = github.com=${{ github.token }}
             substituters = http://192.168.31.14/fred https://niri.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964=
-
-      - name: Enable Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
-        with:
-          use-flakehub: false
-          use-gha-cache: false
 
       - name: Build desktop system
         shell: bash

--- a/dotfiles/.oh-my-zsh/custom/40-functions.zsh
+++ b/dotfiles/.oh-my-zsh/custom/40-functions.zsh
@@ -40,7 +40,7 @@ gitsig() {
 }
 
 git-sync-main() {
-    setopt localoptions errexit nounset pipefail
+    setopt localoptions nounset pipefail
 
     # Get current branch
     local current
@@ -77,9 +77,17 @@ git-sync-main() {
 }
 
 pushcache() {
-    # localoptions scopes option changes to this function (zsh-only).
-    # 'set -euo pipefail' leaks errexit/nounset into the parent shell.
-    setopt localoptions errexit nounset pipefail
+    # Do NOT use 'setopt errexit' here — if any command fails before the
+    # function returns, zsh exits the *entire interactive shell* because
+    # localoptions never gets the chance to restore the old value.
+    setopt localoptions nounset pipefail
+
+    local jobs
+    if command -v nproc &>/dev/null; then
+        jobs="$(nproc)"
+    else
+        jobs="$(sysctl -n hw.ncpu)"
+    fi
 
     # Detect Home Manager root (newer HM first)
     local HM_ROOT HM_PATH USER_PROFILE
@@ -93,26 +101,36 @@ pushcache() {
     fi
 
     HM_PATH=$(readlink -f "$HM_ROOT")
-
     USER_PROFILE=$(readlink -f "/etc/profiles/per-user/${USER}")
+
+    # System profile path differs between NixOS and nix-darwin
+    local SYS_PROFILE
+    if [ -e /run/current-system ]; then
+        SYS_PROFILE=/run/current-system
+    elif [ -e /nix/var/nix/profiles/system ]; then
+        SYS_PROFILE=/nix/var/nix/profiles/system
+    else
+        echo "Could not find system profile" >&2
+        return 1
+    fi
 
     echo "Pushing home-manager cache to attic..."
     echo "  HM root: $HM_ROOT"
     attic push fred "$HM_PATH" \
         --ignore-upstream-cache-filter \
-        -j "$(nproc)"
+        -j "$jobs" || { echo "Failed to push home-manager cache" >&2; return 1; }
 
     echo
     echo "Pushing per-user cache to attic..."
     attic push fred "$USER_PROFILE" \
         --ignore-upstream-cache-filter \
-        -j "$(nproc)"
+        -j "$jobs" || { echo "Failed to push per-user cache" >&2; return 1; }
 
     echo
     echo "Pushing current-system cache to attic..."
-    attic push fred /run/current-system \
+    attic push fred "$SYS_PROFILE" \
         --ignore-upstream-cache-filter \
-        -j "$(nproc)"
+        -j "$jobs" || { echo "Failed to push system cache" >&2; return 1; }
 }
 
 updatenix() {

--- a/flake/hosts/darwin.nix
+++ b/flake/hosts/darwin.nix
@@ -4,16 +4,23 @@
 #   darwinConfigurations = import ./flake/hosts/darwin.nix { inherit self; };
 {
   self,
+  freminal,
   ...
 }:
 {
   "Freds-MacBook-Pro" = self.lib.mkDarwinSystem {
     hostName = "Freds-MacBook-Pro";
-    hmModules = [ ../../hosts/darwin/Freds-MacBook-Pro/home.nix ];
+    hmModules = [
+      ../../hosts/darwin/Freds-MacBook-Pro/home.nix
+      freminal.homeManagerModules.default
+    ];
   };
 
   "Freds-Mac-Studio" = self.lib.mkDarwinSystem {
     hostName = "Freds-Mac-Studio";
-    hmModules = [ ../../hosts/darwin/Freds-Mac-Studio/home.nix ];
+    hmModules = [
+      ../../hosts/darwin/Freds-Mac-Studio/home.nix
+      freminal.homeManagerModules.default
+    ];
   };
 }

--- a/flake/lib/mk-darwin-system.nix
+++ b/flake/lib/mk-darwin-system.nix
@@ -47,6 +47,9 @@ darwin.lib.darwinSystem {
       ;
 
     inherit isDarwin;
+    sopsNixInput = inputs.sops-nix;
+    catppuccinInput = catppuccin;
+    extraUsers = [ ];
   };
 
   modules = [
@@ -87,6 +90,7 @@ darwin.lib.darwinSystem {
             stateVersion
             isDarwin
             ;
+          catppuccinInput = catppuccin;
         };
       };
 

--- a/flake/lib/mk-darwin-system.nix
+++ b/flake/lib/mk-darwin-system.nix
@@ -55,6 +55,7 @@ darwin.lib.darwinSystem {
   modules = [
     (_: {
       nixpkgs.overlays = [ (import ./../../overlays/default.nix) ];
+      networking.hostName = hostName;
     })
     ../../modules/base/deployment-meta.nix
     ../../modules/base/system.nix
@@ -67,7 +68,11 @@ darwin.lib.darwinSystem {
         useUserPackages = true;
 
         users.${user} = {
-          imports = [ ../../modules/base/home.nix ] ++ hmModules;
+          imports = [
+            ../../modules/base/home.nix
+            ../../modules/services/attic/attic_client.nix
+          ]
+          ++ hmModules;
 
           catppuccin = {
             enable = true;

--- a/hosts/darwin/Freds-Mac-Studio/configuration.nix
+++ b/hosts/darwin/Freds-Mac-Studio/configuration.nix
@@ -1,8 +1,19 @@
 {
+  config,
   ...
 }:
 {
   imports = [
     ../../../profiles/darwin.nix
+    ../../../modules/services/github-runners.nix
   ];
+
+  sops.secrets."github-token" = { };
+
+  ci.githubRunners = {
+    enable = true;
+    repo = "FredSystems/nixos";
+    defaultTokenFile = config.sops.secrets."github-token".path;
+    runnerCount = 4;
+  };
 }

--- a/hosts/darwin/Freds-MacBook-Pro/configuration.nix
+++ b/hosts/darwin/Freds-MacBook-Pro/configuration.nix
@@ -1,24 +1,13 @@
 {
-  config,
   ...
 }:
 {
   imports = [
     ../../../profiles/darwin.nix
     ../../../features/ai/opencode
-    ../../../modules/services/github-runners.nix
   ];
 
   ai = {
     opencode.enable = true;
-  };
-
-  sops.secrets."github-token" = { };
-
-  ci.githubRunners = {
-    enable = true;
-    repo = "FredSystems/nixos";
-    defaultTokenFile = config.sops.secrets."github-token".path;
-    runnerCount = 2;
   };
 }

--- a/hosts/darwin/Freds-MacBook-Pro/configuration.nix
+++ b/hosts/darwin/Freds-MacBook-Pro/configuration.nix
@@ -1,13 +1,24 @@
 {
+  config,
   ...
 }:
 {
   imports = [
     ../../../profiles/darwin.nix
     ../../../features/ai/opencode
+    ../../../modules/services/github-runners.nix
   ];
 
   ai = {
     opencode.enable = true;
+  };
+
+  sops.secrets."github-token" = { };
+
+  ci.githubRunners = {
+    enable = true;
+    repo = "FredSystems/nixos";
+    defaultTokenFile = config.sops.secrets."github-token".path;
+    runnerCount = 2;
   };
 }

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -14,17 +14,10 @@ in
   imports =
     lib.optional isDarwin inputs.home-manager.darwinModules.default
     ++ lib.optional isDarwin ../services/homebrew.nix
-    # Linux-only NixOS modules
-    # catppuccin NixOS module is needed on all Linux systems (e.g. GRUB theming
-    # in features/common/boot).  Use catppuccinInput so stable systems get a
-    # catppuccin build whose nixpkgs dependency matches their channel.
-    # catppuccin.nix sets catppuccin.enable = true for all Linux systems.
     ++ lib.optional isLinux catppuccinInput.nixosModules.catppuccin
     ++ lib.optional isLinux ../../features
     ++ lib.optional isLinux ../../modules/base/user.nix
     ++ lib.optional isLinux ./catppuccin.nix;
-
-  security.sudo.wheelNeedsPassword = false;
 
   nix = {
     settings = {
@@ -57,6 +50,9 @@ in
     };
     optimise.automatic = true;
   };
+}
+// lib.optionalAttrs isLinux {
+  security.sudo.wheelNeedsPassword = false;
 
   # The goModules fixed-output derivation in nixpkgs includes "GOPROXY" in
   # impureEnvVars, meaning it inherits GOPROXY from the Nix daemon's environment.
@@ -67,7 +63,7 @@ in
   # proxy.golang.org (GCS) for uncached entries, which also fails.
   # mirrors.aliyun.com/goproxy/ is backed by Alibaba Cloud OSS (not GCS)
   # and confirmed to serve all required modules directly.
-  systemd.services.nix-daemon.environment = lib.optionalAttrs isLinux {
+  systemd.services.nix-daemon.environment = {
     GOPROXY = "https://mirrors.aliyun.com/goproxy/";
     GONOSUMDB = "*";
   };

--- a/modules/services/github-runners.nix
+++ b/modules/services/github-runners.nix
@@ -215,6 +215,7 @@ in
       environment.systemPackages = [
         pkgs.curl
         pkgs.jq
+        pkgs.xz
       ];
     }
 

--- a/modules/services/github-runners.nix
+++ b/modules/services/github-runners.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  isDarwin ? false,
   ...
 }:
 
@@ -10,6 +11,7 @@ with lib;
 let
   cfg = config.ci.githubRunners;
   hostname = config.networking.hostName;
+  isLinux = !isDarwin;
 
   # Cleanup helper: delete runner by name before (re)registering
   cleanupRunner = pkgs.writeShellScriptBin "github-runner-cleanup" ''
@@ -42,11 +44,69 @@ let
     fi
   '';
 
-  # Construct a github-runners entry
+  # Darwin: wrapper script that does cleanup → configure → run for one runner.
+  # Each runner gets its own working directory under /var/lib/github-runners/<name>.
+  mkDarwinRunnerScript =
+    runnerName: tokenFile: url: ephemeral:
+    pkgs.writeShellScript "github-runner-${runnerName}" ''
+      set -euo pipefail
+
+      RUNNER_NAME="${runnerName}"
+      TOKEN_FILE="${tokenFile}"
+      REPO="${cfg.repo}"
+      URL="${url}"
+      WORK_DIR="/var/lib/github-runners/$RUNNER_NAME"
+
+      # Ensure working directory exists
+      mkdir -p "$WORK_DIR"
+
+      # Cleanup stale registration
+      ${cleanupRunner}/bin/github-runner-cleanup "$RUNNER_NAME" "$TOKEN_FILE" "$REPO"
+
+      # Get a short-lived registration token from the GitHub API
+      PAT="$(cat "$TOKEN_FILE")"
+      REG_TOKEN="$(
+        ${pkgs.curl}/bin/curl -sf -X POST \
+          -H "Authorization: token $PAT" \
+          -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/$REPO/actions/runners/registration-token" \
+        | ${pkgs.jq}/bin/jq -r '.token'
+      )"
+
+      if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
+        echo "ERROR: Failed to obtain registration token" >&2
+        exit 1
+      fi
+
+      cd "$WORK_DIR"
+
+      # Remove any previous configuration
+      if [ -f .runner ]; then
+        ${pkgs.github-runner}/bin/Runner.Listener remove \
+          --token "$REG_TOKEN" 2>/dev/null || true
+      fi
+
+      # Configure the runner
+      ${pkgs.github-runner}/bin/Runner.Listener configure \
+        --unattended \
+        --url "$URL" \
+        --token "$REG_TOKEN" \
+        --name "$RUNNER_NAME" \
+        --labels "self-hosted,macOS,ARM64" \
+        --work "$WORK_DIR/_work" \
+        ${optionalString ephemeral "--ephemeral"} \
+        --replace
+
+      # Run the runner (blocks until job completes if ephemeral, or until stopped)
+      exec ${pkgs.github-runner}/bin/Runner.Listener run
+    '';
+
+  # Construct a github-runners entry (shared logic for building the flat list)
   mkRunner =
     id: runnerCfg:
     let
-      runnerName = if runnerCfg.name != null then runnerCfg.name else "nixos-${hostname}-${id}";
+      prefix = if isDarwin then "darwin" else "nixos";
+      runnerName = if runnerCfg.name != null then runnerCfg.name else "${prefix}-${hostname}-${id}";
 
       tokenFile = if runnerCfg.tokenFile != null then runnerCfg.tokenFile else cfg.defaultTokenFile;
 
@@ -63,6 +123,30 @@ let
     };
 
   runnersList = mapAttrsToList mkRunner cfg.runners;
+
+  # Build the full list of all runners (auto-generated + custom)
+  allRunners =
+    let
+      prefix = if isDarwin then "darwin" else "nixos";
+      autoRunners = genList (i: {
+        id = "runner-${toString (i + 1)}";
+        name = "${prefix}-${hostname}-runner-${toString (i + 1)}";
+        tokenFile = cfg.defaultTokenFile;
+        url = "https://github.com/${cfg.repo}";
+        ephemeral = true;
+      }) cfg.runnerCount;
+
+      customRunners = map (r: {
+        inherit (r) id;
+        inherit (r.value)
+          name
+          tokenFile
+          url
+          ephemeral
+          ;
+      }) runnersList;
+    in
+    autoRunners ++ customRunners;
 
 in
 {
@@ -95,7 +179,7 @@ in
             name = mkOption {
               type = types.nullOr types.str;
               default = null;
-              description = "Explicit runner name (defaults to nixos-<host>-<id>).";
+              description = "Explicit runner name (defaults to <platform>-<host>-<id>).";
             };
 
             url = mkOption {
@@ -125,76 +209,146 @@ in
 
   ###### IMPLEMENTATION ######
 
-  config = mkIf cfg.enable {
-    environment.systemPackages = [
-      pkgs.curl
-      pkgs.jq
-    ];
+  config = mkIf cfg.enable (
+    {
+      # ── Shared ────────────────────────────────────────────────────────
+      environment.systemPackages = [
+        pkgs.curl
+        pkgs.jq
+      ];
+    }
 
-    # Generate services.github-runners entries
-    services.github-runners = mkMerge [
-      # Auto-generated runners based on runnerCount
-      (listToAttrs (
-        genList (i: {
-          name = "runner-${toString (i + 1)}";
-          value = {
-            enable = true;
-            url = "https://github.com/${cfg.repo}";
-            name = "nixos-${hostname}-runner-${toString (i + 1)}";
-            tokenFile = cfg.defaultTokenFile;
-            ephemeral = true;
-          };
-        }) cfg.runnerCount
-      ))
-
-      # Custom runners from the runners attrset
-      (listToAttrs (
-        map (r: {
-          name = r.id;
-          inherit (r) value;
-        }) runnersList
-      ))
-    ];
-
-    # Inject cleanup logic into systemd units (CORRECT UNIT NAMES)
-    systemd.services =
-      let
-        # Auto-generated runner services
-        autoRunnerServices = listToAttrs (
+    # ── Linux (NixOS) ────────────────────────────────────────────────
+    # Uses optionalAttrs (not mkIf) because systemd.services and
+    # services.github-runners do not exist as options in nix-darwin.
+    // optionalAttrs isLinux {
+      # Generate services.github-runners entries
+      services.github-runners = mkMerge [
+        # Auto-generated runners based on runnerCount
+        (listToAttrs (
           genList (i: {
-            name = "github-runner-runner-${toString (i + 1)}";
+            name = "runner-${toString (i + 1)}";
             value = {
-              serviceConfig = {
-                ExecStartPre = lib.mkBefore [
-                  "+${cleanupRunner}/bin/github-runner-cleanup nixos-${hostname}-runner-${toString (i + 1)} ${cfg.defaultTokenFile} ${cfg.repo}"
-                ];
-              };
+              enable = true;
+              url = "https://github.com/${cfg.repo}";
+              name = "nixos-${hostname}-runner-${toString (i + 1)}";
+              tokenFile = cfg.defaultTokenFile;
+              ephemeral = true;
             };
           }) cfg.runnerCount
-        );
+        ))
 
-        # Custom runner services
-        customRunnerServices = foldl' (
-          acc: r:
-          let
-            svcName = "github-runner-${r.id}";
-            runnerName = r.value.name;
-          in
-          acc
-          // {
-            ${svcName} = {
-              serviceConfig = {
-                ExecStartPre = lib.mkBefore [
-                  "+${cleanupRunner}/bin/github-runner-cleanup ${runnerName} ${r.value.tokenFile} ${cfg.repo}"
+        # Custom runners from the runners attrset
+        (listToAttrs (
+          map (r: {
+            name = r.id;
+            inherit (r) value;
+          }) runnersList
+        ))
+      ];
+
+      # Inject cleanup logic into systemd units
+      systemd.services =
+        let
+          # Auto-generated runner services
+          autoRunnerServices = listToAttrs (
+            genList (i: {
+              name = "github-runner-runner-${toString (i + 1)}";
+              value = {
+                serviceConfig = {
+                  ExecStartPre = lib.mkBefore [
+                    "+${cleanupRunner}/bin/github-runner-cleanup nixos-${hostname}-runner-${toString (i + 1)} ${cfg.defaultTokenFile} ${cfg.repo}"
+                  ];
+                };
+              };
+            }) cfg.runnerCount
+          );
+
+          # Custom runner services
+          customRunnerServices = foldl' (
+            acc: r:
+            let
+              svcName = "github-runner-${r.id}";
+              runnerName = r.value.name;
+            in
+            acc
+            // {
+              ${svcName} = {
+                serviceConfig = {
+                  ExecStartPre = lib.mkBefore [
+                    "+${cleanupRunner}/bin/github-runner-cleanup ${runnerName} ${r.value.tokenFile} ${cfg.repo}"
+                  ];
+                };
+              };
+            }
+          ) { } runnersList;
+        in
+        mkMerge [
+          autoRunnerServices
+          customRunnerServices
+        ];
+    }
+
+    # ── Darwin (launchd) ─────────────────────────────────────────────
+    # Uses optionalAttrs (not mkIf) because launchd.daemons does not
+    # exist as an option in NixOS.
+    // optionalAttrs isDarwin {
+      # Ensure the runner working directory exists
+      system.activationScripts.postActivation.text =
+        let
+          mkDir = r: "mkdir -p /var/lib/github-runners/${r.name}";
+        in
+        concatStringsSep "\n" (map mkDir allRunners);
+
+      launchd.daemons = listToAttrs (
+        map (r: {
+          name = "github-runner-${r.id}";
+          value = {
+            # The wrapper script handles everything: cleanup, configure, run
+            script = toString (mkDarwinRunnerScript r.name r.tokenFile r.url r.ephemeral);
+
+            serviceConfig = {
+              # Run as root so we can read sops secret files and create
+              # working directories.  The runner itself drops privileges
+              # internally when executing workflow steps.
+              UserName = "root";
+              GroupName = "wheel";
+
+              # Restart on exit (ephemeral runners exit after each job)
+              KeepAlive = true;
+
+              # Wait 5 seconds before restarting to avoid hammering the API
+              ThrottleInterval = 5;
+
+              # Working directory
+              WorkingDirectory = "/var/lib/github-runners/${r.name}";
+
+              # Log files for debugging
+              StandardOutPath = "/var/log/github-runner-${r.id}.out.log";
+              StandardErrorPath = "/var/log/github-runner-${r.id}.err.log";
+
+              # Ensure network is available before starting
+              RunAtLoad = true;
+
+              # Set PATH so the runner can find nix and other tools
+              EnvironmentVariables = {
+                PATH = concatStringsSep ":" [
+                  "/run/current-system/sw/bin"
+                  "/nix/var/nix/profiles/default/bin"
+                  "/usr/local/bin"
+                  "/usr/bin"
+                  "/bin"
+                  "/usr/sbin"
+                  "/sbin"
                 ];
+                # Tell the runner where the Nix daemon socket is
+                NIX_SSL_CERT_FILE = "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt";
+                HOME = "/var/lib/github-runners/${r.name}";
               };
             };
-          }
-        ) { } runnersList;
-      in
-      mkMerge [
-        autoRunnerServices
-        customRunnerServices
-      ];
-  };
+          };
+        }) allRunners
+      );
+    }
+  );
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -21,9 +21,14 @@ final: prev: {
   # (nixpkgs commit 40231286, added as a darwin sandbox workaround).  On any
   # system with sandbox = true (the NixOS default), Nix refuses to even
   # schedule the build.  The flag is not needed for Linux builds, so strip it.
-  github-runner = prev.github-runner.overrideAttrs (_: {
-    __noChroot = false;
-  });
+  # On darwin, keep __noChroot = true (the upstream default) since the darwin
+  # sandbox requires it.
+  github-runner = prev.github-runner.overrideAttrs (
+    _:
+    prev.lib.optionalAttrs (!prev.stdenv.isDarwin) {
+      __noChroot = false;
+    }
+  );
 
   # Shadow the deprecated top-level `pkgs.hostPlatform` warnAlias (added
   # 2025-10-28 in nixpkgs aliases.nix) with the real value so that packages

--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -15,6 +15,7 @@
     ../features/desktop/alacritty
     ../features/desktop/githubdesktop
     ../features/desktop/ghostty
+    ../features/desktop/freminal
     ../features/desktop/wezterm
     ../features/desktop/zed
     ../features/desktop/yubikey
@@ -58,6 +59,7 @@
   nixpkgs.hostPlatform = lib.mkDefault "aarch64-darwin";
 
   desktop = {
+    freminal.enable = true;
     wezterm.enable = true;
     alacritty.enable = true;
     zed.enable = true;


### PR DESCRIPTION
## Summary

- **Cross-platform GitHub Actions runners**: Rewrote `modules/services/github-runners.nix` to support both NixOS (systemd) and darwin (launchd). Enabled 2 self-hosted runners on Freds-MacBook-Pro.
- **Darwin CI overhaul**: Rewrote `ci-darwin.yaml` with input-aware `flake.lock` change detection, self-hosted macOS runners, and Attic binary cache push — matching the Linux CI patterns.
- **Attic client on darwin**: Added `attic_client.nix` to darwin home-manager imports so `attic` is available on macOS hosts.
- **Cross-platform `pushcache`**: Fixed `pushcache` shell function — removed `errexit` (kills interactive zsh), replaced `nproc` with `sysctl -n hw.ncpu` on macOS, and auto-detects system profile path (`/run/current-system` vs `/nix/var/nix/profiles/system`).
- **Overlay fix**: `github-runner` overlay only strips `__noChroot` on Linux; keeps upstream default on darwin.
- **Freminal**: Added `freminal.homeManagerModules.default` to both darwin hosts.
- **`networking.hostName`**: Set explicitly in `mk-darwin-system.nix` (null by default on darwin, caused string coercion errors).

## Build verification

All darwin configurations build successfully (MacBook Pro + Mac Studio, system + home-manager activation packages). No evaluation warnings.