### PR TITLE
chore(flake/sops-nix): `bef289e2` -> `8eaee5c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1700,11 +1700,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776771786,
-        "narHash": "sha256-DRFGPfFV6hbrfO9a1PH1FkCi7qR5FgjSqsQGGvk1rdI=",
+        "lastModified": 1777338324,
+        "narHash": "sha256-bc+ZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "bef289e2248991f7afeb95965c82fbcd8ff72598",
+        "rev": "8eaee5c45428b28b8c47a83e4c09dccec5f279b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                |
| ----------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`9841e329`](https://github.com/Mic92/sops-nix/commit/9841e329a66c2c71990a8b233060c7207a075f4c) | `` update vendorHash ``                |
| [`71ea0675`](https://github.com/Mic92/sops-nix/commit/71ea067569f845ca7f6aa33632df5dc0dfd2a6e8) | `` Bump github.com/Mic92/ssh-to-age `` |