### PR TITLE
chore(flake/catppuccin): `bdf0285d` -> `b85b328e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776420287,
-        "narHash": "sha256-0P2QyDM8R1FFww//TNDLTRVnVkQxVdbEVQiVuyD1SqY=",
+        "lastModified": 1776681486,
+        "narHash": "sha256-akO/L6Jt4341uBnf3CIpJOTTYyCBQsSvP2hnikV2oMY=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "bdf0285dc7978ebd78b76054631d7ef05680895e",
+        "rev": "b85b328ecc9874f4e7424db2820333c148e8dd66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                     |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`b85b328e`](https://github.com/catppuccin/nix/commit/b85b328ecc9874f4e7424db2820333c148e8dd66) | `` chore(deps): update actions/upload-pages-artifact action to v5 (#895) `` |
| [`baedd53f`](https://github.com/catppuccin/nix/commit/baedd53f6a455adb4dc1f9c735fb69435436149c) | `` chore(deps): update cachix/cachix-action action to v17 (#875) ``         |