### PR TITLE
chore(flake/nixpkgs-stable): `10e7ad5b` -> `a4bf0661`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1156,11 +1156,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`6826611f`](https://github.com/NixOS/nixpkgs/commit/6826611f551cb977352a3f85471458023cd49101) | `` .github: Bump cachix/install-nix-action from 31.10.4 to 31.10.5 ``            |
| [`2d88aef3`](https://github.com/NixOS/nixpkgs/commit/2d88aef387652e2ac534f6aab2eaf39aef8c3712) | `` .github: Bump korthout/backport-action from 4.3.0 to 4.4.0 ``                 |
| [`6826611f`](https://github.com/NixOS/nixpkgs/commit/6826611f551cb977352a3f85471458023cd49101) | `` .github: Bump cachix/install-nix-action from 31.10.4 to 31.10.5 ``            |
| [`2d88aef3`](https://github.com/NixOS/nixpkgs/commit/2d88aef387652e2ac534f6aab2eaf39aef8c3712) | `` .github: Bump korthout/backport-action from 4.3.0 to 4.4.0 ``                 |
| [`47f085fd`](https://github.com/NixOS/nixpkgs/commit/47f085fd632744f86eb32bf929c9c6dd5bca6f8c) | `` teleport_17: 17.7.19 -> 17.7.20 ``                                            |
| [`26ed7b84`](https://github.com/NixOS/nixpkgs/commit/26ed7b849615b5f0957aa29b85b3df8cd65686de) | `` teleport_18: 18.7.0 -> 18.7.2 ``                                              |
| [`d002a29c`](https://github.com/NixOS/nixpkgs/commit/d002a29cfa2331c24426626b0e5cacb6b87751ea) | `` ungoogled-chromium: 147.0.7727.101-1 -> 147.0.7727.116-1 ``                   |
| [`23000dbe`](https://github.com/NixOS/nixpkgs/commit/23000dbe4c363554c6ce35df47c99cc7f73fd0c1) | `` noriskclient-launcher-unwrapped: 0.6.17 -> 0.6.19 ``                          |
| [`6410e872`](https://github.com/NixOS/nixpkgs/commit/6410e872af02eb6fb1abd2790b5a8026eae9de1a) | `` dnsmasq: 2.91 -> 2.92 ``                                                      |
| [`c1b471fc`](https://github.com/NixOS/nixpkgs/commit/c1b471fc3727d444fb5e63561c3ff7536f3706e6) | `` dnsmasq: apply patch for CVE-2026-6507 ``                                     |
| [`4ee121c2`](https://github.com/NixOS/nixpkgs/commit/4ee121c2adf942d2e84de8a189f0a72ebe8a3ab0) | `` librewolf-unwrapped: 149.0.2-2 -> 150.0-1 ``                                  |
| [`da23f305`](https://github.com/NixOS/nixpkgs/commit/da23f305d2840ad8ada57ead5d2ab36bdfeb63b1) | `` erlang_28: 28.4.3 -> 28.5 ``                                                  |
| [`0645ec52`](https://github.com/NixOS/nixpkgs/commit/0645ec5295bdc56768553a4624d91993d3d5fa00) | `` vimPlugins.mellow-nvim: init at 0-unstable-2026-03-30 ``                      |
| [`14080e19`](https://github.com/NixOS/nixpkgs/commit/14080e1971fe7bc2bba8a9e80e42676242dbcc05) | `` radicle-desktop: 0.9.0 -> 0.10.0 ``                                           |
| [`06b12eda`](https://github.com/NixOS/nixpkgs/commit/06b12eda7aa8311755adb85d3fc8ac37ae8a3802) | `` radicle-desktop: add updateScript ``                                          |
| [`127ae44e`](https://github.com/NixOS/nixpkgs/commit/127ae44e150d537be1c21a66640147f7e0591fe5) | `` radicle-desktop: 0.8.0 -> 0.9.0 ``                                            |
| [`c5b3bd3f`](https://github.com/NixOS/nixpkgs/commit/c5b3bd3f9adc5991400b60aa7ae356ebd269233c) | `` nss_latest: 3.123 -> 3.123.1 ``                                               |
| [`d40e6648`](https://github.com/NixOS/nixpkgs/commit/d40e6648cb12555a72750029b612984f8181f693) | `` emacs30: add a patch to fix upstream bug 80851 ``                             |
| [`b6e516cf`](https://github.com/NixOS/nixpkgs/commit/b6e516cfb4fe82a43bf14593283fbe227f4cbdd0) | `` electron-chromedriver_41: 41.2.0 -> 41.3.0 ``                                 |
| [`f5a7e736`](https://github.com/NixOS/nixpkgs/commit/f5a7e736ff50ca6f129911957c68be790525fa13) | `` electron_41-bin: 41.2.0 -> 41.3.0 ``                                          |
| [`4dbeed12`](https://github.com/NixOS/nixpkgs/commit/4dbeed124a2c3a10d4f844aa9f926962d7413832) | `` electron-chromedriver_40: 40.8.5 -> 40.9.2 ``                                 |
| [`bc3894ae`](https://github.com/NixOS/nixpkgs/commit/bc3894aebfc360c0e1560812f7ea6f95c638a70e) | `` electron_40-bin: 40.8.5 -> 40.9.2 ``                                          |
| [`80ed6a10`](https://github.com/NixOS/nixpkgs/commit/80ed6a10e984f34fcd5c91eeae70e343a937406f) | `` electron-chromedriver_39: 39.8.7 -> 39.8.9 ``                                 |
| [`3e7a4e93`](https://github.com/NixOS/nixpkgs/commit/3e7a4e93aec7aa1808e7e1c92ea23e9c63680eef) | `` electron_39-bin: 39.8.7 -> 39.8.9 ``                                          |
| [`e057c15a`](https://github.com/NixOS/nixpkgs/commit/e057c15a143de53ab868b5bcedd70ec0e55ff34e) | `` electron-source.electron_41: 41.2.2 -> 41.3.0 ``                              |
| [`56858b4b`](https://github.com/NixOS/nixpkgs/commit/56858b4b8b038f16b5e3b9262bad82123e3da4fa) | `` electron-source.electron_41: 41.2.0 -> 41.2.2 ``                              |
| [`52b93c1e`](https://github.com/NixOS/nixpkgs/commit/52b93c1edeaeadbaf253d8b2e28bb5303700a457) | `` electron-source.electron_40: 40.8.5 -> 40.9.2 ``                              |
| [`bf4c034b`](https://github.com/NixOS/nixpkgs/commit/bf4c034b5d90c57180e9eb08f7dbbd1fc509875e) | `` electron-source.electron_39: 39.8.7 -> 39.8.9 ``                              |
| [`0ecd4aca`](https://github.com/NixOS/nixpkgs/commit/0ecd4aca511fe55501adcd38ec4b4c87e761e4c5) | `` gclient2nix: update depot-tools ``                                            |
| [`6ef38207`](https://github.com/NixOS/nixpkgs/commit/6ef38207959426d5d48f5ff53eb0fe0e21103434) | `` radicle-httpd: 0.24.0 -> 0.25.0 ``                                            |
| [`0006d992`](https://github.com/NixOS/nixpkgs/commit/0006d992b8c3f65974009ac97fd967f35ee14f49) | `` gitlab-runner: 18.10.1 -> 18.11.1 ``                                          |
| [`17f2df1f`](https://github.com/NixOS/nixpkgs/commit/17f2df1ff1e570fd3f93e497966d95d13dbb8078) | `` pdns-recursor: 5.2.8 -> 5.2.9 ``                                              |
| [`c991a26e`](https://github.com/NixOS/nixpkgs/commit/c991a26eb324d3ce524a736b6b9f786505306714) | `` dnsdist: 1.9.12 -> 1.9.14 ``                                                  |
| [`27de5f75`](https://github.com/NixOS/nixpkgs/commit/27de5f7508565939ae6d0d82c8ee95d76a089d02) | `` rustls-ffi: 0.15.2 -> 0.15.3 ``                                               |
| [`39cdf306`](https://github.com/NixOS/nixpkgs/commit/39cdf30656b7cc4362d0221c26cd1b5d3db614f7) | `` tor-browser: add whispersofthedawn as maintainer ``                           |
| [`eb31c6fb`](https://github.com/NixOS/nixpkgs/commit/eb31c6fb580a4a4a97eba35e144db28553e6f570) | `` mullvad-browser: add whispersofthedawn as maintainer ``                       |
| [`868e12d0`](https://github.com/NixOS/nixpkgs/commit/868e12d07fe3779ba0b23d5749b2c18559e77bfd) | `` tor-browser: 15.0.9 -> 15.10.0 ``                                             |
| [`3c5ac0ca`](https://github.com/NixOS/nixpkgs/commit/3c5ac0ca77e3e336987225f07e888d38a594c832) | `` mullvad-browser: 15.0.9 -> 15.10.0 ``                                         |
| [`8b1b09d5`](https://github.com/NixOS/nixpkgs/commit/8b1b09d51a7142e3c2573df4522d40a320f03c22) | `` maintainers: rename dawnofmidnight → whispersofthedawn, add matrix ``         |
| [`93cb66fd`](https://github.com/NixOS/nixpkgs/commit/93cb66fde15d1b09f8a105f88a404ec8b69d601a) | `` nixosTests.powerdns: fix evaluation ``                                        |
| [`c838d41a`](https://github.com/NixOS/nixpkgs/commit/c838d41aa08b3e82230eff0ca7ffb19ef2600c6d) | `` pdns: 4.9.8 -> 4.9.14 ``                                                      |
| [`64cbaaec`](https://github.com/NixOS/nixpkgs/commit/64cbaaec1302a64fb8a4f2b5c5cdb5cda225c9f9) | `` nanomq: use nix-update-script ``                                              |
| [`1e600925`](https://github.com/NixOS/nixpkgs/commit/1e60092566e1feba1920c121cc17ab751cf480fd) | `` nanomq: 0.24.10 -> 0.24.11 ``                                                 |
| [`a336c5ef`](https://github.com/NixOS/nixpkgs/commit/a336c5eff2b8ef1479f24bae858b8780314ceb55) | `` linux_xanmod_latest: 6.19.13 -> 6.19.14 ``                                    |
| [`38d7e145`](https://github.com/NixOS/nixpkgs/commit/38d7e145173c604eb126c9ae5817d77112bf72ee) | `` linux_xanmod: 6.18.23 -> 6.18.24 ``                                           |
| [`2497e802`](https://github.com/NixOS/nixpkgs/commit/2497e802faf80b4f0c13411e174eabcc822aed0b) | `` packagekit: 1.3.2 → 1.3.3 ``                                                  |
| [`d59d0069`](https://github.com/NixOS/nixpkgs/commit/d59d0069055886b3148fbb5bc1c115ef8726c0b5) | `` prl-tools: 26.3.0-57392 -> 26.3.1-57396 ``                                    |
| [`67090792`](https://github.com/NixOS/nixpkgs/commit/67090792bbfe5e1ab76b485da692649cc2df1141) | `` Revert "zellij: 0.43.1 -> 0.44.0" ``                                          |
| [`5a109242`](https://github.com/NixOS/nixpkgs/commit/5a109242c6a6094b43306157e113bd39fc0a51d1) | `` Revert "zellij: 0.44.0 -> 0.44.1" ``                                          |
| [`902cb9d7`](https://github.com/NixOS/nixpkgs/commit/902cb9d73af994479156de44f670a58c7c3b8933) | `` chromium,chromedriver: 147.0.7727.101 -> 147.0.7727.116 ``                    |
| [`209b0b89`](https://github.com/NixOS/nixpkgs/commit/209b0b89f090904102480b81506f7af7bdab5779) | `` google-chrome: 147.0.7727.101 -> 147.0.7727.116 ``                            |
| [`ef680aa3`](https://github.com/NixOS/nixpkgs/commit/ef680aa3a272dcc3922b9b74512cf30951708e8c) | `` ovn: 25.09.0 -> 25.09.3 ``                                                    |
| [`c52a2334`](https://github.com/NixOS/nixpkgs/commit/c52a233459caf011318190a0d143baee00d37beb) | `` strongswan: 6.0.5 -> 6.0.6 ``                                                 |
| [`57a8152b`](https://github.com/NixOS/nixpkgs/commit/57a8152bce6a37eaf62657bbd7af0dd84e50d2b4) | `` nodejs_24: fix openssl related tests ``                                       |
| [`f63c1430`](https://github.com/NixOS/nixpkgs/commit/f63c1430a88671458527af81788c118b0c17f55d) | `` nodejs_24: 24.14.1 -> 24.15.0 ``                                              |
| [`7ac6b151`](https://github.com/NixOS/nixpkgs/commit/7ac6b151399233199a98d1efbded08908e2e15a1) | `` linux_6_12: 6.12.82 -> 6.12.83 ``                                             |
| [`bd1def11`](https://github.com/NixOS/nixpkgs/commit/bd1def11c9f9b4e2d2b85a70f6ee3741ed38d56c) | `` linux_6_18: 6.18.23 -> 6.18.24 ``                                             |
| [`a6e428d4`](https://github.com/NixOS/nixpkgs/commit/a6e428d4fe39d25c1bc14518e47633cc99dba538) | `` linux_6_19: 6.19.13 -> 6.19.14 ``                                             |
| [`efecfcb0`](https://github.com/NixOS/nixpkgs/commit/efecfcb08921d61e4d6a56fae18a9dce9d7a4244) | `` linux_7_0: 7.0 -> 7.0.1 ``                                                    |
| [`0b196124`](https://github.com/NixOS/nixpkgs/commit/0b1961244cf6c2632938d45899449cdc7172de28) | `` python3Packages.mitmproxy: 12.2.1 -> 12.2.2 ``                                |
| [`fecda816`](https://github.com/NixOS/nixpkgs/commit/fecda8164434007671a5a2b4a5613f8a78a7d05b) | `` dprint-plugins.dprint-plugin-biome: 0.12.7 -> 0.12.8 ``                       |
| [`0fe43b17`](https://github.com/NixOS/nixpkgs/commit/0fe43b17fe56b5ea3f0d01ac91fb5831fe5c1303) | `` dioxus-cli: use wasm-bindgen-cli_0_2_118 ``                                   |
| [`3da18ad2`](https://github.com/NixOS/nixpkgs/commit/3da18ad29e457038d4d17353bafd51c65301fe33) | `` wasm-bindgen-cli_0_2_118: init ``                                             |
| [`03c5205c`](https://github.com/NixOS/nixpkgs/commit/03c5205c99cf1a8072c7ba5cc2e446dded9d577a) | `` openbao: 2.5.2 -> 2.5.3 ``                                                    |
| [`11de58c6`](https://github.com/NixOS/nixpkgs/commit/11de58c6eb3e49f5584f6ec3e9ad6a5e3da96603) | `` vivaldi: 7.9.3970.50 -> 7.9.3970.55 ``                                        |
| [`24babe91`](https://github.com/NixOS/nixpkgs/commit/24babe91828d9cce5e35ee34ff9691223dda6275) | `` nixos/systemd/initrd: fix modprobe ``                                         |
| [`777c903d`](https://github.com/NixOS/nixpkgs/commit/777c903de8e0cf21413016010160350fe3460feb) | `` qbz: 1.2.7 -> 1.2.8 ``                                                        |
| [`727510a4`](https://github.com/NixOS/nixpkgs/commit/727510a4589aa23f30c25d9961f5dec0093ac022) | `` matrix-continuwuity: adjust rocksdb build with upstream ``                    |
| [`ce528eea`](https://github.com/NixOS/nixpkgs/commit/ce528eead23849bd0a86e6e076c0d0adb8915661) | `` matrix-continuwuity: 0.5.6 -> 0.5.7 ``                                        |
| [`797022ea`](https://github.com/NixOS/nixpkgs/commit/797022ead2b21fda8e0e0e06035987aefb0a72df) | `` matrix-continuwuity: add bartoostveen as a maintainer ``                      |
| [`d7fb1086`](https://github.com/NixOS/nixpkgs/commit/d7fb10861a695935a61930edc5707d36a807caff) | `` maintainers: add bartoostveen ``                                              |
| [`ab33b178`](https://github.com/NixOS/nixpkgs/commit/ab33b178b8c29b21923d2db08ee51e4561562975) | `` ruby_4_0: 4.0.2 -> 4.0.3 ``                                                   |
| [`44a778d4`](https://github.com/NixOS/nixpkgs/commit/44a778d4126ab4963d2526d889073b65b433ac43) | `` erlang_28: 28.4.2 -> 28.4.3 ``                                                |
| [`d3f2a0ba`](https://github.com/NixOS/nixpkgs/commit/d3f2a0ba414f1ef7707ce3d8822a280e4bb27579) | `` erlang_27: 27.3.4.10 -> 27.3.4.11 ``                                          |
| [`b63d6cc2`](https://github.com/NixOS/nixpkgs/commit/b63d6cc23b30deafa6fef048655d4a6d21e7ecfd) | `` psysh: 0.12.21 -> 0.12.22 ``                                                  |
| [`c7f320c3`](https://github.com/NixOS/nixpkgs/commit/c7f320c397d37506630a9de47f04b0c41b36d048) | `` psysh: 0.12.20 -> 0.12.21 ``                                                  |
| [`e30cf480`](https://github.com/NixOS/nixpkgs/commit/e30cf4804068231f34e7322465ab6733470d246a) | `` psysh: 0.12.19 -> 0.12.20 ``                                                  |
| [`2507083a`](https://github.com/NixOS/nixpkgs/commit/2507083ab591f61f58e8f068f0a3f69b8ee1e707) | `` psysh: refactor ``                                                            |
| [`cc05f58a`](https://github.com/NixOS/nixpkgs/commit/cc05f58a2920a5457b4f1c5027318e19d1f1c3c4) | `` psysh: add piotrkwiecinski as maintainer ``                                   |
| [`2f419dee`](https://github.com/NixOS/nixpkgs/commit/2f419deece363cf948690f338a920fe3f96d2d70) | `` psysh: 0.12.7 -> 0.12.19 ``                                                   |
| [`5d9a6478`](https://github.com/NixOS/nixpkgs/commit/5d9a6478569d6c745be570a119450ce0ea546cb0) | `` psysh: unbreak, update `vendorHash` ``                                        |
| [`36894b4f`](https://github.com/NixOS/nixpkgs/commit/36894b4f7fb475b94e5b71ab0cc4018574ff3f8c) | `` erlang_26: 26.2.5.19 -> 26.2.5.20 ``                                          |
| [`0a33ee46`](https://github.com/NixOS/nixpkgs/commit/0a33ee463e5bc867ddadc51f0505154b7ec8efb8) | `` irpf: 2026-1.0 -> 2026-1.1 ``                                                 |
| [`23f5fd2f`](https://github.com/NixOS/nixpkgs/commit/23f5fd2f62fd309fe080a9b3a0ec4370fba83127) | `` irpf: Remove unnecessary internal file version ``                             |
| [`c6762d73`](https://github.com/NixOS/nixpkgs/commit/c6762d73788ced5f2ca44f4a5ed7154499a993a0) | `` zvm: 0.8.11 -> 0.8.14 ``                                                      |
| [`28374ab4`](https://github.com/NixOS/nixpkgs/commit/28374ab4e1f5f69d2cd9304f777a52e2364fed96) | `` forgejo-runner: 12.8.2 -> 12.9.0 ``                                           |
| [`1db28486`](https://github.com/NixOS/nixpkgs/commit/1db28486453ce4091f96303bdfda5cc4b0edae84) | `` buildbox: 1.4.0 -> 1.4.4 ``                                                   |
| [`2e47d312`](https://github.com/NixOS/nixpkgs/commit/2e47d3128eca631b0617d6eb52cb6bd2032ef9b8) | `` llvmPackages_git: 23.0.0-unstable-2026-04-05 -> 23.0.0-unstable-2026-04-19 `` |
| [`214009d6`](https://github.com/NixOS/nixpkgs/commit/214009d688d3406d4484bf91a384ec722a85e057) | `` warehouse: 2.1.0 -> 2.2.0 ``                                                  |
| [`7e34f16c`](https://github.com/NixOS/nixpkgs/commit/7e34f16cb7d0e17ac811977024c4f4c5e33e2cf4) | `` bcachefs-tools: 1.37.4 -> 1.38.0 ``                                           |
| [`436ddc91`](https://github.com/NixOS/nixpkgs/commit/436ddc9157488de8bd8d3e02f12d3e454e1a1492) | `` qq: 2026-02-05 -> 2026-04-01 ``                                               |
| [`b038298d`](https://github.com/NixOS/nixpkgs/commit/b038298de6fdbebdd78e289f0865cb406ce49df7) | `` python3Packages.distributed: 2025.12.0 -> 2026.1.1 ``                         |
| [`bd7e0cec`](https://github.com/NixOS/nixpkgs/commit/bd7e0cec163cf3786dc9b341735525ee183232ef) | `` python3Packages.distributed: 2025.11.0 -> 2025.12.0 ``                        |
| [`8fbd6d36`](https://github.com/NixOS/nixpkgs/commit/8fbd6d366530639cd4c147ef1cc7a708d9df7ba0) | `` wavelog: 2.3.1 -> 2.4 ``                                                      |
| [`93073a47`](https://github.com/NixOS/nixpkgs/commit/93073a47760e72f41e6ebf290f8310aff9d3678b) | `` wavelog: 2.2.2 -> 2.3.1 ``                                                    |
| [`48d60f2f`](https://github.com/NixOS/nixpkgs/commit/48d60f2f145cbb35a6f07226fbe274d3e4a5e1f0) | `` wavelog: 2.2.1 -> 2.2.2 ``                                                    |
| [`768b5df8`](https://github.com/NixOS/nixpkgs/commit/768b5df809bc2d18adaee03753e031d7847086b2) | `` wavelog: 2.1.2 -> 2.2.1 ``                                                    |
| [`4522776d`](https://github.com/NixOS/nixpkgs/commit/4522776d42c52bca8e78467b828004703f0e558c) | `` zvm: 0.8.10 -> 0.8.11 ``                                                      |
| [`5c8c5e8f`](https://github.com/NixOS/nixpkgs/commit/5c8c5e8f23abfe6af1d395de7f8426b8d99939d8) | `` zvm: 0.8.8 -> 0.8.10 ``                                                       |
| [`9fa32010`](https://github.com/NixOS/nixpkgs/commit/9fa320108f53c25ad98921a5c94ca28508e3bc0c) | `` firefox-esr-140-unwrapped: 140.9.1esr -> 140.10.0esr ``                       |
| [`a8ed112f`](https://github.com/NixOS/nixpkgs/commit/a8ed112f98e4d0ae4d6dcba0c764cb4e995e0b2a) | `` firefox-bin-unwrapped: 149.0.2 -> 150.0 ``                                    |
| [`9fc03e16`](https://github.com/NixOS/nixpkgs/commit/9fc03e1651e0eda70b54f724e4e51acc860bfa40) | `` firefox-unwrapped: 149.0.2 -> 150.0 ``                                        |
| [`3ca8ef93`](https://github.com/NixOS/nixpkgs/commit/3ca8ef93c847fc8b90a7b0c114fe08c519ac109a) | `` openasar: 0-unstable-2026-03-28 -> 0-unstable-2026-04-18 ``                   |
| [`3414965b`](https://github.com/NixOS/nixpkgs/commit/3414965bd5239b136dab07cce6b8c817beb0a2fe) | `` garage_2: 2.2.0 -> 2.3.0 ``                                                   |
| [`deede64f`](https://github.com/NixOS/nixpkgs/commit/deede64fb1b8a4eeeb062b66a5c91e3bc2da8679) | `` umami: use pnpm build and ignore unneeded steps ``                            |
| [`c3321b79`](https://github.com/NixOS/nixpkgs/commit/c3321b796fc2388444003bc53b9a8eeaacef2355) | `` umami: 3.0.3 -> 3.1.0 ``                                                      |
| [`1c055c30`](https://github.com/NixOS/nixpkgs/commit/1c055c3076f12c5dab2bd541bda8deab0e4a8a44) | `` umami: refer to prisma, prisma-engines and geocities via finalAttrs ``        |
| [`440fdf9d`](https://github.com/NixOS/nixpkgs/commit/440fdf9d5c0dd0ee490476c004fcae1cab0b9eb5) | `` firefly-iii: 6.4.22 -> 6.5.9 ``                                               |
| [`b24db723`](https://github.com/NixOS/nixpkgs/commit/b24db7236d7b5b78c35b84f8cf4db8c9270f5ffb) | `` hyprmon: 0.0.14 -> 0.0.15 ``                                                  |
| [`a453de5a`](https://github.com/NixOS/nixpkgs/commit/a453de5a8f84aa512367f678b9ed82023d4172ad) | `` rgx: 0.10.2 -> 0.12.0 ``                                                      |
| [`86b0b5c0`](https://github.com/NixOS/nixpkgs/commit/86b0b5c04589fecca1576c59b5f64c65c24ad8ed) | `` opencryptoki: 3.25.0 -> 3.26.0-unstable-2026-04-09 ``                         |
| [`51a57978`](https://github.com/NixOS/nixpkgs/commit/51a579784d26142b781b822ca11845e8b862d561) | `` rquickshare: migrate from fetcherVersion = 1 to fetcherVersion = 3 ``         |
| [`6c545663`](https://github.com/NixOS/nixpkgs/commit/6c545663d368f1d34832c044df9d9717297a3b61) | `` rquickshare: add sarunint as maintainer ``                                    |
| [`89653765`](https://github.com/NixOS/nixpkgs/commit/896537659cdac775b4d6eddb81e5e83fdd94c0ed) | `` rquickshare: fix Tauri libraries minor version mismatch ``                    |
| [`d4bedb6f`](https://github.com/NixOS/nixpkgs/commit/d4bedb6fc53aa6bdbe16baa8689c353726e79ea2) | `` mpv-unwrapped: set `dontVersionCheck = true;` for darwin ``                   |
| [`36f9c8d5`](https://github.com/NixOS/nixpkgs/commit/36f9c8d5f7d2eed2f1ea215dc9e499a2dd9d557a) | `` xvfb: don't update for now ``                                                 |
| [`91e0c9ac`](https://github.com/NixOS/nixpkgs/commit/91e0c9ac1211c537b819c0dc1aad91728510c9ed) | `` xorg-server: 21.1.21 -> 21.1.22 ``                                            |
| [`eb796522`](https://github.com/NixOS/nixpkgs/commit/eb7965220365454219596609dd08d2eb14a62b6e) | `` pyload-ng: add knownVulnerabilities ``                                        |
| [`0efa1205`](https://github.com/NixOS/nixpkgs/commit/0efa12058462955d5351c69ae053dd59664fca97) | `` dropbox: 217.4.4417 -> 246.4.3513 ``                                          |
| [`aa634124`](https://github.com/NixOS/nixpkgs/commit/aa6341245d11a3a31cae65980052509e6983a25d) | `` firefly-iii-data-importer: 2.0.4 -> 2.2.2 ``                                  |
| [`0fbe215c`](https://github.com/NixOS/nixpkgs/commit/0fbe215c75c970ca5268ecec743b47422c2e3678) | `` snapshot: 49.0 → 49.1 ``                                                      |
| [`3498c15f`](https://github.com/NixOS/nixpkgs/commit/3498c15f4217f3f5f4c660cee2737acc6191fb49) | `` quadrapassel: 49.2.1 → 49.2.3 ``                                              |
| [`1fb76b9b`](https://github.com/NixOS/nixpkgs/commit/1fb76b9b43af5410f70d5410f2b864fcd51e1039) | `` localsearch: 3.10.1 → 3.10.2 ``                                               |
| [`212e5788`](https://github.com/NixOS/nixpkgs/commit/212e5788ec35e0bec5b266b63791e88684d00a4d) | `` gspell: 1.14.0 → 1.14.2 ``                                                    |
| [`e70bc181`](https://github.com/NixOS/nixpkgs/commit/e70bc181e794bd8e96af21210ebe445e4b08de7c) | `` gnome-remote-desktop: 49.1 → 49.2 ``                                          |
| [`69f30a95`](https://github.com/NixOS/nixpkgs/commit/69f30a95684346212b52eb8ebaf71dc56fefd5f4) | `` gnome-console: 49.1 → 49.2 ``                                                 |
| [`b135f9d3`](https://github.com/NixOS/nixpkgs/commit/b135f9d3a575902930467c82d1a283cf2271d4b6) | `` libshumate: 1.5.2 → 1.5.3 ``                                                  |
| [`fae24e1e`](https://github.com/NixOS/nixpkgs/commit/fae24e1ea43a0e2d1d9478299367a70efd9afcec) | `` libspelling: 0.4.9 → 0.4.10 ``                                                |
| [`8c6704f2`](https://github.com/NixOS/nixpkgs/commit/8c6704f2915dda21e1c18796f72f7438d5b785b8) | `` evolution: 3.58.2 → 3.58.3 ``                                                 |
| [`bf050188`](https://github.com/NixOS/nixpkgs/commit/bf0501887f57bf65f2096ac884e1f4a97e39dc75) | `` evolution-data-server: 3.58.2 → 3.58.3 ``                                     |
| [`9085dea0`](https://github.com/NixOS/nixpkgs/commit/9085dea03f1c9302ecf3bf151282b8197b215215) | `` gnome-user-docs: 49.1 → 49.4 ``                                               |
| [`e49de694`](https://github.com/NixOS/nixpkgs/commit/e49de694200e2c32901298c61b9e6ed51e8c4179) | `` gnome-maps: 49.3 → 49.4 ``                                                    |
| [`2c44dd9e`](https://github.com/NixOS/nixpkgs/commit/2c44dd9e9dc0271371eeb7c03fabe4c2af8091ed) | `` gnome-maps: 49.2 → 49.3 ``                                                    |
| [`0bfeaf8a`](https://github.com/NixOS/nixpkgs/commit/0bfeaf8ae2545590d265f51047a7f1d29ec06b0c) | `` gnome-sudoku: 49.3 → 49.4 ``                                                  |
| [`289946dd`](https://github.com/NixOS/nixpkgs/commit/289946dd44181f79d0f5173b3b0bcd397d23c06f) | `` gnome-calculator: Fix TLS support for currency conversion ``                  |
| [`0f80befb`](https://github.com/NixOS/nixpkgs/commit/0f80befbf53b5e67e5e94933f7931e081e7cc972) | `` gnome-sudoku: 49.2 → 49.3 ``                                                  |
| [`aaf14ac0`](https://github.com/NixOS/nixpkgs/commit/aaf14ac0dcc9121292b5915355126a55ed8f9187) | `` gnome-terminal: 3.58.0 → 3.58.1 ``                                            |
| [`6e53e87f`](https://github.com/NixOS/nixpkgs/commit/6e53e87f2dd875d3df565176ae0999b7f1794c73) | `` gucharmap: 17.0.0 → 17.0.1 ``                                                 |
| [`3fb60a70`](https://github.com/NixOS/nixpkgs/commit/3fb60a7071f3c48be926092f7395430573fe9bce) | `` libshumate: 1.5.1 → 1.5.2 ``                                                  |
| [`69fbeb37`](https://github.com/NixOS/nixpkgs/commit/69fbeb37cbd0fa7146d436a4b1f5a6aa9465804a) | `` loupe: 49.1 → 49.2 ``                                                         |
| [`1af662e7`](https://github.com/NixOS/nixpkgs/commit/1af662e7a963ade8e7ade161975a09d4fb62ccf8) | `` eog: 47.0 → 49.1 ``                                                           |
| [`3de6d13f`](https://github.com/NixOS/nixpkgs/commit/3de6d13f5652b40e266ef03c7d44140b244866e9) | `` gnome-calendar: 49.0.1 → 49.1 ``                                              |
| [`ecc24c21`](https://github.com/NixOS/nixpkgs/commit/ecc24c2194dfdae090a31e03014c25ba70e335e9) | `` gnome-calculator: Fix TLS support for currency conversion ``                  |
| [`3880ee89`](https://github.com/NixOS/nixpkgs/commit/3880ee8931e5b8faddbfdd56cf5fc4f32c25e544) | `` gnome-software: 49.2 → 49.3 ``                                                |
| [`9ca05ad5`](https://github.com/NixOS/nixpkgs/commit/9ca05ad505489f966d3f0d200482e57e9c18d2c9) | `` gnome-control-center: 49.4 → 49.5 ``                                          |
| [`b16238e0`](https://github.com/NixOS/nixpkgs/commit/b16238e04c3a033b86de9dc81d172507fc3662d9) | `` gnome-control-center: 49.3 → 49.4 ``                                          |
| [`77adc4a8`](https://github.com/NixOS/nixpkgs/commit/77adc4a8f7ff333941a598e2863a050a5b825f69) | `` gnome-control-center: fix crash with hands-free profile ``                    |
| [`9d8a6ad2`](https://github.com/NixOS/nixpkgs/commit/9d8a6ad262b44475057a18522d96f7b83c73fb3a) | `` gnome-control-center: 49.2.2 → 49.3 ``                                        |
| [`bf3844b3`](https://github.com/NixOS/nixpkgs/commit/bf3844b3252e55e0e6c585556e41781be6a1d30c) | `` gnome-settings-daemon: fix crash with hands-free profile ``                   |
| [`c3aa8fda`](https://github.com/NixOS/nixpkgs/commit/c3aa8fdacb81f016efff84f7c4c6568cee3affea) | `` dovecot: add missing dependency libxcrypt ``                                  |
| [`985556ea`](https://github.com/NixOS/nixpkgs/commit/985556ea9fb7b3e5cbf01b952d239dc2d2e425cf) | `` nixos/restic: prevent start when rebuilding system ``                         |
| [`23617bfd`](https://github.com/NixOS/nixpkgs/commit/23617bfd0c9a5b39c138819a2700ae5540f4aff5) | `` libglycin: 2.0.7 -> 2.0.8 ``                                                  |
| [`9118b5b2`](https://github.com/NixOS/nixpkgs/commit/9118b5b2a32cafdd50f3a8a0eb834170503b22a8) | `` gnome-shell: 49.3 → 49.4 ``                                                   |
| [`ac8cec63`](https://github.com/NixOS/nixpkgs/commit/ac8cec63465db327756568fb6cdfc9490a43bc3e) | `` gnome-shell: fix gnome-shell-portal-helper ``                                 |
| [`96039667`](https://github.com/NixOS/nixpkgs/commit/96039667f40b4f16b8ee1d71b1cb9b283d6abdaf) | `` gnome-shell: fix crash with hands-free profile ``                             |
| [`f33d536d`](https://github.com/NixOS/nixpkgs/commit/f33d536d311f225f77b64e33f73bdfc11c5876a4) | `` gnome-desktop: 44.4 → 44.5 ``                                                 |
| [`33668d9c`](https://github.com/NixOS/nixpkgs/commit/33668d9cd84b3816a719fc613e97b0b4cf5379be) | `` gnome-online-accounts: 3.56.3 → 3.56.4 ``                                     |
| [`124435f3`](https://github.com/NixOS/nixpkgs/commit/124435f3992ffb33da06b36b61b1f9c88bd53446) | `` gnome-online-accounts: 3.56.2 → 3.56.3 ``                                     |
| [`7d66d030`](https://github.com/NixOS/nixpkgs/commit/7d66d030bed1765fba1cdabc98bf27b0eeffdab8) | `` gthumb: 3.12.9 → 3.12.10 ``                                                   |
| [`dbcceb88`](https://github.com/NixOS/nixpkgs/commit/dbcceb88b61e671f82613dc8b9693c991b811e14) | `` mutter: 49.3 → 49.4 ``                                                        |
| [`2660fd3c`](https://github.com/NixOS/nixpkgs/commit/2660fd3c8e696c1d9c45cb43a1c7a77bd73011d0) | `` nautilus: 49.3 → 49.4 ``                                                      |
| [`51da0008`](https://github.com/NixOS/nixpkgs/commit/51da0008fae59debca62c7025d6402316843aef2) | `` nautilus: 49.2 → 49.3 ``                                                      |
| [`843834c8`](https://github.com/NixOS/nixpkgs/commit/843834c890bdbd6b8bbb12ab2b7dd86c5693b129) | `` papers: 49.3 → 49.4 ``                                                        |
| [`d6d624be`](https://github.com/NixOS/nixpkgs/commit/d6d624be0df791661d1083ed774645897a77c6a9) | `` papers: 49.2 → 49.3 ``                                                        |
| [`9b03d045`](https://github.com/NixOS/nixpkgs/commit/9b03d04524a163144cb8ce40a8b547f6dcb0cb09) | `` gnome-shell: 49.2 → 49.3 ``                                                   |
| [`9fc9f376`](https://github.com/NixOS/nixpkgs/commit/9fc9f376712469190e167b02be713c6e0df29023) | `` gnome-text-editor: 49.0 → 49.1 ``                                             |
| [`77265fdc`](https://github.com/NixOS/nixpkgs/commit/77265fdc290fd739901bec0daea086572204c16d) | `` gthumb: 3.12.8.2 → 3.12.9 ``                                                  |
| [`558e130a`](https://github.com/NixOS/nixpkgs/commit/558e130a503c5484acc3b3deacb1c17c7e8ee000) | `` gthumb: 3.12.8.1 → 3.12.8.2 ``                                                |
| [`d37a3ca2`](https://github.com/NixOS/nixpkgs/commit/d37a3ca2c73fc57c0a9a89fb8af6cfce5c0070b8) | `` mutter: 49.2 → 49.3 ``                                                        |
| [`f715f4d4`](https://github.com/NixOS/nixpkgs/commit/f715f4d40abc76f3aebd935bacc900a98c077472) | `` typos: use finalAttrs ``                                                      |
| [`d3230798`](https://github.com/NixOS/nixpkgs/commit/d32307988ad434eb26aa4ada4de0b21b605e5f21) | `` release-plz: use finalAttrs ``                                                |
| [`afc7fe68`](https://github.com/NixOS/nixpkgs/commit/afc7fe685e7e687465b48553c1bb5f8fabbaa308) | `` kissat: use finalAttrs ``                                                     |
| [`5b7a792a`](https://github.com/NixOS/nixpkgs/commit/5b7a792ac010fba8b453832a58e2baf1165b5fd3) | `` cargo-valgrind: use finalAttrs ``                                             |
| [`fd090f47`](https://github.com/NixOS/nixpkgs/commit/fd090f47d2bbe34ad053e00e283f164b71d5234e) | `` cargo-udeps: use finalAttrs ``                                                |
| [`24a0a103`](https://github.com/NixOS/nixpkgs/commit/24a0a1034257b1e7508c2fd12359b2568aecf1c4) | `` cargo-spellcheck: use finalAttrs ``                                           |
| [`215359e1`](https://github.com/NixOS/nixpkgs/commit/215359e1cfb50eb5d487ca2b29953936835b7a4f) | `` cargo-show-asm: use finalAttrs ``                                             |
| [`9e4dbb13`](https://github.com/NixOS/nixpkgs/commit/9e4dbb131080577cf4ec902e1d423fdbcf95682d) | `` cargo-semver-checks: use finalAttrs ``                                        |
| [`d55c3f52`](https://github.com/NixOS/nixpkgs/commit/d55c3f52e2bade39989cb4381c6160890a7711f5) | `` cargo-rdme: use finalAttrs ``                                                 |