### PR TITLE
chore(flake/niri): `55b5b1fc` -> `f8cc32a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1035,11 +1035,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1776435348,
-        "narHash": "sha256-qsZnMThxTqxCJZ7DEKu3DD3KjIPcuUBvZ0C9a2uIvaQ=",
+        "lastModified": 1776509722,
+        "narHash": "sha256-oHVMjAMBukYnGeEE0EtCQsx8cNRv8WadHD8ZV3oZFSM=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "55b5b1fc9481ab267603a1099e5d4b4ebc7394d7",
+        "rev": "f8cc32a3aba29fdacd06d80b0986028cfd413a22",
         "type": "github"
       },
       "original": {
@@ -1068,11 +1068,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1776432730,
-        "narHash": "sha256-Pq1ZVvRGq/IFiFH6vkNwMfZEpWk23NjgGdX50COdj/c=",
+        "lastModified": 1776505268,
+        "narHash": "sha256-+hK+EgAwuRG+lhqwOkKfXlqMEdELIoTMdjfVosIlLb0=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "c814c656c53ea9d69f5afb45c88f4dc4d25338cd",
+        "rev": "9e5716a9dbf7dbf9622a95a5bd23a898867759c6",
         "type": "github"
       },
       "original": {
@@ -1140,11 +1140,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1776221942,
-        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
+        "lastModified": 1776434932,
+        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
+        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`f8cc32a3`](https://github.com/sodiboo/niri-flake/commit/f8cc32a3aba29fdacd06d80b0986028cfd413a22) | `` Update flake.lock `` |
| [`2f6c8c76`](https://github.com/sodiboo/niri-flake/commit/2f6c8c76d16b7a2066a9d50851eee7deb1659d43) | `` Update flake.lock `` |
| [`946e4063`](https://github.com/sodiboo/niri-flake/commit/946e40637c8000b73de511faac31dd3a83fdcd45) | `` Update flake.lock `` |
| [`900cfd39`](https://github.com/sodiboo/niri-flake/commit/900cfd392168f6cf120bf0dd7e02deb7d54e4b55) | `` Update flake.lock `` |