### PR TITLE
chore(flake/freminal): `a9c91056` -> `4f6888d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1776713449,
-        "narHash": "sha256-TEzbydqfq3+Z8iXyuelFMITKpL2FC/z3vNuRrWR0vf4=",
+        "lastModified": 1776793725,
+        "narHash": "sha256-Iqkg3sEca0UA5xBzEKARht+qG8M8VQkW4uVD8+KE+vQ=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "a9c910566398f178a44ea895e0756568a829661c",
+        "rev": "4f6888d654b71c5dec2edd8856878223e67a1a00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
| [`33721f85`](https://github.com/fredsystems/freminal/commit/33721f855c7950e6e0c91aad77fa83f1abf3f997) | `` fix: 323 — PR review corrections for window geometry persistence ``                                                                       |
| [`b30f2a41`](https://github.com/fredsystems/freminal/commit/b30f2a419470ce1a9d7ca5a31eef39911b93ac5d) | `` fix: mark row dirty in truncate_cells_to_width ``                                                                                         |
| [`6d328f7e`](https://github.com/fredsystems/freminal/commit/6d328f7ebb3af6310e55575a8ecbf956cc88323d) | `` feat: persist window geometry, refine settings UX, enable session restore by default ``                                                   |
| [`c5fcbf09`](https://github.com/fredsystems/freminal/commit/c5fcbf0970569dff52a344683558293c4cb4e642) | `` fix: clip alt-screen row cells on shrink to prevent stale right-edge artifact ``                                                          |
| [`e2e64f9e`](https://github.com/fredsystems/freminal/commit/e2e64f9ec42f477ef3a35311b5d49d23f725949b) | `` fix: 61 — PR review corrections (split direction, active pane/tab, CWD, geometry, apply_variables, no auto-save with explicit command) `` |
| [`53f78df3`](https://github.com/fredsystems/freminal/commit/53f78df303fb40442760d225da2ca53d999a7fce) | `` fix: save-layout prompt — suppress terminal focus steal, focus text field once ``                                                         |
| [`b4dfed67`](https://github.com/fredsystems/freminal/commit/b4dfed67e68896615c5614e698b41ca60d9ea69b) | `` fix: save layout prompt as floating window; delete buttons in layout library ``                                                           |
| [`293f5a8d`](https://github.com/fredsystems/freminal/commit/293f5a8d6e66770010981777c1d81a25a15e2a1a) | `` fix: layout save captures current window and prompts for name ``                                                                          |
| [`8052bf5b`](https://github.com/fredsystems/freminal/commit/8052bf5b617c1553a9a3827e9428b6ec57903220) | `` test: 61.12 — end-to-end layout tests (multi-window, round-trip, discover, malformed) ``                                                  |
| [`e8303888`](https://github.com/fredsystems/freminal/commit/e8303888d8576b6c8eca77370531f20975f23f72) | `` feat: 61.11 — Startup settings tab, config_example.toml, nix module ``                                                                    |
| [`f01ee1d4`](https://github.com/fredsystems/freminal/commit/f01ee1d409e58e61bcf6cc185b79f6ff36e700df) | `` feat: 61.10 — window geometry restoration (position + size from layout) ``                                                                |
| [`0fda068a`](https://github.com/fredsystems/freminal/commit/0fda068a6bdb2cc116a531128d1310b035df77d3) | `` feat: 61.9 — auto-save and restore last session on exit/startup ``                                                                        |
| [`a13dd7c9`](https://github.com/fredsystems/freminal/commit/a13dd7c94a603a7d9d6382c1accee7f27b5e400e) | `` feat: 61.7 + 61.8 — layout library discovery and Layouts menu ``                                                                          |
| [`bb5ed15f`](https://github.com/fredsystems/freminal/commit/bb5ed15fa55e2c3fbfca9629851ec18dda81470f) | `` feat: 61.6 — save current layout (child_pid, to_layout_panes, save_layout) ``                                                             |
| [`606f862e`](https://github.com/fredsystems/freminal/commit/606f862e5519bcd5ceb80cdd285941beea07a1ef) | `` feat: 61.4 — shell and environment overrides per pane ``                                                                                  |
| [`b822f88a`](https://github.com/fredsystems/freminal/commit/b822f88a26ef0a97898bd7ee1fe1b287d430cc85) | `` feat: 61.3 — startup command injection via pty_write_tx ``                                                                                |
| [`a92b4573`](https://github.com/fredsystems/freminal/commit/a92b4573668b00999ee3b7cd144a96ab19ccc069) | `` feat: 61.2 — layout engine, TabId::offset, --layout CLI wiring ``                                                                         |
| [`80bae061`](https://github.com/fredsystems/freminal/commit/80bae061bd10262ffb62ea08631b67328bafcd6a) | `` feat: 61.1 + 61.5 — layout types, TOML parser, CLI flags, keybindings ``                                                                  |