### PR TITLE
chore(flake/home-manager): `c81775b6` -> `5d564059`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776701552,
-        "narHash": "sha256-CCRzOEFg6JwCdZIR5dLD0ypah5/e2JQVuWQ/l3rYrPY=",
+        "lastModified": 1776777932,
+        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c81775b640d4507339d127f5adb4105f6015edf2",
+        "rev": "5d5640599a0050b994330328b9fd45709c909720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`5d564059`](https://github.com/nix-community/home-manager/commit/5d5640599a0050b994330328b9fd45709c909720) | `` atuin: fix logs.dir override for preferXdgDirectories `` |
| [`70762722`](https://github.com/nix-community/home-manager/commit/7076272297955163b0cced013798845651d301af) | `` ci: bound runtime and force sandboxed builds ``          |
| [`6658732d`](https://github.com/nix-community/home-manager/commit/6658732d338b38c80a5ddfee5f94827428314d77) | `` ci: drop default workflow token permissions ``           |
| [`67f2a145`](https://github.com/nix-community/home-manager/commit/67f2a145a96658d83c9ec05b6f581eab8f68f73f) | `` ci: run both parse checks in one keep-going step ``      |
| [`c555a4a3`](https://github.com/nix-community/home-manager/commit/c555a4a34a260493be5adb795c54e013c58f2d34) | `` ci: add nix and lix parse checks ``                      |