### PR TITLE
chore(flake/niri): `94a35e10` -> `bcc58e67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1035,11 +1035,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1776711702,
-        "narHash": "sha256-X3NTbAyE/+dJl/drMbdHzyfPPdI39y4MMwm3/aLJl5s=",
+        "lastModified": 1776791170,
+        "narHash": "sha256-mf9M2WgY+DnQ0EbpLDTguBfKo9pegSD3VpU4aR6hOnE=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "94a35e10a15e7279243176cf1f7a9e6a8b3e6035",
+        "rev": "bcc58e672eea56892ebba58671e37dca00b701fc",
         "type": "github"
       },
       "original": {
@@ -1068,11 +1068,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1776706941,
-        "narHash": "sha256-nnv27JD0FOOqs1Hh67kydXFzZoEu8e0QyMf0R9AXaIw=",
+        "lastModified": 1776783539,
+        "narHash": "sha256-ii2IJlNOFssGjwfGOXeOg5ZRg9fw0mWy0JS8Cbu+efo=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "e9c182a13c1d12762351ec01ce0ec711d41b0337",
+        "rev": "3a3a97ec2ad760d8c7b0ff3e33f674794822d341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`bcc58e67`](https://github.com/sodiboo/niri-flake/commit/bcc58e672eea56892ebba58671e37dca00b701fc) | `` Update flake.lock `` |
| [`32bed686`](https://github.com/sodiboo/niri-flake/commit/32bed686f4fd8274a5e4a58d071687a74e19821e) | `` Update flake.lock `` |