### PR TITLE
chore(flake/nixvim): `698d1749` -> `e61a31b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1353,11 +1353,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1776452249,
-        "narHash": "sha256-tpCsY9kIEfcitiV3JwUqYTmxwewwZKQlZSNUBqb9kF0=",
+        "lastModified": 1777161489,
+        "narHash": "sha256-368EaWDQFDLa/pyjKp2CuxHUNypPJKDDr8zlGEb1Bsg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "698d17490e19e2e360a6ce49b1af9134d1c6eacd",
+        "rev": "e61a31b597ce59e1d4fea3c59b8d89edd915ecd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`e61a31b5`](https://github.com/nix-community/nixvim/commit/e61a31b597ce59e1d4fea3c59b8d89edd915ecd6) | `` plugins/lz-n: support importing plugin specs ``      |
| [`f6fd130a`](https://github.com/nix-community/nixvim/commit/f6fd130ad3b95c3c039fd7f882825c49f7e70bde) | `` lib/plugins: add public callSetup override ``        |
| [`53d9c3c5`](https://github.com/nix-community/nixvim/commit/53d9c3c50bd6d63c9b0c54d31e20f58c8f93b1da) | `` plugins/blink-indent: use optional setup ``          |
| [`92ec3b4c`](https://github.com/nix-community/nixvim/commit/92ec3b4c3ed0a33d203ec3479a64e6cdc11d88ec) | `` plugins/fff: use optional setup ``                   |
| [`3f710c04`](https://github.com/nix-community/nixvim/commit/3f710c0440e763afdd91f3ad1ba2d715181dc18b) | `` lib/plugins: add optional setup plumbing ``          |
| [`0f6b0223`](https://github.com/nix-community/nixvim/commit/0f6b0223220fad3911d03861bc6114a78e22b964) | `` modules/commands: support command preview ``         |
| [`02bf85b6`](https://github.com/nix-community/nixvim/commit/02bf85b6d41c474e81642bff792914965def4475) | `` tests: skip builds for warning-only cases ``         |
| [`494348a8`](https://github.com/nix-community/nixvim/commit/494348a800c262e1419929babc351326ad6c7f88) | `` modules/lazyload: fix provider warning formatting `` |
| [`3a831afd`](https://github.com/nix-community/nixvim/commit/3a831afd078c9890ba8919ee8b40001b897073ca) | `` modules/lazyload: fix provider warning detection ``  |
| [`b6842418`](https://github.com/nix-community/nixvim/commit/b684241888d9271ab5196383e24098ad4400a372) | `` plugins/spring-boot: add module and java warning ``  |
| [`fcb1d4b9`](https://github.com/nix-community/nixvim/commit/fcb1d4b95feb1b557e9b951e70d96da5fcc6c18e) | `` plugins/treesitter: add highlight disable option ``  |
| [`61aff3d4`](https://github.com/nix-community/nixvim/commit/61aff3d45e59671b9f931c523e3a6654fd8bd152) | `` lib/options: fix typo ``                             |
| [`ee8269e4`](https://github.com/nix-community/nixvim/commit/ee8269e46fc869ae2b114be1873f205c5ee43183) | `` plugins/lint: add auto-install support ``            |
| [`f63fae13`](https://github.com/nix-community/nixvim/commit/f63fae13354dfd8749cd226e6b506cea52eb2fd3) | `` ci: generate nvim-lint linter list ``                |
| [`948b6c01`](https://github.com/nix-community/nixvim/commit/948b6c0125b35eab7b37e7f7edc79552027075a1) | `` plugins/lsp: add capabilities example ``             |
| [`53aad7a9`](https://github.com/nix-community/nixvim/commit/53aad7a9aaadaec21d740117ba0f0531b9a9b3cd) | `` CONTRIBUTING: explain common test attrset names ``   |
| [`27414212`](https://github.com/nix-community/nixvim/commit/27414212a202bf3ceeef7397bd54f69f0d73b888) | `` modules/top-level/files: use localOpts in example `` |
| [`8846a4f2`](https://github.com/nix-community/nixvim/commit/8846a4f2323aa2b519a62a87d287446f89306280) | `` plugins/dropbar: align name_regex with upstream ``   |
| [`b95b90f8`](https://github.com/nix-community/nixvim/commit/b95b90f8c99c3a9c0182a3d0e454249cfb9dcbcc) | `` ci: add nix and lix parse checks ``                  |
| [`4efe04e7`](https://github.com/nix-community/nixvim/commit/4efe04e747eda20b847f7fe6ea8e50c2f7261a0c) | `` treewide: fix incorrect string escapes ``            |