### PR TITLE
chore(flake/sops-nix-stable): `d4971dd5` -> `bef289e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1720,11 +1720,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776119890,
-        "narHash": "sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M=",
+        "lastModified": 1776771786,
+        "narHash": "sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d4971dd58c6627bfee52a1ad4237637c0a2fb0cd",
+        "rev": "bef289e2248991f7afeb95965c82fbcd8ff72598",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                 |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`fbedbb8c`](https://github.com/Mic92/sops-nix/commit/fbedbb8cb1eef3e42c1d25bd59138e2bd0503364) | `` fix(systemd): require mounts for encryption keys. `` |
| [`bc02e2e5`](https://github.com/Mic92/sops-nix/commit/bc02e2e5f6d49b51911ae0765d63d2a31f18387d) | `` chore: nix fmt sops/default.nix ``                   |