### PR TITLE
feat: server kernel pin (manual-merge cadence) and weekly CVE scan

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,11 +5,11 @@
     "config:best-practices",
     "default:pinDigestsDisabled",
   ],
-  lockFileMaintenance: {
-    enabled: true,
-    automerge: true,
-    schedule: ["* 12 * * 0"],
-  },
+  // lockFileMaintenance intentionally omitted: the update-flakes workflow
+  // (.github/workflows/update-flakes.yaml) iterates every root flake input
+  // weekly and opens per-input PRs with proper diffs.  lockFileMaintenance
+  // would wholesale-rewrite flake.lock and bypass the manual-merge cadence
+  // for nixpkgs-kernel, since it ignores per-package enabled:false rules.
   timezone: "Etc/UTC",
   schedule: ["* 12 * * 0"],
   enabledManagers: ["custom.regex", "nix", "github-actions"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,5 +79,17 @@
       matchPackageNames: ["amir20/dozzle"],
       automerge: true,
     },
+    {
+      // Server kernel pin — managed exclusively by the monthly
+      // `update-manual` job in .github/workflows/update-flakes.yaml so
+      // kernel bumps land as manual-review PRs on a planned-reboot
+      // cadence.  Disable Renovate for this input entirely to avoid
+      // duplicate PRs and accidental auto-merges.  Must be the last
+      // rule in this list so it wins against the "nix automerge" rule
+      // above (Renovate merges packageRules in order; later wins).
+      matchManagers: ["nix"],
+      matchPackageNames: ["nixpkgs-kernel"],
+      enabled: false,
+    },
   ],
 }

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -93,7 +93,7 @@ jobs:
         id: vulnix
         shell: bash
         run: |
-          set -uo pipefail
+          set -euo pipefail
 
           kind="${{ matrix.system.kind }}"
           name="${{ matrix.system.name }}"
@@ -104,15 +104,26 @@ jobs:
             *)      echo "Unknown kind: $kind" >&2; exit 1 ;;
           esac
 
-          echo "Building derivation set for ${kind}/${name}..."
+          echo "Resolving derivation for ${kind}/${name}..."
           # We don't actually need to BUILD — vulnix can scan a .drv path.
           # `nix path-info --derivation` resolves the .drv without building.
+          # Run under set -e so a resolution failure fails the step instead
+          # of silently producing an empty report (which would otherwise let
+          # the aggregator close the rolling issue on a scan failure).
           drv=$(nix path-info --derivation "$attr")
+          if [ -z "$drv" ]; then
+            echo "::error::nix path-info returned empty derivation for $attr" >&2
+            exit 1
+          fi
           echo "Derivation: $drv"
 
-          # vulnix exits 0 when no CVEs, 1 when whitelisted-only, 2 when
-          # un-whitelisted CVEs are present.  We capture all three so the
-          # aggregator job can decide what to do with them.
+          # vulnix exit codes:
+          #   0 → no CVEs
+          #   1 → only whitelisted CVEs
+          #   2 → un-whitelisted CVEs present
+          # Anything else is an unexpected failure (e.g. NVD fetch error,
+          # crash) and MUST fail the step so the aggregator never treats a
+          # broken scan as "system is clean".
           set +e
           nix shell nixpkgs#vulnix --command \
             vulnix --json "$drv" > vulnix.json 2> vulnix.stderr
@@ -122,16 +133,34 @@ jobs:
           echo "vulnix exit code: $rc"
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
 
-          # Normalize empty output to an empty JSON array so jq downstream
-          # never sees a parse error.
-          if [ ! -s vulnix.json ]; then
-            echo '[]' > vulnix.json
-          fi
-
           echo "--- vulnix stderr ---"
           cat vulnix.stderr || true
           echo "--- vulnix json (first 200 lines) ---"
           head -200 vulnix.json || true
