### PR TITLE
chore(flake/nixpkgs-stable): `e07580da` -> `10e7ad5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1156,11 +1156,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1776560675,
-        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`131bdde9`](https://github.com/NixOS/nixpkgs/commit/131bdde916515ba0f14e51337a1eb7f5a71169bb) | `` github: Serialize git worktree initialization ``                                             |
| [`0da32d47`](https://github.com/NixOS/nixpkgs/commit/0da32d47d2924f3f32d77c2b4f209e09c0bb88fa) | `` mprisence: 1.5.1 -> 1.5.2 ``                                                                 |
| [`9d7f4b59`](https://github.com/NixOS/nixpkgs/commit/9d7f4b59596f4b41486d6ca7bc1543c94d64c224) | `` ci/parse: Test latest Lix ``                                                                 |
| [`a2e02bc8`](https://github.com/NixOS/nixpkgs/commit/a2e02bc8bd89cce24f82b06f18d7b47c4cd11838) | `` ci/parse: Fail on warning ``                                                                 |
| [`da8deebd`](https://github.com/NixOS/nixpkgs/commit/da8deebda9b6e07613c3f1c01762d1022c7148a4) | `` python3Packages.stackprinter: 0.2.12 -> 0.2.13 ``                                            |
| [`8064a467`](https://github.com/NixOS/nixpkgs/commit/8064a46756d1759c9fe5caa019d35709134f7183) | `` authelia: 4.39.18 -> 4.39.19 ``                                                              |
| [`591bf39b`](https://github.com/NixOS/nixpkgs/commit/591bf39bac9426faf28d456c53429707acf88eaa) | `` mattermostLatest: 11.5.1 -> 11.5.3 ``                                                        |
| [`dc92feb2`](https://github.com/NixOS/nixpkgs/commit/dc92feb2db56dd834d9a12c2ea46cf1f781bb48f) | `` dotnetCorePackages: fix evaluation in cross ``                                               |
| [`80a912ec`](https://github.com/NixOS/nixpkgs/commit/80a912ec5d577d9ba993c8cf45441828671b2a30) | `` zellij: 0.44.0 -> 0.44.1 ``                                                                  |
| [`1cf55ff1`](https://github.com/NixOS/nixpkgs/commit/1cf55ff1f1198d3fcd09c15d58fcbca0a1beffa5) | `` mattermost: 10.11.13 -> 10.11.14 ``                                                          |
| [`fe88116b`](https://github.com/NixOS/nixpkgs/commit/fe88116b6825cbfb5fb17920f825a384cfd8b7f6) | `` yubihsm-shell: 2.7.2 -> 2.7.3 ``                                                             |
| [`0df05cc7`](https://github.com/NixOS/nixpkgs/commit/0df05cc74f48a812a8fd40fa1b3b4521d590fef2) | `` zellij: 0.43.1 -> 0.44.0 ``                                                                  |
| [`6df3f8db`](https://github.com/NixOS/nixpkgs/commit/6df3f8db9a1659c23deafbff25d660314d69e581) | `` qemu-user: update URL in comment ``                                                          |
| [`47b55a03`](https://github.com/NixOS/nixpkgs/commit/47b55a036c35379debd59c9a9e05c4ca6f28eaa5) | `` mmctl: allow overrides ``                                                                    |
| [`13c18c6d`](https://github.com/NixOS/nixpkgs/commit/13c18c6d451faf3fae6f69e735cf36cc2e902f90) | `` mmctl: don't add an update script ``                                                         |
| [`0149f4a8`](https://github.com/NixOS/nixpkgs/commit/0149f4a82108f5979baaa855f9f2ce63e93c03ef) | `` mattermost: use GH releases for updates ``                                                   |
| [`757dcf0a`](https://github.com/NixOS/nixpkgs/commit/757dcf0a770031e765b3266a2183baf53c6b28b0) | `` mattermost: fix override for mattermostLatest ``                                             |
| [`067d9c5f`](https://github.com/NixOS/nixpkgs/commit/067d9c5f271bface37948310ddf64f8ec137e5dc) | `` mattermostLatest: 11.4.0 -> 11.5.1 ``                                                        |
| [`eb66d973`](https://github.com/NixOS/nixpkgs/commit/eb66d973b2458a207ff9f59b2227b59e97c3ed2e) | `` mattermostLatest: 11.3.0 -> 11.4.0 ``                                                        |
| [`ea423d46`](https://github.com/NixOS/nixpkgs/commit/ea423d4630adca14ea4f281ee3916fe7e1765115) | `` tandoor-recipes: 2.6.6 -> 2.6.9 ``                                                           |
| [`fb5504b4`](https://github.com/NixOS/nixpkgs/commit/fb5504b42486b997fc898038ecfc17677f276d1d) | `` qbz: 1.2.4 -> 1.2.7 ``                                                                       |
| [`bccadb83`](https://github.com/NixOS/nixpkgs/commit/bccadb835860c8e314631687e3631b19861b807f) | `` dolibarr: add CVE-2026-23500 to knownVulnerabilities ``                                      |
| [`2b348cfc`](https://github.com/NixOS/nixpkgs/commit/2b348cfcf30290e2fe4a564152272e38f1ccf2d6) | `` python3Packages.qh3: skip broken tests on darwin ``                                          |
| [`f17a41bf`](https://github.com/NixOS/nixpkgs/commit/f17a41bfcb5c5da1d5fdf966b06cbbe9543a1abb) | `` python3Packages.qh3: 1.7.0 -> 1.7.1 ``                                                       |
| [`5ffb31e6`](https://github.com/NixOS/nixpkgs/commit/5ffb31e6386902823200e4320e90a4eeb8426dba) | `` python3Packages.qh3: 1.6.0 -> 1.7.0 ``                                                       |
| [`eb44112d`](https://github.com/NixOS/nixpkgs/commit/eb44112d0f443ce543f7f8d5b3eacaa1670692d8) | `` python3Packages.qh3: 1.5.6 -> 1.6.0 ``                                                       |
| [`178ffb8c`](https://github.com/NixOS/nixpkgs/commit/178ffb8c1d1ea6c4020744a9709aa68b882399ed) | `` python3Packages.m2crypto: 0.47.0 -> 0.48.0 ``                                                |
| [`b2378ae9`](https://github.com/NixOS/nixpkgs/commit/b2378ae9c8642a62aec97f9258faa19e407b5c4e) | `` python3Packages.m2crypto: 0.46.2 -> 0.47.0 ``                                                |
| [`6cf18358`](https://github.com/NixOS/nixpkgs/commit/6cf183585178c6450b6e79fa17b9b90b190afef2) | `` python3Packages.m2crypto: 0.45.1 -> 0.46.2 ``                                                |
| [`1095e0d2`](https://github.com/NixOS/nixpkgs/commit/1095e0d20b6ba43886af3a0e7e6ca74f46e42934) | `` python3Packages.m2crypto: add sarahec as maintainer ``                                       |
| [`442d140e`](https://github.com/NixOS/nixpkgs/commit/442d140e471662ac76122723afe969062bf1f4fc) | `` python3Packages.m2crypto: build from GitLab source ``                                        |
| [`15a67b2c`](https://github.com/NixOS/nixpkgs/commit/15a67b2ce10f4f00f2f725e0cba903388ca9a0fa) | `` static-web-server: 2.39.0 -> 2.42.0 ``                                                       |
| [`7ef25900`](https://github.com/NixOS/nixpkgs/commit/7ef25900f24fe84367c071f325c6480db38b4755) | `` static-web-server: add progrm_jarvis to maintainers ``                                       |
| [`53512291`](https://github.com/NixOS/nixpkgs/commit/535122912c8fdcb21dca312bbe8c9fd5cc542cee) | `` static-web-server: handle files from nix store epoch+1 ``                                    |
| [`7b8917ee`](https://github.com/NixOS/nixpkgs/commit/7b8917ee0499d473cd7cebd8b89ae2b9209c087d) | `` tigervnc: 1.16.1 -> 1.16.2 ``                                                                |
| [`42845fbc`](https://github.com/NixOS/nixpkgs/commit/42845fbcb12be3adf2947adbfdd2b30b70594c3c) | `` tigervnc: 1.16.0 -> 1.16.1 ``                                                                |
| [`99b6b095`](https://github.com/NixOS/nixpkgs/commit/99b6b095fbecb794f1daaed4596a95b07f711a13) | `` tigervnc: support building w0vncserver ``                                                    |
| [`a0675b1e`](https://github.com/NixOS/nixpkgs/commit/a0675b1ea67bc39c220bc8d6e21026b4563e3c07) | `` tigervnc: 1.15.0 -> 1.16.0 ``                                                                |
| [`bda8662f`](https://github.com/NixOS/nixpkgs/commit/bda8662f32052c5bea841055de2f888bf1fb2f9a) | `` freshrss: fix CVE-2025-62166 ``                                                              |
| [`029a14bf`](https://github.com/NixOS/nixpkgs/commit/029a14bfc007e39b9c548a452c95b39af912deb6) | `` juju: 3.6.12 -> 3.6.21 ``                                                                    |
| [`e0b1609b`](https://github.com/NixOS/nixpkgs/commit/e0b1609b9cc0d0f2a488f462b8dd2e6ee3bd5f54) | `` tinyproxy: add patch for CVE-2026-31842 ``                                                   |
| [`f52db20f`](https://github.com/NixOS/nixpkgs/commit/f52db20f318698f150c3f635ce2c5f32289e2fad) | `` tinyproxy: 1.11.2 -> 1.11.3 ``                                                               |
| [`e82f9288`](https://github.com/NixOS/nixpkgs/commit/e82f9288bb5866ad49e8b258c3f4b8de45c39042) | `` editorconfig-core-c: 0.12.9 -> 0.12.11 ``                                                    |
| [`2a1cf130`](https://github.com/NixOS/nixpkgs/commit/2a1cf130b439bd38be260842b03bb292b29a6ca9) | `` brave: 1.89.132 -> 1.89.137 ``                                                               |
| [`bcc29f47`](https://github.com/NixOS/nixpkgs/commit/bcc29f473a68c72803d5c1880087065a99dcfdab) | `` rcu: Drop OPNA2608 from meta.maintainers ``                                                  |
| [`7a4533f7`](https://github.com/NixOS/nixpkgs/commit/7a4533f7fbd1f2b098230b454712c24c1f0de223) | `` rcu: Fix passthru.tests.version check ``                                                     |
| [`40eb1737`](https://github.com/NixOS/nixpkgs/commit/40eb173764c50e0440553265040ee9c3b811e9fe) | `` rcu: 4.0.33 -> 4.0.34 ``                                                                     |
| [`f7a7d0c1`](https://github.com/NixOS/nixpkgs/commit/f7a7d0c189a9d7b45c73560f050fd2e3e7435951) | `` beszel: 0.18.6 -> 0.18.7 ``                                                                  |
| [`9d646f41`](https://github.com/NixOS/nixpkgs/commit/9d646f418c5d2433e17f3058f57dafb38432f772) | `` webkitgtk_6_0: 2.52.2 → 2.52.3 ``                                                            |
| [`26de0251`](https://github.com/NixOS/nixpkgs/commit/26de02518fe6e2286e0cdf60429edf8145d27bd6) | `` nixos: maximise mmap ASLR entropy on x86_64 and AArch64 ``                                   |
| [`2124f507`](https://github.com/NixOS/nixpkgs/commit/2124f507bb7d5331b6ea594e00cdb6dda2bf44d3) | `` dotnetCorePackages.sdk_11_0: 11.0.100-preview.2.26159.112 -> 11.0.100-preview.3.26207.106 `` |
| [`d17dec91`](https://github.com/NixOS/nixpkgs/commit/d17dec91f50003f554c12f4107253573eca000c7) | `` dotnetCorePackages.sdk_8_0: 8.0.419 -> 8.0.420 ``                                            |
| [`761c07fc`](https://github.com/NixOS/nixpkgs/commit/761c07fccd7bf5365de6e1cc7186f9fa803fd9a5) | `` dotnetCorePackages.sdk_10_0: 10.0.201 -> 10.0.202 ``                                         |
| [`14ab2b4e`](https://github.com/NixOS/nixpkgs/commit/14ab2b4e3e40c4143d06bd978a13e57da62e5050) | `` dotnetCorePackages.sdk_9_0: 9.0.312 -> 9.0.313 ``                                            |
| [`8ffac7d9`](https://github.com/NixOS/nixpkgs/commit/8ffac7d9e317d9982fab85f4e5b1eeb5bad54918) | `` nuget-package-hook: add helper to create .nupkg.metadata ``                                  |
| [`56468627`](https://github.com/NixOS/nixpkgs/commit/56468627c140f61e177b47e7c66d31553479a8d3) | `` dotnet-sdk_{10,11}: apply muxer path precedence patch ``                                     |
| [`d823cfd5`](https://github.com/NixOS/nixpkgs/commit/d823cfd5c7bf70c55345a9abf027548b5f4a30d3) | `` dotnetCorePackages.combinePackages: set DOTNET_HOST_PATH in wrappers ``                      |
| [`128f8c2e`](https://github.com/NixOS/nixpkgs/commit/128f8c2eb9cbfc0266d7693869f7e3e4355a63ed) | `` dotnet-sdk_{10,11}: provide $out/bin/dnx ``                                                  |
| [`2a890f7d`](https://github.com/NixOS/nixpkgs/commit/2a890f7d8f060f21f4ec59f9113851751bb3b468) | `` test/dotnet: add cross-target test ``                                                        |
| [`2b8752d9`](https://github.com/NixOS/nixpkgs/commit/2b8752d90dd1b6976ce76b2c47bae0380e55e3fd) | `` dotnet: update URLs for eol packages ``                                                      |
| [`b7741d43`](https://github.com/NixOS/nixpkgs/commit/b7741d435df43786eb1908234a10cd217838a6a5) | `` dotnet: combine binary and source update scripts ``                                          |
| [`cc037e8b`](https://github.com/NixOS/nixpkgs/commit/cc037e8bfff5b0fff94b2bcb4951ec600c7fabe6) | `` dotnet: combine binary and source expressions ``                                             |
| [`7bc62c74`](https://github.com/NixOS/nixpkgs/commit/7bc62c743ab5bda48b54de5d9de2b1399be821b3) | `` dotnet: move vmr update script to file ``                                                    |
| [`887f5487`](https://github.com/NixOS/nixpkgs/commit/887f54875e63abe05378ab910b7623796db9469e) | `` dotnetCorePackages.sdk_10_0-source: use 2xx sdk ``                                           |
| [`7f6f0da1`](https://github.com/NixOS/nixpkgs/commit/7f6f0da13e8a1176495d7573f1d22506d13cbeec) | `` dotnet: remove unused deps ``                                                                |
| [`2f03127f`](https://github.com/NixOS/nixpkgs/commit/2f03127f821990dc38c54c092bd67d4200dc6b7d) | `` dotnet: combine binary and source release directories ``                                     |
| [`6ab80eca`](https://github.com/NixOS/nixpkgs/commit/6ab80ecaabc89384c6666fe9569900626bf5f599) | `` dotnet/update.nix: fix update of sdk without bootstrap ``                                    |
| [`79fd93f1`](https://github.com/NixOS/nixpkgs/commit/79fd93f13682c684d0c2f3676f8530e28d6028c8) | `` pretalx: mark vulnerable ``                                                                  |
| [`4c24c16d`](https://github.com/NixOS/nixpkgs/commit/4c24c16d32ec00649b62e11d54a9686b5fcd468e) | `` webkitgtk_6_0: 2.52.1 → 2.52.2 ``                                                            |
| [`3b3b6d14`](https://github.com/NixOS/nixpkgs/commit/3b3b6d1480efdb8b8d83959617bd43c9c879e3c1) | `` python3Packages.ansible-core: patch cli stub ``                                              |
| [`69439255`](https://github.com/NixOS/nixpkgs/commit/694392551a9c71d08b89b92bd970727b293ace10) | `` podman-desktop: 1.23.1 -> 1.26.2 ``                                                          |
| [`2fc3eac1`](https://github.com/NixOS/nixpkgs/commit/2fc3eac1937f28aef33b475aebd4028f3696b96a) | `` podman-desktop: pin nodejs version for fetchPnpmDeps ``                                      |
| [`976881a6`](https://github.com/NixOS/nixpkgs/commit/976881a69b976fc61d859f676f4ea8e1b664b819) | `` podman-desktop: move env variable(s) into env for structuredAttrs ``                         |
| [`236fd3e8`](https://github.com/NixOS/nixpkgs/commit/236fd3e82c79c810624c1510e6f6dd7832554312) | `` noriskclient-launcher-unwrapped: fix hash ``                                                 |
| [`06b8fd67`](https://github.com/NixOS/nixpkgs/commit/06b8fd67652e91abdf32d92063e63c2539bfb5b0) | `` noriskclient-launcher-unwrapped: add meta.changelog ``                                       |
| [`4819ee28`](https://github.com/NixOS/nixpkgs/commit/4819ee28cf299a06430dfbf4daa899c651f408d2) | `` noriskclient-launcher-unwrapped: 0.6.16 -> 0.6.17 ``                                         |