### PR TITLE
chore(flake/home-manager): `d401492e` -> `5b56ad02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776373306,
-        "narHash": "sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs=",
+        "lastModified": 1776562531,
+        "narHash": "sha256-Lh5Ns9DI67E+lSMOCGK0S+mFPy0mz0yOGiJTUXiR9JI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d401492e2acd4fea42f7705a3c266cea739c9c36",
+        "rev": "5b56ad02dc643808b8af6d5f3ff179e2ce9593f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`5b56ad02`](https://github.com/nix-community/home-manager/commit/5b56ad02dc643808b8af6d5f3ff179e2ce9593f4) | `` modules/helix: fix pkill line on Darwin ``                                         |
| [`565e5349`](https://github.com/nix-community/home-manager/commit/565e5349208fe7d0831ef959103c9bafbeac0681) | `` neovim: expose `sideloadInitLua` option to control the generation of `init.lua` `` |
| [`dee1c38c`](https://github.com/nix-community/home-manager/commit/dee1c38cf07e0a19912aed040088c8cf93091421) | `` modules/helix: fix incorrect string escape ``                                      |
| [`08b283ae`](https://github.com/nix-community/home-manager/commit/08b283aeda66c11d0573347c23ff927df99ec340) | `` yazi: add option for {file}`$XDG_CONFIG_HOME/yazi/vfs.toml` ``                     |
| [`a0dab602`](https://github.com/nix-community/home-manager/commit/a0dab602845cc7b0b980e201453c7454de24075b) | `` helix: reload config with USR1 signal ``                                           |
| [`8941f29d`](https://github.com/nix-community/home-manager/commit/8941f29d42b444e5956ef6dddc64f311897c2c8e) | `` opencode: add extraPackages option ``                                              |
| [`6ddeb76a`](https://github.com/nix-community/home-manager/commit/6ddeb76a5db8f5bc57cf1601a761e34cb0dcd8ff) | `` zsh: expose internal lib ``                                                        |