### PR TITLE
chore(flake/nixpkgs-stable): `1766437c` -> `c7f47036`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1156,11 +1156,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1776221942,
-        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
+        "lastModified": 1776434932,
+        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
+        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`d3669ab0`](https://github.com/NixOS/nixpkgs/commit/d3669ab0c085933ea836d49a1608c7527d3e5396) | `` .github: Bump actions/create-github-app-token from 3.0.0 to 3.1.1 ``                 |
| [`6e2a2103`](https://github.com/NixOS/nixpkgs/commit/6e2a2103052f732495947783d674fed01ead25b9) | `` .github: Bump actions/upload-artifact from 7.0.0 to 7.0.1 ``                         |
| [`ad144548`](https://github.com/NixOS/nixpkgs/commit/ad144548340b75334430ee51fa5bae2fb20bd91f) | `` .github: Bump actions/github-script from 8.0.0 to 9.0.0 ``                           |
| [`79c325a5`](https://github.com/NixOS/nixpkgs/commit/79c325a5cecf0f3d59dc1c844779cae4e20049bb) | `` .github: Bump peter-evans/create-pull-request from 8.1.0 to 8.1.1 ``                 |
| [`a2061607`](https://github.com/NixOS/nixpkgs/commit/a2061607a477b3f8308404022d996dd6882c6f48) | `` nixos/all-hardware.nix: conditionally enable module aliases removed in linux v7.0 `` |
| [`0f7fd9bc`](https://github.com/NixOS/nixpkgs/commit/0f7fd9bc68ed4965f937f3690b60704361818ea3) | `` lix-diff: 1.4.1 -> 1.5.0 ``                                                          |
| [`0d0ee9c3`](https://github.com/NixOS/nixpkgs/commit/0d0ee9c3e4ed8a98f07a4efbfccb57df5a19fbb2) | `` nixos/vlagent: fix typo in command line ``                                           |
| [`f54a5402`](https://github.com/NixOS/nixpkgs/commit/f54a5402fd9b7ebe8a7222cd92813f49af58b00c) | `` miracle-wm: Point meta.homepage to the actual homepage ``                            |
| [`dc02a812`](https://github.com/NixOS/nixpkgs/commit/dc02a812ce27ae5b0e0d5e0cead4514f48b7f005) | `` ci/github-script/manual-file-edits: init ``                                          |
| [`86395b32`](https://github.com/NixOS/nixpkgs/commit/86395b32f9e32e124dfeea6c3572d703385f2598) | `` nss_latest: 3.122.1 -> 3.123 ``                                                      |
| [`e01b1397`](https://github.com/NixOS/nixpkgs/commit/e01b1397cce35e3189fc74dc4ecbb7ae29b16d92) | `` librewolf-bin-unwrapped: 149.0-1 -> 149.0.2-2 ``                                     |
| [`daf043a9`](https://github.com/NixOS/nixpkgs/commit/daf043a92f80e2465805949f062e6131ad0b8d43) | `` ungoogled-chromium: 147.0.7727.55-1 -> 147.0.7727.101-1 ``                           |
| [`bd320727`](https://github.com/NixOS/nixpkgs/commit/bd32072721b827df18a3a206da1af087a7dc9ed6) | `` actual-server: 26.3.0 -> 26.4.0 ``                                                   |
| [`851b8fca`](https://github.com/NixOS/nixpkgs/commit/851b8fca2ea551617161ca70bf91d51a4f0f17e4) | `` prismlauncher-unwrapped: 11.0.1 -> 11.0.2 ``                                         |
| [`1c62205e`](https://github.com/NixOS/nixpkgs/commit/1c62205e59053ac94fa5fbd4136571ed2d236faf) | `` bcachefs-tools: 1.37.3 -> 1.37.4 ``                                                  |
| [`7863003a`](https://github.com/NixOS/nixpkgs/commit/7863003a360063c96d694b76b89e8c9144bae539) | `` bcachefs-tools: 1.37.2 -> 1.37.3 ``                                                  |
| [`4357306f`](https://github.com/NixOS/nixpkgs/commit/4357306f8a494c3075fe872ef9e8f52ba3f6cdab) | `` bcachefs-tools: 1.37.1 -> 1.37.2 ``                                                  |
| [`bc32e6e2`](https://github.com/NixOS/nixpkgs/commit/bc32e6e2ffe5cc561b03782e0d7f32969de4197f) | `` bcachefs-tools: 1.37.0 -> 1.37.1 ``                                                  |
| [`9891fd94`](https://github.com/NixOS/nixpkgs/commit/9891fd9496f45e2f1f4a950e2777eeb18bc426e0) | `` bcachefs-tools: 1.36.1 -> 1.37.0 ``                                                  |
| [`ffb69b49`](https://github.com/NixOS/nixpkgs/commit/ffb69b4953218ddcef3b9ddcf7d33b62218a1853) | `` bcachefs-tools: don't assume `modprobe` is in the PATH ``                            |
| [`32e5a7ee`](https://github.com/NixOS/nixpkgs/commit/32e5a7ee3ea55eca9c3da21340fe03313223cfac) | `` opam: 2.5.0 -> 2.5.1 ``                                                              |
| [`a8677618`](https://github.com/NixOS/nixpkgs/commit/a86776182273ac0f82dd13d2f84f9145757dcd1a) | `` ocamlPackages.oui: 0-unstable-2025-10-08 -> 0-unstable-2025-11-20 ``                 |
| [`47a7b211`](https://github.com/NixOS/nixpkgs/commit/47a7b2110bbc3138dbfd4c94ea3ecde035bc436c) | `` opam-publish: 2.7.0 -> 2.7.1 ``                                                      |
| [`3fbbd1db`](https://github.com/NixOS/nixpkgs/commit/3fbbd1db8a1cdd732ba22e557cc5044116c9aa67) | `` opam: 2.4.1 -> 2.5.0 ``                                                              |
| [`c0e1ef86`](https://github.com/NixOS/nixpkgs/commit/c0e1ef86a3c02429afdc41dc8e5a420a4f159a6b) | `` luanti: add knownVulnerabilities affecting versions >= 5.0.0 < 5.15.2 ``             |
| [`7e0917c9`](https://github.com/NixOS/nixpkgs/commit/7e0917c9c3113dd869cc413042fe4795f6db4cff) | `` linuxPackages.bcachefs: allow kernel 7.0 ``                                          |
| [`33408fa0`](https://github.com/NixOS/nixpkgs/commit/33408fa0b3971d907300318cbd574bd5f0386354) | `` dolibarr: mark as insecure ``                                                        |
| [`4a2946eb`](https://github.com/NixOS/nixpkgs/commit/4a2946eb7f8be3944d2b0df801891d2d6b74a640) | `` chromium,chromedriver: 147.0.7727.55 -> 147.0.7727.101 ``                            |
| [`65e44885`](https://github.com/NixOS/nixpkgs/commit/65e44885cb8024d34233148010100d953de25e93) | `` mdns-scanner: 0.27.0 -> 0.27.1 ``                                                    |
| [`b813ac92`](https://github.com/NixOS/nixpkgs/commit/b813ac92cabefb6b19d2cf06a59b3c4cb5cb5f32) | `` mdns-scanner: add passthru.updateScript ``                                           |
| [`7237bb2d`](https://github.com/NixOS/nixpkgs/commit/7237bb2d771dde5d74f26e4d0283bb812c93359f) | `` google-chrome: 147.0.7727.55 -> 147.0.7727.101 ``                                    |
| [`4b29665c`](https://github.com/NixOS/nixpkgs/commit/4b29665caa17b949865715160040ade6fd697db2) | `` mastodon: 4.5.8 -> 4.5.9 ``                                                          |
| [`0a0695ac`](https://github.com/NixOS/nixpkgs/commit/0a0695ac6529bf8dbd8bb22911c35da9c631bdd2) | `` bluesky-pds: 0.4.208 -> 0.4.219 ``                                                   |
| [`8ac58d16`](https://github.com/NixOS/nixpkgs/commit/8ac58d16752c610f0ebbaba26a88f160eca678fd) | `` rustls-ffi: 0.15.1 -> 0.15.2 ``                                                      |
| [`6761439c`](https://github.com/NixOS/nixpkgs/commit/6761439ceb1ac997fe668e4c5368edea2063efee) | `` buildbox: 1.3.54 -> 1.4.0 ``                                                         |
| [`5a74b1f5`](https://github.com/NixOS/nixpkgs/commit/5a74b1f57bdce1f6898ac2b5d3aa372d7136f4ee) | `` ocamlPackages.ppx_mikmatch: init at 1.3 ``                                           |
| [`3c271ca9`](https://github.com/NixOS/nixpkgs/commit/3c271ca97341f16ed41e0cc584ce60f71ad8f4fc) | `` mdns-scanner: 0.26.3 -> 0.27.0 ``                                                    |
| [`f9df5921`](https://github.com/NixOS/nixpkgs/commit/f9df5921c42e4c84b5bf71f9b197f69fd9048848) | `` gajim: add socks support to httpx ``                                                 |
| [`39db85a3`](https://github.com/NixOS/nixpkgs/commit/39db85a3e208f7c8713abcc5174112e1a59c1c29) | `` victoriametrics: 1.139.0 -> 1.140.0 ``                                               |
| [`3c9412fa`](https://github.com/NixOS/nixpkgs/commit/3c9412fa9ff56477eab81bce248d41a28a1c019a) | `` jackett: 0.24.1542 -> 0.24.1591 ``                                                   |
| [`f2b9d4db`](https://github.com/NixOS/nixpkgs/commit/f2b9d4db30cc4511d634b4689a005cb81d2f6f92) | `` nextcloud{31,32}.packages.apps.recognize: fix taskset command not found ``           |
| [`03cfd6cb`](https://github.com/NixOS/nixpkgs/commit/03cfd6cbe4c32f1ced6c4ddb966d91be70423fe8) | `` floorp: 12.12.0 -> 12.12.1 ``                                                        |
| [`bc89367e`](https://github.com/NixOS/nixpkgs/commit/bc89367e0ef174931b298224ef3882e3b43ebc96) | `` nixos/librenms: remove mtr since it is not used anymore ``                           |
| [`26c6ff7f`](https://github.com/NixOS/nixpkgs/commit/26c6ff7f9f73ea20075e81024b6c657b8fe257e6) | `` librenms: backport fix for CVE-2026-6204 ``                                          |
| [`e2ed2d87`](https://github.com/NixOS/nixpkgs/commit/e2ed2d87649ca1fa8833783ebb73115999c95159) | `` vaultwarden: 1.35.6 -> 1.35.7 ``                                                     |
| [`96e1f284`](https://github.com/NixOS/nixpkgs/commit/96e1f284bfab3e553c261f38d529619eb602a103) | `` vaultwarden.webvault: 2026.1.1+0 -> 2026.2.0+0 ``                                    |
| [`a78fef64`](https://github.com/NixOS/nixpkgs/commit/a78fef6468d6a4eb03325d063954c5b1230c92b0) | `` vaultwarden: 1.35.4 -> 1.35.6 ``                                                     |
| [`298578ca`](https://github.com/NixOS/nixpkgs/commit/298578caf72a9318af2ac15415b31fa9b4af0050) | `` bookstack: fix vendorHash ``                                                         |
| [`90388c47`](https://github.com/NixOS/nixpkgs/commit/90388c477d3a74989e4f425068916cb8bce03095) | `` servo: fix feature flag ``                                                           |
| [`4485f26d`](https://github.com/NixOS/nixpkgs/commit/4485f26dce2d5c62b63d11f89650df9f38fa62a9) | `` servo: 0.0.6 -> 0.1.0 ``                                                             |
| [`dbc48ae1`](https://github.com/NixOS/nixpkgs/commit/dbc48ae17d27c7c3caf1913fe3b5b1e8200cdd93) | `` linux_7_0: init at 7.0 ``                                                            |
| [`6e8e5e15`](https://github.com/NixOS/nixpkgs/commit/6e8e5e1525021daccf1ee77d701bfc8622777f9b) | `` rust_1_94: init ``                                                                   |
| [`cc894de9`](https://github.com/NixOS/nixpkgs/commit/cc894de9dee4733d20ed9ba75891dd912afaa752) | `` google-cloud-sdk: CVE-2026-27459 ``                                                  |
| [`fd28b583`](https://github.com/NixOS/nixpkgs/commit/fd28b5839f552d6ce6b45f69fd51f629f4654801) | `` nixos/sssd: remove unnecessary capabilities ``                                       |
| [`49daad72`](https://github.com/NixOS/nixpkgs/commit/49daad72a7d5ef0b1ef7683e3e987d3178029b08) | `` hedgedoc: 1.10.6 -> 1.10.7 ``                                                        |
| [`ac858272`](https://github.com/NixOS/nixpkgs/commit/ac85827229b0e48291b7857f1d230f8dc87e1793) | `` vscode-extensions.leonardssh.vscord: 5.3.8 -> 5.3.9 ``                               |