### PR TITLE
chore(flake/nixpkgs): `b12141ef` -> `1c3fe55a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1172,11 +1172,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -44,6 +44,22 @@ final: prev: {
     else
       prev.dateutils;
 
+  # `direnv`'s checkPhase runs `make test-go test-bash test-fish test-zsh`.
+  # On darwin, the fish test suite hangs indefinitely (CI hits the 6h max
+  # execution time with no output).  Tracked upstream:
+  # https://github.com/NixOS/nixpkgs/issues/507531 (still open).  The related
+  # zsh sigsuspend issue (#513543) is fixed in our pinned nixpkgs, but the
+  # fish hang appears to be a separate codesign/sigsuspend interaction
+  # (see also #208951).  Disable the check phase on darwin only; Linux still
+  # runs the full test suite.
+  direnv =
+    if prev.stdenv.isDarwin then
+      prev.direnv.overrideAttrs (_: {
+        doCheck = false;
+      })
+    else
+      prev.direnv;
+
   # Shadow the deprecated top-level `pkgs.hostPlatform` warnAlias (added
   # 2025-10-28 in nixpkgs aliases.nix) with the real value so that packages
   # which still reference `pkgs.hostPlatform` (e.g. the Flutter build

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -30,6 +30,20 @@ final: prev: {
     }
   );
 
+  # Workaround for the staging-next autoconf update that forces Clang to
+  # `-std=gnu23`, breaking C code that isn't C23-compliant.  See upstream
+  # tracking issue: https://github.com/NixOS/nixpkgs/issues/511329.
+  # `dateutils` 0.4.11 fails to compile `dgrep.c` under C23 on aarch64-darwin
+  # (Clang is the default C compiler on macOS, so this only affects darwin).
+  # Pin CFLAGS back to the previous default of gnu17 via configureFlags.
+  dateutils =
+    if prev.stdenv.isDarwin then
+      prev.dateutils.overrideAttrs (old: {
+        configureFlags = (old.configureFlags or [ ]) ++ [ "CFLAGS=-std=gnu17" ];
+      })
+    else
+      prev.dateutils;
+
   # Shadow the deprecated top-level `pkgs.hostPlatform` warnAlias (added
   # 2025-10-28 in nixpkgs aliases.nix) with the real value so that packages
   # which still reference `pkgs.hostPlatform` (e.g. the Flutter build


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`29a3279f`](https://github.com/NixOS/nixpkgs/commit/29a3279f4d154b104d8ac8300680ad8ea0773856) | `` terraform-plugin-docs: 0.24.0 -> 0.25.0 ``                                                           |
| [`2da27b8c`](https://github.com/NixOS/nixpkgs/commit/2da27b8c58f189e1249902f0182e4a1cc333c94b) | `` dumpyara: init at 1.1.0 ``                                                                           |
| [`5b43b78d`](https://github.com/NixOS/nixpkgs/commit/5b43b78d94bea3ebd8a01d02b29ca02d58b349c0) | `` itch-dl: 0.6.1 -> 0.7.2 ``                                                                           |
| [`964fef6a`](https://github.com/NixOS/nixpkgs/commit/964fef6a7902a3c558980b84c9237698e213ff80) | `` vega-cli: removed maintainer ``                                                                      |
| [`f46c546e`](https://github.com/NixOS/nixpkgs/commit/f46c546efca3cd53e79321572425a88f4f2d6d69) | `` terraform-providers.pagerduty_pagerduty: 3.32.2 -> 3.32.3 ``                                         |
| [`7685a643`](https://github.com/NixOS/nixpkgs/commit/7685a643866bab316d6fdde455a0c44d3702bfa9) | `` nixos/unifi: bump default jrePackage for compat with unifi ``                                        |
| [`a883139b`](https://github.com/NixOS/nixpkgs/commit/a883139bdabc154d2bc70942a5d8ed9fddcb18a1) | `` tempo: 2.10.4 -> 2.10.5 ``                                                                           |
| [`fad6a5df`](https://github.com/NixOS/nixpkgs/commit/fad6a5df8c40e8639eab9a2e82a36901fcf6680c) | `` android-studio: 2025.3.3.7 -> 2025.3.4.6 ``                                                          |
| [`62fd31a6`](https://github.com/NixOS/nixpkgs/commit/62fd31a6cac13c59ff9c826a2147a7b20b6cce71) | `` python3Packages.pyjvcprojector: 2.0.5 -> 2.0.6 ``                                                    |
| [`9c56dc66`](https://github.com/NixOS/nixpkgs/commit/9c56dc667093e1ed2c873991fb55a7da037091a8) | `` stdenv.mkDerivation: fully expand out dependency variables ``                                        |
| [`2f4a1e0a`](https://github.com/NixOS/nixpkgs/commit/2f4a1e0ade73cc00b2eb7251f4e14040c633a88a) | `` python3Packages.bx-py-utils: 116 -> 118 ``                                                           |
| [`638f56df`](https://github.com/NixOS/nixpkgs/commit/638f56df21de50a30826ac38cfe01573e170ae61) | `` python3Packages.lupa: build from source ``                                                           |
| [`5e347175`](https://github.com/NixOS/nixpkgs/commit/5e347175022ba2da7f7b4dfb436ba55a3ac798b2) | `` stdenv.mkDerivation: inline function calls ``                                                        |
| [`407f9757`](https://github.com/NixOS/nixpkgs/commit/407f9757dbadc8e1ab1850c36cb3666443f16bba) | `` stdenv.mkDerivation: remove pie hardening flag warning ``                                            |
| [`9500a7bf`](https://github.com/NixOS/nixpkgs/commit/9500a7bff7e3f83ab03524c9915a3d3658f516a7) | `` stdenv.mkDerivation: remove duplicate assertions ``                                                  |
| [`82da9cf4`](https://github.com/NixOS/nixpkgs/commit/82da9cf45c21f9b93b48d8ef40ff6005dfc5a53b) | `` python3Packages.buildPythonPackage: ban pytestFlagsArray ``                                          |
| [`00b1ba42`](https://github.com/NixOS/nixpkgs/commit/00b1ba422859f7be7cd267aa1eb90f88f3d360de) | `` python3Packages: transition from pytestFlagsArray (round 3) ``                                       |
| [`6fd28ab3`](https://github.com/NixOS/nixpkgs/commit/6fd28ab3b0ede0c39ee6b5592163662266128d30) | `` wolfssl: drop ``                                                                                     |
| [`82b9c887`](https://github.com/NixOS/nixpkgs/commit/82b9c8879be6a7c77cd51b23160e066c40d0b62f) | `` art-standalone: patch out wolfSSL dependency ``                                                      |
| [`dadb9d4e`](https://github.com/NixOS/nixpkgs/commit/dadb9d4ebc8304ce511b22f2aa8fe33a39e2b3e7) | `` haproxy: drop wolfSSL support ``                                                                     |
| [`e337b3ae`](https://github.com/NixOS/nixpkgs/commit/e337b3ae4f603cf82aa4ab16eeaa3692f5cfcec1) | `` curl: drop wolfSSL support ``                                                                        |
| [`89d326f7`](https://github.com/NixOS/nixpkgs/commit/89d326f7a52be496953980a2a45d032605f4a8f2) | `` riemann_c_client: drop wolfSSL support ``                                                            |
| [`9a808c29`](https://github.com/NixOS/nixpkgs/commit/9a808c298b54284cbc73bc825ce444b08d4253ea) | `` qt5.qtwebkit: drop ``                                                                                |
| [`4ca9c70c`](https://github.com/NixOS/nixpkgs/commit/4ca9c70c29d647ff451529d135b5112088f4513e) | `` python3Packages.pyqt5: drop withWebKit flag ``                                                       |
| [`741db42b`](https://github.com/NixOS/nixpkgs/commit/741db42b2189e42294576b3269d01b024acb8d2e) | `` qtwebkit-plugins: drop, no consumers ``                                                              |
| [`ad2d8e9c`](https://github.com/NixOS/nixpkgs/commit/ad2d8e9cfe4cd8a32f417752ad29d1fae1c9f8a2) | `` openmodelica: drop ``                                                                                |
| [`dda0b2b2`](https://github.com/NixOS/nixpkgs/commit/dda0b2b2ad6ffa9236b39971d1bf5e1f0d5cb715) | `` smfh: 1.4 -> 1.5 ``                                                                                  |
| [`4eb35b3a`](https://github.com/NixOS/nixpkgs/commit/4eb35b3ae0fc8d741cd706bcf94ae67426b03037) | `` goldendict: drop, use goldendict-ng instead ``                                                       |
| [`143f6e05`](https://github.com/NixOS/nixpkgs/commit/143f6e057ee1b004eae014df0c96d4e13cc637d0) | `` smtube: drop, depends on insecure&unmaintained qtwebkit ``                                           |
| [`daaf1c7d`](https://github.com/NixOS/nixpkgs/commit/daaf1c7d6d1fd57c22d9ddfe54467278002b632e) | `` apmplanner2: drop, depends on insecure&unmaintained qtwebkit ``                                      |
| [`ef5701a2`](https://github.com/NixOS/nixpkgs/commit/ef5701a29318ce3c1e3597b7e37a37faa531b727) | `` cb2bib: drop, depends on insecure&unmaintained qtwebkit ``                                           |
| [`1579e32f`](https://github.com/NixOS/nixpkgs/commit/1579e32f95779f235888c63f6d13ea1a63d8ea4e) | `` quiterss: drop, unmaintained upstream since 2022 ``                                                  |
| [`3fc3bb33`](https://github.com/NixOS/nixpkgs/commit/3fc3bb33b20ea598e08f5a483476f7f60429f22f) | `` fontmatrix: drop, archived upstream 2024-10-24 ``                                                    |
| [`04847458`](https://github.com/NixOS/nixpkgs/commit/048474585107873da3c8a69bdbd543f77a4bfe18) | `` vacuum: drop, unmaintained upstream since 2021 ``                                                    |
| [`7b8fbb83`](https://github.com/NixOS/nixpkgs/commit/7b8fbb83b040dd5945fdd9c6c3ca4fbc42a235ec) | `` nixnote2: drop, unmaintained upstream since 2017 ``                                                  |
| [`99b73698`](https://github.com/NixOS/nixpkgs/commit/99b73698a77b1cc1754cc4c451876a2fdf78485b) | `` mythtv: drop withWebKit toggle ``                                                                    |
| [`4dea84b5`](https://github.com/NixOS/nixpkgs/commit/4dea84b5e680b5858fe5428bd61b04388f858d8c) | `` qgis-ltr: drop withWebKit toggle ``                                                                  |
| [`2798f785`](https://github.com/NixOS/nixpkgs/commit/2798f78504eaec69ce25ebb1cdd5c246d80e79e4) | `` readeck: 0.21.5 -> 0.22.2 ``                                                                         |
| [`f322bbe8`](https://github.com/NixOS/nixpkgs/commit/f322bbe86c9f842057905460e570668e08cd42f1) | `` ustream-ssl-wolfssl: drop ``                                                                         |
| [`ac722e11`](https://github.com/NixOS/nixpkgs/commit/ac722e11b8c5240a350ba5f85d846586d65f7910) | `` libubox-wolfssl: drop ``                                                                             |
| [`ebb01310`](https://github.com/NixOS/nixpkgs/commit/ebb013106f3ce766e83bbdb925e5fb42c579d047) | `` rpcs3: use vendored wolfSSL and update `meta.license` ``                                             |
| [`bd7079c5`](https://github.com/NixOS/nixpkgs/commit/bd7079c55d9a459e2c52cecd6c70f782ba9e7b9b) | `` {lomiri,lomiri-qt6}.lomiri-ui-toolkit: 1.3.5904 -> 1.3.5905 ``                                       |
| [`2581c1fc`](https://github.com/NixOS/nixpkgs/commit/2581c1fcbe7353d59254f46850a592d0db309b77) | `` tree-sitter-grammars.tree-sitter-rescript: 5.0.0-unstable-2025-03-03 -> 6.0.0-unstable-2026-04-26 `` |
| [`b2a801ce`](https://github.com/NixOS/nixpkgs/commit/b2a801ce5454c6091062fc935dc2b4cc3ddbae9e) | `` addwater: 1.2.9.1 -> 1.3 ``                                                                          |
| [`37955437`](https://github.com/NixOS/nixpkgs/commit/37955437a78e6effe93022d70a131ff88e92a08e) | `` fetchPnpmDeps: don't fail on empty lockfile ``                                                       |
| [`7c4031f3`](https://github.com/NixOS/nixpkgs/commit/7c4031f35c9350468fddc6718f015de414752f01) | `` rpcs3: 0.0.39-unstable-2026-02-20 -> 0.0.40-unstable-2026-04-25 ``                                   |
| [`255f7cd2`](https://github.com/NixOS/nixpkgs/commit/255f7cd2d48d31b04df32494c4b27138be885595) | `` uhttpd: use the default version of `libubox` ``                                                      |
| [`0ed8424c`](https://github.com/NixOS/nixpkgs/commit/0ed8424ca33155a261aa2f462e82dd2a21aa49af) | `` lightway: 0-unstable-2026-04-10 -> 0-unstable-2026-04-24 ``                                          |
| [`73167c96`](https://github.com/NixOS/nixpkgs/commit/73167c96fcf3c085acc0d1b6da2e5ec7817fc43a) | `` jjui: 0.10.3 -> 0.10.4 ``                                                                            |
| [`937bc9b4`](https://github.com/NixOS/nixpkgs/commit/937bc9b4c03e25545fd8057a1570063a52f3db1b) | `` opencode: 1.14.24 -> 1.14.25 ``                                                                      |
| [`6926e99c`](https://github.com/NixOS/nixpkgs/commit/6926e99cffd71462f9b44c9d748a18674af2ea9c) | `` stdenv.mkDerivation: define dependencies and propagatedDependencies as separate variables ``         |
| [`44853158`](https://github.com/NixOS/nixpkgs/commit/448531580f8771c40b0dffbfdcd24a18166cd346) | `` qt5.qtwebengine: drop ``                                                                             |
| [`ca8f12e8`](https://github.com/NixOS/nixpkgs/commit/ca8f12e883262954d92c19877c6360cf5c669473) | `` cisco-packet-tracer_8: drop ``                                                                       |
| [`6b1544fd`](https://github.com/NixOS/nixpkgs/commit/6b1544fd6b9cfbc5debdd544df110664b4f06cdc) | `` teamspeak3: drop ``                                                                                  |
| [`9bfcba60`](https://github.com/NixOS/nixpkgs/commit/9bfcba60c90bed50fa448d6fbc713dacfd84ff7d) | `` pentobi: drop ``                                                                                     |
| [`6fdf9178`](https://github.com/NixOS/nixpkgs/commit/6fdf9178917973e56b7f8a6e63a3536d2255c743) | `` nmapsi4: drop ``                                                                                     |
| [`70e95a80`](https://github.com/NixOS/nixpkgs/commit/70e95a80f01feaad0755f0c2d7262c5444813091) | `` deltatouch: drop ``                                                                                  |
| [`db60650a`](https://github.com/NixOS/nixpkgs/commit/db60650a727fa496c19e5299607fa244fa9378a6) | `` stdenv.mkDerivation: use `head foo` instead of `elemAt foo 0` ``                                     |
| [`52d15834`](https://github.com/NixOS/nixpkgs/commit/52d158340eeee1e5ead3244c612239b6205e3dfc) | `` stdenv.mkDerivation: compare to [] instead of using builtins.length ``                               |
| [`c1afa719`](https://github.com/NixOS/nixpkgs/commit/c1afa719bbd04c6924b737017701fe71be61fae1) | `` nixosTests.lomiri-music-app: Fix systemd message regex for mediascanner2 extractor startup ``        |
| [`7c9f14e2`](https://github.com/NixOS/nixpkgs/commit/7c9f14e288395089ff414d5cc62a13e74968f7dc) | `` kdeltachat: drop ``                                                                                  |
| [`a73cea57`](https://github.com/NixOS/nixpkgs/commit/a73cea5776df92f536a56ad206d99939d1584b54) | `` luminanceHDR: drop ``                                                                                |
| [`f8da8aa9`](https://github.com/NixOS/nixpkgs/commit/f8da8aa947c6afaf1815d09b65b590b533b7fa14) | `` gfie: drop ``                                                                                        |
| [`00a14d17`](https://github.com/NixOS/nixpkgs/commit/00a14d17f5073358181a989acbb5618d33b8a062) | `` semantik: drop ``                                                                                    |
| [`7ed92185`](https://github.com/NixOS/nixpkgs/commit/7ed9218538c231557b20778c274c3bcb2b04f1c2) | `` psi: drop ``                                                                                         |
| [`65f12fd8`](https://github.com/NixOS/nixpkgs/commit/65f12fd82d0a57e45aa19df2fcbe637366849028) | `` mindforger: drop ``                                                                                  |
| [`03757433`](https://github.com/NixOS/nixpkgs/commit/037574333e983c8446efc7eb6d2b55cdf44b8944) | `` qt5.qtwebview: drop ``                                                                               |
| [`d51e8c2d`](https://github.com/NixOS/nixpkgs/commit/d51e8c2db132c53671477e2b56b922bb73a30763) | `` eagle: drop ``                                                                                       |
| [`c6c169db`](https://github.com/NixOS/nixpkgs/commit/c6c169dbbc23f78de0f113f50c72a8518c42f43f) | `` yacas-gui: drop ``                                                                                   |
| [`b466dce6`](https://github.com/NixOS/nixpkgs/commit/b466dce63d2dc936e6c0f0f7ea93b5bc553aa855) | `` clipgrab: drop ``                                                                                    |
| [`9d952d2e`](https://github.com/NixOS/nixpkgs/commit/9d952d2ee0239ae8a5cf6aa5edb301359bf789de) | `` mellowplayer: drop ``                                                                                |
| [`9d1e3157`](https://github.com/NixOS/nixpkgs/commit/9d1e315721203fb71803251f8e0e9318306bdc5b) | `` kchmviewer: drop ``                                                                                  |
| [`0dcbfd03`](https://github.com/NixOS/nixpkgs/commit/0dcbfd038c9a0f699b54d7f551c7895d05663ce5) | `` python3Packages.pyqtwebengine: drop ``                                                               |
| [`b822c71b`](https://github.com/NixOS/nixpkgs/commit/b822c71ba3fe00622d8c6bb0f5e5d34d213598b1) | `` orange{3,-{canvas-core,widget-base}}: drop ``                                                        |
| [`4142633a`](https://github.com/NixOS/nixpkgs/commit/4142633ab2e6a3145873f17005ece448dffc0e1a) | `` notepadqq: drop ``                                                                                   |
| [`1b80c670`](https://github.com/NixOS/nixpkgs/commit/1b80c670e46b2d5c42466413ff21b0c2eafcd188) | `` pyqt5-stubs: drop ``                                                                                 |
| [`1c1a5b59`](https://github.com/NixOS/nixpkgs/commit/1c1a5b59c35f40302ae114c1facdd0ad9588e540) | `` globalprotect-openconnect: drop ``                                                                   |
| [`5a306a77`](https://github.com/NixOS/nixpkgs/commit/5a306a774696046dfa0a4fe2ba14826f2be4cd6a) | `` nixos/globalprotect-vpn: drop ``                                                                     |
| [`1e224dab`](https://github.com/NixOS/nixpkgs/commit/1e224dab1e3b587c952e4139ce3592a7400b2a60) | `` supercollider: remove qt5 webengine support ``                                                       |
| [`4043181f`](https://github.com/NixOS/nixpkgs/commit/4043181fb3453862080d60e17fc4fc01d61e0235) | `` vivisect: fully disable gui ``                                                                       |
| [`c1834898`](https://github.com/NixOS/nixpkgs/commit/c1834898ebdc484ae4f68ce0395a3de336108f77) | `` python3Packages.pyside2: fully disable webengine ``                                                  |
| [`a9b6cc5d`](https://github.com/NixOS/nixpkgs/commit/a9b6cc5d7c8cc2b0b5ada92afa7d6fb4c7fcfb1f) | `` gpsbabel: remove map preview to avoid qtwebengine dep ``                                             |
| [`2cd13120`](https://github.com/NixOS/nixpkgs/commit/2cd13120677124fc1e56b97644f20731f6f8e3de) | `` psi-plus: 1.5.2115 -> 1.5.2139, migrate to qt6 ``                                                    |
| [`e217a25c`](https://github.com/NixOS/nixpkgs/commit/e217a25c1baa503e10fbeaf361cc25a8a00ab5e4) | `` openshot-qt: 3.3.0 -> 3.5.1-unstable-2026-04-22, migrate to qt6 ``                                   |
| [`6f2929f0`](https://github.com/NixOS/nixpkgs/commit/6f2929f0c2415f5366350e9e128c8b10971d5c60) | `` libopenshot: 0.4.0 -> 0.7.0-unstable-2026-04-21, migrate to qt6 ``                                   |
| [`b79b8c66`](https://github.com/NixOS/nixpkgs/commit/b79b8c660edf2200f24d028adda6437711672d5f) | `` libopenshot-audio: migrate to by-name ``                                                             |
| [`98a01c4e`](https://github.com/NixOS/nixpkgs/commit/98a01c4e415e5bb6eb78b5bbc452e590fab26072) | `` huggle: 3.4.13 -> 3.4.14, move to qt6 ``                                                             |
| [`c6da7ad6`](https://github.com/NixOS/nixpkgs/commit/c6da7ad6a43d23cadfd929862c929460026bfd2c) | `` libirc: unstable-2022-10-15 -> 0-unstable-2025-11-09, move to qt6 ``                                 |
| [`3128eb64`](https://github.com/NixOS/nixpkgs/commit/3128eb648bf6f5814e298f3bc37af6e66240afd0) | `` nixos/home-assistant-matter-hub: init ``                                                             |
| [`def8615c`](https://github.com/NixOS/nixpkgs/commit/def8615cba88b355e11583600e769c02ff478559) | `` nh{,-unwrapped}: 4.3.1 -> 4.3.2 ``                                                                   |
| [`a41c3fc0`](https://github.com/NixOS/nixpkgs/commit/a41c3fc0571964b487822420ad87372bcebf2da2) | `` python3Packages.indevolt-api: 1.2.3 -> 1.6.0 ``                                                      |
| [`6bc6ec5e`](https://github.com/NixOS/nixpkgs/commit/6bc6ec5efac9b2eb7db6dac5bd8f63ee5bfc0275) | `` terraform-providers.ovh_ovh: 2.13.0 -> 2.13.1 ``                                                     |
| [`b89e7484`](https://github.com/NixOS/nixpkgs/commit/b89e7484773785ba3496b9774138742903d8033f) | `` home-assistant-matter-hub: init at 2.0.41 ``                                                         |
| [`34a0d844`](https://github.com/NixOS/nixpkgs/commit/34a0d8447899e0d189c52124244c757043b21817) | `` stdenv.mkDerivation: inline variable ``                                                              |
| [`e70789fb`](https://github.com/NixOS/nixpkgs/commit/e70789fb5a2fea7cbf45bdc68a372eb894f994f2) | `` stdenv.mkDerivation: inline variable ``                                                              |
| [`d38a01c2`](https://github.com/NixOS/nixpkgs/commit/d38a01c2594d7f5bb1e7d94ba5ed46807cad3213) | `` stdenv.mkDerivation: inline functions already in scope ``                                            |
| [`d946d320`](https://github.com/NixOS/nixpkgs/commit/d946d320435fd4fb79ca85512506bce385dbc739) | `` grafanaPlugins.redis-app: 2.2.1 -> 2.3.2 ``                                                          |
| [`e3aedf55`](https://github.com/NixOS/nixpkgs/commit/e3aedf557275e4b4f292bc8332caacb7607e7673) | `` python3Packages.imap-tools: 1.12.0 -> 1.12.1 ``                                                      |
| [`afc6eee8`](https://github.com/NixOS/nixpkgs/commit/afc6eee8a6d905889c8e19482696865a308ce872) | `` python3Packages.farama-notifications: 0.0.4 -> 0.0.6 ``                                              |
| [`db4da326`](https://github.com/NixOS/nixpkgs/commit/db4da3263f79445e6413d14fddd65583521a6964) | `` vega-cli: added maintainer ``                                                                        |
| [`095b50d0`](https://github.com/NixOS/nixpkgs/commit/095b50d045130be4231bef34431e7f1ffb820783) | `` vega-cli: simplifed the redirection ``                                                               |
| [`019e2017`](https://github.com/NixOS/nixpkgs/commit/019e2017e2c70eeb24bc10c3096f07762f6c41da) | `` vega-cli: patched to use direct jq ``                                                                |
| [`a07d262b`](https://github.com/NixOS/nixpkgs/commit/a07d262b8889a217f3d502242b619a290a6ce33f) | `` stdenv.mkDerivation: inline variable ``                                                              |
| [`0080eb12`](https://github.com/NixOS/nixpkgs/commit/0080eb12264f7ece6f09fd97d215053e932868e7) | `` stdenv.mkDerivation: inline toPretty usage ``                                                        |
| [`59264b68`](https://github.com/NixOS/nixpkgs/commit/59264b680a908ffed6af2969be39cda94b6dbb28) | `` stdenv.mkDerivation: inline several `let` variables ``                                               |
| [`e0db9a87`](https://github.com/NixOS/nixpkgs/commit/e0db9a8776d80a24ec98afd6780b317c22d62945) | `` stdenv.mkDerivation: remove concat ``                                                                |
| [`f6f8219c`](https://github.com/NixOS/nixpkgs/commit/f6f8219ce4be6b30ce8b7b67b7d4b6208637c70e) | `` luaPackages: update on 2026-04-26 ``                                                                 |
| [`67b0620e`](https://github.com/NixOS/nixpkgs/commit/67b0620e08a20c3e6d739b33e4dbdc8a86c43cf7) | `` cargo-show-asm: 0.2.57 -> 0.2.58 ``                                                                  |
| [`6b6d15b8`](https://github.com/NixOS/nixpkgs/commit/6b6d15b8208b68aa358277bc85d3dc1333a6334b) | `` fetchPnpmDeps: deprecate fetcherVersion = 1, schedule removal for 26.11 ``                           |
| [`9b65faee`](https://github.com/NixOS/nixpkgs/commit/9b65faeee0da071522ab2b069823fa02fecf1c75) | `` code-cursor: 3.1.15 -> 3.2.11 ``                                                                     |
| [`967997bc`](https://github.com/NixOS/nixpkgs/commit/967997bc529d366944941e945a131a61a18b9911) | `` ec: 0.3.1 -> 0.3.2 ``                                                                                |
| [`1333b9dd`](https://github.com/NixOS/nixpkgs/commit/1333b9dd5d5e210abf8dca6e18a93fb33bbdc382) | `` python3Packages.sagemaker-core: 1.0.77 -> 1.0.78 ``                                                  |
| [`ec26f553`](https://github.com/NixOS/nixpkgs/commit/ec26f553fbbc7eeead6325599518f9209b1ad70e) | `` fzf: 0.71.0 -> 0.72.0 ``                                                                             |
| [`ac04430c`](https://github.com/NixOS/nixpkgs/commit/ac04430cec25be0c66df016f30ebcef661ce035f) | `` git-cliff: 2.12.0 -> 2.13.1 ``                                                                       |
| [`be70cf6c`](https://github.com/NixOS/nixpkgs/commit/be70cf6cc8bf061483354c82434c60f2b0b1c3ab) | `` go-judge: 1.11.4 -> 1.12.0 ``                                                                        |
| [`fbdd89e9`](https://github.com/NixOS/nixpkgs/commit/fbdd89e999208175ca2dc639cbe44ec8d6eef634) | `` outline: 1.6.1 -> 1.7.0 ``                                                                           |
| [`64aec86c`](https://github.com/NixOS/nixpkgs/commit/64aec86c56701c12297a30466e663c24e8b946eb) | `` rstudio{,-server}: 2026.01.1+403 -> 2026.04.0+526 ``                                                 |
| [`e096a9bc`](https://github.com/NixOS/nixpkgs/commit/e096a9bc50f68fa661b74d8795db4a977376adef) | `` python3Packages.crewai: 1.14.1 -> 1.14.3 ``                                                          |
| [`523bab86`](https://github.com/NixOS/nixpkgs/commit/523bab8632c8ec3819bedefd33daa33d4fc8c06b) | `` kcl-kafka: 0.17.0 -> 0.18.0 ``                                                                       |
| [`2317d154`](https://github.com/NixOS/nixpkgs/commit/2317d15496ece5c515d270d6ff4a17e6d2640ae4) | `` solanum: set main program ``                                                                         |
| [`3aeb74e6`](https://github.com/NixOS/nixpkgs/commit/3aeb74e6d2795ff280b1fe7f9123689e9bb61d22) | `` solanum: replace hyperscan with vectorscan ``                                                        |
| [`98e608cd`](https://github.com/NixOS/nixpkgs/commit/98e608cdc7d25f7372b31dd18f03795c8c9321ff) | `` vimPlugins.fff-nvim: 0.5.2 -> 0.6.4 ``                                                               |
| [`97d8c310`](https://github.com/NixOS/nixpkgs/commit/97d8c3106eadab431a5315a98a700fb900f2fca2) | `` beeper: 4.2.653 -> 4.2.770 ``                                                                        |
| [`8cee3374`](https://github.com/NixOS/nixpkgs/commit/8cee3374930115a251919f53a0258915da0e8c04) | `` rspamd: 3.14.3 -> 4.0.1 ``                                                                           |
| [`2fbc4f46`](https://github.com/NixOS/nixpkgs/commit/2fbc4f46188649b69c52c7abfe2063764f3156d8) | `` lgogdownloader: fix build, c++17 and matching jsoncpp ABI ``                                         |
| [`77f5f853`](https://github.com/NixOS/nixpkgs/commit/77f5f853a23305ac4c72e4584854a69a362c8354) | `` gpxsee: 16.3 -> 16.6 ``                                                                              |
| [`bba77e69`](https://github.com/NixOS/nixpkgs/commit/bba77e69fc1642c39698af393c4e379cfe26cf8e) | `` python3Packages.aioboto3: disable DynamoDB tests with aiobotocore 3.x ``                             |
| [`6b0cc412`](https://github.com/NixOS/nixpkgs/commit/6b0cc41224cc42a5f2517af95e9f1a832a6632f0) | `` mongodb-compass: 1.49.4 -> 1.49.5 ``                                                                 |
| [`1f7e9e4e`](https://github.com/NixOS/nixpkgs/commit/1f7e9e4e9498e11804d33d6cd31db4495e81bf74) | `` pgdog: 0.1.37 -> 0.1.38 ``                                                                           |
| [`8bc34646`](https://github.com/NixOS/nixpkgs/commit/8bc34646a4e5f4b18140f3bb62439bc9d1919afc) | `` sequoia-git: avoid `rec` keyword ``                                                                  |
| [`8cd85c85`](https://github.com/NixOS/nixpkgs/commit/8cd85c8590ea4254d7d06049ee4ce9c87478528b) | `` python3Packages.pydo: 0.30.0 -> 0.31.0 ``                                                            |
| [`192343cd`](https://github.com/NixOS/nixpkgs/commit/192343cd24bdd5edb86a9a7df81c037ad04753b1) | `` nixos/kmscon: spawn kmscon on tty1 only if the display manager is disabled ``                        |
| [`bbf6d7a7`](https://github.com/NixOS/nixpkgs/commit/bbf6d7a7fe9d28e060992304379e035fa31fd269) | `` nixos/mattermost: mention v11 change as breaking ``                                                  |
| [`05b6489e`](https://github.com/NixOS/nixpkgs/commit/05b6489eb29f73d76c623b69868c62bf8470d622) | `` nixos/mattermost: drop MySQL support ``                                                              |
| [`9742f6aa`](https://github.com/NixOS/nixpkgs/commit/9742f6aa07c72c5b9aacddb4ea8d09fcaad187f5) | `` opentabletdriver: disable update notification for the GUI ``                                         |
| [`c5b3a5cc`](https://github.com/NixOS/nixpkgs/commit/c5b3a5cc2e1ab01039f62fef551e64c69b46cd95) | `` mattermost: 10.11.15 -> 11.6.1 ``                                                                    |
| [`947e720b`](https://github.com/NixOS/nixpkgs/commit/947e720bb4ed743c621039a701fee38141ca32ea) | `` xdg-desktop-portal-hyprland: 1.3.11 -> 1.3.12 ``                                                     |
| [`d64ed317`](https://github.com/NixOS/nixpkgs/commit/d64ed31792d85e49ad607f75e6cf57624349beab) | `` aquamarine: 0.10.0 -> 0.11.0 ``                                                                      |
| [`da9b29a3`](https://github.com/NixOS/nixpkgs/commit/da9b29a32199a28656e485f45b244476c3bef6b2) | `` opentabletdriver: fix wrapping the GUI binary with GTK stuff ``                                      |
| [`138a97c7`](https://github.com/NixOS/nixpkgs/commit/138a97c79309130d7c29e6d66bf292f1a5b0081c) | `` libcdio-paranoia: drop `--disable-cd-version-script` on Darwin ``                                    |
| [`159a3d95`](https://github.com/NixOS/nixpkgs/commit/159a3d95712d3681201b1e655c1d72fe70ab26fb) | `` terraform-providers.yandex-cloud_yandex: 0.199.0 -> 0.201.0 ``                                       |
| [`32b71525`](https://github.com/NixOS/nixpkgs/commit/32b71525bab388b17165d108a5932fab26fbe06d) | `` jwx: 3.0.13 -> 4.0.0 ``                                                                              |
| [`7e8e754c`](https://github.com/NixOS/nixpkgs/commit/7e8e754cd75f2e83d0c001b7d037dd88cd23b246) | `` wiki-go: 1.8.7 -> 1.8.8 ``                                                                           |
| [`dc8a048e`](https://github.com/NixOS/nixpkgs/commit/dc8a048eafc7d748aeb5239d5897f0d8d8f0fc43) | `` opentabletdriver: 0.6.6.2 -> 0.6.7 ``                                                                |
| [`e7eb6868`](https://github.com/NixOS/nixpkgs/commit/e7eb6868d56c37c2837990e223a398d966d59e6d) | `` overridePythonAttrs: support extension-style newArgs ``                                              |
| [`d4956bb3`](https://github.com/NixOS/nixpkgs/commit/d4956bb361b6f3eb689e313b9fa0c27d7dddd93e) | `` tests.overriding: add overridePythonAttrs-plain ``                                                   |
| [`61eb775a`](https://github.com/NixOS/nixpkgs/commit/61eb775af1a1db29025dcdc14584713fdff9c0c0) | `` wasm-pack: add hythera as maintainer ``                                                              |
| [`c97c8abf`](https://github.com/NixOS/nixpkgs/commit/c97c8abf6af7e6ffcdb8fc1e04912540b8fc93d1) | `` armagetronad: 0.2.9.2.5 -> 0.2.9.3.0 ``                                                              |
| [`190bd872`](https://github.com/NixOS/nixpkgs/commit/190bd87264e04e6d71766caddc8db0d21cf12b91) | `` splint: Build with gnu99 ``                                                                          |
| [`850a398b`](https://github.com/NixOS/nixpkgs/commit/850a398b99302fec5cd632a09cd80027d46743a1) | `` pydeps: 3.0.3 -> 3.0.6 ``                                                                            |
| [`82c72823`](https://github.com/NixOS/nixpkgs/commit/82c72823c063b15f0f802eb96a1b843833136066) | `` mutt: 2.3.1 -> 2.3.2 ``                                                                              |
| [`a7e19c9a`](https://github.com/NixOS/nixpkgs/commit/a7e19c9a6d3f3c1f2a420233e6c92198ed4b50f7) | `` libcdio-paranoia: fix Darwin build by setting `CFLAGS=-std=gnu17` ``                                 |
| [`abe7c457`](https://github.com/NixOS/nixpkgs/commit/abe7c457d40099b3db2d3935ca2668ef94d5f82d) | `` muffet: 2.11.2 -> 2.11.3 ``                                                                          |
| [`1b7fc1d9`](https://github.com/NixOS/nixpkgs/commit/1b7fc1d90a92b281779c1971e8a238a5b6893f2b) | `` python3Packages.lizard: 1.21.6 -> 1.22.1 ``                                                          |
| [`1cb208a3`](https://github.com/NixOS/nixpkgs/commit/1cb208a3ec083d5e24432855e99933ac95dd4251) | `` sigma-cli: 3.0.1 -> 3.0.2 ``                                                                         |
| [`b04e069c`](https://github.com/NixOS/nixpkgs/commit/b04e069cf65f764a954a73c2e93c9f1fa6edf444) | `` home-assistant-custom-lovelace-modules.sankey-chart: 4.0.2 -> 4.1.0 ``                               |
| [`fdececb4`](https://github.com/NixOS/nixpkgs/commit/fdececb42d94d36bbd4bf2981a4c75ba50b558fc) | `` mattermost: 10.11.14 -> 10.11.15 ``                                                                  |
| [`32f87f66`](https://github.com/NixOS/nixpkgs/commit/32f87f66d30e4ae30714af334d0ace8aa66a9f24) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.82.88 -> 1.82.89 ``                            |
| [`3c533122`](https://github.com/NixOS/nixpkgs/commit/3c5331225fb0b2dabc3397318ef5edad27f9e6d8) | `` python3Packages: transition from pytestFlagsArray ``                                                 |
| [`2c2f310c`](https://github.com/NixOS/nixpkgs/commit/2c2f310c5a079331366b4bce1cee9f15a3401304) | `` python3Packages.fsspec-xrootd: 0.5.3 -> 0.5.4 ``                                                     |
| [`3d7b5979`](https://github.com/NixOS/nixpkgs/commit/3d7b59797a8160b9c5b2e57a212fadc905b03e57) | `` kmscon: 9.3.4 -> 9.3.5 ``                                                                            |
| [`7ef35057`](https://github.com/NixOS/nixpkgs/commit/7ef350572309a31eb5c0fde7e6456af2d8fd3474) | `` libretro.fbalpha2012: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                              |
| [`018bac79`](https://github.com/NixOS/nixpkgs/commit/018bac795f2436bd1b021f707b2087eb28f58fa8) | `` python3Packages.pubnub: 10.6.2 -> 10.6.3 ``                                                          |
| [`7add9a76`](https://github.com/NixOS/nixpkgs/commit/7add9a7657786437506c57f18dedbcf3c3a588d2) | `` yarn2nix: remove more mentions of it ``                                                              |
| [`b4c84ada`](https://github.com/NixOS/nixpkgs/commit/b4c84adadd187dc174b696fabc90133943277d89) | `` cargo-edit: 0.13.9 -> 0.13.10 ``                                                                     |
| [`5794e120`](https://github.com/NixOS/nixpkgs/commit/5794e1209a2690f5b558512b3f4fd080baa2f6b8) | `` doc/beam: update docs for mixRelease frontend deps ``                                                |
| [`effc9ce2`](https://github.com/NixOS/nixpkgs/commit/effc9ce2e66c9024b3e63c04083b457b7b542004) | `` doc/javascript: update link to plausible example ``                                                  |
| [`3025b736`](https://github.com/NixOS/nixpkgs/commit/3025b736d82908ac0b9ea89ca6711ad390b94851) | `` python3Packages.pyexploitdb: 0.3.23 -> 0.3.24 ``                                                     |
| [`db42215b`](https://github.com/NixOS/nixpkgs/commit/db42215bf65ef80df2c2fd4c5459d8dda40b2627) | `` hyprwayland-scanner: 0.4.5 -> 0.4.6 ``                                                               |
| [`f23096a1`](https://github.com/NixOS/nixpkgs/commit/f23096a175f03537d4ce6a6ccfc1ce82a3c1a50b) | `` optnix: 0.3.1 -> 0.3.2 ``                                                                            |
| [`6b1f3470`](https://github.com/NixOS/nixpkgs/commit/6b1f347004e3096049b6d8de8fe37cb9c0aa43e7) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 0.34.0 -> 1.0.0 ``                         |
| [`62833e6d`](https://github.com/NixOS/nixpkgs/commit/62833e6d841e0f7d3279b9aa57d97f786520f2e5) | `` powershell: remove preset TERM, no use ``                                                            |
| [`1eae57a7`](https://github.com/NixOS/nixpkgs/commit/1eae57a7fb4fef9dc73544866534f5b71c676a51) | `` powershell: fix crash on `sudo pwsh` while within PowerShell ``                                      |
| [`52c04b20`](https://github.com/NixOS/nixpkgs/commit/52c04b202eb88f7d5c77f8d861aa297e35ea2d24) | `` vscode-extensions.redhat.ansible: 26.4.2 -> 26.4.4 ``                                                |
| [`f569ea9e`](https://github.com/NixOS/nixpkgs/commit/f569ea9ec0474e7dafeeb30aaa44abcd0d2b2de3) | `` fastfetch: 2.62.0 -> 2.62.1 ``                                                                       |
| [`b8fa89da`](https://github.com/NixOS/nixpkgs/commit/b8fa89da188106c2a3d73e92417826ea2d3c0177) | `` terraform-providers.aminueza_minio: 3.32.1 -> 3.33.1 ``                                              |
| [`13b28bc4`](https://github.com/NixOS/nixpkgs/commit/13b28bc4ee2646a28b50abbd65c766448413dbf3) | `` calibre-web: fix build ``                                                                            |
| [`64d08a34`](https://github.com/NixOS/nixpkgs/commit/64d08a34291f2541dabec99d330d811851b6b39d) | `` terraform-providers.hetznercloud_hcloud: 1.60.1 -> 1.61.0 ``                                         |
| [`efb05e1f`](https://github.com/NixOS/nixpkgs/commit/efb05e1f5997c213880a10a5611d225781517a11) | `` postman: 11.93.0 -> 11.94.0 ``                                                                       |
| [`834ac879`](https://github.com/NixOS/nixpkgs/commit/834ac87990e428a9532bf961cfd4fb204ba262d4) | `` python3Packages.awsiotsdk: 1.28.2 -> 1.29.0 ``                                                       |
| [`8cafe345`](https://github.com/NixOS/nixpkgs/commit/8cafe345b658f1ebe5195bf85363a897aae36de7) | `` vscode-extensions.ms-vscode.cpptools: 1.31.4 -> 1.31.5 ``                                            |
| [`94df4ec4`](https://github.com/NixOS/nixpkgs/commit/94df4ec48a991038e4b2acda0d168a7b664d785a) | `` koffan: 2.9.0 -> 2.10.0 ``                                                                           |
| [`bea3efec`](https://github.com/NixOS/nixpkgs/commit/bea3efecfa326a7d90215e51fa234258a220838f) | `` nixos/limine: disable editor for secure boot ``                                                      |
| [`dd64cb0a`](https://github.com/NixOS/nixpkgs/commit/dd64cb0a6d348a2e8b298cdfc1ea69ed98bc58e6) | `` openlist: 4.1.10 -> 4.2.1 ``                                                                         |
| [`b503a42d`](https://github.com/NixOS/nixpkgs/commit/b503a42d98c36aa5c53a310490c670dcacb80d95) | `` qtcreator: 19.0.0 -> 19.0.1 ``                                                                       |
| [`a722b88e`](https://github.com/NixOS/nixpkgs/commit/a722b88e59e3fe80075f2c9ce9a7259510568965) | `` cocogitto: add gs-101 as maintainer ``                                                               |
| [`ac3d33c6`](https://github.com/NixOS/nixpkgs/commit/ac3d33c64b74cea3a2fc0bc04363e8c9710cf996) | `` vimPlugins.{isabelle-lsp-nvim,isabelle-syn-nvim}: init ``                                            |
| [`7f408aae`](https://github.com/NixOS/nixpkgs/commit/7f408aaeb6418f3ef790e3ad98160ba3bf10553f) | `` terraform-providers.integrations_github: 6.11.1 -> 6.12.0 ``                                         |
| [`a6f96f46`](https://github.com/NixOS/nixpkgs/commit/a6f96f4689a94d4a000cb69d144abd29a0508fc3) | `` limine: 11.4.1 -> 12.0.2 ``                                                                          |
| [`9d7c37f0`](https://github.com/NixOS/nixpkgs/commit/9d7c37f0692d04fbc832cfabfc76efc25f28855f) | `` leocad: fix meta attributes ``                                                                       |
| [`6aed63b8`](https://github.com/NixOS/nixpkgs/commit/6aed63b8450ee1ee89c581bb351ebe656c9988ee) | `` terraform-providers.hashicorp_aws: 6.38.0 -> 6.42.0 ``                                               |
| [`d6cd6503`](https://github.com/NixOS/nixpkgs/commit/d6cd650396431ef4f5382bca5c8907be2ee96c96) | `` terraform-providers.datadog_datadog: 4.5.0 -> 4.6.0 ``                                               |
| [`9eadbe41`](https://github.com/NixOS/nixpkgs/commit/9eadbe410655e1bf4f0e612391bc9a5316ff5981) | `` hyprwire: 0.3.0 -> 0.3.1 ``                                                                          |
| [`13c8247d`](https://github.com/NixOS/nixpkgs/commit/13c8247d177843e05733193feaaea6f67fe1c877) | `` hyprlauncher: 0.1.5 -> 0.1.6 ``                                                                      |
| [`c4101317`](https://github.com/NixOS/nixpkgs/commit/c41013171fe0f1f44f4e8c973633359d0487cbfa) | `` rl-2605: add a note about new darwin tools ``                                                        |
| [`d586b0d0`](https://github.com/NixOS/nixpkgs/commit/d586b0d0d76f7c42880f7007b55503c4e0c5daf9) | `` dms-shell: 1.4.4.1 -> 1.4.5 ``                                                                       |
| [`de08959e`](https://github.com/NixOS/nixpkgs/commit/de08959e422a100730b3ec26d9b5ba7f7092bd9c) | `` androidenv.test-suite: 7fb1f87547f5d4c6 -> 46e2779744ab55bb ``                                       |
| [`087e4a04`](https://github.com/NixOS/nixpkgs/commit/087e4a043e0d7288fad266598872afa10d38c30c) | `` dyff: 1.11.3 -> 1.11.4 ``                                                                            |
| [`bfcd286f`](https://github.com/NixOS/nixpkgs/commit/bfcd286f1d1904b244addccb3770667c98a388e1) | `` buku: fix 5.1.1 with `withServer = true` ``                                                          |
| [`2ce6c59a`](https://github.com/NixOS/nixpkgs/commit/2ce6c59a8569cb0b1fb535d32406e566a1ef0333) | `` tsgolint: 0.21.1 -> 0.22.0 ``                                                                        |
| [`98fb2de2`](https://github.com/NixOS/nixpkgs/commit/98fb2de20fb5c9db747507d464881f422e21d4d5) | `` lk-jwt-service: 0.4.3 -> 0.4.4 ``                                                                    |
| [`52815a11`](https://github.com/NixOS/nixpkgs/commit/52815a118ce5c7fa2f1fda7ba78521a8ceecbb93) | `` h2o: include Perl JSON library to the path for binaries ``                                           |
| [`7f4c1348`](https://github.com/NixOS/nixpkgs/commit/7f4c1348fc242f919c114a2998acf0e014016acf) | `` h2o: 2.3.0-rolling-2026-02-28 → 2.3.0-rolling-2026-04-15 ``                                          |
| [`a8d1958f`](https://github.com/NixOS/nixpkgs/commit/a8d1958fbced9bd9b20631e77875878ab457435e) | `` luaPackages.lua-https: init at 0-unstable-2025-02-28 ``                                              |
| [`520bd5ec`](https://github.com/NixOS/nixpkgs/commit/520bd5ec68bb5bc15936cba21dd813aad9ec9d3f) | `` gh-cherry-pick: 1.3.1 -> 1.4.0 ``                                                                    |
| [`5aeb3eed`](https://github.com/NixOS/nixpkgs/commit/5aeb3eedadfaed53b357c2474648452a21d20626) | `` python3Packages.pydantic-ai-slim: 1.86.1 -> 1.87.0 ``                                                |
| [`05344293`](https://github.com/NixOS/nixpkgs/commit/05344293765e9a61bdb9d8dad25c39679a47dfe9) | `` python3Packages.pydantic-graph: 1.86.1 -> 1.87.0 ``                                                  |
| [`b4d2680e`](https://github.com/NixOS/nixpkgs/commit/b4d2680e611fe017f5a25c9c975e31c3596a257e) | `` libretro.play: 0-unstable-2026-04-13 -> 0-unstable-2026-04-23 ``                                     |
| [`578d189a`](https://github.com/NixOS/nixpkgs/commit/578d189ab1c7de414cf758847229f89a8d3ca55b) | `` home-assistant-custom-components.waste_collection_schedule: 2.20.0 -> 2.21.0 ``                      |
| [`3ec85378`](https://github.com/NixOS/nixpkgs/commit/3ec853785e013826e5236e93c45e35dd04d3ff48) | `` home-assistant-custom-components.solax_modbus: 2026.04.3 -> 2026.04.4 ``                             |
| [`7b00352a`](https://github.com/NixOS/nixpkgs/commit/7b00352afaa37e2cf4718e1fe63d7717cf8a1c69) | `` home-assistant-custom-components.browser-mod: 2.10.2 -> 2.11.0 ``                                    |
| [`630b8e59`](https://github.com/NixOS/nixpkgs/commit/630b8e59f17592e557affc7711797266cf45a864) | `` home-assistant-custom-components.bodymiscale: 2026.4.2 -> 2026.4.3 ``                                |
| [`ee25f9eb`](https://github.com/NixOS/nixpkgs/commit/ee25f9eb9625de22382d17ebe2512c84c5ba8146) | `` home-assistant-custom-components.battery_notes: 3.4.4 -> 3.4.5 ``                                    |
| [`c3fcb51e`](https://github.com/NixOS/nixpkgs/commit/c3fcb51eff48134c461106acef36117780ff9ab1) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.324 -> 0.13.325 ``            |
| [`bd619e42`](https://github.com/NixOS/nixpkgs/commit/bd619e42057916911a9da3b9e8f4b16fa603bf8a) | `` python3Packages.homeassistant-stubs: 2026.4.3 -> 2026.4.4 ``                                         |
| [`695851a7`](https://github.com/NixOS/nixpkgs/commit/695851a7f1cd95ceca06a1f13750a365ddfbec69) | `` context7-mcp: 2.1.8 -> 2.2.0 ``                                                                      |
| [`1a1c2550`](https://github.com/NixOS/nixpkgs/commit/1a1c25501f3f1882dcdbd0e95550cad64d4b621c) | `` python3Packages.py-netgear-plus: 0.6.1 -> 0.6.3 ``                                                   |
| [`ea1a52ae`](https://github.com/NixOS/nixpkgs/commit/ea1a52aea9190c7cbbef1eca11d4167fd93f940a) | `` ketesa: 1.2.0 -> 1.2.1 ``                                                                            |
| [`e349edf3`](https://github.com/NixOS/nixpkgs/commit/e349edf3f0f4b3e4328ddfa249d0c7631b5e8e51) | `` lilo: unbreak ``                                                                                     |
| [`12f55355`](https://github.com/NixOS/nixpkgs/commit/12f553550f8fa63fb0e18d00ce769a4860ab4334) | `` nixos/systemd-networkd: add new options for v260 ``                                                  |
| [`2407f6b0`](https://github.com/NixOS/nixpkgs/commit/2407f6b04342156d59cdbcfff4ae894ac8bb208d) | `` firefly-iii: 6.5.9 -> 6.6.1 ``                                                                       |
| [`ec972777`](https://github.com/NixOS/nixpkgs/commit/ec9727773a78dd447428ceaeefb11b15d7f643f9) | `` typescript-go: 0-unstable-2026-04-16 -> 0-unstable-2026-04-24 ``                                     |
| [`9a203df5`](https://github.com/NixOS/nixpkgs/commit/9a203df54f5eb7f10944b85bfff816483b966487) | `` terraform-providers.topicusonderwijs_octodns: 1.1.5 -> 1.2.0 ``                                      |
| [`835b3f77`](https://github.com/NixOS/nixpkgs/commit/835b3f77b288047c2d26dfc07cbc017ebcf1df2d) | `` nixos/luksroot: Improve systemd stage 1 assertion messages ``                                        |
| [`76ed5b15`](https://github.com/NixOS/nixpkgs/commit/76ed5b15d6e707a4e1a7c210258b4be19f98bfa8) | `` deezer-desktop: 7.1.150 -> 7.1.170 ``                                                                |
| [`b8d4d826`](https://github.com/NixOS/nixpkgs/commit/b8d4d826976a93f5009a23000d304aa860273e97) | `` doc/javascript: remove yarn2nix docs and redirect ``                                                 |
| [`e18d84b7`](https://github.com/NixOS/nixpkgs/commit/e18d84b7b3ad5a4c2492a4fc9c4558487fdbc7dd) | `` doc/rl-2605: add yarn2nix deprecation notice ``                                                      |
| [`a3f6c413`](https://github.com/NixOS/nixpkgs/commit/a3f6c41323d8713a671b58f8bc157cffd9cc01bc) | `` yarn2nix: drop and throw for all of it ``                                                            |
| [`320eddd9`](https://github.com/NixOS/nixpkgs/commit/320eddd9be71a600159d1aea4daf7e98ae324c4d) | `` duplicati: 2.3.0.0 -> 2.3.0.1 ``                                                                     |
| [`83abb365`](https://github.com/NixOS/nixpkgs/commit/83abb365aa596e2c639901e06358476c081fc713) | `` spruce: 1.32.0 -> 1.35.0 ``                                                                          |
| [`ce8e406d`](https://github.com/NixOS/nixpkgs/commit/ce8e406d5e007e29180044c0ae2bb00ccb9db5ba) | `` linux_6_19: remove ``                                                                                |
| [`27398c2c`](https://github.com/NixOS/nixpkgs/commit/27398c2c3e05206410f246410161f095b0566c91) | `` zammad: remove yarn2nix from update script ``                                                        |
| [`0b07722b`](https://github.com/NixOS/nixpkgs/commit/0b07722b0aaabcf25ce6f22a39ec295f3a3661b4) | `` sticky-notes: fixup_yarn_lock -> fixup-yarn-lock ``                                                  |
| [`65bc0f80`](https://github.com/NixOS/nixpkgs/commit/65bc0f80d00e4c6f3870b12df80b9e61a15594e5) | `` python3Packages.dm-control: 1.0.39 -> 1.0.40 ``                                                      |
| [`f861b5b1`](https://github.com/NixOS/nixpkgs/commit/f861b5b1c123a371e861e7cc18d2f3bfd1acfe03) | `` libretro.mesen: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                                    |
| [`f8175dfa`](https://github.com/NixOS/nixpkgs/commit/f8175dfa46cf8961b312d23dc2c7ff3550649a3c) | `` phpunit: 13.1.5 -> 13.1.7 ``                                                                         |
| [`e44ab7bc`](https://github.com/NixOS/nixpkgs/commit/e44ab7bc14a3804dde944ba7688f76905cf8b7bb) | `` home-assistant-custom-components.solax_modbus: 2026.04.3 -> 2026.04.4 ``                             |
| [`6c955cf8`](https://github.com/NixOS/nixpkgs/commit/6c955cf8bab74af60bf31cfe26e9c70b8ba8fdac) | `` python3Packages.skops: 0.13.0 -> 0.14 ``                                                             |
| [`0d32b50a`](https://github.com/NixOS/nixpkgs/commit/0d32b50a808d5cb676371b77a52095342c1fa92d) | `` homer: 26.4.1 -> 26.4.2 ``                                                                           |
| [`f735749a`](https://github.com/NixOS/nixpkgs/commit/f735749a3ca50809a4030eccd9feedcc78f97d65) | `` encrypted-dns-server: 0.9.18 -> 0.9.19 ``                                                            |
| [`123ddea7`](https://github.com/NixOS/nixpkgs/commit/123ddea7a94abfe357a1e28fad55505a5fcda828) | `` motrix-next: 3.6.8 -> 3.8.3, disable tests on macOS ``                                               |
| [`4defc9d4`](https://github.com/NixOS/nixpkgs/commit/4defc9d4dd0bfac80433739a143259d668546abe) | `` mujoco: 3.7.0 -> 3.8.0 ``                                                                            |
| [`cbf7d4ce`](https://github.com/NixOS/nixpkgs/commit/cbf7d4ce36f5e94f9cf9d17511a2ddd421191619) | `` wakatime-cli: 2.3.1 -> 2.7.0 ``                                                                      |
| [`dc734a7c`](https://github.com/NixOS/nixpkgs/commit/dc734a7cfba781d5a365c5565e0d8efffa93e5a6) | `` gemini-cli-bin: 0.38.1 -> 0.39.1 ``                                                                  |
| [`a6da9590`](https://github.com/NixOS/nixpkgs/commit/a6da95906d59ec88f8349111133f27fe986e7028) | `` lgogdownloader-gui: migrate to qt6 ``                                                                |
| [`3601a843`](https://github.com/NixOS/nixpkgs/commit/3601a8430bde4d11753ad3145520df65f11e7fe2) | `` gitqlient: 1.6.3 -> 1.6.3-unstable-2025-09-11, migrate to qt6, unbreak ``                            |
| [`706cd17d`](https://github.com/NixOS/nixpkgs/commit/706cd17dbdb6c4b264a80fe1579341d5d05f4376) | `` mnemosyne: clean up ``                                                                               |
| [`bf5b8907`](https://github.com/NixOS/nixpkgs/commit/bf5b890773402d4fc14a9664191b7207e9f36897) | `` ci/github-script/merge: clarify maintainership is based on target branch ``                          |
| [`1eb09bb8`](https://github.com/NixOS/nixpkgs/commit/1eb09bb82ac8427a38d13409169afe6bbd4b37c4) | `` kiro: 0.11.131 -> 0.11.133 ``                                                                        |
| [`a587e45f`](https://github.com/NixOS/nixpkgs/commit/a587e45f4f345fe2a79278fddabb2e4bb1ce5e6e) | `` scrutiny{,-collector}: convert to finalAttrs ``                                                      |
| [`c4ab7684`](https://github.com/NixOS/nixpkgs/commit/c4ab7684495355d7b721157e70482021a2f05c51) | `` aprutil: unvendor patch ``                                                                           |
| [`10d240d4`](https://github.com/NixOS/nixpkgs/commit/10d240d417961ab700b99adc5a87e2d3d43ddbb1) | `` aprutil: unbreak Darwin/LLVM compilation ``                                                          |
| [`6691cb04`](https://github.com/NixOS/nixpkgs/commit/6691cb04d67141045bc13474f96d581adb7031a1) | `` terraform-providers.vancluever_acme: 2.47.0 -> 2.48.0 ``                                             |
| [`e513a9da`](https://github.com/NixOS/nixpkgs/commit/e513a9da6535f15e84cd02aa6f91d5fb00d49876) | `` scrutiny{,-collector}: 0.9.0 -> 0.9.1 ``                                                             |
| [`fb266d76`](https://github.com/NixOS/nixpkgs/commit/fb266d7643d867cde267b9551e6fcf2191910e86) | `` nixos/channel: fix channel linkage if broken channel link already exists ``                          |
| [`45225c04`](https://github.com/NixOS/nixpkgs/commit/45225c04ce1210f45d512b682ddcb15b69a8d0ab) | `` nixosTests.incus: add test of container channel setup ``                                             |
| [`61cc9267`](https://github.com/NixOS/nixpkgs/commit/61cc9267fa407181420cb453ade04c0d6dcbeaae) | `` misconfig-mapper: 1.15.4 -> 1.15.5 ``                                                                |
| [`dbc49534`](https://github.com/NixOS/nixpkgs/commit/dbc4953411f3ac0233a22ed36ed53be36a20f2a3) | `` rs-tftpd: 0.5.3 -> 1.0.0 ``                                                                          |
| [`e2acb506`](https://github.com/NixOS/nixpkgs/commit/e2acb5061abf30cd6f0358f07bb0d6da632af4ae) | `` plover_5: init referencing python3Packages.plover_5 ``                                               |
| [`318747e3`](https://github.com/NixOS/nixpkgs/commit/318747e3c22fa4af72a9dba4804db36b71814022) | `` plover_4: init referencing python3Packages.plover_4 ``                                               |
| [`a005a75d`](https://github.com/NixOS/nixpkgs/commit/a005a75d69c663a75bd3b209d2fa5de40624b34c) | `` python3Packages.plover_5: init ``                                                                    |
| [`5f6315fb`](https://github.com/NixOS/nixpkgs/commit/5f6315fba0e92733fb9da6e0f185a628d267a013) | `` python3Packages.plover_5: copy from python3Packages.plover_4 ``                                      |
| [`15655c9b`](https://github.com/NixOS/nixpkgs/commit/15655c9b0d97245be3a8dbcc3863ea584830f783) | `` python3Packages.plover_4: add ShamrockLee to maintainers ``                                          |
| [`12e0d3a2`](https://github.com/NixOS/nixpkgs/commit/12e0d3a21cd44ec08f5561e86c7defff4ce4e83e) | `` python3Packages.plover_4: modernise ``                                                               |
| [`14b4884f`](https://github.com/NixOS/nixpkgs/commit/14b4884f7adb0b89bac98c34bc9e1606ebdc60f1) | `` plover: init referencing python3Packages.plover with aliases ``                                      |
| [`18870167`](https://github.com/NixOS/nixpkgs/commit/188701672b4babf83cbae557a211e2fb209dba2e) | `` python3Packages.plover: init referencing python3Packages.plover_4 ``                                 |
| [`0954aa20`](https://github.com/NixOS/nixpkgs/commit/0954aa206e197559dc7982212ed2ce1319949cd2) | `` python3Packages.plover_4: move from plover.dev ``                                                    |
| [`1681cb9c`](https://github.com/NixOS/nixpkgs/commit/1681cb9c64057dc59a7db825a707637022e01578) | `` pyradio: 0.9.3.11.29 -> 0.9.3.11.30 ``                                                               |
| [`c6f8d43c`](https://github.com/NixOS/nixpkgs/commit/c6f8d43c60b48924870fe07f495af5669f63789c) | `` plover.dev: rename to plover ``                                                                      |
| [`907c48e3`](https://github.com/NixOS/nixpkgs/commit/907c48e3ca7606f0357982b5960fc3abcedd2316) | `` plover.dev: add better parameterization ``                                                           |
| [`f8b3c814`](https://github.com/NixOS/nixpkgs/commit/f8b3c814a19c9dbd1284262270a6012d0f64333d) | `` plover.dev: add pandapip1 to maintainers ``                                                          |
| [`e27c0ae0`](https://github.com/NixOS/nixpkgs/commit/e27c0ae0d5128e835caa212da367ea9f427cce19) | `` plover.dev: add additional meta information ``                                                       |
| [`3113377e`](https://github.com/NixOS/nixpkgs/commit/3113377e4bfb732630cbfcf425a41daf82ffedb1) | `` plover.dev: get rid of with lib in meta ``                                                           |
| [`1e116a46`](https://github.com/NixOS/nixpkgs/commit/1e116a46a71a21c02869159992aeaf927ac42492) | `` plover.dev: fix license ``                                                                           |
| [`02ee7668`](https://github.com/NixOS/nixpkgs/commit/02ee7668c7d6ca1e4387a10779f88dda64b13d1f) | `` plover.dev: unbork ``                                                                                |
| [`4d05dc3e`](https://github.com/NixOS/nixpkgs/commit/4d05dc3e571388c5314ccc07e747a6097dab13c1) | `` python3Packages.plover-stroke: init at 1.1.0 ``                                                      |
| [`3603c9b4`](https://github.com/NixOS/nixpkgs/commit/3603c9b403333304be83769edb0c3f51d71c38de) | `` python3Packages.rtf-tokenize: init at 1.0.0 ``                                                       |
| [`45619258`](https://github.com/NixOS/nixpkgs/commit/45619258ea4ae703108d4a8f120d3fee85e93fa2) | `` hmcl: 3.12.4 -> 3.13.2 ``                                                                            |
| [`3a4fdd72`](https://github.com/NixOS/nixpkgs/commit/3a4fdd72305baaebdc7d417ad3ec1b54ddc82ff9) | `` libretro.fmsx: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20 ``                                     |
| [`dd49e43c`](https://github.com/NixOS/nixpkgs/commit/dd49e43cdccf38bcafb80dac2c932f3cbe76d59e) | `` python3Packages.scikit-base: 0.13.2 -> 1.0.0 ``                                                      |
| [`bee54186`](https://github.com/NixOS/nixpkgs/commit/bee54186fc456e6b10a6111fa88db3137d75a441) | `` perlPackages.Apppapersway: 2.001 -> 3.000 ``                                                         |
| [`7eff9471`](https://github.com/NixOS/nixpkgs/commit/7eff94713a6bcf7509d753a4f5cbaec7bb843ab5) | `` rusty-path-of-building: 0.2.15 -> 0.2.16 ``                                                          |
| [`2b6b1fe7`](https://github.com/NixOS/nixpkgs/commit/2b6b1fe746158d32c5c170e8e7bdd69b7df348ef) | `` python3Packages.whodap: 0.1.15 -> 0.1.16 ``                                                          |
| [`6b22f027`](https://github.com/NixOS/nixpkgs/commit/6b22f02764edd9e1c128f5aa7f2e8422505aaf6a) | `` vscode-extensions.detachhead.basedpyright: 1.39.2 -> 1.39.3 ``                                       |
| [`3cfcc431`](https://github.com/NixOS/nixpkgs/commit/3cfcc431f9d6130e301aa06af9c7dbf1511a415a) | `` libretro.gambatte: 0-unstable-2026-04-11 -> 0-unstable-2026-04-24 ``                                 |
| [`2f5562f4`](https://github.com/NixOS/nixpkgs/commit/2f5562f43d6b33730b4c25f63c099dacef15018a) | `` python3Packages.langgraph-cli: 0.4.23 -> 0.4.24 ``                                                   |
| [`df8df389`](https://github.com/NixOS/nixpkgs/commit/df8df3897b920e0869c9015e52fac9428833c6a7) | `` cog: 0.1.8 -> 0.1.9 ``                                                                               |
| [`b07e5b10`](https://github.com/NixOS/nixpkgs/commit/b07e5b10021117877bcca152fdc07b96cb7b16e6) | `` zookeeper_mt: unbreak ``                                                                             |
| [`d448ac68`](https://github.com/NixOS/nixpkgs/commit/d448ac68923d64a8c70e994e3e18662c3baebf66) | `` rauthy: unset meta.platforms ``                                                                      |
| [`aba7aa12`](https://github.com/NixOS/nixpkgs/commit/aba7aa121ed55cade477a9c08e1837e1af594589) | `` rauthy: add myself to maintainers ``                                                                 |
| [`5d20497d`](https://github.com/NixOS/nixpkgs/commit/5d20497deeb54fb02d705c047480953b4f3e673f) | `` rauthy: 0.34.3 -> 0.35.1 ``                                                                          |
| [`d1b99668`](https://github.com/NixOS/nixpkgs/commit/d1b99668b1a4509e7183a408c24bd5d194629400) | `` rauthy: simplify package ``                                                                          |
| [`a682538c`](https://github.com/NixOS/nixpkgs/commit/a682538cf27d3175e97ef26a855f77968aced12e) | `` qrq: fix build with gcc15 ``                                                                         |
| [`daf2d8fc`](https://github.com/NixOS/nixpkgs/commit/daf2d8fc7ea0c812e63dbc22f91bf8bc6ad3ec52) | `` snx-rs: 5.3.0 -> 6.0.1 ``                                                                            |
| [`95a3a84e`](https://github.com/NixOS/nixpkgs/commit/95a3a84e48202a8bc624edea5726794d703a3d91) | `` nixos/dhparams: deprecate, schedule removal ``                                                       |
| [`452ba3f4`](https://github.com/NixOS/nixpkgs/commit/452ba3f4e09278cecc38c9d4f5a9a1757a19e997) | `` checkov: 3.2.521 -> 3.2.524 ``                                                                       |
| [`e662dce3`](https://github.com/NixOS/nixpkgs/commit/e662dce35aaa19d2d2a60cc0639c2c8c34e2e2e8) | `` olympus-unwrapped: 26.04.16.02 -> 26.04.22.01 ``                                                     |
| [`667d6ea8`](https://github.com/NixOS/nixpkgs/commit/667d6ea8ca07347f4116e4b060239bc47e0d1f78) | `` libretro.vba-next: 0-unstable-2024-10-21 -> 0-unstable-2026-04-20 ``                                 |
| [`d733bdc3`](https://github.com/NixOS/nixpkgs/commit/d733bdc3007fe767f912f18b05651369539dc368) | `` niri: 25.11 -> 26.04 ``                                                                              |
| [`4c458be6`](https://github.com/NixOS/nixpkgs/commit/4c458be6b67190ab7dc53162789f4d79ee448c8a) | `` niri: adopt by zimward ``                                                                            |
| [`f104bbaf`](https://github.com/NixOS/nixpkgs/commit/f104bbaf7e24abbaf6e1c029bdbe48022a14a2c6) | `` kin-openapi: 0.135.0 -> 0.136.0 ``                                                                   |
| [`23592165`](https://github.com/NixOS/nixpkgs/commit/23592165aa3d8f03ab2f34db3bd110defd2dfaf3) | `` python3Packages.qh3: 1.7.1 -> 1.7.3 ``                                                               |
| [`1b3bda10`](https://github.com/NixOS/nixpkgs/commit/1b3bda10e2f16623d9883aa822d51df87891dc86) | `` flow: 0.309.0 -> 0.311.0 ``                                                                          |
| [`3f12add4`](https://github.com/NixOS/nixpkgs/commit/3f12add432564c1d4d8759f08e3334cc1770689d) | `` trayscale: 0.18.7 -> 0.18.8 ``                                                                       |
| [`e949b6dc`](https://github.com/NixOS/nixpkgs/commit/e949b6dc1d696bffeb504ce7fa409d12d313350a) | `` nixos/fontconfig: default `useEmbeddedBitmaps` to `true` unconditionally ``                          |
| [`05a51b5b`](https://github.com/NixOS/nixpkgs/commit/05a51b5b48202c6de2c789c430bf5da56dbfce29) | `` chef-cli: 5.6.23 -> 6.1.29 ``                                                                        |
| [`a3e7180c`](https://github.com/NixOS/nixpkgs/commit/a3e7180cdbcb23b43e25d49637020dd62fd181c9) | `` Revert "yarn-berry: 4.13.0 -> 4.14.1" ``                                                             |
| [`66fdd48f`](https://github.com/NixOS/nixpkgs/commit/66fdd48f964383e305a3d10b08ca997f351020de) | `` osu-lazer: 2026.418.0 -> 2026.425.0 ``                                                               |
| [`27460f23`](https://github.com/NixOS/nixpkgs/commit/27460f233507293b140acc0570cd9baeb02685d3) | `` osu-lazer-bin: 2026.418.0 -> 2026.425.0 ``                                                           |
| [`968c47e2`](https://github.com/NixOS/nixpkgs/commit/968c47e2b37d223768b4bb0e979f3d264713c5ad) | `` terraform-providers.spotinst_spotinst: 1.234.0 -> 1.235.0 ``                                         |
| [`76c4e0ba`](https://github.com/NixOS/nixpkgs/commit/76c4e0ba4f9e6ae5d406cd9f0f43a377eeff5329) | `` nix-unit: 2.30.0 -> 2.34.0 ``                                                                        |
| [`fa95d781`](https://github.com/NixOS/nixpkgs/commit/fa95d7818af944768aa2fdab9e18eb4738aebc19) | `` nix-du: 1.2.3 -> 1.2.4 ``                                                                            |
| [`a577a57e`](https://github.com/NixOS/nixpkgs/commit/a577a57e8a7db15b44b43d6d3390023265af50bd) | `` home-manager: 0-unstable-2026-04-14 -> 0-unstable-2026-04-24 ``                                      |
| [`3cda8e0a`](https://github.com/NixOS/nixpkgs/commit/3cda8e0ac1bde697a408992fde68d63612ddd185) | `` openvr: unbreak jsoncpp abi ``                                                                       |
| [`fbad76ad`](https://github.com/NixOS/nixpkgs/commit/fbad76ade1e17477c532032423f592185dfbb1e7) | `` ananicy-rules-cachyos: 0-unstable-2026-04-15 -> 0-unstable-2026-04-23 ``                             |
| [`1b7bdfb5`](https://github.com/NixOS/nixpkgs/commit/1b7bdfb5e3d8418116276ccd876c6001a87c28dc) | `` zed-editor: 0.233.5 -> 0.233.10 ``                                                                   |
| [`0bdf29dd`](https://github.com/NixOS/nixpkgs/commit/0bdf29dd36e0f63bbf8a41082a95fc36d84335d4) | `` smpmgr: 0.17.0 -> 0.18.0 ``                                                                          |

*... and 2317 more commits (truncated)*