### PR TITLE
chore(flake/catppuccin): `f41cc1cf` -> `e82c195f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777024856,
-        "narHash": "sha256-OQ+yIcRMXo4UaHyX+W5DCgBvJ5dZo/3kFGWPJiuR6x8=",
+        "lastModified": 1777505151,
+        "narHash": "sha256-ul1iRBfVX2vc971tHHhVtxX2hycU3nVwgO005OcOKnw=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f41cc1cf13647e482b7317396f749840ef715e16",
+        "rev": "e82c195f2276825b0a08024fdaff80f965edcd69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                 |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`e82c195f`](https://github.com/catppuccin/nix/commit/e82c195f2276825b0a08024fdaff80f965edcd69) | `` Add support for Home Assistant (#885) ``                             |
| [`2c5610cf`](https://github.com/catppuccin/nix/commit/2c5610cf1583a70df719f90a1f2d2e29521a9f4a) | `` Revert "ci(format): allow writing to actions (#907)" (#908) ``       |
| [`37d0991e`](https://github.com/catppuccin/nix/commit/37d0991ebbb26324282dd54c678c9b5a02a2637d) | `` ci(format): allow writing to actions (#907) ``                       |
| [`d8d200d2`](https://github.com/catppuccin/nix/commit/d8d200d2c71c0326bab7cfbaba497db97587fc61) | `` Exempt workflow from branch protection rules. (#906) ``              |
| [`f050dd28`](https://github.com/catppuccin/nix/commit/f050dd2874f439372f6fa86e9e0a7537407657cf) | `` docs: add advanced section (#904) ``                                 |
| [`758ed538`](https://github.com/catppuccin/nix/commit/758ed53829f31bf71cd9330313bfcb139dd7b30f) | `` ci(update-locks): don't run if changes have not been made (#905) ``  |
| [`ea21443e`](https://github.com/catppuccin/nix/commit/ea21443e55c1acca99a69076539e71eaffb87db5) | `` Revert "ci: checkout with default token" (#903) ``                   |
| [`5c3d5f02`](https://github.com/catppuccin/nix/commit/5c3d5f02e882522439eb9197fd1ee084ffa46288) | `` ci: checkout with default token (#902) ``                            |
| [`89794a2a`](https://github.com/catppuccin/nix/commit/89794a2a3023e14d51574499a23edc9945950d03) | `` feat(packages): scope the output (#901) ``                           |
| [`353fe943`](https://github.com/catppuccin/nix/commit/353fe94372afabf13e98ae36620152251ccd2d36) | `` feat(catppuccinBuildHook): init (#899) ``                            |
| [`d42c6cc2`](https://github.com/catppuccin/nix/commit/d42c6cc21452b7b9f45748c6d68017a6ad28193b) | `` feat: structuredAttrs, strictDeps and more modernizeations (#900) `` |
| [`ec795976`](https://github.com/catppuccin/nix/commit/ec7959767cd032a8693289cb10dc19ce17a1ff0b) | `` feat(pkgs): add lastModified to manually defined packages (#812) ``  |