### PR TITLE
chore(flake/home-manager): `6f59831b` -> `503480e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777151655,
-        "narHash": "sha256-Th3a5OZyEy4kCoyLfefnt+2dwRIrFQqYgMsayF9qzFw=",
+        "lastModified": 1777498633,
+        "narHash": "sha256-+3xXjfFz7y1gNG/9tQgjdxFKsQZYcDUxz1RbzmdgXj8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f59831b23d03bbf4fbd13ad167ae25da294cc14",
+        "rev": "503480e51357c7beca8c19bde560af1491a372d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`503480e5`](https://github.com/nix-community/home-manager/commit/503480e51357c7beca8c19bde560af1491a372d0) | `` github-copilot-cli: add module ``                                      |
| [`f92e976f`](https://github.com/nix-community/home-manager/commit/f92e976f404151b818da26a00acde5328095798a) | `` maintainers: add ojsef39 ``                                            |
| [`8c8e5389`](https://github.com/nix-community/home-manager/commit/8c8e5389e75a36bee53920de8ee24f017b3ae03e) | `` tldr-update: add dependency on network-online ``                       |
| [`d3b4e4b1`](https://github.com/nix-community/home-manager/commit/d3b4e4b1bd59aedd3d4eb0a8df7162edb6da4607) | `` services.walker: fix paths for walker v2 ``                            |
| [`af59809e`](https://github.com/nix-community/home-manager/commit/af59809e9413ec8adb9597a8636491af356fe525) | `` thunderbird: add language packs and policies ``                        |
| [`b1b08eea`](https://github.com/nix-community/home-manager/commit/b1b08eeaff1bb794b0deeea54c6749b1e15ca910) | `` thunderbird: clarify external gnupg ``                                 |
| [`c3571827`](https://github.com/nix-community/home-manager/commit/c3571827078769e4ae4cc4612385c01c38d608d1) | `` thunderbird: support ews accounts ``                                   |
| [`c2f07e2d`](https://github.com/nix-community/home-manager/commit/c2f07e2dca4ca9426446578921474921b4275109) | `` thunderbird: default office365 to oauth2 ``                            |
| [`ae6aeb9d`](https://github.com/nix-community/home-manager/commit/ae6aeb9dbce75c2f2f262eb1adc6971046ccaf64) | `` thunderbird: map account auth methods ``                               |
| [`8ec5a714`](https://github.com/nix-community/home-manager/commit/8ec5a714dbbeb3fda00bd9758175555ebbad4d07) | `` rofi: allow list values in extraConfig ``                              |
| [`98213962`](https://github.com/nix-community/home-manager/commit/982139628581c309b6a25c55deed564b546ebf74) | `` thunderbird: add msg filter rules description ``                       |
| [`4f77c535`](https://github.com/nix-community/home-manager/commit/4f77c535e06fdb6a91d576dd465bb0d1d865b5ae) | `` thunderbird: html signature support ``                                 |
| [`dd6a8772`](https://github.com/nix-community/home-manager/commit/dd6a8772d4faa9627fd342342c77b0afca59eba3) | `` qalculate: add autocalc to the example ``                              |
| [`79f8430e`](https://github.com/nix-community/home-manager/commit/79f8430e7d3fb61f947971432fd2527d591df4c7) | `` restic: unset systemd `PrivateTmp` option ``                           |
| [`c1140540`](https://github.com/nix-community/home-manager/commit/c1140540536d483e2730320100f6835d62c94fdf) | `` gurk: change config signal_db_path to data_dir ``                      |
| [`a28e848a`](https://github.com/nix-community/home-manager/commit/a28e848a01044f47679453aae75f6253bef7903e) | `` chromium: address plasma integration review ``                         |
| [`d45a13f9`](https://github.com/nix-community/home-manager/commit/d45a13f96c3589c92547466c14573f3442496bf2) | `` {home-environment,bash,zsh}: support ignoring null sessionVariables `` |
| [`62f445c1`](https://github.com/nix-community/home-manager/commit/62f445c13c84df6a388b86b0a02f8aa08a7295a3) | `` {bash,zsh}: align sessionVariables type ``                             |
| [`466d5909`](https://github.com/nix-community/home-manager/commit/466d5909eb35f0c7d7b7ce6aa2073d5abfde49c8) | `` tests: remove unused file ``                                           |
| [`b408d49b`](https://github.com/nix-community/home-manager/commit/b408d49b845167add697937761a89c41c996ac7a) | `` syncthing: fix the application of allProxy ``                          |
| [`e97a9fd6`](https://github.com/nix-community/home-manager/commit/e97a9fd6a63802d1750fb23cd89419d3854a6dba) | `` maintainers: update all-maintainers.nix ``                             |
| [`7f8bbc93`](https://github.com/nix-community/home-manager/commit/7f8bbc93d63401e41368d6ddc46a4f631610fa90) | `` mkFirefoxModule: document impermanence extensions ``                   |
| [`c97d9213`](https://github.com/nix-community/home-manager/commit/c97d92137300ab075c2eca2d83a8b4d81921a4f0) | `` mkFirefoxModule: add firefox devedition example ``                     |
| [`4883af6e`](https://github.com/nix-community/home-manager/commit/4883af6edbdf222c66edb545d312f4e40030a2be) | `` syncthing: avoid init for default gui address ``                       |
| [`e82d4a4e`](https://github.com/nix-community/home-manager/commit/e82d4a4ecd18363aa2054cbaa3e32e4134c3dbf4) | `` copyApps: workaround for macOS 26.3 signature bug ``                   |
| [`c55c498c`](https://github.com/nix-community/home-manager/commit/c55c498c9aa205b16cca78b57a7275625726d532) | `` targets/darwin: set TERMINFO_DIRS ``                                   |
| [`0add2d43`](https://github.com/nix-community/home-manager/commit/0add2d439a2c94affd9afadbabeed9524e568f52) | `` Translate using Weblate (French) ``                                    |
| [`7cdccd0d`](https://github.com/nix-community/home-manager/commit/7cdccd0db96fd1d35522634be365ee3b7674efd7) | `` Translate using Weblate (Polish) ``                                    |
| [`c968134e`](https://github.com/nix-community/home-manager/commit/c968134e0654e5226846a076d19a68dc1c644d78) | `` floorp: fix Darwin app bundle name ``                                  |
| [`5bfbc1f6`](https://github.com/nix-community/home-manager/commit/5bfbc1f6ca0c257d8709bf975f6b318d93eb2efc) | `` tests: fix neovim program test ``                                      |
| [`8a2fdaf6`](https://github.com/nix-community/home-manager/commit/8a2fdaf6b4ffeff599b2d2456972aa8cabe0dc47) | `` tests: fix firefox program tests ``                                    |
| [`00b9fac3`](https://github.com/nix-community/home-manager/commit/00b9fac3769b9e5cd2b2e5195e3b8396ba509da9) | `` tests: buildbot tests enableBig ``                                     |
| [`3e4b3118`](https://github.com/nix-community/home-manager/commit/3e4b3118423706973c68bc11c44571de68e83901) | `` onlyoffice: fix settings option example type ``                        |
| [`38bf0202`](https://github.com/nix-community/home-manager/commit/38bf0202cae280174cbb80fc24a63978f16333f7) | `` files: change target type to disallow empty strings ``                 |