### PR TITLE
chore(flake/freminal): `4f6888d6` -> `c537ae15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1776793725,
-        "narHash": "sha256-Iqkg3sEca0UA5xBzEKARht+qG8M8VQkW4uVD8+KE+vQ=",
+        "lastModified": 1776900868,
+        "narHash": "sha256-Pc2LDlrYFuC4OYyKzxvHbFpjKL/9ZpQ6Fyt/poFHRh4=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "4f6888d654b71c5dec2edd8856878223e67a1a00",
+        "rev": "c537ae15d0ec8652fa6fa7290957c7a6fc90d682",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`a4130753`](https://github.com/fredsystems/freminal/commit/a41307533c073b8af869e76bafe06d0e3edd79e4) | `` fix: address Copilot review feedback on PR #324 ``                                        |
| [`c029c6e6`](https://github.com/fredsystems/freminal/commit/c029c6e626e51ac9ac359ee8fb614a3dde95cc44) | `` docs: 70.O.5 — clarify Arc<Mutex<…>> rationale on RenderState / WindowPostRenderer ``     |
| [`8c59aa7f`](https://github.com/fredsystems/freminal/commit/8c59aa7fee8b31e560cda2cc99e2e9df456adcb9) | `` refactor: 70.O.4 — group build_background_instances params into BackgroundFrame ``        |
| [`91298f0b`](https://github.com/fredsystems/freminal/commit/91298f0b5909942d20241f4a48300a22f4e96ef3) | `` refactor: 70.O.3 — take &str in collect_text instead of &String ``                        |
| [`901f6789`](https://github.com/fredsystems/freminal/commit/901f67892373773bca3182fcb45be27fc1acfcab) | `` refactor: 70.O.1 — drop get_ prefix from accessors (C-GETTER) ``                          |
| [`2d7f8104`](https://github.com/fredsystems/freminal/commit/2d7f810466ac8cc4c34746ebc4237a6d79851960) | `` refactor: 70.N — add send_or_log! macro and apply at 28 call sites ``                     |
| [`e3f1eae4`](https://github.com/fredsystems/freminal/commit/e3f1eae4718c1d7df1e5d090dac086f6eb64fe49) | `` refactor: 70.M — extract shared param_or helper ``                                        |
| [`2f127e66`](https://github.com/fredsystems/freminal/commit/2f127e6636fd5d482602e790905560d169b4f1d7) | `` refactor: 70.L — remove bare dead-code attributes ``                                      |
| [`73fb1637`](https://github.com/fredsystems/freminal/commit/73fb1637a7408621e1911903b52718a1ab3d6fc0) | `` refactor: 70.K — typify CSI command modes (ED, EL, TBC) ``                                |
| [`af442c17`](https://github.com/fredsystems/freminal/commit/af442c170ffdc69e404571f878bde73985b2a752) | `` docs: mark Task 70.J subtasks complete ``                                                 |
| [`5ab0132a`](https://github.com/fredsystems/freminal/commit/5ab0132a3b8b408f92586fe681095baa867b44e8) | `` refactor: 70.J.3 — split freminal/src/gui/mod.rs into sibling modules ``                  |
| [`79c22dde`](https://github.com/fredsystems/freminal/commit/79c22dde20789fe60abe8c0c5128539dcfc8c8a3) | `` refactor: 70.J.2 — extract 6 TerminalHandler dispatch groups ``                           |
| [`29aca5c4`](https://github.com/fredsystems/freminal/commit/29aca5c405a95806051a29ead8c3bc99cdbfc134) | `` refactor: 70.J.1.c — extract 8 Buffer impl groups into submodules ``                      |
| [`b9f8247b`](https://github.com/fredsystems/freminal/commit/b9f8247bdb246e5ee571ea7f4002ff6e867181a9) | `` refactor: 70.J.1.b — extract Buffer tab-stop methods to buffer/tabs.rs ``                 |
| [`0f4cd68d`](https://github.com/fredsystems/freminal/commit/0f4cd68d49e9e789ca414f6b5af9d0a59dd41d4e) | `` refactor: 70.J.1.a — convert buffer.rs to buffer/mod.rs (facade setup) ``                 |
| [`2bab51c1`](https://github.com/fredsystems/freminal/commit/2bab51c1d0fe58febff3b420b001a226b5d250ba) | `` refactor: 70.I.1 — replace in_band_resize_enabled bool with InBandResizeMode enum ``      |
| [`0babe081`](https://github.com/fredsystems/freminal/commit/0babe0812f7e30824e62984e9649aeb6dd644c1f) | `` docs: 70.H.e + 70.H.3 — mark complete in plan doc ``                                      |
| [`2ab6f7cd`](https://github.com/fredsystems/freminal/commit/2ab6f7cd4bc26ca02dd71f5bed53ee36241330cd) | `` refactor: 70.H.3 — explicit cast-lint tripwires in library crates ``                      |
| [`9900e989`](https://github.com/fredsystems/freminal/commit/9900e989aa35d25621b1f7eede14ad13cf308053) | `` refactor: 70.H.e — eliminate raw casts in emulator + common tail ``                       |
| [`4c664dd6`](https://github.com/fredsystems/freminal/commit/4c664dd628333a7f3e1f96d161b14af6861e45df) | `` refactor: 70.H.d — eliminate raw casts in GUI shaping cluster ``                          |
| [`d92e171d`](https://github.com/fredsystems/freminal/commit/d92e171da98d8c932ef4618fc3d09fc090d83b2b) | `` refactor: 70.H.c — eliminate raw casts in renderer cluster (atlas + vertex) ``            |
| [`0e034b5d`](https://github.com/fredsystems/freminal/commit/0e034b5dc3ffb15f22a89e63a2b882434bf7366b) | `` refactor: 70.H.b — eliminate raw casts in freminal-terminal-emulator/src/input.rs ``      |
| [`5b181403`](https://github.com/fredsystems/freminal/commit/5b18140399e11dab08b32b7226c1e6d9af85de44) | `` refactor: 70.H.a — eliminate raw casts in buffer.rs ``                                    |
| [`6cd74a28`](https://github.com/fredsystems/freminal/commit/6cd74a286e4b71ae7a1fc673e891b2c5b40d0b51) | `` docs: 70.G — defer bounded-channel work pending measurements ``                           |
| [`83b2bca1`](https://github.com/fredsystems/freminal/commit/83b2bca15a24a99db9f243593697df4aacb3e035) | `` refactor: 70.F — thread hygiene: named threads ``                                         |
| [`313acee3`](https://github.com/fredsystems/freminal/commit/313acee38d0c191a91c3a1ea0f445e94954d2a70) | `` refactor: 70.E — typed errors for GPU renderer ``                                         |
| [`9501faab`](https://github.com/fredsystems/freminal/commit/9501faabbb72ccc0e7f309334421d6f56a0ef132) | `` refactor: 70.D — eliminate production panic sites ``                                      |
| [`dd1e3a7d`](https://github.com/fredsystems/freminal/commit/dd1e3a7d40ea7d775357ae262190a255aa616c99) | `` refactor: 70.C — relocate TerminalHandler to freminal-terminal-emulator ``                |
| [`e820d8f8`](https://github.com/fredsystems/freminal/commit/e820d8f866360d6cf8f9bd91ba8b1711865740ea) | `` refactor: 70.B.2 + 70.B.3 — replace anyhow::Result with typed errors in library crates `` |
| [`d859783a`](https://github.com/fredsystems/freminal/commit/d859783a784ec752e09481defd8edc7377d38323) | `` refactor: 70.B.1 — add typed error enums for anyhow elimination ``                        |
| [`ff0a4645`](https://github.com/fredsystems/freminal/commit/ff0a46451a95ccf1e5c80981e6895083721a9bfe) | `` fix: 70.A.1 — document codepoint cast safety and add non-ASCII regression tests ``        |
| [`1d8caac3`](https://github.com/fredsystems/freminal/commit/1d8caac393450920ddeba8799e1e7ea619944129) | `` chore: bump workspace version to v0.8.0 ``                                                |
| [`2253483f`](https://github.com/fredsystems/freminal/commit/2253483f6fd2a8d358bdfbbbe5b7c552442506ab) | `` update plans ``                                                                           |
| [`e56e2e3a`](https://github.com/fredsystems/freminal/commit/e56e2e3add8bbdf32883b18ad4d1970073f5c930) | `` update planes ``                                                                          |