+
+          case "$rc" in
+            0|1|2) ;;
+            *)
+              echo "::error::vulnix exited with unexpected code $rc — failing step to avoid masking a broken scan" >&2
+              exit "$rc"
+              ;;
+          esac
+
+          # vulnix prints "[]" for clean scans, but guard anyway in case a
+          # future version emits nothing on stdout.  At this point a missing
+          # file means rc was 0/1/2 (handled above), so it's safe to treat
+          # absence as "no findings".
+          if [ ! -s vulnix.json ]; then
+            echo '[]' > vulnix.json
+          fi
+
+          # Final sanity check: stdout must be valid JSON.  If it isn't,
+          # something is wrong and we must NOT let the aggregator treat
+          # this scan as clean.
+          if ! jq -e 'type == "array"' vulnix.json >/dev/null; then
+            echo "::error::vulnix output is not a JSON array — failing step" >&2
+            exit 1
+          fi
 
       - name: Upload vulnix report
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -147,7 +176,11 @@ jobs:
     name: Update CVE report issue
     runs-on: ubuntu-latest
     needs: [scan]
-    if: ${{ always() && needs.scan.result != 'cancelled' }}
+    # Only aggregate when every matrix job succeeded.  A failed scan must
+    # NOT trigger an issue update — otherwise a system whose scan crashed
+    # would silently disappear from the report and could even cause the
+    # rolling issue to be closed if the surviving scans were clean.
+    if: ${{ needs.scan.result == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -262,27 +295,36 @@ jobs:
 
           title="CVE report"
 
-          # Find existing issue (open OR closed) with exact title and our label
+          # Ensure the cve-report label exists up-front so we can apply it
+          # to the issue regardless of whether we found it by label or by
+          # title fallback.  Idempotent.
+          gh label create cve-report \
+            --color B60205 \
+            --description "Rolling vulnix CVE scan report" \
+            >/dev/null 2>&1 || true
+
+          # Find existing issue by EXACT TITLE only (any state, any labels).
+          # Searching by label was too brittle: if the label gets renamed or
+          # removed manually, we'd create a duplicate issue on the next
+          # non-zero scan.  Title-based lookup means the workflow keeps
+          # finding its own issue even if someone fiddles with labels.
           existing=$(gh issue list \
             --state all \
-            --label cve-report \
             --search "in:title \"$title\"" \
-            --limit 5 \
-            --json number,state,title \
+            --limit 10 \
+            --json number,state,title,labels \
             --jq "[.[] | select(.title == \"$title\")] | first")
 
           number=$(jq -r '.number // empty' <<< "$existing")
           state=$(jq -r '.state // empty' <<< "$existing")
+          has_label=$(jq -r '
+            .labels // [] | map(.name) | index("cve-report") != null
+          ' <<< "$existing")
 
           if [ -z "$number" ]; then
             # No issue yet.  Only create one if we have findings.
             if [ "$TOTAL" -gt 0 ]; then
               echo "Creating new CVE report issue..."
-              # Ensure label exists (idempotent)
-              gh label create cve-report \
-                --color B60205 \
-                --description "Rolling vulnix CVE scan report" \
-                || true
               gh issue create \
                 --title "$title" \
                 --label cve-report \
@@ -293,7 +335,13 @@ jobs:
             exit 0
           fi
 
-          echo "Found existing issue #${number} (state=${state})"
+          echo "Found existing issue #${number} (state=${state}, labelled=${has_label})"
+
+          # Re-apply the label defensively in case it was removed manually.
+          if [ "$has_label" != "true" ]; then
+            echo "cve-report label missing on issue #${number} — re-applying"
+            gh issue edit "$number" --add-label cve-report
+          fi
 
           if [ "$TOTAL" -eq 0 ]; then
             # Update body so the closed issue still reflects the latest scan,

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -1,0 +1,314 @@
+---
+name: CVE scan (vulnix)
+
+# Weekly vulnix scan of every nixosConfiguration + darwinConfiguration in
+# this flake.  Results are aggregated into a single rolling GitHub issue
+# (title: "CVE report") that is updated in place each run, so we never get
+# weekly issue spam.  When zero CVEs are found across all systems, the
+# rolling issue is closed automatically.
+#
+# Scheduled for Monday 07:00 UTC, ~2h after the Sunday update-flakes
+# auto-merge window, so we always scan against the freshly-updated lock.
+
+on:
+  schedule:
+    # Monday 07:00 UTC
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  # =====================================================================
+  # Discover every NixOS + darwin configuration to scan
+  # =====================================================================
+  find-systems:
+    name: Find systems
+    runs-on: ubuntu-latest
+    outputs:
+      systems: ${{ steps.out.outputs.systems }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+
+      - id: out
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          nixos=$(nix eval --json .#nixosConfigurations --apply builtins.attrNames)
+          darwin=$(nix eval --json .#darwinConfigurations --apply 'builtins.attrNames' || echo '[]')
+
+          # Tag each name with its kind so the scan job knows which
+          # attribute path to evaluate.
+          systems=$(jq -cn \
+            --argjson nixos "$nixos" \
+            --argjson darwin "$darwin" \
+            '[
+               ($nixos  | map({kind: "nixos",  name: .})),
+               ($darwin | map({kind: "darwin", name: .}))
+             ] | add')
+
+          echo "Systems to scan: $systems"
+          echo "systems=$systems" >> "$GITHUB_OUTPUT"
+
+  # =====================================================================
+  # Scan each system independently
+  # =====================================================================
+  scan:
+    name: Scan ${{ matrix.system.kind }}/${{ matrix.system.name }}
+    runs-on: ubuntu-latest
+    needs: [find-systems]
+    strategy:
+      fail-fast: false
+      matrix:
+        system: ${{ fromJson(needs.find-systems.outputs.systems) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc "$AGENT_TOOLSDIRECTORY" || true
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+
+      - name: Enable Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+        with:
+          use-flakehub: false
+          use-gha-cache: true
+
+      - name: Run vulnix
+        id: vulnix
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          kind="${{ matrix.system.kind }}"
+          name="${{ matrix.system.name }}"
+
+          case "$kind" in
+            nixos)  attr=".#nixosConfigurations.${name}.config.system.build.toplevel" ;;
+            darwin) attr=".#darwinConfigurations.${name}.system" ;;
+            *)      echo "Unknown kind: $kind" >&2; exit 1 ;;
+          esac
+
+          echo "Building derivation set for ${kind}/${name}..."
+          # We don't actually need to BUILD — vulnix can scan a .drv path.
+          # `nix path-info --derivation` resolves the .drv without building.
+          drv=$(nix path-info --derivation "$attr")
+          echo "Derivation: $drv"
+
+          # vulnix exits 0 when no CVEs, 1 when whitelisted-only, 2 when
+          # un-whitelisted CVEs are present.  We capture all three so the
+          # aggregator job can decide what to do with them.
+          set +e
+          nix shell nixpkgs#vulnix --command \
+            vulnix --json "$drv" > vulnix.json 2> vulnix.stderr
+          rc=$?
+          set -e
+
+          echo "vulnix exit code: $rc"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          # Normalize empty output to an empty JSON array so jq downstream
+          # never sees a parse error.
+          if [ ! -s vulnix.json ]; then
+            echo '[]' > vulnix.json
+          fi
+
+          echo "--- vulnix stderr ---"
+          cat vulnix.stderr || true
+          echo "--- vulnix json (first 200 lines) ---"
+          head -200 vulnix.json || true
+
+      - name: Upload vulnix report
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: vulnix-${{ matrix.system.kind }}-${{ matrix.system.name }}
+          path: vulnix.json
+          retention-days: 30
+
+  # =====================================================================
+  # Aggregate all reports into a single rolling GitHub issue
+  # =====================================================================
+  aggregate:
+    name: Update CVE report issue
+    runs-on: ubuntu-latest
+    needs: [scan]
+    if: ${{ always() && needs.scan.result != 'cancelled' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download all vulnix reports
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          path: reports
+          pattern: vulnix-*
+          merge-multiple: false
+
+      - name: Build markdown report
+        id: report
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          {
+            echo "# CVE report"
+            echo
+            echo "_Last updated: $(date -u +'%Y-%m-%d %H:%M UTC') — [run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
+            echo
+          } > body.md
+
+          total=0
+          systems_with_cves=()
+
+          shopt -s nullglob
+          for dir in reports/vulnix-*/; do
+            artifact=$(basename "$dir")
+            # artifact name is "vulnix-<kind>-<name>"
+            spec=${artifact#vulnix-}
+            kind=${spec%%-*}
+            name=${spec#*-}
+            json="${dir}vulnix.json"
+            [ -f "$json" ] || continue
+
+            count=$(jq 'if type == "array" then length else 0 end' "$json")
+            total=$((total + count))
+
+            if [ "$count" -gt 0 ]; then
+              systems_with_cves+=("${kind}/${name}:${count}")
+            fi
+          done
+
+          {
+            if [ "$total" -eq 0 ]; then
+              echo "## No vulnerabilities found"
+              echo
+              echo "All scanned systems are clean."
+              echo
+            else
+              echo "## ${total} vulnerable derivations across ${#systems_with_cves[@]} system(s)"
+              echo
+            fi
+
+            echo "## Per-system summary"
+            echo
+            echo "| System | Vulnerable derivations |"
+            echo "| --- | --- |"
+            for dir in reports/vulnix-*/; do
+              artifact=$(basename "$dir")
+              spec=${artifact#vulnix-}
+              kind=${spec%%-*}
+              name=${spec#*-}
+              json="${dir}vulnix.json"
+              [ -f "$json" ] || continue
+              count=$(jq 'if type == "array" then length else 0 end' "$json")
+              echo "| \`${kind}/${name}\` | ${count} |"
+            done
+            echo
+
+            if [ "$total" -gt 0 ]; then
+              echo "## Details"
+              echo
+              for dir in reports/vulnix-*/; do
+                artifact=$(basename "$dir")
+                spec=${artifact#vulnix-}
+                kind=${spec%%-*}
+                name=${spec#*-}
+                json="${dir}vulnix.json"
+                [ -f "$json" ] || continue
+                count=$(jq 'if type == "array" then length else 0 end' "$json")
+                [ "$count" -eq 0 ] && continue
+
+                echo "<details><summary><strong>${kind}/${name}</strong> — ${count} item(s)</summary>"
+                echo
+                echo "| Derivation | CVEs |"
+                echo "| --- | --- |"
+                jq -r '
+                  .[]? |
+                  "| `\(.name // .pname // "unknown")` | \((.affected_by // []) | join(", ")) |"
+                ' "$json"
+                echo
+                echo "</details>"
+                echo
+              done
+            fi
+          } >> body.md
+
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+
+          echo "--- report body ---"
+          cat body.md
+
+      - name: Find or update CVE report issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ steps.report.outputs.total }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          title="CVE report"
+
+          # Find existing issue (open OR closed) with exact title and our label
+          existing=$(gh issue list \
+            --state all \
+            --label cve-report \
+            --search "in:title \"$title\"" \
+            --limit 5 \
+            --json number,state,title \
+            --jq "[.[] | select(.title == \"$title\")] | first")
+
+          number=$(jq -r '.number // empty' <<< "$existing")
+          state=$(jq -r '.state // empty' <<< "$existing")
+
+          if [ -z "$number" ]; then
+            # No issue yet.  Only create one if we have findings.
+            if [ "$TOTAL" -gt 0 ]; then
+              echo "Creating new CVE report issue..."
+              # Ensure label exists (idempotent)
+              gh label create cve-report \
+                --color B60205 \
+                --description "Rolling vulnix CVE scan report" \
+                || true
+              gh issue create \
+                --title "$title" \
+                --label cve-report \
+                --body-file body.md
+            else
+              echo "No issue exists and no CVEs found — nothing to do."
+            fi
+            exit 0
+          fi
+
+          echo "Found existing issue #${number} (state=${state})"
+
+          if [ "$TOTAL" -eq 0 ]; then
+            # Update body so the closed issue still reflects the latest scan,
+            # then close it if it's open.
+            gh issue edit "$number" --body-file body.md
+            if [ "$state" = "OPEN" ]; then
+              echo "Closing issue (zero CVEs)..."
+              gh issue close "$number" \
+                --comment "Latest scan found zero vulnerable derivations. Closing."
+            fi
+          else
+            gh issue edit "$number" --body-file body.md
+            if [ "$state" = "CLOSED" ]; then
+              echo "Reopening issue (CVEs detected)..."
+              gh issue reopen "$number" \
+                --comment "New CVEs detected — see updated body."
+            fi
+          fi

--- a/.github/workflows/update-flakes.yaml
+++ b/.github/workflows/update-flakes.yaml
@@ -30,10 +30,10 @@ jobs:
     name: Get Flake Inputs
     runs-on: ubuntu-latest
     outputs:
-      auto-inputs: ${{ steps.split.outputs.auto-inputs }}
-      manual-inputs: ${{ steps.split.outputs.manual-inputs }}
-      run-auto: ${{ steps.dispatch.outputs.run-auto }}
-      run-manual: ${{ steps.dispatch.outputs.run-manual }}
+      auto_inputs: ${{ steps.split.outputs.auto_inputs }}
+      manual_inputs: ${{ steps.split.outputs.manual_inputs }}
+      run_auto: ${{ steps.dispatch.outputs.run_auto }}
+      run_manual: ${{ steps.dispatch.outputs.run_manual }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -53,8 +53,8 @@ jobs:
             '$all | map(select(. as $i | $m | index($i)))')
           auto=$(jq -nc --argjson all "$all" --argjson m "$MANUAL_INPUTS" \
             '$all | map(select(. as $i | $m | index($i) | not))')
-          echo "auto-inputs={\"flake\": $auto}"     >> "$GITHUB_OUTPUT"
-          echo "manual-inputs={\"flake\": $manual}" >> "$GITHUB_OUTPUT"
+          echo "auto_inputs={\"flake\": $auto}"     >> "$GITHUB_OUTPUT"
+          echo "manual_inputs={\"flake\": $manual}" >> "$GITHUB_OUTPUT"
 
       - id: dispatch
         # Decide which downstream jobs run based on the trigger.
@@ -84,18 +84,18 @@ jobs:
               esac
               ;;
           esac
-          echo "run-auto=$run_auto"     >> "$GITHUB_OUTPUT"
-          echo "run-manual=$run_manual" >> "$GITHUB_OUTPUT"
+          echo "run_auto=$run_auto"     >> "$GITHUB_OUTPUT"
+          echo "run_manual=$run_manual" >> "$GITHUB_OUTPUT"
 
   update-auto:
     name: update-auto-${{ matrix.flake }}
     runs-on: ubuntu-latest
     needs: get-flake-inputs
-    if: needs.get-flake-inputs.outputs.run-auto == 'true'
+    if: needs.get-flake-inputs.outputs.run_auto == 'true'
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.get-flake-inputs.outputs.auto-inputs) }}
+      matrix: ${{ fromJson(needs.get-flake-inputs.outputs.auto_inputs) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -127,11 +127,11 @@ jobs:
     name: update-manual-${{ matrix.flake }}
     runs-on: ubuntu-latest
     needs: get-flake-inputs
-    if: needs.get-flake-inputs.outputs.run-manual == 'true'
+    if: needs.get-flake-inputs.outputs.run_manual == 'true'
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.get-flake-inputs.outputs.manual-inputs) }}
+      matrix: ${{ fromJson(needs.get-flake-inputs.outputs.manual_inputs) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-flakes.yaml
+++ b/.github/workflows/update-flakes.yaml
@@ -3,8 +3,23 @@ name: update-flakes
 
 on:
   schedule:
+    # Weekly auto-merge run for everything except the manual-merge inputs.
     - cron: "0 5 * * 0"
+    # Monthly run for the manual-merge inputs (currently: nixpkgs-kernel).
+    # Server kernel bumps require a planned reboot, so they get reviewed
+    # by hand instead of riding the auto-merge train.
+    - cron: "0 6 1 * *"
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Which input set to update"
+        type: choice
+        required: true
+        default: "auto"
+        options:
+          - auto
+          - manual
+          - both
 
 permissions:
   contents: write
@@ -15,7 +30,10 @@ jobs:
     name: Get Flake Inputs
     runs-on: ubuntu-latest
     outputs:
-      flake-inputs: ${{ steps.get-flake-inputs.outputs.flake-inputs }}
+      auto-inputs: ${{ steps.split.outputs.auto-inputs }}
+      manual-inputs: ${{ steps.split.outputs.manual-inputs }}
+      run-auto: ${{ steps.dispatch.outputs.run-auto }}
+      run-manual: ${{ steps.dispatch.outputs.run-manual }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,19 +41,61 @@ jobs:
           sparse-checkout: flake.lock
           persist-credentials: false
 
-      - id: get-flake-inputs
+      - id: split
+        # Single source of truth for which inputs are manual-merge.  Add a
+        # name to MANUAL_INPUTS to move it out of the weekly auto-merge run
+        # and into the monthly manual-review run.
+        env:
+          MANUAL_INPUTS: '["nixpkgs-kernel"]'
         run: |
-          flake_inputs="$(jq -c '.nodes.root.inputs | {flake: keys}' flake.lock)"
-          echo "flake-inputs=${flake_inputs}" >> "$GITHUB_OUTPUT"
+          all=$(jq -c '.nodes.root.inputs | keys' flake.lock)
+          manual=$(jq -nc --argjson all "$all" --argjson m "$MANUAL_INPUTS" \
+            '$all | map(select(. as $i | $m | index($i)))')
+          auto=$(jq -nc --argjson all "$all" --argjson m "$MANUAL_INPUTS" \
+            '$all | map(select(. as $i | $m | index($i) | not))')
+          echo "auto-inputs={\"flake\": $auto}"     >> "$GITHUB_OUTPUT"
+          echo "manual-inputs={\"flake\": $manual}" >> "$GITHUB_OUTPUT"
 
-  update-flake:
-    name: update-${{ matrix.flake }}
+      - id: dispatch
+        # Decide which downstream jobs run based on the trigger.
+        # - schedule "0 5 * * 0"   -> weekly auto run
+        # - schedule "0 6 1 * *"   -> monthly manual run
+        # - workflow_dispatch      -> honor the `target` input
+        env:
+          EVENT: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+          TARGET: ${{ github.event.inputs.target }}
+        run: |
+          run_auto=false
+          run_manual=false
+          case "$EVENT" in
+            schedule)
+              if [[ "$SCHEDULE" == "0 5 * * 0" ]]; then
+                run_auto=true
+              elif [[ "$SCHEDULE" == "0 6 1 * *" ]]; then
+                run_manual=true
+              fi
+              ;;
+            workflow_dispatch)
+              case "$TARGET" in
+                auto)   run_auto=true ;;
+                manual) run_manual=true ;;
+                both)   run_auto=true; run_manual=true ;;
+              esac
+              ;;
+          esac
+          echo "run-auto=$run_auto"     >> "$GITHUB_OUTPUT"
+          echo "run-manual=$run_manual" >> "$GITHUB_OUTPUT"
+
+  update-auto:
+    name: update-auto-${{ matrix.flake }}
     runs-on: ubuntu-latest
     needs: get-flake-inputs
+    if: needs.get-flake-inputs.outputs.run-auto == 'true'
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.get-flake-inputs.outputs.flake-inputs) }}
+      matrix: ${{ fromJson(needs.get-flake-inputs.outputs.auto-inputs) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,3 +122,39 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-branch-prefix: update-
           automerge: true
+
+  update-manual:
+    name: update-manual-${{ matrix.flake }}
+    runs-on: ubuntu-latest
+    needs: get-flake-inputs
+    if: needs.get-flake-inputs.outputs.run-manual == 'true'
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-flake-inputs.outputs.manual-inputs) }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+          ref: main
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: accept-flake-config = true
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github[bot]"
+
+      - uses: fredsystems/flake-update-action@76d4f6b1d4d924c9ff073075b685d96474fb87f2 # v3.0.4
+        with:
+          dependency: ${{ matrix.flake }}
+          pull-request-token: ${{ secrets.PAT }}
+          pull-request-author: github[bot] <noreply@github.com>
+          delete-branch: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-branch-prefix: update-
+          automerge: false

--- a/flake.lock
+++ b/flake.lock
@@ -1138,6 +1138,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-kernel": {
+      "locked": {
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1777077449,
@@ -1486,6 +1502,7 @@
         "niri": "niri",
         "nixos-needsreboot": "nixos-needsreboot",
         "nixpkgs": "nixpkgs_10",
+        "nixpkgs-kernel": "nixpkgs-kernel",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixvim": "nixvim",
         "precommit-base": "precommit-base",

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,18 @@
     };
 
     # CI: server
+    #
+    # Pinned-kernel input.  Tracks the same nixos-25.11 channel as
+    # nixpkgs-stable but lives as its own flake input so the kernel can be
+    # bumped on its own cadence (monthly, manual-merge PR via the
+    # update-flakes workflow) instead of riding the weekly auto-merged
+    # nixpkgs-stable bump.  Servers consume linuxPackages_6_12 from this
+    # input via modules/system/kernel-pin.nix.
+    nixpkgs-kernel = {
+      url = "github:nixos/nixpkgs/nixos-25.11";
+    };
+
+    # CI: server
     home-manager-stable = {
       url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs-stable";
@@ -136,6 +148,7 @@
       self,
       nixpkgs,
       nixpkgs-stable,
+      nixpkgs-kernel,
       home-manager,
       home-manager-stable,
       catppuccin,
@@ -228,6 +241,7 @@
           forAllSystems
           # Channel inputs used as defaults for server nodes
           nixpkgs-stable
+          nixpkgs-kernel
           home-manager-stable
           catppuccin-stable
           sops-nix-stable

--- a/flake/deployment/colmena.nix
+++ b/flake/deployment/colmena.nix
@@ -38,6 +38,7 @@ let
     nixpkgs
     catppuccin-stable
     sops-nix-stable
+    nixpkgs-kernel
     ;
 
   # The colmena flake input — renamed to avoid clashing with the `colmena`
@@ -116,6 +117,7 @@ let
         extraUsers = [ ];
         catppuccinInput = catppuccin-stable;
         sopsNixInput = sops-nix-stable;
+        kernelPkgsInput = nixpkgs-kernel;
         catppuccinWallpapers = self.packages."x86_64-linux".catppuccin-wallpapers;
       };
 

--- a/flake/lib/mk-system.nix
+++ b/flake/lib/mk-system.nix
@@ -30,6 +30,8 @@
 #   hmInput          = inputs.home-manager     (unstable)
 #   catppuccinInput  = inputs.catppuccin       (unstable)
 #   sopsNixInput     = inputs.sops-nix         (unstable)
+#   kernelPkgsInput  = inputs.nixpkgs-kernel   (server kernel pin source;
+#                                               unused on desktops)
 #   isDesktop        = false  – gates the desktop package tree
 {
   inputs,
@@ -55,6 +57,7 @@
   hmInput ? inputs.home-manager,
   catppuccinInput ? inputs.catppuccin,
   sopsNixInput ? inputs.sops-nix,
+  kernelPkgsInput ? inputs.nixpkgs-kernel,
   isDesktop ? false,
 }:
 let
@@ -77,6 +80,7 @@ let
       isDesktop
       catppuccinInput
       sopsNixInput
+      kernelPkgsInput
       isDarwin
       ;
 

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -17,6 +17,7 @@ in
     ++ lib.optional isLinux catppuccinInput.nixosModules.catppuccin
     ++ lib.optional isLinux ../../features
     ++ lib.optional isLinux ../../modules/base/user.nix
+    ++ lib.optional isLinux ../../modules/system/kernel-pin.nix
     ++ lib.optional isLinux ./catppuccin.nix;
 
   nix = {

--- a/modules/system/kernel-pin.nix
+++ b/modules/system/kernel-pin.nix
@@ -1,0 +1,38 @@
+# modules/system/kernel-pin.nix
+#
+# Pin the kernel on Linux server hosts to the LTS 6.12 line, sourced from a
+# dedicated `nixpkgs-kernel` flake input rather than the host's normal pkgs
+# tree.  This decouples kernel bumps (which require a reboot to take effect)
+# from the weekly auto-merged nixpkgs-stable churn, so kernel updates land
+# on their own monthly, manual-merge cadence via .github/workflows/update-flakes.yaml.
+#
+# Scope:
+#   * Servers (isDesktop = false, isDarwin = false): pin applied.
+#   * Desktops / laptops (isDesktop = true): no-op.  Daytona and maranello
+#     keep their own boot.kernelPackages = pkgs.linuxPackages_latest.
+#   * Darwin (isDarwin = true): no-op.
+#
+# The pin uses lib.mkDefault so an individual server can still override
+# (e.g. to test a newer kernel) by setting boot.kernelPackages explicitly.
+{
+  lib,
+  kernelPkgsInput,
+  system,
+  isDesktop ? false,
+  isDarwin ? false,
+  ...
+}:
+let
+  pinActive = !isDesktop && !isDarwin;
+
+  # Import the kernel-pin nixpkgs once per host.  We only need the kernel
+  # attributes; this is a separate evaluation from the host's main pkgs
+  # tree but shares the cache.nixos.org binary cache because it points at
+  # a real nixpkgs commit.
+  kernelPkgs = import kernelPkgsInput { inherit system; };
+in
+{
+  config = lib.mkIf pinActive {
+    boot.kernelPackages = lib.mkDefault kernelPkgs.linuxPackages_6_12;
+  };
+}


### PR DESCRIPTION
## Summary

Three logically-independent changes shipped together because they were investigated in the same session:

1. **`feat(kernel)`** — pin server kernel to `nixos-25.11` with a separate manual-merge update cadence.
2. **`chore(renovate)`** — remove `lockFileMaintenance` (redundant with `update-flakes` and would bypass the kernel pin).
3. **`feat(ci)`** — add a weekly `vulnix` CVE scan that aggregates results into a single rolling GitHub issue.

Atomic commits — review/revert each independently.

## 1. Server kernel pin

**Why**: Kernel updates require planned reboots. Auto-merging weekly nixpkgs bumps onto the kernel input was causing servers to be one reboot away from a new kernel at all times. We want kernel bumps as **monthly manual-review PRs** while keeping all other inputs on the existing weekly auto-merge cadence.

**How**:
- New `nixpkgs-kernel` flake input tracking `nixos-25.11` (same channel as `nixpkgs-stable` → cache.nixos.org hits intact).
- Threaded through `specialArgs` as `kernelPkgsInput` to the new `modules/system/kernel-pin.nix`.
- Module sets `boot.kernelPackages = linuxPackages_6_12` with `lib.mkDefault`, gated on `!isDesktop && !isDarwin`. Desktops (`Daytona`, `maranello`) keep their existing `linuxPackages_latest` override; darwin unaffected.
- `update-flakes.yaml` split into auto/manual matrices via a single `MANUAL_INPUTS='["nixpkgs-kernel"]'` env var (single source of truth):
  - **auto** matrix → Sun 05:00 UTC, `automerge: true` (existing behavior, all other inputs)
  - **manual** matrix → 1st of month 06:00 UTC, `automerge: false` (kernel only)
  - `workflow_dispatch` now offers `auto` / `manual` / `both` choice
- Trailing Renovate `packageRule` disables `nixpkgs-kernel` for the `nix` manager (must be last — Renovate evaluates rules in order, later wins).

**Verified**:
- All 7 servers resolve to kernel `6.12.84`.
- `Daytona` stays on `7.0.1` (linuxPackages_latest).
- darwin still evaluates.
- Colmena hive still evaluates.
- Workflows lint clean (`actionlint`, `yamllint`).

## 2. `lockFileMaintenance` removal

**Why**: Originally suspected `update-flakes` was missing some inputs (`colmena`, `pre-commit-hooks` showed zero merged PRs). Investigation of `flake-update-action`'s `action.yml` and the actual job logs from run `24950582443` proved the action covers every input — those low-PR inputs simply hadn't moved upstream during scan windows.

`lockFileMaintenance` is therefore redundant. It is also actively harmful now that `nixpkgs-kernel` is pinned, because `lockFileMaintenance` ignores per-package `enabled: false` rules and would wholesale-rewrite `flake.lock`, bypassing the manual-merge cadence.

Replaced with an inline comment documenting the rationale.

## 3. Weekly vulnix CVE scan

**Why**: Visibility into known CVEs against the locked nixpkgs commits, so we don't drift indefinitely on a known-vulnerable kernel/stack between flake updates.

**How**:
- `.github/workflows/cve-scan.yaml`, scheduled Monday 07:00 UTC (~2h after Sunday auto-merges land — always scans the freshly-updated lock).
- Discovers every `nixosConfiguration` (9) and `darwinConfiguration` (2) dynamically via `nix eval` on `attrNames`. Auto-extends as hosts are added.
- Runs on `ubuntu-latest` (free) — no actual build required. `nix path-info --derivation` resolves the `.drv` graph, vulnix scans the requisite tree directly.
- Magic Nix Cache speeds up evaluation across runs.
- Per-system `vulnix.json` artifacts retained 30 days for forensic review.
- **Single rolling GitHub issue** (`title: "CVE report"`, `label: cve-report`):
  - Found existing issue → edits body in place.
  - Total CVEs hits 0 → closes the issue.
  - New CVEs appear after a clean run → reopens.
  - No issue at all + no findings → does nothing.

**Verified locally**:
- vulnix exits 2 when CVEs found, captured under `set +e` so matrix jobs stay green.
- Real run on `fredvps`: 132 vulnerable derivations, valid JSON output, schema matches the markdown template (`affected_by`, `name`, `pname`, etc.).
- `actionlint` clean.

## Original blocker (separately resolved)

Session was triggered by `nixos-rebuild switch` on Daytona being blocked by the `dbus-implementation: dbus -> broker` switch inhibitor. Resolved out-of-band with `nixos-rebuild boot` + reboot — confirmed working by user.