### PR TITLE
chore(flake/apple-fonts): `6f4eed8c` -> `746df8b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "sf-pro": "sf-pro"
       },
       "locked": {
-        "lastModified": 1776924392,
-        "narHash": "sha256-gcOiPC+kKae35uni+9qqb5/3dhbrZboKS06I5QQ2z7w=",
+        "lastModified": 1777376912,
+        "narHash": "sha256-aLvNGToDh5g3Lm2NoTPN3ifYLxlCs3yF7qO3qZ1X46s=",
         "owner": "Lyndeno",
         "repo": "apple-fonts.nix",
-        "rev": "6f4eed8c37574cb41697dc02721939842b15b785",
+        "rev": "746df8b060c2f16080ea2faf502fee652b733047",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                              |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`746df8b0`](https://github.com/Lyndeno/apple-fonts.nix/commit/746df8b060c2f16080ea2faf502fee652b733047) | `` fix: OTF files not being built `` |
| [`0e3a17b8`](https://github.com/Lyndeno/apple-fonts.nix/commit/0e3a17b81e6a84bbb02feea31dc4c5a9c52cd6cc) | `` Increase hydra interval ``        |