### PR TITLE
chore(flake/catppuccin): `b85b328e` -> `f41cc1cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776681486,
-        "narHash": "sha256-akO/L6Jt4341uBnf3CIpJOTTYyCBQsSvP2hnikV2oMY=",
+        "lastModified": 1777024856,
+        "narHash": "sha256-OQ+yIcRMXo4UaHyX+W5DCgBvJ5dZo/3kFGWPJiuR6x8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "b85b328ecc9874f4e7424db2820333c148e8dd66",
+        "rev": "f41cc1cf13647e482b7317396f749840ef715e16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                            |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`f41cc1cf`](https://github.com/catppuccin/nix/commit/f41cc1cf13647e482b7317396f749840ef715e16) | `` chore(deps): update pnpm to v10.33.2 (#874) ``                  |
| [`a086c02c`](https://github.com/catppuccin/nix/commit/a086c02cf16ab45851cdc97f012317dff83004bb) | `` chore(site): update deps (#898) ``                              |
| [`c6dacc00`](https://github.com/catppuccin/nix/commit/c6dacc00750a729ccadc67222e86440cfa7ad788) | `` chore(deps): update actions/deploy-pages action to v5 (#879) `` |
| [`2f8cd59c`](https://github.com/catppuccin/nix/commit/2f8cd59ce353bf70f70468f6eb4feb0e59c24f5f) | `` chore: update flakes (#897) ``                                  |