### PR TITLE
chore(flake/nixpkgs): `4bd9165a` -> `b12141ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1172,11 +1172,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`ece6acc1`](https://github.com/NixOS/nixpkgs/commit/ece6acc1e38c944b4bedad2bfc175b0d16e3506d) | `` nixos-test-driver: fix handling of type-check-disabled case ``                               |
| [`6e29dd2b`](https://github.com/NixOS/nixpkgs/commit/6e29dd2b9b633df0f64cf449fbab63a76f489356) | `` dwproton-bin: dwproton-10.0-23 -> dwproton-10.0-24 ``                                        |
| [`ba304971`](https://github.com/NixOS/nixpkgs/commit/ba30497175955cefca9b122baa030a3cbbd0548d) | `` home-assistant-custom-components.powercalc: 1.20.12 -> 1.20.13 ``                            |
| [`24a8a44d`](https://github.com/NixOS/nixpkgs/commit/24a8a44d8c918ef550626ea58dbd4483f59ed331) | `` sdl_gamecontrollerdb: 0-unstable-2026-04-10 -> 0-unstable-2026-04-15 ``                      |
| [`57ea9d40`](https://github.com/NixOS/nixpkgs/commit/57ea9d40d23553ac75456f5528dadbc8e16d129a) | `` libretro.prboom: 0-unstable-2026-04-10 -> 0-unstable-2026-04-11 ``                           |
| [`83f6805a`](https://github.com/NixOS/nixpkgs/commit/83f6805a7c4e86a051dcb163858f16f56571d9f2) | `` code-cursor: add mime registration ``                                                        |
| [`11badd73`](https://github.com/NixOS/nixpkgs/commit/11badd73eeba0ebd13d4a8dfe1fbd83da080c4f5) | `` xsokoban: fix build with gcc15 ``                                                            |
| [`ea9c4724`](https://github.com/NixOS/nixpkgs/commit/ea9c47245293251bd4e622821ecf452f74d48509) | `` datafusion-cli: 53.0.0 -> 53.1.0 ``                                                          |
| [`c894ecca`](https://github.com/NixOS/nixpkgs/commit/c894ecca74606ca96e860b84b743a623d8bbd251) | `` uutils-tar: 0-unstable-2026-02-24 -> 0-unstable-2026-04-16 ``                                |
| [`b17c8e21`](https://github.com/NixOS/nixpkgs/commit/b17c8e219af0ec98ab3666b94e6f368bffa6b26c) | `` uutils-tar: fix updateScript ``                                                              |
| [`142919df`](https://github.com/NixOS/nixpkgs/commit/142919df8ee4d4c86008982e64e5c503891faeb5) | `` gst-thumbnailers: enable `strictDeps` and `__structuredAttrs` ``                             |
| [`3f68b393`](https://github.com/NixOS/nixpkgs/commit/3f68b39364f2f5e732b60d73e960b04ba19ac835) | `` gst-thumbnailers: add thunze to maintainers ``                                               |
| [`a52450cd`](https://github.com/NixOS/nixpkgs/commit/a52450cd56e4469d2338117c50ff33b2c5619a7a) | `` gst-thumbnailers: enable tests ``                                                            |
| [`29c3f245`](https://github.com/NixOS/nixpkgs/commit/29c3f2456404342d3d8dd8141dd971ec5f97b03e) | `` gst-thumbnailers: add `meta.changelog` ``                                                    |
| [`db021660`](https://github.com/NixOS/nixpkgs/commit/db021660632aaecc8997667512b6513b732a8d8c) | `` gst-thumbnailers: 1.0.alpha.1 -> 1.0.0 ``                                                    |
| [`dff7ff2b`](https://github.com/NixOS/nixpkgs/commit/dff7ff2b9916d71ce187da193e38419cfe6e9aaa) | `` gst-thumbnailers: add update script ``                                                       |
| [`f50949a3`](https://github.com/NixOS/nixpkgs/commit/f50949a327495be99107ed32c1dbf4e65cf73fee) | `` gst-thumbnailers: add package test ``                                                        |
| [`5b088487`](https://github.com/NixOS/nixpkgs/commit/5b088487cb4f5e19d34379150528c2c846abb7a9) | `` Revert "nixos/amazon-image: default to raw format instead of vpc" ``                         |
| [`14bd7757`](https://github.com/NixOS/nixpkgs/commit/14bd7757eea5e2fabee03fb6fb7e4c9cca0c60d0) | `` vintagestory: 1.21.6 -> 1.21.7 ``                                                            |
| [`7adbbca8`](https://github.com/NixOS/nixpkgs/commit/7adbbca8302bb698e8c992782734785114f21d60) | `` pretalx: 2026.1.0 -> 2026.1.1 ``                                                             |
| [`72a37f98`](https://github.com/NixOS/nixpkgs/commit/72a37f984c0417d8a741e50decd9f44aeca58c74) | `` mate-panel-with-applets: Disable man output ``                                               |
| [`51be85b9`](https://github.com/NixOS/nixpkgs/commit/51be85b9f9a4cf7034ff6a6e190d10c6752b962f) | `` postgresqlPackages.apache_datasketches: datasketches-cpp: 5.0.2 -> 5.2.0 ``                  |
| [`b8bcc004`](https://github.com/NixOS/nixpkgs/commit/b8bcc00431640ac5e750365c2285edc16e56af45) | `` postgresqlPackages.apache_datasketches: fix build with gcc15 ``                              |
| [`b7bd9f57`](https://github.com/NixOS/nixpkgs/commit/b7bd9f57bbd175bdf4cdee4811451510ec17164c) | `` uutils-acl: 0.0.1-unstable-2026-04-01 -> 0.0.1-unstable-2026-04-16 ``                        |
| [`64c8a534`](https://github.com/NixOS/nixpkgs/commit/64c8a534f2dd3418cfebce36257d88e21f940493) | `` osu-lazer: 2026.406.0 -> 2026.418.0 ``                                                       |
| [`d261b325`](https://github.com/NixOS/nixpkgs/commit/d261b3251c0925ea4775bf732d383b8a06944280) | `` osu-lazer-bin: 2026.406.0 -> 2026.418.0 ``                                                   |
| [`5c9b038e`](https://github.com/NixOS/nixpkgs/commit/5c9b038ead41eac176854c48c2daaa48a7b6a783) | `` evcc: 0.304.3 -> 0.305.0 ``                                                                  |
| [`83225b31`](https://github.com/NixOS/nixpkgs/commit/83225b318b20f3e10c5bd61722ecbf2883cd4070) | `` python3Packages.flask-security: 5.7.1 -> 5.8.0 ``                                            |
| [`59872509`](https://github.com/NixOS/nixpkgs/commit/59872509b60467a35b8f212528b0659857f3463c) | `` opencode: 1.4.10 -> 1.4.11 ``                                                                |
| [`9153c15d`](https://github.com/NixOS/nixpkgs/commit/9153c15dafd8458f7142996fe5f75781f75a10fd) | `` obsidian: add prince213 as maintainer ``                                                     |
| [`88986586`](https://github.com/NixOS/nixpkgs/commit/88986586e5f8a57e43b5137c92391ad5603f2fad) | `` obsidian: pin electron to 39 ``                                                              |
| [`022ff150`](https://github.com/NixOS/nixpkgs/commit/022ff1506440fb2ebd72a8e1a74e488ca3320187) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.323 -> 0.13.324 ``    |
| [`f419f35c`](https://github.com/NixOS/nixpkgs/commit/f419f35cff24cae8e19e04fce8aaeeeaf8856a06) | `` vrcvideocacher: init at 2026.4.4 ``                                                          |
| [`a0b55e2c`](https://github.com/NixOS/nixpkgs/commit/a0b55e2cfc24c4001547deb9c6895822533e52cb) | `` cargo-deny: 0.19.1 -> 0.19.4 ``                                                              |
| [`b2963c32`](https://github.com/NixOS/nixpkgs/commit/b2963c32d0b936ae6e16ba4b1a73e38bcd43ecca) | `` vscode-extensions.google.colab: 0.7.3 -> 0.8.0 ``                                            |
| [`54a45aa3`](https://github.com/NixOS/nixpkgs/commit/54a45aa3a908c3f3706c7826cb3034018adca12b) | `` vscode-extensions.anthropic.claude-code: 2.1.112 -> 2.1.114 ``                               |
| [`ff1a9f40`](https://github.com/NixOS/nixpkgs/commit/ff1a9f40ca2577f40aad8ee09d116616db53191c) | `` claude-code-bin: 2.1.112 -> 2.1.114 ``                                                       |
| [`4a6918cf`](https://github.com/NixOS/nixpkgs/commit/4a6918cffa39da6ed0d29852fb124960ca5ae081) | `` linux_5_10: 5.10.252 -> 5.10.253 ``                                                          |
| [`ffc652cf`](https://github.com/NixOS/nixpkgs/commit/ffc652cfcbb1deedf4a73284b6f408f3e37be88d) | `` linux_5_15: 5.15.202 -> 5.15.203 ``                                                          |
| [`aec6f3e5`](https://github.com/NixOS/nixpkgs/commit/aec6f3e58f1b3f6404684a3a3890e5409602627a) | `` linux_6_1: 6.1.168 -> 6.1.169 ``                                                             |
| [`54492bae`](https://github.com/NixOS/nixpkgs/commit/54492bae65b1770eae2efcc9f09da964f7ec6d84) | `` linux_6_6: 6.6.134 -> 6.6.135 ``                                                             |
| [`abc3f6ea`](https://github.com/NixOS/nixpkgs/commit/abc3f6ea6422231acdab1118c32c7571f5712196) | `` linux_6_12: 6.12.81 -> 6.12.82 ``                                                            |
| [`278635a3`](https://github.com/NixOS/nixpkgs/commit/278635a3c0f1d769a1c2b8300b961de256348b44) | `` linux_6_18: 6.18.22 -> 6.18.23 ``                                                            |
| [`16a9a62b`](https://github.com/NixOS/nixpkgs/commit/16a9a62be022e9bedce7ab09874a578960761ef5) | `` linux_6_19: 6.19.12 -> 6.19.13 ``                                                            |
| [`e19cb380`](https://github.com/NixOS/nixpkgs/commit/e19cb3808e348bde7203f6fb20e8594493452390) | `` python3Packages.boto3-stubs: 1.42.90 -> 1.42.91 ``                                           |
| [`0458bc3e`](https://github.com/NixOS/nixpkgs/commit/0458bc3e79003f2e953d2e02fa105e065a518534) | `` python3Packages.mypy-boto3-sts: 1.42.3 -> 1.42.91 ``                                         |
| [`d6bc0b90`](https://github.com/NixOS/nixpkgs/commit/d6bc0b9066ab75f01ef21885c0a231f697d65049) | `` python3Packages.mypy-boto3-sagemaker: 1.42.88 -> 1.42.91 ``                                  |
| [`2b98d26c`](https://github.com/NixOS/nixpkgs/commit/2b98d26c601e8819d7040c8539f3aa1e1120b41d) | `` python3Packages.mypy-boto3-quicksight: 1.42.80 -> 1.42.91 ``                                 |
| [`b55d3f93`](https://github.com/NixOS/nixpkgs/commit/b55d3f9307d39528666318c44c2c7a97423bc52c) | `` python3Packages.mypy-boto3-neptune: 1.42.57 -> 1.42.91 ``                                    |
| [`d1e59005`](https://github.com/NixOS/nixpkgs/commit/d1e59005fa969c84a23a8008989764247461e070) | `` python3Packages.mypy-boto3-imagebuilder: 1.42.88 -> 1.42.91 ``                               |
| [`e466c9f2`](https://github.com/NixOS/nixpkgs/commit/e466c9f20b944954442071bcb78063f9975fa566) | `` python3Packages.mypy-boto3-groundstation: 1.42.35 -> 1.42.91 ``                              |
| [`dee51b05`](https://github.com/NixOS/nixpkgs/commit/dee51b0504ebd78d995cc5175c6550ab8d5ff7e8) | `` python3Packages.mypy-boto3-connect: 1.42.90 -> 1.42.91 ``                                    |
| [`b5f9bff6`](https://github.com/NixOS/nixpkgs/commit/b5f9bff65a7e0111abe11b97c36d82af160fbf13) | `` python3Packages.mypy-boto3-cleanrooms: 1.42.52 -> 1.42.91 ``                                 |
| [`2054cfc0`](https://github.com/NixOS/nixpkgs/commit/2054cfc0eecd56e0c1098b2f917bf44c8de11788) | `` python3Packages.iamdata: 0.1.202604171 -> 0.1.202604181 ``                                   |
| [`a902d0c1`](https://github.com/NixOS/nixpkgs/commit/a902d0c14ac2ce8b337a13d6b3641350dd5768dc) | `` android-studio: 2025.3.3.6 -> 2025.3.3.7 ``                                                  |
| [`bac78ed4`](https://github.com/NixOS/nixpkgs/commit/bac78ed4fdcf5c56bfce1f975eb2f90640d97a91) | `` python3Packages.pyenphase: 2.4.7 -> 2.4.8 ``                                                 |
| [`0cd96482`](https://github.com/NixOS/nixpkgs/commit/0cd964822afa00a97afb5dc8899838be4f12e598) | `` jjui: 0.10.2 -> 0.10.3 ``                                                                    |
| [`0908dc95`](https://github.com/NixOS/nixpkgs/commit/0908dc952f5fe44cb0fc987717b2bb04f8f46c36) | `` src-cli: 7.0.3 -> 7.1.0 ``                                                                   |
| [`3627bbbd`](https://github.com/NixOS/nixpkgs/commit/3627bbbd644dde8a464722f5594ec30c394c8764) | `` threatest: 1.2.6 -> 1.3.0 ``                                                                 |
| [`7b762fd2`](https://github.com/NixOS/nixpkgs/commit/7b762fd2541bda7ffcf1db93d03031cd4e33cc57) | `` nuclei: 3.7.1 -> 3.8.0 ``                                                                    |
| [`38d1b224`](https://github.com/NixOS/nixpkgs/commit/38d1b224d760787747167bc90efc3e18ac61db7e) | `` pantheon.switchboard-plug-about: fixup build, missing json-glib ``                           |
| [`40bb0eb3`](https://github.com/NixOS/nixpkgs/commit/40bb0eb34b0bd7fc8c8ae5683d693f1dbd5250a0) | `` rubyPackages.debug: init at 1.11.1 ``                                                        |
| [`f13acb40`](https://github.com/NixOS/nixpkgs/commit/f13acb40d689bec6ca3228be7a9dd4f4a569b342) | `` python3Packages.homematicip: 2.7.0 -> 2.8.0 ``                                               |
| [`de9c957e`](https://github.com/NixOS/nixpkgs/commit/de9c957e8b18556757ee3aa6d48e2cc90dd6bdcd) | `` drone-scp: 1.8.0 -> 1.8.1 ``                                                                 |
| [`9ef1da31`](https://github.com/NixOS/nixpkgs/commit/9ef1da31a531b262887fd50f751b409b81d53b0c) | `` openssl_4_0: init at 4.0.0 ``                                                                |
| [`1cc3b783`](https://github.com/NixOS/nixpkgs/commit/1cc3b783ec94d04dc2a7f10f2b26d5b1b26f887f) | `` gotenberg: 8.30.1 -> 8.31.0 ``                                                               |
| [`41d01744`](https://github.com/NixOS/nixpkgs/commit/41d017444bbbb949793acd8f8cf8b6fbc284a74d) | `` python3Packages.python-benedict: 0.35.0 -> 0.36.0 ``                                         |
| [`c5a18929`](https://github.com/NixOS/nixpkgs/commit/c5a1892904d87ea0ae890534723cd2e80c017132) | `` terraform-providers.ovh_ovh: 2.12.0 -> 2.13.0 ``                                             |
| [`46dc938d`](https://github.com/NixOS/nixpkgs/commit/46dc938d4fd5ef0d6d850257d2817fa7bf298730) | `` postgresqlPackages.postgis: 3.6.2 -> 3.6.3 ``                                                |
| [`5b7580af`](https://github.com/NixOS/nixpkgs/commit/5b7580af5a5c7607fa69f402da2f66e580699f10) | `` ruff: 0.15.10 -> 0.15.11 ``                                                                  |
| [`de46d8b3`](https://github.com/NixOS/nixpkgs/commit/de46d8b30b36ff8c4ec7558280d132dde117219a) | `` sqruff: 0.37.3 -> 0.38.0 ``                                                                  |
| [`f6f50b09`](https://github.com/NixOS/nixpkgs/commit/f6f50b0979d0593201b2e16537dab2447d102eeb) | `` apple-sdk.sourceRelease: make an alias of darwin.sourceRelease ``                            |
| [`fdd34f1b`](https://github.com/NixOS/nixpkgs/commit/fdd34f1b2399ba9adf6b6f20f8cb57f13e88335d) | `` lsyncd: migrate to use darwin.sourceRelease ``                                               |
| [`d4004186`](https://github.com/NixOS/nixpkgs/commit/d40041864f11e70255613d0954cf6118b2f43462) | `` darwin.top: migrate to use darwin.sourceRelease ``                                           |
| [`508e8f3b`](https://github.com/NixOS/nixpkgs/commit/508e8f3b51bcaefe1392ba4d947c19b9963ffbcf) | `` darwin.text_cmds: migrate to use darwin.sourceRelease ``                                     |
| [`40792f50`](https://github.com/NixOS/nixpkgs/commit/40792f5021c544e09f6f183de1caa750edd62858) | `` darwin.system_cmds: migrate to use darwin.sourceRelease ``                                   |
| [`895f2f48`](https://github.com/NixOS/nixpkgs/commit/895f2f48cd19167f5d86b76cade2e0dda5064802) | `` darwin.shell_cmds: migrate to use darwin.sourceRelease ``                                    |
| [`03b82c06`](https://github.com/NixOS/nixpkgs/commit/03b82c06f1a28f7d4a337ac872e9f2dc93d4cc25) | `` darwin.removefile: migrate to use darwin.sourceRelease ``                                    |
| [`930108f0`](https://github.com/NixOS/nixpkgs/commit/930108f0bbe7dfabaeb862dee7ff1c1987eba930) | `` darwin.PowerManagement: migrate to use darwin.sourceRelease ``                               |
| [`b117fd03`](https://github.com/NixOS/nixpkgs/commit/b117fd0320ddf2719966cad3b75d409bfc71cf77) | `` darwin.network_cmds: migrate to use darwin.sourceRelease ``                                  |
| [`d284d13f`](https://github.com/NixOS/nixpkgs/commit/d284d13f1cc6766d246c1cc19cf7bbb97e9ea36d) | `` darwin.libresolv: migrate to use darwin.sourceRelease ``                                     |
| [`9cd197eb`](https://github.com/NixOS/nixpkgs/commit/9cd197eb1dafde832d67ce62c156c7115325c00a) | `` darwin.libpcap: migrate to use darwin.sourceRelease ``                                       |
| [`b4d105ca`](https://github.com/NixOS/nixpkgs/commit/b4d105cafaee3e038dfe45affb293af23fe8ea14) | `` darwin.IOKitTools: migrate to use darwin.sourceRelease ``                                    |
| [`1fd34d3e`](https://github.com/NixOS/nixpkgs/commit/1fd34d3ed3aab86f1a7bb180d5a5a19c2be77232) | `` darwin.file_cmds: migrate to use darwin.sourceRelease ``                                     |
| [`7ad69515`](https://github.com/NixOS/nixpkgs/commit/7ad69515599cdf1ff41ba93965a24718eafe7d31) | `` darwin.dyld: migrate to use darwin.sourceRelease ``                                          |
| [`4f980622`](https://github.com/NixOS/nixpkgs/commit/4f980622d917566ddedce28bd654a7a63b618f38) | `` darwin.doc_cmds: migrate to use darwin.sourceRelease ``                                      |
| [`857b04c8`](https://github.com/NixOS/nixpkgs/commit/857b04c8ed9aa5e658b46e1ae05d19b2ed50d659) | `` darwin.diskdev_cmds: migrate to use darwin.sourceRelease ``                                  |
| [`44fc4a5e`](https://github.com/NixOS/nixpkgs/commit/44fc4a5e8b45e321b8485608bd715c1ade55ae7d) | `` darwin.copyfile: migrate to use darwin.sourceRelease ``                                      |
| [`5d841aa4`](https://github.com/NixOS/nixpkgs/commit/5d841aa494cb412598c52ef23714d70f401cd438) | `` darwin.bootstrap_cmds: migrate to use darwin.sourceRelease ``                                |
| [`74193706`](https://github.com/NixOS/nixpkgs/commit/7419370682914c14f2752179166aae6cfeed210d) | `` darwin.AvailabilityVersions: migrate to use darwin.sourceRelease ``                          |
| [`f9f16e25`](https://github.com/NixOS/nixpkgs/commit/f9f16e259f2a7a55e04103eb933656d83a3b48b1) | `` darwin.adv_cmds: migrate to use darwin.sourceRelease ``                                      |
| [`e3e8c0c2`](https://github.com/NixOS/nixpkgs/commit/e3e8c0c2cf42fd4e7f71b66287192a3588c2543d) | `` darwin.mkAppleDerivation: migrate to use darwin.sourceRelease ``                             |
| [`b00e2f3b`](https://github.com/NixOS/nixpkgs/commit/b00e2f3bc505f2d2de6314057b85356b5eb5ab59) | `` darwin.sourceRelease: add ``                                                                 |
| [`28f8f156`](https://github.com/NixOS/nixpkgs/commit/28f8f156711ce2d7c7e65e6a38732efb5f5270f5) | `` python3Packages.homeassistant-stubs: 2026.4.2 -> 2026.4.3 ``                                 |
| [`51451649`](https://github.com/NixOS/nixpkgs/commit/51451649040907ec33ceab8dcaf04056c02f9f27) | `` libretro.stella2014: 0-unstable-2024-10-21 -> 0-unstable-2026-04-12 ``                       |
| [`a0d14380`](https://github.com/NixOS/nixpkgs/commit/a0d14380f21c4bafe84cf4d4b7722ada625e2a24) | `` turingdb: 1.28 -> 1.29 ``                                                                    |
| [`5e993cf5`](https://github.com/NixOS/nixpkgs/commit/5e993cf56ccc9b65dfa77826344ced78c5c5b1c2) | `` giter8: init at 0.18.0 ``                                                                    |
| [`b80b63a4`](https://github.com/NixOS/nixpkgs/commit/b80b63a44ad514c1208aee180f0534f925382ce7) | `` python3Packages.yoto-api: 2.2.3 -> 2.2.5 ``                                                  |
| [`0fc124be`](https://github.com/NixOS/nixpkgs/commit/0fc124bee54fc20611b3282cb1c93c51dfa0814e) | `` home-assistant-custom-components.tuya_local: 2026.4.0 -> 2026.4.2 ``                         |
| [`84b6f71d`](https://github.com/NixOS/nixpkgs/commit/84b6f71d4739fa1df8cd8f6df7c2b49cc7f140c5) | `` home-assistant-custom-components.yoto_ha: 3.1.0 -> 3.1.1 ``                                  |
| [`9782cdf9`](https://github.com/NixOS/nixpkgs/commit/9782cdf9c1fcec0695dca9092fcd3440d3572f12) | `` home-assistant-custom-components.solax_modbus: 2026.04.2 -> 2026.04.3 ``                     |
| [`2dc3e2b2`](https://github.com/NixOS/nixpkgs/commit/2dc3e2b29531743ef837cde1d717d6e25bb4d61e) | `` home-assistant-custom-components.oref_alert: 6.17.1 -> 6.18.0 ``                             |
| [`a75e1274`](https://github.com/NixOS/nixpkgs/commit/a75e12744b5e729516868a9ab10f485e30a644dc) | `` home-assistant-custom-components.bodymiscale: 2024.6.0 -> 2026.4.2 ``                        |
| [`a11de64f`](https://github.com/NixOS/nixpkgs/commit/a11de64ff74f42dcdd512d8aefb051904a55b0ba) | `` code-cursor: 3.0.16 -> 3.1.15 ``                                                             |
| [`3164460a`](https://github.com/NixOS/nixpkgs/commit/3164460a3b1a8660aa20082a6cf96ac518b2d2ad) | `` home-assistant: 2026.4.2 -> 2026.4.3 ``                                                      |
| [`105ab0dc`](https://github.com/NixOS/nixpkgs/commit/105ab0dcbfd9f5fd313544d449d5f849f67acccf) | `` python3Packages.satel-integra: 1.1.0 -> 1.2.1 ``                                             |
| [`d0b34e7b`](https://github.com/NixOS/nixpkgs/commit/d0b34e7b1bf0cef26742ccc97daf5ab534b76b3c) | `` python3Packages.pyenphase: 2.4.7 -> 2.4.8 ``                                                 |
| [`a4d12dfc`](https://github.com/NixOS/nixpkgs/commit/a4d12dfc475fb9dba3c77ac4f2362f911c486218) | `` python3Packages.imgw-pib: 2.0.4 -> 2.1.0 ``                                                  |
| [`e6f9a5d7`](https://github.com/NixOS/nixpkgs/commit/e6f9a5d7f5fac3a91eb6141d1228856253fccfce) | `` python3Packages.bumble: 0.0.226 -> 0.0.227 ``                                                |
| [`7ea07aab`](https://github.com/NixOS/nixpkgs/commit/7ea07aab4cb183cc2ab0222d9a9913ab4bcd519a) | `` python3Packages.aioamazondevices: 13.3.2 -> 13.4.2 ``                                        |
| [`b4786f4a`](https://github.com/NixOS/nixpkgs/commit/b4786f4a91976f9ef8ed6c461c814823322021eb) | `` python3Packages.rio-tiler: 9.0.4 -> 9.0.6 ``                                                 |
| [`6fa956a7`](https://github.com/NixOS/nixpkgs/commit/6fa956a7308306f370d3d9184f1baf34e96468ca) | `` nixos/v4l2-relayd: Don't create dummy video device ``                                        |
| [`edf1e54c`](https://github.com/NixOS/nixpkgs/commit/edf1e54ca5526aa64f3546c2b274d1ef7089670c) | `` retroarch-assets: 1.22.0-unstable-2026-04-09 -> 1.22.0-unstable-2026-04-11 ``                |
| [`289b1c6c`](https://github.com/NixOS/nixpkgs/commit/289b1c6c0632fdcdfee6bb2c7aa1e6c0edb77195) | `` home-assistant-custom-components.octopus_energy: 18.1.2 -> 18.2.1 ``                         |
| [`7997ddb6`](https://github.com/NixOS/nixpkgs/commit/7997ddb68ac034aafa3cac6809c73c944582bff4) | `` pretalx.plugins.youtube: 2.5.0 -> 2.6.0 ``                                                   |
| [`aa3b2d2d`](https://github.com/NixOS/nixpkgs/commit/aa3b2d2d7ac8bb22fbabc41718df38ff30bec1ef) | `` pretalx.plugins.vimeo: 2.6.0 -> 2.7.0 ``                                                     |
| [`37908d0e`](https://github.com/NixOS/nixpkgs/commit/37908d0e3b9155b4f7bb0c8fee88fa273127b3a5) | `` pretalx.plugins.venueless: 1.7.0 -> 1.8.0 ``                                                 |
| [`2865c424`](https://github.com/NixOS/nixpkgs/commit/2865c4249f4a684f8c686d55c386eaff99492178) | `` pretalx.plugins.public-voting: 1.9.0 -> 1.10.0 ``                                            |
| [`3a9fa069`](https://github.com/NixOS/nixpkgs/commit/3a9fa06989921b5fd57403f8f4c88e71ff30ec00) | `` pretalx.plugins.pages: 1.8.0 -> 1.9.0 ``                                                     |
| [`ef2bc20b`](https://github.com/NixOS/nixpkgs/commit/ef2bc20beda7a017ee5adeaed2ce08b9a77aac24) | `` pretalx.plugins.media-ccc-de: 1.6.0 -> 1.7.0 ``                                              |
| [`7e543061`](https://github.com/NixOS/nixpkgs/commit/7e543061554c494095452a10809cb19a78f4c2bf) | `` pretalx.plugins.downstream: 1.3.1 -> 1.5.0 ``                                                |
| [`8cedca33`](https://github.com/NixOS/nixpkgs/commit/8cedca33d90f763a224f89b8f084e335493f009f) | `` pretalx: 2025.2.2 -> 2026.1.0 ``                                                             |
| [`c55f0984`](https://github.com/NixOS/nixpkgs/commit/c55f0984b0cd950b380a97cccfb5f5e605f8d09b) | `` python3Packages.whitenoise: refactor ``                                                      |
| [`01949aa3`](https://github.com/NixOS/nixpkgs/commit/01949aa39999c44bbe9a8ce6c73404c022d6149c) | `` python3Packages.celery: disable failing tests ``                                             |
| [`1702818a`](https://github.com/NixOS/nixpkgs/commit/1702818a2827426440752dfabed0122001b6d85b) | `` python3Packages.dj-rest-auth: 7.0.2 -> 7.2.0 ``                                              |
| [`bd5f2f6d`](https://github.com/NixOS/nixpkgs/commit/bd5f2f6d841333134a55dfd4e8e1769917250554) | `` python3Packages.graphene-django: disable failing tests ``                                    |
| [`bb22c84e`](https://github.com/NixOS/nixpkgs/commit/bb22c84e70a4ace843acdc3b84a120372a827bd0) | `` nixos/ipu6: Fix device persistence and pipewire integration ``                               |
| [`6fe4fb80`](https://github.com/NixOS/nixpkgs/commit/6fe4fb8095c1c1c3adff67b554ba1b3f627ca00e) | `` netatalk: 4.4.1 -> 4.4.2 ``                                                                  |
| [`872f630f`](https://github.com/NixOS/nixpkgs/commit/872f630f8784aef7d693d744a8bdec9c0c9f0152) | `` devcontainer: 0.85.0 -> 0.86.0 ``                                                            |
| [`dd5a1dd6`](https://github.com/NixOS/nixpkgs/commit/dd5a1dd6d048d34a3d2af22b635dac05c98a0bcf) | `` gpxsee: 16.2 -> 16.3 ``                                                                      |
| [`e5dba655`](https://github.com/NixOS/nixpkgs/commit/e5dba655b6ca52684b242820f633be8186778154) | `` pgdog: 0.1.36 -> 0.1.37 ``                                                                   |
| [`baea8fde`](https://github.com/NixOS/nixpkgs/commit/baea8fde7d26d111caf9a28854eb3c5114890255) | `` emscripten: 5.0.0 -> 5.0.6 ``                                                                |
| [`892294bf`](https://github.com/NixOS/nixpkgs/commit/892294bfe1bbcf0b3d131edb3e8ddad9923ec2fa) | `` pdf-oxide: init at 0.3.32 ``                                                                 |
| [`b95222f2`](https://github.com/NixOS/nixpkgs/commit/b95222f26f6a9456452d788d9ed2d74880b4dbb3) | `` binaryen: 126 -> 129 ``                                                                      |
| [`25d772c2`](https://github.com/NixOS/nixpkgs/commit/25d772c2f32e2cfdbaaef10e10bd7a84b7635e02) | `` samba: 4.22.7 -> 4.23.5 ``                                                                   |
| [`acc0d329`](https://github.com/NixOS/nixpkgs/commit/acc0d329b05456f25c68be554d511e9b0ceb6fd9) | `` terraform-providers.yandex-cloud_yandex: 0.197.0 -> 0.199.0 ``                               |
| [`8a90c382`](https://github.com/NixOS/nixpkgs/commit/8a90c38299923e70cdea498898b4e2df1c726c3e) | `` python3Packages.geniushub-client: 0.7.3 -> 0.7.4 ``                                          |
| [`0ef58da1`](https://github.com/NixOS/nixpkgs/commit/0ef58da13df37112e32f454abe250876a8101acf) | `` python3Packages.django-tables2: 2.8.0 -> 3.0.0 ``                                            |
| [`5814cbd1`](https://github.com/NixOS/nixpkgs/commit/5814cbd1334ab278a1e704628562a69632f59de4) | `` cljfmt: 0.16.3 -> 0.16.4 ``                                                                  |
| [`41a3c8fb`](https://github.com/NixOS/nixpkgs/commit/41a3c8fbd4be7c7855d6705c88ad93e4330ec1d3) | `` terraform-providers/1password_onepassword: 2.2.0 -> 3.3.1 ``                                 |
| [`7171a289`](https://github.com/NixOS/nixpkgs/commit/7171a2892d63b84658bc9df2931cfc4e9acae950) | `` python3Packages.langchain-aws: 1.4.3 -> 1.4.4 ``                                             |
| [`f803141a`](https://github.com/NixOS/nixpkgs/commit/f803141a64c364c160e6c0b87ca60c85da9637eb) | `` exo: 1.0.69 -> 1.0.70 ``                                                                     |
| [`c7140456`](https://github.com/NixOS/nixpkgs/commit/c7140456d184f88c8ffb66846e49c2909d8b23f7) | `` python3Packages.py-netgear-plus: 0.5.1 -> 0.6.1 ``                                           |
| [`29cbeb3d`](https://github.com/NixOS/nixpkgs/commit/29cbeb3df96f21ce699b0b91160436a078fe99a6) | `` python3Packages.mlx-vlm: enable on linux ``                                                  |
| [`238ba37c`](https://github.com/NixOS/nixpkgs/commit/238ba37c4314a56354c71217ceb9f9aafc94ef71) | `` opencode: disable model fetching when building ``                                            |
| [`9dfe8d16`](https://github.com/NixOS/nixpkgs/commit/9dfe8d16dcb9fc27f0b1189b040841bb72597516) | `` az-pim-cli: 1.13.0 -> 1.14.0 ``                                                              |
| [`9606246a`](https://github.com/NixOS/nixpkgs/commit/9606246af0b73dcc5a48f903d22921686b99856a) | `` terraform-providers: fix quoting in update script ``                                         |
| [`549ad67a`](https://github.com/NixOS/nixpkgs/commit/549ad67ac5f85586121d77d52ede742c608385cc) | `` python3Packages.ibind: init at 0.1.22 ``                                                     |
| [`fb67d50d`](https://github.com/NixOS/nixpkgs/commit/fb67d50dca441bb00b5588be490dd72b937ae344) | `` nh-unwrapped: 4.3.0 -> 4.3.1 ``                                                              |
| [`f8ab79ae`](https://github.com/NixOS/nixpkgs/commit/f8ab79aef0a54e2cedffe150e5bdddea2dc05d05) | `` opencommit: 3.2.18 -> 3.2.19 ``                                                              |
| [`78b5496f`](https://github.com/NixOS/nixpkgs/commit/78b5496f42710d9561842b7dcb6d472b87251f54) | `` opencode: 1.4.6 -> 1.4.10 ``                                                                 |
| [`5903e004`](https://github.com/NixOS/nixpkgs/commit/5903e00478dc95c6d8d15980ceda7de15fbc828c) | `` home-assistant-custom-lovelace-modules.sankey-chart: 3.11.0 -> 4.0.2 ``                      |
| [`85b5c8a9`](https://github.com/NixOS/nixpkgs/commit/85b5c8a9af4c1e5513a787dc84d6f92300c894c2) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.82.84 -> 1.82.88 ``                    |
| [`b751a26a`](https://github.com/NixOS/nixpkgs/commit/b751a26a4a6c823ddf9d82413c901a89e326692f) | `` lianad: 13.1 -> 14.0 ``                                                                      |
| [`6b93a0f3`](https://github.com/NixOS/nixpkgs/commit/6b93a0f3bceddbda281c2314b2d60c582d42b56c) | `` python3Packages.fsspec-xrootd: 0.5.2 -> 0.5.3 ``                                             |
| [`2d5f9701`](https://github.com/NixOS/nixpkgs/commit/2d5f9701028b8e6a0098b14de957f592aff55931) | `` liana: 13.1 -> 14.0 ``                                                                       |
| [`f44b6362`](https://github.com/NixOS/nixpkgs/commit/f44b636277153ef05c2d6a3f65b4af60f3c63fcd) | `` python3Packages.nbdev: 3.0.12 -> 3.0.15 ``                                                   |
| [`e824b2d8`](https://github.com/NixOS/nixpkgs/commit/e824b2d89cce134700687e852dc090a42f1e2509) | `` thunderkittens: init at 0-unstable-2026-04-07 ``                                             |
| [`708cb74f`](https://github.com/NixOS/nixpkgs/commit/708cb74f752def0ebebcb761be07bc759d224d9a) | `` lomiri-qt6.gmenuharness: init at 0.1.5 ``                                                    |
| [`d97e6eb2`](https://github.com/NixOS/nixpkgs/commit/d97e6eb2ef67aa293951cf36df3cbb515586c026) | `` lomiri.gmenuharness: 0.1.4 -> 0.1.5 ``                                                       |
| [`78affe86`](https://github.com/NixOS/nixpkgs/commit/78affe86988e5b2c1ad22ea0bac21b4fad56c42a) | `` home-assistant-custom-components.roborock_custom_map: 0.1.4 -> 0.1.5 ``                      |
| [`daf739d6`](https://github.com/NixOS/nixpkgs/commit/daf739d66bcaa7a6ea8b1951ccf5facb3997be33) | `` asak: 0.3.7 -> 0.4.0 ``                                                                      |
| [`e2a86ab7`](https://github.com/NixOS/nixpkgs/commit/e2a86ab719a83fcec4ef76f7ae18170be53d8dc0) | `` uutils-hostname: 0-unstable-2026-03-08 -> 0-unstable-2026-04-16 ``                           |
| [`2bb85065`](https://github.com/NixOS/nixpkgs/commit/2bb850652c2ca5c44d52003b65132936f5619371) | `` uutils-login: 0-unstable-2026-04-07 -> 0-unstable-2026-04-16 ``                              |
| [`161d6498`](https://github.com/NixOS/nixpkgs/commit/161d649804003128596bc4d3f1e013740e91e997) | `` terraform-providers.cloudamqp_cloudamqp: 1.44.0 -> 1.44.4 ``                                 |
| [`2a62347f`](https://github.com/NixOS/nixpkgs/commit/2a62347f7356b6b5f38381b15db6a57b3d0b9d3b) | `` vex-tui: 2.0.2 -> 2.1.0 ``                                                                   |
| [`a223c050`](https://github.com/NixOS/nixpkgs/commit/a223c050f3873b4070cf46602813d11b7bed32ea) | `` atlas: 1.1.0 -> 1.2.0 ``                                                                     |
| [`50361702`](https://github.com/NixOS/nixpkgs/commit/50361702a5fab56da0321c8e26cb02dc5a094110) | `` wasm-tools: 1.246.2 -> 1.247.0 ``                                                            |
| [`e7c89456`](https://github.com/NixOS/nixpkgs/commit/e7c894560b7ed79ad405c3dc1afe4c7c0d1db24a) | `` vulkanscenegraph: 1.1.13 -> 1.1.14 ``                                                        |
| [`096cb960`](https://github.com/NixOS/nixpkgs/commit/096cb96074e091fb0ab11fa447eb7ada60c51daf) | `` gh-skyline: 0.1.7 -> 0.1.8 ``                                                                |
| [`e427fd53`](https://github.com/NixOS/nixpkgs/commit/e427fd538ebf499e9983f04494233244a776b04a) | `` git-conventional-commits: 2.7.2 -> 2.9.0 ``                                                  |
| [`86c5e37e`](https://github.com/NixOS/nixpkgs/commit/86c5e37e7eec679b4d78c387a7f27c575b1c3955) | `` odiff: 4.3.3 -> 4.3.8 ``                                                                     |
| [`0a9a8d83`](https://github.com/NixOS/nixpkgs/commit/0a9a8d8311fd2999742f83f2cae91387652097a1) | `` python3Packages.rapidocr: 3.8.0 -> 3.8.1 ``                                                  |
| [`355e0ec3`](https://github.com/NixOS/nixpkgs/commit/355e0ec371f9ef957bbc29dadf18c391a72f6474) | `` vscode-extensions.redhat.ansible: 26.3.5 -> 26.4.2 ``                                        |
| [`659737ff`](https://github.com/NixOS/nixpkgs/commit/659737ffe66065d2f7076ef08e7eb925732410c8) | `` maintainers: drop pneumaticat ``                                                             |
| [`623fd596`](https://github.com/NixOS/nixpkgs/commit/623fd5964b4b43494db990b461114dae5e48fa27) | `` scala-cli: 1.12.5 -> 1.13.0 ``                                                               |
| [`6f22328d`](https://github.com/NixOS/nixpkgs/commit/6f22328da48a3f5530a03fdd936e59e1d557e527) | `` xivlauncher: remove runtime package dependencies ``                                          |
| [`2641aee5`](https://github.com/NixOS/nixpkgs/commit/2641aee5fe57f5a5ab67ca5e56a8bbf604fffbc8) | `` terraform-providers.aminueza_minio: 3.30.0 -> 3.32.1 ``                                      |
| [`20e14a9e`](https://github.com/NixOS/nixpkgs/commit/20e14a9e4219ca85517305df3eb39b2d72d5a17e) | `` python3Packages.bidsschematools: modernize ``                                                |
| [`afcc14ca`](https://github.com/NixOS/nixpkgs/commit/afcc14ca7d24658c409847dbb0c2e75dfa6c0328) | `` lockbook-desktop: 26.4.9 -> 26.4.13 ``                                                       |
| [`43324fd7`](https://github.com/NixOS/nixpkgs/commit/43324fd71f0ad009190a14f6d15e523062f76c96) | `` python3Packages.tyro: 1.0.12 -> 1.0.13 ``                                                    |
| [`24bd62dd`](https://github.com/NixOS/nixpkgs/commit/24bd62ddf7c6f21a041d607cf53af66e85157233) | `` skkDictionaries.assoc: 0-unstable-2024-08-28 -> 0-unstable-2026-04-11 ``                     |
| [`231170aa`](https://github.com/NixOS/nixpkgs/commit/231170aa16b03d8f26ffe05322cf84f4df400e25) | `` nixpkgs-plugin-update: use nix-prefetch-github ``                                            |
| [`d5aa00c0`](https://github.com/NixOS/nixpkgs/commit/d5aa00c05dd99cb306c33f79be7d8ceeab0fb925) | `` zed-editor: add maintainer schembriaiden ``                                                  |
| [`27199b9a`](https://github.com/NixOS/nixpkgs/commit/27199b9a8c14920adb2c5f20af27db1a8a77b381) | `` hyprlock: 0.9.3 -> 0.9.4 ``                                                                  |
| [`63c7e6bf`](https://github.com/NixOS/nixpkgs/commit/63c7e6bfdbb65f49c359becaa9dbdb4423ed34c3) | `` zed-editor: 0.231.2 -> 0.232.2 ``                                                            |
| [`613ae198`](https://github.com/NixOS/nixpkgs/commit/613ae198188f4fc54dd200d521d93870ba7f0d31) | `` python3Packages.openfga-sdk: 0.10.0 -> 0.10.1 ``                                             |
| [`2f78a71b`](https://github.com/NixOS/nixpkgs/commit/2f78a71bb6f1909a2f47f3e541ac1f97b9651373) | `` mdterm: init at 2.0.0 ``                                                                     |
| [`03123e84`](https://github.com/NixOS/nixpkgs/commit/03123e8452e6b2fe7bdfd7ccf821007e12ea3d01) | `` python3Packages.python-arango: 8.3.1 -> 8.3.2 ``                                             |
| [`ad763e44`](https://github.com/NixOS/nixpkgs/commit/ad763e44fb5b85d0092351cc0ed08751ec7d1767) | `` nixpkgs-plugin-update: handle special chars in tags ``                                       |
| [`18ce325b`](https://github.com/NixOS/nixpkgs/commit/18ce325b08a297c54ad04aaf1ed7be7da4d1ec6f) | `` cargo-codspeed: 4.4.1 -> 4.5.0 ``                                                            |
| [`65f69374`](https://github.com/NixOS/nixpkgs/commit/65f69374ab04ecaa8917b19e5884fb5f254c4ed5) | `` canfigger: 0.3.0 -> 0.3.1 ``                                                                 |
| [`0fac9de2`](https://github.com/NixOS/nixpkgs/commit/0fac9de23efdcdd37a448d66421d93849bd1abb1) | `` koffan: 2.3.1 -> 2.9.0 ``                                                                    |
| [`5761a0b8`](https://github.com/NixOS/nixpkgs/commit/5761a0b819e1970c73486be3191ceaafb84d26f0) | `` dovecot: build with fts_flatcurve ``                                                         |
| [`582e18b3`](https://github.com/NixOS/nixpkgs/commit/582e18b3e18a7054cd46ba5ac092993fe9b0ffaa) | `` vim: fix `addon-info.json` syntax ``                                                         |
| [`c86aa6ed`](https://github.com/NixOS/nixpkgs/commit/c86aa6ed9b35494da42432aa9ab576743780075f) | `` json-sort: init at 0.1.1 ``                                                                  |
| [`3d378f70`](https://github.com/NixOS/nixpkgs/commit/3d378f7030395a1d92b793dede9930a33b9d9091) | `` terraform-providers.datadog_datadog: 4.4.0 -> 4.5.0 ``                                       |
| [`104714c9`](https://github.com/NixOS/nixpkgs/commit/104714c92bf355645a3a693f7b2d9439fdf7e3fa) | `` lk-jwt-service: 0.4.2 -> 0.4.3 ``                                                            |
| [`f1bcb617`](https://github.com/NixOS/nixpkgs/commit/f1bcb61731224bd8440510fc620d3c51f3e51c85) | `` nixos-test-driver: use configuration file instead of scattered env vars ``                   |
| [`b894a641`](https://github.com/NixOS/nixpkgs/commit/b894a6412bb72e2ac00b6c61ebb8e7b2eacb71ab) | `` osrm-backend: 6.0.0 -> 26.4.0 ``                                                             |
| [`43a25e1a`](https://github.com/NixOS/nixpkgs/commit/43a25e1a9e43a40bcab925bee88253e1efaf2df7) | `` postfix-tlspol: 1.8.27 -> 1.9.0 ``                                                           |
| [`223b891d`](https://github.com/NixOS/nixpkgs/commit/223b891d876911833badee4283fc8d90aa69a6a4) | `` vimPlugins.nvim-treesitter-legacy: don't warn on allowAliases == false ``                    |
| [`6d30b03c`](https://github.com/NixOS/nixpkgs/commit/6d30b03cf466012480332ae1332e4907d77aa746) | `` forgejo-cli: 0.4.1 -> 0.5.0 ``                                                               |
| [`c74b0195`](https://github.com/NixOS/nixpkgs/commit/c74b019541c0a1baf40fc8efe867d9b4208e0675) | `` librewolf-unwrapped: 149.0-1 -> 149.0.2-2 ``                                                 |
| [`39ec37ee`](https://github.com/NixOS/nixpkgs/commit/39ec37eeb46813cec6849d9e5e42b51cdf34c468) | `` seerr: 3.1.1 -> 3.2.0 ``                                                                     |
| [`5c12f371`](https://github.com/NixOS/nixpkgs/commit/5c12f3710323bc83430ec3ebae3a5558b008d905) | `` basex: 12.2 -> 12.3 ``                                                                       |
| [`70946dbc`](https://github.com/NixOS/nixpkgs/commit/70946dbcfc05c99b6635310282c1c63562dcef54) | `` wayle: init at 0.2.1 ``                                                                      |
| [`bf92b131`](https://github.com/NixOS/nixpkgs/commit/bf92b1316a1b9e9db0b38836ce838f83da563a06) | `` dotnetCorePackages.sdk_11_0: 11.0.100-preview.2.26159.112 -> 11.0.100-preview.3.26207.106 `` |
| [`aa81354e`](https://github.com/NixOS/nixpkgs/commit/aa81354e44f2352d1aa2fc71835a3fd89107ff6a) | `` dotnetCorePackages.sdk_8_0: 8.0.419 -> 8.0.420 ``                                            |
| [`1d10784c`](https://github.com/NixOS/nixpkgs/commit/1d10784cf981f59dc24906d857cd3ee97e335fb5) | `` dotnetCorePackages.sdk_10_0: 10.0.201 -> 10.0.202 ``                                         |
| [`f90421bb`](https://github.com/NixOS/nixpkgs/commit/f90421bb2a74364540f27391f17917bc1d7218de) | `` dotnetCorePackages.sdk_9_0: 9.0.312 -> 9.0.313 ``                                            |
| [`bfc94a6c`](https://github.com/NixOS/nixpkgs/commit/bfc94a6c9e64bffc75e3d936413209c42b3b7923) | `` nuget-package-hook: add helper to create .nupkg.metadata ``                                  |
| [`998719b9`](https://github.com/NixOS/nixpkgs/commit/998719b97b1cbba1fc6e511496c529d1917cf556) | `` dotnet-sdk_{10,11}: apply muxer path precedence patch ``                                     |
| [`9ec199be`](https://github.com/NixOS/nixpkgs/commit/9ec199bef9322f6216f3aadfc33d65a1fc84912b) | `` dotnetCorePackages.combinePackages: set DOTNET_HOST_PATH in wrappers ``                      |
| [`f2f37583`](https://github.com/NixOS/nixpkgs/commit/f2f375833c5dccefbbe5412180da75d4d48450de) | `` dotnet-sdk_{10,11}: provide $out/bin/dnx ``                                                  |
| [`37b5be74`](https://github.com/NixOS/nixpkgs/commit/37b5be744fee04976801cb0cf98ca05f88186bf2) | `` test/dotnet: add cross-target test ``                                                        |
| [`4172435a`](https://github.com/NixOS/nixpkgs/commit/4172435a898304c7dbbc0522702ebe6fbaa7bd8f) | `` dotnet: update URLs for eol packages ``                                                      |
| [`25b82b35`](https://github.com/NixOS/nixpkgs/commit/25b82b35f811ab53c4b310fadfec60cd4e232532) | `` dotnet: combine binary and source update scripts ``                                          |
| [`928e583e`](https://github.com/NixOS/nixpkgs/commit/928e583edf9cdee08afb5f23670a881536e34ae2) | `` dotnet: combine binary and source expressions ``                                             |
| [`312229da`](https://github.com/NixOS/nixpkgs/commit/312229da6fe08219bf46cd62aae969f331180c63) | `` blender: fix build on aarch64-linux (missing sse2neon dep) ``                                |
| [`7e6a9f58`](https://github.com/NixOS/nixpkgs/commit/7e6a9f58a3a40541aa6c7ad8e8c841937d0903bd) | `` ocaml-ng.ocamlPackages_4_14.ocaml: fix ARM64 bug ``                                          |
| [`214251f3`](https://github.com/NixOS/nixpkgs/commit/214251f348d5ae951ec2c4e001445498f43f771c) | `` python3Packages.unsloth: 2026.4.1 -> 2026.4.5 ``                                             |
| [`d8d77f85`](https://github.com/NixOS/nixpkgs/commit/d8d77f85b17d8bf57fa6ad87feee5e027058d447) | `` python3Packages.unsloth-zoo: 2026.4.2 -> 2026.4.7 ``                                         |
| [`9eca444a`](https://github.com/NixOS/nixpkgs/commit/9eca444abb5713510b8394b9d44d23c85790e40f) | `` python3Packages.sentence-transformers: 5.3.0 -> 5.4.1 ``                                     |
| [`9c0ebcb9`](https://github.com/NixOS/nixpkgs/commit/9c0ebcb9345ac6cf2d1a72dc573689cc1010d0e5) | `` python3Packages.docling-ibm-models: 3.11.0 -> 3.13.0 ``                                      |
| [`9ee392c5`](https://github.com/NixOS/nixpkgs/commit/9ee392c5b30dd4b92baa975870dfaf934945711d) | `` python3Packages.transformers: 5.5.0 -> 5.5.4 ``                                              |
| [`7616097c`](https://github.com/NixOS/nixpkgs/commit/7616097cfbc4afdb497723a4c843f6a0ff689ea5) | `` python3Packages.huggingface-hub: 1.9.0 -> 1.10.2 ``                                          |
| [`04a36b6f`](https://github.com/NixOS/nixpkgs/commit/04a36b6fe21c1ee7fa9fc3b7c681976f979f0458) | `` openems: fix build with boost 1.89 ``                                                        |
| [`667a1240`](https://github.com/NixOS/nixpkgs/commit/667a124021ed1d8bbdb1cf66a61499f4fdd7afcd) | `` nixos/sshd: remove 'banner' option, in favour of settings.Banner ``                          |
| [`ca79b459`](https://github.com/NixOS/nixpkgs/commit/ca79b45947b5a20baeed529f515f9c91c285c4cc) | `` sdformat: rename to sdformatlinux ``                                                         |
| [`25cbb5af`](https://github.com/NixOS/nixpkgs/commit/25cbb5af257c3fe0312803a014e8389863c29b94) | `` kodiPackages.steam-launcher: 3.5.1 -> 3.7.11 ``                                              |
| [`df17d7a1`](https://github.com/NixOS/nixpkgs/commit/df17d7a1494204c6a9475b3330ae82a99e7161d2) | `` nixos/test-driver: add remaining tests to passthru.tests ``                                  |
| [`c39cb78c`](https://github.com/NixOS/nixpkgs/commit/c39cb78c7a5f44e2b10dfe10a995406aaebe25c2) | `` .github: Bump actions/github-script from 8.0.0 to 9.0.0 ``                                   |
| [`a641fbe9`](https://github.com/NixOS/nixpkgs/commit/a641fbe9538b3e083e384bf74736781ce4cc7fee) | `` .github: Bump actions/create-github-app-token from 3.0.0 to 3.1.1 ``                         |
| [`a0eec11b`](https://github.com/NixOS/nixpkgs/commit/a0eec11bf739dbee76006975bbd9a00e65b54bbe) | `` .github: Bump actions/upload-artifact from 7.0.0 to 7.0.1 ``                                 |
| [`3a60da88`](https://github.com/NixOS/nixpkgs/commit/3a60da8896da579a1db41bd8adb6094cb270c14f) | `` .github: Bump peter-evans/create-pull-request from 8.1.0 to 8.1.1 ``                         |
| [`744cdf47`](https://github.com/NixOS/nixpkgs/commit/744cdf471f9b5e6935027b6e477349e6dcadfcde) | `` protonplus: 0.5.17 -> 0.5.19 ``                                                              |
| [`1158cab6`](https://github.com/NixOS/nixpkgs/commit/1158cab619b234574f03c35a07161d6a9be5c658) | `` beads: enable auto update ``                                                                 |
| [`b1e8f7cc`](https://github.com/NixOS/nixpkgs/commit/b1e8f7cc5ddb43c184c87dcc14fced85f344ae0e) | `` ketesa: 1.1.0 -> 1.2.0 ``                                                                    |
| [`a9128c6c`](https://github.com/NixOS/nixpkgs/commit/a9128c6c5b6bedd7266bba8ab2bf370ab6871037) | `` cudaPackages.nccl-tests: 2.18.2 -> 2.18.3 ``                                                 |
| [`3b0f2e9d`](https://github.com/NixOS/nixpkgs/commit/3b0f2e9d9bbd582b1101b95279884460eb44faee) | `` scalr-cli: 0.17.8 -> 0.18.0 ``                                                               |
| [`721d31c4`](https://github.com/NixOS/nixpkgs/commit/721d31c42e529de04a7d93193dff5baa254ec10e) | `` libretro.play: 0-unstable-2026-04-07 -> 0-unstable-2026-04-13 ``                             |
| [`3055cc5d`](https://github.com/NixOS/nixpkgs/commit/3055cc5d023ddd9b0cca02dcb6253f6a97022689) | `` espup: 0.16.0 -> 0.17.0 ``                                                                   |
| [`0e1d424d`](https://github.com/NixOS/nixpkgs/commit/0e1d424d7415df3af6d29b165720d2bd3cec930e) | `` context7-mcp: 2.1.7 -> 2.1.8 ``                                                              |
| [`3ee50786`](https://github.com/NixOS/nixpkgs/commit/3ee50786ecb6d3bcc05fbef1a58cee7cb46a4332) | `` steelix: 0-unstable-2026-03-29 -> 0-unstable-2026-04-16 ``                                   |
| [`eb1864b0`](https://github.com/NixOS/nixpkgs/commit/eb1864b09eac0976fc15b2f6ef32fb6fd3df871e) | `` peergos: 1.22.0 -> 1.24.0 ``                                                                 |
| [`98ac9b1e`](https://github.com/NixOS/nixpkgs/commit/98ac9b1e5238823df384a691f4ef3f53ec822636) | `` jpegli: 0-unstable-2026-03-20 -> 0-unstable-2026-04-13 ``                                    |
| [`e5271885`](https://github.com/NixOS/nixpkgs/commit/e5271885308b42c0fac958c8767709aacc1d5a2c) | `` typescript-go: 0-unstable-2026-04-08 -> 0-unstable-2026-04-16 ``                             |
| [`3c6388f4`](https://github.com/NixOS/nixpkgs/commit/3c6388f43c1644d02ab5eb44831c61d94772ff74) | `` boringssl: 0.20260327.0 -> 0.20260413.0 ``                                                   |
| [`ffe9c192`](https://github.com/NixOS/nixpkgs/commit/ffe9c19225812cde5d3dd3783cdb4a0ffac6d694) | `` deezer-desktop: 7.1.140 -> 7.1.150 ``                                                        |
| [`8bc05463`](https://github.com/NixOS/nixpkgs/commit/8bc05463a98ffeb9742298456c85f796be290060) | `` rattler-build: 0.61.4 -> 0.62.2 ``                                                           |
| [`bd2c7880`](https://github.com/NixOS/nixpkgs/commit/bd2c78805c1439d2a0b2be35c828b6fca7dfb279) | `` atuin: 18.15.1 -> 18.15.2 ``                                                                 |
| [`1373ce18`](https://github.com/NixOS/nixpkgs/commit/1373ce18abcd332baa4fb43930a5cb35a95543bb) | `` zig: set __structuredAttrs ``                                                                |
| [`278d50f1`](https://github.com/NixOS/nixpkgs/commit/278d50f1344ff9b279e6a395927fc3d6cb5005bc) | `` zls: set __structuredAttrs ``                                                                |
| [`7f9cbd85`](https://github.com/NixOS/nixpkgs/commit/7f9cbd85b5e66616696ca0857d64746641affacc) | `` python3Packages.uiprotect: 10.2.3 -> 10.2.6 ``                                               |
| [`d38e1d5b`](https://github.com/NixOS/nixpkgs/commit/d38e1d5baa77c22121a461bbf9f74b50451787cb) | `` libation: 13.3.3 -> 13.3.4 ``                                                                |
| [`e9791717`](https://github.com/NixOS/nixpkgs/commit/e9791717e3f2a4bcd7040acc95476ec88ac7d970) | `` okapi-ed: 0.4.1 -> 0.5.0 ``                                                                  |
| [`cb5f4352`](https://github.com/NixOS/nixpkgs/commit/cb5f4352c986c8e9ed2abf3f9b2783a55325baba) | `` phpunit: 13.1.1 -> 13.1.5 ``                                                                 |
| [`63029ebc`](https://github.com/NixOS/nixpkgs/commit/63029ebcc3efc1df32c015f65663a890d60f7555) | `` antigravity: 1.22.2 -> 1.23.2 ``                                                             |
| [`fd1dc23f`](https://github.com/NixOS/nixpkgs/commit/fd1dc23f94b172c1ebff2d8fa0bd0192541c9f7a) | `` kbld: 0.47.2 -> 0.47.3 ``                                                                    |
| [`15557b8b`](https://github.com/NixOS/nixpkgs/commit/15557b8b49cd642e922d2c78e835e8643daeac65) | `` python3Packages.publicsuffixlist: 1.0.2.20260412 -> 1.0.2.20260417 ``                        |
| [`2b3ea2a7`](https://github.com/NixOS/nixpkgs/commit/2b3ea2a7679bf262d6cf35d65482b220a423b437) | `` python3Packages.tencentcloud-sdk-python: 3.1.79 -> 3.1.80 ``                                 |
| [`dfd07ec1`](https://github.com/NixOS/nixpkgs/commit/dfd07ec1006b81e3d0dba78219687e89871c3200) | `` python3Packages.boto3-stubs: 1.42.89 -> 1.42.90 ``                                           |
| [`b1392055`](https://github.com/NixOS/nixpkgs/commit/b1392055219d08b48ccea3162efb0dffc495cb2f) | `` python3Packages.mypy-boto3-rds: 1.42.75 -> 1.42.90 ``                                        |
| [`5d1f647b`](https://github.com/NixOS/nixpkgs/commit/5d1f647b6c191f02db21a0879beac3c1696ace9a) | `` python3Packages.mypy-boto3-mediaconvert: 1.42.88 -> 1.42.90 ``                               |
| [`83acc5a7`](https://github.com/NixOS/nixpkgs/commit/83acc5a7dbe9cbd3aecfb7c6653cec4040fb7707) | `` python3Packages.mypy-boto3-logs: 1.42.83 -> 1.42.90 ``                                       |
| [`0adc79bf`](https://github.com/NixOS/nixpkgs/commit/0adc79bffd8c1ff0637c181673615157765e41e1) | `` python3Packages.mypy-boto3-drs: 1.42.86 -> 1.42.90 ``                                        |
| [`40cc8282`](https://github.com/NixOS/nixpkgs/commit/40cc8282d778ef1648132bc58b64679d451b07de) | `` python3Packages.mypy-boto3-customer-profiles: 1.42.89 -> 1.42.90 ``                          |
| [`f2d11272`](https://github.com/NixOS/nixpkgs/commit/f2d11272caf2a63581780371f2a42405d2e3a4a2) | `` python3Packages.mypy-boto3-connectcases: 1.42.74 -> 1.42.90 ``                               |
| [`ceadcad4`](https://github.com/NixOS/nixpkgs/commit/ceadcad45c2bcb33267d6d72a8ac8cc620f38caa) | `` python3Packages.mypy-boto3-connect: 1.42.88 -> 1.42.90 ``                                    |
| [`fd93b088`](https://github.com/NixOS/nixpkgs/commit/fd93b088127a7b314615fffcc24c9e6407102546) | `` python3Packages.mypy-boto3-cognito-idp: 1.42.59 -> 1.42.90 ``                                |
| [`20c26814`](https://github.com/NixOS/nixpkgs/commit/20c26814b7a61f87d042e7464550a131e59350bd) | `` python3Packages.mypy-boto3-cloudwatch: 1.42.82 -> 1.42.90 ``                                 |
| [`b74c6e30`](https://github.com/NixOS/nixpkgs/commit/b74c6e30ed30c2190a2c15bea0648a6201b8877e) | `` python3Packages.mypy-boto3-autoscaling: 1.42.79 -> 1.42.90 ``                                |
| [`61bd4380`](https://github.com/NixOS/nixpkgs/commit/61bd4380364579b7475b2fb245055c848b5f8c45) | `` python3Packages.mypy-boto3-appstream: 1.42.82 -> 1.42.90 ``                                  |
| [`2c33fa74`](https://github.com/NixOS/nixpkgs/commit/2c33fa740d9361c8b16333e9d4fe8c518bb647b7) | `` python3Packages.iamdata: 0.1.202604161 -> 0.1.202604171 ``                                   |
| [`b624be34`](https://github.com/NixOS/nixpkgs/commit/b624be342e7a355183b3448e8068704d27828a47) | `` wtcat: init at 0.1.3 ``                                                                      |
| [`7c2d2b30`](https://github.com/NixOS/nixpkgs/commit/7c2d2b30782a980c6a97d851bb1bd98f2a06ce5b) | `` hyprmon: 0.0.13 -> 0.0.14 ``                                                                 |
| [`7e5167c8`](https://github.com/NixOS/nixpkgs/commit/7e5167c8e320b14ef7371ac51c4b902ce57fae83) | `` postgresqlPackages.pg_search: 0.22.6 -> 0.23.0 ``                                            |
| [`93c0773c`](https://github.com/NixOS/nixpkgs/commit/93c0773cc9eb8d8e387aec788b75c1fe86f8886c) | `` egctl: 1.7.1 -> 1.7.2 ``                                                                     |
| [`410f238b`](https://github.com/NixOS/nixpkgs/commit/410f238bd3b366c88fd7c88bd4410d008a6a864f) | `` tree-sitter-grammars.tree-sitter-sshclientconfig: 2026.4.9 -> 2026.4.16 ``                   |
| [`ca152174`](https://github.com/NixOS/nixpkgs/commit/ca1521747698b686a6a759bf81e1e14ffaf0d628) | `` fiddler-everywhere: 7.7.2 -> 7.7.3 ``                                                        |
| [`ed9bf911`](https://github.com/NixOS/nixpkgs/commit/ed9bf911cc564628889fbb31456c1d8bc867f99a) | `` wakatime-cli: 2.3.0 -> 2.3.1 ``                                                              |
| [`a97b34cd`](https://github.com/NixOS/nixpkgs/commit/a97b34cda00930d1e15e90a61a49d6b36784608d) | `` foxotron: 2024-09-23 -> 2024-09-23-unstable-2026-03-20 ``                                    |
| [`4efeb9c3`](https://github.com/NixOS/nixpkgs/commit/4efeb9c3009640ebf45c3e3eb22586b983af9a0e) | `` terraform-providers.vancluever_acme: 2.46.1 -> 2.47.0 ``                                     |
| [`8da27065`](https://github.com/NixOS/nixpkgs/commit/8da270652bfce5e76cf57280f7146fd2fee17889) | `` maintainers: add coolGi ``                                                                   |
| [`e6fcf51a`](https://github.com/NixOS/nixpkgs/commit/e6fcf51aecd8396d24682139f77a9ee0baf7e9d2) | `` discordo: 0-unstable-2026-04-09 -> 0-unstable-2026-04-14 ``                                  |
| [`69cf224d`](https://github.com/NixOS/nixpkgs/commit/69cf224d6fa624451f00dd93368e08b34bb0cf0f) | `` vimPlugins.zig-vim: 0-unstable-2026-03-09 -> 0-unstable-2026-04-13 ``                        |
| [`d23959c5`](https://github.com/NixOS/nixpkgs/commit/d23959c5827f35c61f2fb41b4e25c11f039439e7) | `` rainfrog: 0.3.17 -> 0.3.18 ``                                                                |
| [`045adae3`](https://github.com/NixOS/nixpkgs/commit/045adae3916c1e060b23a4c969dedc5e6b67478c) | `` adw-gtk3: 6.4 -> 6.5 ``                                                                      |
| [`acc8ee35`](https://github.com/NixOS/nixpkgs/commit/acc8ee3545079a45a32787af95e19b76f1263b9a) | `` editorconfig-core-c: 0.12.9 -> 0.12.11 ``                                                    |
| [`2318b8e4`](https://github.com/NixOS/nixpkgs/commit/2318b8e414ec51e67bc79531eafe330dee9a8abc) | `` fishPlugins.forgit: 26.04.1 -> 26.04.2 ``                                                    |
| [`3472a226`](https://github.com/NixOS/nixpkgs/commit/3472a2261d4c6992149ce04b7e7e68ab288ca413) | `` aegis-rs: 0.5.0 -> 0.5.1 ``                                                                  |
| [`cf07030d`](https://github.com/NixOS/nixpkgs/commit/cf07030d0c01acdf07c0f5d4f8741049efd93948) | `` libretro.dosbox-pure: 0-unstable-2026-02-17 -> 0-unstable-2026-04-17 ``                      |
| [`dc6ec4e9`](https://github.com/NixOS/nixpkgs/commit/dc6ec4e9608934428753b128e02397275c561eef) | `` tsgolint: 0.21.0 -> 0.21.1 ``                                                                |
| [`2c123b5b`](https://github.com/NixOS/nixpkgs/commit/2c123b5bfc2c85cd07adb70d85d7164248faf448) | `` vultr-cli: 3.9.2 -> 3.10.0 ``                                                                |
| [`e6c9d57e`](https://github.com/NixOS/nixpkgs/commit/e6c9d57e0df1d63e4f48d2e17f5630543d85e663) | `` gf: 0-unstable-2025-12-31 -> 0-unstable-2026-04-11 ``                                        |
| [`0c9a1619`](https://github.com/NixOS/nixpkgs/commit/0c9a1619aad6e6325c42f9b640d80e2a9ffb6887) | `` azure-cli-extensions.ssh: 2.0.6 -> 2.0.7 ``                                                  |
| [`7f38d088`](https://github.com/NixOS/nixpkgs/commit/7f38d0880b2226ceb37fb283c9a26e96e1da4247) | `` traefik-certs-dumper: 2.11.0 -> 2.11.2 ``                                                    |
| [`47c56288`](https://github.com/NixOS/nixpkgs/commit/47c56288b7d31bb2c314ef824e11b148e1f215cc) | `` python3Packages.scikit-base: 0.13.1 -> 0.13.2 ``                                             |
| [`1119caea`](https://github.com/NixOS/nixpkgs/commit/1119caea20df102d86aee7b939f8ef4cfc24fe2b) | `` vencord: 1.14.6 -> 1.14.7 ``                                                                 |
| [`828ff1f8`](https://github.com/NixOS/nixpkgs/commit/828ff1f8d6afcc9f35d9bf3b65520209c274f607) | `` brave-search-cli: 1.2.0 -> 1.5.0 ``                                                          |
| [`dceeb128`](https://github.com/NixOS/nixpkgs/commit/dceeb128cb600348c823e971ec0f049d24fd004c) | `` rust-petname: 2.0.2 -> 3.0.0 ``                                                              |
| [`3caceae6`](https://github.com/NixOS/nixpkgs/commit/3caceae660a66886769ea3fd1ab9d502e20e8f02) | `` lagrange-tui: 1.20.3 -> 1.20.4 ``                                                            |
| [`8e88d68e`](https://github.com/NixOS/nixpkgs/commit/8e88d68e95c387a0894268ea5a935fe080f6fe0c) | `` vscode-extensions.detachhead.basedpyright: 1.39.0 -> 1.39.2 ``                               |
| [`20b9e18b`](https://github.com/NixOS/nixpkgs/commit/20b9e18bf701aea50afee9cec4c13db171c1c485) | `` folio: 25.02 -> 26.01 ``                                                                     |
| [`b795d8ac`](https://github.com/NixOS/nixpkgs/commit/b795d8accaf590a6bf95d4f3154036ebfaabfa88) | `` grafanaPlugins.grafana-metricsdrilldown-app: 2.0.1 -> 2.0.2 ``                               |
| [`03dab953`](https://github.com/NixOS/nixpkgs/commit/03dab953629bca8c5773fda1bd2bb023754d3bd1) | `` river-ultitile: fix build.zig.zon.nix ``                                                     |
| [`c668d04e`](https://github.com/NixOS/nixpkgs/commit/c668d04e60c25d4ad86bb1d80f70126b2593a907) | `` odiff: fix build.zig.zon.nix ``                                                              |
| [`4050cef8`](https://github.com/NixOS/nixpkgs/commit/4050cef8b8d83df10bec038c1f270046f9d7577d) | `` libretro.gambatte: 0-unstable-2026-04-03 -> 0-unstable-2026-04-11 ``                         |
| [`c3840ace`](https://github.com/NixOS/nixpkgs/commit/c3840ace1548eea21f8d2091977064092c2329a1) | `` opentabletdriver: move icon to spec-compliant location ``                                    |
| [`89bc4fa4`](https://github.com/NixOS/nixpkgs/commit/89bc4fa4e3cba21c5934e46f754a2e0c58287543) | `` cog: 0.1.6 -> 0.1.8 ``                                                                       |
| [`cb2ea9b4`](https://github.com/NixOS/nixpkgs/commit/cb2ea9b438f525bfe779930aec9871cda12bd255) | `` nixos/test/strichliste: init ``                                                              |
| [`c3ba8bb3`](https://github.com/NixOS/nixpkgs/commit/c3ba8bb39c4211d919f5080a7e781718af06896f) | `` libretro.swanstation: 0-unstable-2026-03-28 -> 0-unstable-2026-04-10 ``                      |
| [`aa8e7907`](https://github.com/NixOS/nixpkgs/commit/aa8e7907457f8d2555568a2ece20a8448540a611) | `` treewide: pin zig to zig_0_15 ``                                                             |
| [`a2d1fa68`](https://github.com/NixOS/nixpkgs/commit/a2d1fa6832cbf91f6737c4b9b279a47bbc7b4ac5) | `` kak-tree-sitter-unwrapped: 3.2.0 -> 3.2.1 ``                                                 |
| [`a2b73600`](https://github.com/NixOS/nixpkgs/commit/a2b73600f663347905c43e751fd6ca0775cf4ab0) | `` snx-rs: 5.2.4 -> 5.3.0 ``                                                                    |
| [`09ceadef`](https://github.com/NixOS/nixpkgs/commit/09ceadef610c7155a99a1f5f1f356fdfc70bedb2) | `` python3Packages.pytibber: 0.37.0 -> 0.37.1 ``                                                |
| [`99b135bc`](https://github.com/NixOS/nixpkgs/commit/99b135bc06e4e6df5f182c5bb9d4edc639b64846) | `` claude-code: 2.1.111 -> 2.1.112 ``                                                           |
| [`6c97c632`](https://github.com/NixOS/nixpkgs/commit/6c97c632bc47dea13cd2b84bc12c7a498b54f93d) | `` vscode-extensions.anthropic.claude-code: 2.1.111 -> 2.1.112 ``                               |
| [`7829116f`](https://github.com/NixOS/nixpkgs/commit/7829116f65bf0a51762c2d02ef766147755604f2) | `` claude-code-bin: 2.1.111 -> 2.1.112 ``                                                       |
| [`2bef70aa`](https://github.com/NixOS/nixpkgs/commit/2bef70aa86749a565463fb7fd085bb27f55642d4) | `` nss_latest: 3.122.1 -> 3.123 ``                                                              |
| [`5287a52c`](https://github.com/NixOS/nixpkgs/commit/5287a52c9c6e0fd33b1b6e4062623570340c1619) | `` vscode-extensions.charliermarsh.ruff: 2026.38.0 -> 2026.40.0 ``                              |
| [`6f4b55f4`](https://github.com/NixOS/nixpkgs/commit/6f4b55f45f9930b98d8cd541425f0bc9a2c00e6a) | `` miracle-wm: Point meta.homepage to the actual homepage ``                                    |
| [`68b0a395`](https://github.com/NixOS/nixpkgs/commit/68b0a395e987ae2dcd25cc76d0b22f1df720715e) | `` atuin: 18.13.6 -> 18.15.1 ``                                                                 |
| [`8d47239b`](https://github.com/NixOS/nixpkgs/commit/8d47239bbc7ab2d4948cdb9fa084628bd2d8d28d) | `` {zig, zls}: default to v0.16.0 ``                                                            |
| [`208a24bf`](https://github.com/NixOS/nixpkgs/commit/208a24bfa51b877bec6f44a3061529820221acf0) | `` zls: modernize; add zls_0_16 ``                                                              |
| [`196739df`](https://github.com/NixOS/nixpkgs/commit/196739dfe15f8b936397d0e5b597fd5ee86c34b2) | `` ungoogled-chromium: 147.0.7727.55-1 -> 147.0.7727.101-1 ``                                   |
| [`5b666e81`](https://github.com/NixOS/nixpkgs/commit/5b666e810ad5c300e77043934ae6db580ceac3dd) | `` cargo-binstall: 1.18.0 -> 1.18.1 ``                                                          |
| [`90c987c1`](https://github.com/NixOS/nixpkgs/commit/90c987c15c1a24301d299fe3b1d38d202d54e8a0) | `` dvr-scan: init at 1.8.2 ``                                                                   |
| [`838f1611`](https://github.com/NixOS/nixpkgs/commit/838f1611dc4c0078432071819d6fffe046148813) | `` rust-analyzer-unwrapped: 2026-04-06 -> 2026-04-13 ``                                         |

*... and 888 more commits (truncated)*