### PR TITLE
chore(flake/niri): `f8cc32a3` -> `94a35e10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1035,11 +1035,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1776509722,
-        "narHash": "sha256-oHVMjAMBukYnGeEE0EtCQsx8cNRv8WadHD8ZV3oZFSM=",
+        "lastModified": 1776711702,
+        "narHash": "sha256-X3NTbAyE/+dJl/drMbdHzyfPPdI39y4MMwm3/aLJl5s=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "f8cc32a3aba29fdacd06d80b0986028cfd413a22",
+        "rev": "94a35e10a15e7279243176cf1f7a9e6a8b3e6035",
         "type": "github"
       },
       "original": {
@@ -1068,11 +1068,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1776505268,
-        "narHash": "sha256-+hK+EgAwuRG+lhqwOkKfXlqMEdELIoTMdjfVosIlLb0=",
+        "lastModified": 1776706941,
+        "narHash": "sha256-nnv27JD0FOOqs1Hh67kydXFzZoEu8e0QyMf0R9AXaIw=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "9e5716a9dbf7dbf9622a95a5bd23a898867759c6",
+        "rev": "e9c182a13c1d12762351ec01ce0ec711d41b0337",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`94a35e10`](https://github.com/sodiboo/niri-flake/commit/94a35e10a15e7279243176cf1f7a9e6a8b3e6035) | `` Update flake.lock `` |
| [`c175f415`](https://github.com/sodiboo/niri-flake/commit/c175f415488243723dc1a5514b286abbea6f93c1) | `` Update flake.lock `` |
| [`8cd64f0a`](https://github.com/sodiboo/niri-flake/commit/8cd64f0a42a9a3e03974d1d804ff00f66baa2a18) | `` Update flake.lock `` |
| [`84cffff2`](https://github.com/sodiboo/niri-flake/commit/84cffff25a81f6f0cc411767e47f8a2915c70286) | `` Update flake.lock `` |
| [`4f97ae81`](https://github.com/sodiboo/niri-flake/commit/4f97ae810c113582d2a0318ae61ceedb81864d13) | `` Update flake.lock `` |
| [`d96d4363`](https://github.com/sodiboo/niri-flake/commit/d96d43634b2207a6a0f836c693f299642737f4f0) | `` Update flake.lock `` |