### PR TITLE
chore(flake/nixvim): `e61a31b5` -> `a67d9cd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1353,11 +1353,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1777161489,
-        "narHash": "sha256-368EaWDQFDLa/pyjKp2CuxHUNypPJKDDr8zlGEb1Bsg=",
+        "lastModified": 1777236345,
+        "narHash": "sha256-ALOqlq7bE30lsX4rA76hXeQ2aLLEpb44hS+D1+jWS88=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e61a31b597ce59e1d4fea3c59b8d89edd915ecd6",
+        "rev": "a67d9cd6ff725a763afe88727aac73208ded3bf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`a67d9cd6`](https://github.com/nix-community/nixvim/commit/a67d9cd6ff725a763afe88727aac73208ded3bf4) | `` modules/top-level/output: add autowrapRuntimeDeps ``                |
| [`d404af65`](https://github.com/nix-community/nixvim/commit/d404af65e951f648272d178a34cbb2292fb93689) | `` modules/top-level/files: set pname on nvim-config wrapper plugin `` |