### PR TITLE
chore(flake/freminal): `eb286779` -> `e2aa8e8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1776438868,
-        "narHash": "sha256-olSO/R4m14Nivp9aw59bkm3neSCMAqr8b9maGcXBB80=",
+        "lastModified": 1776574380,
+        "narHash": "sha256-MAk3hAS8sn2Z+a4goncm3UwsOKeIKX5T5CTqP7kRswM=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "eb286779f2939779ebe51d78a27465235c590bbd",
+        "rev": "e2aa8e8e0db6d58b9464879e2ba547b9ccca25ea",
         "type": "github"
       },
       "original": {
@@ -1557,11 +1557,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776395632,
-        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
+        "lastModified": 1776568404,
+        "narHash": "sha256-Xng/brVgk+0+ggo/4xnaxb5v4lU82RxPpmFlMHXLGYg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
+        "rev": "e65c31bc66b9194a9fc5b5a9f97ac049523f9438",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`e2aa8e8e`](https://github.com/fredsystems/freminal/commit/e2aa8e8e0db6d58b9464879e2ba547b9ccca25ea) | `` don't lint icns file ``                                                                   |
| [`cd2dc472`](https://github.com/fredsystems/freminal/commit/cd2dc472dd7b4d0ffaabba8fb92ad3ec0308bad3) | `` chore(deps): update apple-actions/import-codesign-certs action to v6.1.0 ``               |
| [`187cbaf8`](https://github.com/fredsystems/freminal/commit/187cbaf8a9f42e6ac2bfaf1925ccbc1563f5df0f) | `` chore(deps): lock file maintenance ``                                                     |
| [`a9864042`](https://github.com/fredsystems/freminal/commit/a9864042efc6583987a272bdcfd1a6b92b30873d) | `` chore(deps): update taiki-e/install-action action to v2.75.18 ``                          |
| [`c0d11c06`](https://github.com/fredsystems/freminal/commit/c0d11c068f7ab2db7ce6cfc991ab919184b527de) | `` chore(deps): update rust crate tracing-appender to v0.2.5 ``                              |
| [`dc294571`](https://github.com/fredsystems/freminal/commit/dc29457143d35624c53003ac2a4c6bf1e2c879e4) | `` chore(deps): update rust crate test-log to v0.2.20 ``                                     |
| [`1af500a1`](https://github.com/fredsystems/freminal/commit/1af500a1aad18d738aaf954e536fbb4722aadee6) | `` chore(deps): update rust crate assert_cmd to v2.2.1 ``                                    |
| [`a9bb219c`](https://github.com/fredsystems/freminal/commit/a9bb219c18804e75cb9ec449313a0276e02f6c42) | `` fix canonical path for config on mac ``                                                   |
| [`83041ea1`](https://github.com/fredsystems/freminal/commit/83041ea128e0838d37bb13a146a12d527d248aee) | `` update for .app ``                                                                        |
| [`33015e4c`](https://github.com/fredsystems/freminal/commit/33015e4c405fa57024e4e70bb282d345e68a89a4) | `` fix: correct icon path for cargo-bundle, move perf to linux-only devshell ``              |
| [`16ee886a`](https://github.com/fredsystems/freminal/commit/16ee886a407afb3fc3896331f309e398449ea266) | `` fix: add app icon to cargo-bundle config for macOS .app ``                                |
| [`05376d98`](https://github.com/fredsystems/freminal/commit/05376d98ebaecabc7e5b94b7f36bb0eb72abad0f) | `` fix: replace broken signing action with manual codesign/notarize and add debug logging `` |
| [`cea017ed`](https://github.com/fredsystems/freminal/commit/cea017ed7d27154ba464af9de43ed39ede90d8b4) | `` fix: stage .app at repo root before signing to fix zip path ``                            |
| [`49b70d21`](https://github.com/fredsystems/freminal/commit/49b70d2186dbdd1c447c496d5a3dc098d1bd3edc) | `` fix: add notarization log step to diagnose rejection reasons ``                           |
| [`da037538`](https://github.com/fredsystems/freminal/commit/da037538632210735072ac141125f55beaff2073) | `` fix: add macOS entitlements for notarization and re-enable codesigning ``                 |
| [`e58d6dc1`](https://github.com/fredsystems/freminal/commit/e58d6dc1d3cd1b050113ce5a98933cd8eca9fc98) | `` apple app signing ``                                                                      |
| [`850815ce`](https://github.com/fredsystems/freminal/commit/850815ce19ebc045db57ff0a14ecc763ea8ad00a) | `` feat: create macOS .app bundle in Nix package and HM module ``                            |
| [`241f6f13`](https://github.com/fredsystems/freminal/commit/241f6f13a6cbb87379c1e4ec2022436ac656b065) | `` fix: replace broken build timestamp with git describe, add RPM packaging ``               |