### PR TITLE
chore(flake/home-manager): `5b56ad02` -> `c81775b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776562531,
-        "narHash": "sha256-Lh5Ns9DI67E+lSMOCGK0S+mFPy0mz0yOGiJTUXiR9JI=",
+        "lastModified": 1776701552,
+        "narHash": "sha256-CCRzOEFg6JwCdZIR5dLD0ypah5/e2JQVuWQ/l3rYrPY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b56ad02dc643808b8af6d5f3ff179e2ce9593f4",
+        "rev": "c81775b640d4507339d127f5adb4105f6015edf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`c81775b6`](https://github.com/nix-community/home-manager/commit/c81775b640d4507339d127f5adb4105f6015edf2) | `` xdg-autostart: allow empty readonly autostart ``           |
| [`56b4526c`](https://github.com/nix-community/home-manager/commit/56b4526cfdac480268b54ee1124efb732b792af1) | `` nixos: guard home.uid with tryEval ``                      |
| [`1072f064`](https://github.com/nix-community/home-manager/commit/1072f064e2c47a249f09800e7c0fe4e96ab9b433) | `` fish: clarify setCursor option mapping ``                  |
| [`78ceb2dd`](https://github.com/nix-community/home-manager/commit/78ceb2dd5c16309c25ce97ecd4687f24e6ab6366) | `` rbw: do not serialize 'null' settings ``                   |
| [`0a8d50ed`](https://github.com/nix-community/home-manager/commit/0a8d50edf28d537ce7538fbbf207fa7939d41abc) | `` docs/nix-flakes: clarify extraSpecialArgs usage ``         |
| [`4bfce11e`](https://github.com/nix-community/home-manager/commit/4bfce11ea820df0359f73736fd59c7e8f53641a6) | `` xdg-user-dirs: add 'projects' ``                           |
| [`12ceb397`](https://github.com/nix-community/home-manager/commit/12ceb3974a79b0bcd78974c86c474a0bd3697e8c) | `` tests/xdg-user-dirs-*: do not use 'PROJECTS' ``            |
| [`1ab3a4b7`](https://github.com/nix-community/home-manager/commit/1ab3a4b78ebbf13d4ae786180bc8b7de9741cf30) | `` test(tests): add --big-only filter ``                      |
| [`29f355a7`](https://github.com/nix-community/home-manager/commit/29f355a7338f30f32142f4ff44e805d47d0086b1) | `` tests: decode non-UTF-8 nix build output ``                |
| [`b85e8fff`](https://github.com/nix-community/home-manager/commit/b85e8fff941d0cce275a627a3c2f40b3c4a96e08) | `` lib/deprecations: suppress no-op state-version warnings `` |
| [`1e9bdc6d`](https://github.com/nix-community/home-manager/commit/1e9bdc6d35c917f1f2f9f6adddfee7ad9c33a245) | `` swaync: update style documentation link ``                 |