### PR TITLE
chore(flake/nixpkgs-stable): `c7f47036` -> `e07580da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1156,11 +1156,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1776434932,
-        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
+        "lastModified": 1776560675,
+        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
+        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`96932643`](https://github.com/NixOS/nixpkgs/commit/96932643825740355adbff5f5b729ebdfde05aa9) | `` knope: init at 0.22.4 ``                                                      |
| [`7a20f9a4`](https://github.com/NixOS/nixpkgs/commit/7a20f9a4d9c464c1c7b9ce88e38c7ba2e4fa4810) | `` Revert "signal-desktop: deprecate commandLineArgs override" ``                |
| [`2a50b969`](https://github.com/NixOS/nixpkgs/commit/2a50b96965ee6196b597ce307d9de2666e0e0cbb) | `` linux_xanmod_latest: 6.19.12 -> 6.19.13 ``                                    |
| [`dd36c373`](https://github.com/NixOS/nixpkgs/commit/dd36c3739d6119c684dc3c83a18c5e10630b76b8) | `` linux_xanmod: 6.18.22 -> 6.18.23 ``                                           |
| [`b3bb6979`](https://github.com/NixOS/nixpkgs/commit/b3bb697924eafdb184160e80473df8baf9020b12) | `` osu-lazer: 2026.406.0 -> 2026.418.0 ``                                        |
| [`df5ce766`](https://github.com/NixOS/nixpkgs/commit/df5ce76681f45114221a147c05d35145cbbb7b52) | `` osu-lazer-bin: 2026.406.0 -> 2026.418.0 ``                                    |
| [`5f951181`](https://github.com/NixOS/nixpkgs/commit/5f95118111d506b20d36ba0bac5b4c0310f25dc1) | `` boringssl: 0.20260327.0 -> 0.20260413.0 ``                                    |
| [`468c1495`](https://github.com/NixOS/nixpkgs/commit/468c14958186e22f3988336e8f90fae350962ed7) | `` gst-thumbnailers: enable `strictDeps` and `__structuredAttrs` ``              |
| [`bdee969b`](https://github.com/NixOS/nixpkgs/commit/bdee969b3fcbb157809754d8125d05e4236f0bde) | `` gst-thumbnailers: init at 1.0.alpha.1 ``                                      |
| [`24b8be3d`](https://github.com/NixOS/nixpkgs/commit/24b8be3d4f65b20183ef3f1fcb16f33e3b8ba66c) | `` linux_5_10: 5.10.252 -> 5.10.253 ``                                           |
| [`946d613b`](https://github.com/NixOS/nixpkgs/commit/946d613b4161dd1070ce36c3de82db8984e37ead) | `` linux_5_15: 5.15.202 -> 5.15.203 ``                                           |
| [`d9822583`](https://github.com/NixOS/nixpkgs/commit/d98225836d1d1b37505767275717392657b658fc) | `` linux_6_1: 6.1.168 -> 6.1.169 ``                                              |
| [`cab34485`](https://github.com/NixOS/nixpkgs/commit/cab34485404de6e29bfd76d8ca24eebddc0436af) | `` linux_6_6: 6.6.134 -> 6.6.135 ``                                              |
| [`6720ff1b`](https://github.com/NixOS/nixpkgs/commit/6720ff1b3318f051ad02c66560af5393cdb64f24) | `` linux_6_12: 6.12.81 -> 6.12.82 ``                                             |
| [`f494ddf6`](https://github.com/NixOS/nixpkgs/commit/f494ddf65525583f36965585e3be96c31413d42a) | `` linux_6_18: 6.18.22 -> 6.18.23 ``                                             |
| [`0fe74522`](https://github.com/NixOS/nixpkgs/commit/0fe7452233281d9432a5b5598ee73de8fca3880d) | `` linux_6_19: 6.19.12 -> 6.19.13 ``                                             |
| [`d4949f01`](https://github.com/NixOS/nixpkgs/commit/d4949f01d5a5c0b72dc9b91c52772f15b38a81ba) | `` openssl_4_0: fixup differences from nixpkgs master ``                         |
| [`1e5dac87`](https://github.com/NixOS/nixpkgs/commit/1e5dac8753273d30f8f93de7325ff5239cfd97f1) | `` openssl_4_0: init at 4.0.0 ``                                                 |
| [`5a5f3536`](https://github.com/NixOS/nixpkgs/commit/5a5f35361bd956b985e2603e0732822e3a8cad29) | `` lockbook-desktop: 26.4.9 -> 26.4.13 ``                                        |
| [`65745bb9`](https://github.com/NixOS/nixpkgs/commit/65745bb9892dbf8961a0022afa042cf36f538bfb) | `` lockbook: 26.4.8 -> 26.4.13 ``                                                |
| [`0a76c406`](https://github.com/NixOS/nixpkgs/commit/0a76c40675d0f18057ba5feeacc77223d7341d92) | `` jenkins: 2.541.3 -> 2.555.1 ``                                                |
| [`8604201e`](https://github.com/NixOS/nixpkgs/commit/8604201e05eb257febd197088cda017d5710ab35) | `` nixos/luksroot: remove aes_generic ``                                         |
| [`94a59d08`](https://github.com/NixOS/nixpkgs/commit/94a59d089766a76da4046afa87f5cc94017d852c) | `` nixos/stratisroot: remove aes_generic ``                                      |
| [`d5c2bee0`](https://github.com/NixOS/nixpkgs/commit/d5c2bee0d3bc6d06c19f924e5e7da5b7c3cfd8ff) | `` forgejo: 14.0.4 -> 15.0.0 ``                                                  |
| [`15cfbe8a`](https://github.com/NixOS/nixpkgs/commit/15cfbe8a7e4a7f8218db9c5806931bc9ba5c6e38) | `` phpPackages.composer: 2.8.12 -> 2.9.7 ``                                      |
| [`b853bf5e`](https://github.com/NixOS/nixpkgs/commit/b853bf5ee8583b4e1e9281347cc517614246be4a) | `` librewolf-unwrapped: 149.0-1 -> 149.0.2-2 ``                                  |
| [`5184f249`](https://github.com/NixOS/nixpkgs/commit/5184f249ab8e810388fb828730f019c8986649a3) | `` nextcloud33Packages.apps.memories: init at 8.0.1 ``                           |
| [`e1f12b2a`](https://github.com/NixOS/nixpkgs/commit/e1f12b2a7c28b99c64c2c616fb2761d12e367dd6) | `` python3Packages.pypdf: 6.9.2 -> 6.10.0 ``                                     |
| [`2ea821d4`](https://github.com/NixOS/nixpkgs/commit/2ea821d4919183542c173facc91b4b0f31e86b3e) | `` php85: 8.5.4 -> 8.5.5 ``                                                      |
| [`fd3a4857`](https://github.com/NixOS/nixpkgs/commit/fd3a4857bbaabec7fd155ba876fd33035271e6e1) | `` thunderbird: disable crash reporter for now to fix build ``                   |
| [`7fccd9bf`](https://github.com/NixOS/nixpkgs/commit/7fccd9bf43eef75827a64d31fbfe4297282d8ed5) | `` thunderbird: 148.0.1 -> 149.0.2 ``                                            |
| [`8de4b7cf`](https://github.com/NixOS/nixpkgs/commit/8de4b7cf443234382734cecadc07658c644dd9e2) | `` llvmPackages_git: 23.0.0-unstable-2026-03-29 -> 23.0.0-unstable-2026-04-05 `` |
| [`38edfa71`](https://github.com/NixOS/nixpkgs/commit/38edfa714feb449b4fd087b6fe3de97d9d38f196) | `` rgx: 0.10.1 -> 0.10.2 ``                                                      |
| [`7d460a54`](https://github.com/NixOS/nixpkgs/commit/7d460a5480da647a94c042751939adae0c328399) | `` boringssl: 0.20260211.0 -> 0.20260327.0 ``                                    |
| [`6fbbb777`](https://github.com/NixOS/nixpkgs/commit/6fbbb777a46591934b65454869e88cdd9734cc7f) | `` wrangler: 4.61.1 -> 4.62.0 ``                                                 |