### PR TITLE
fix(zed): pin file tree to left, migrate deprecated settings

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -2,3 +2,4 @@ noice
 nd
 edn
 ags
+deriver

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -249,7 +249,7 @@ jobs:
       - name: Build markdown report
         id: report
         env:
-          EXPECTED_NIXOS:  ${{ needs.find-systems.outputs.nixos }}
+          EXPECTED_NIXOS: ${{ needs.find-systems.outputs.nixos }}
         shell: bash
         run: |
           set -euo pipefail
@@ -520,7 +520,7 @@ jobs:
       - name: Find or update CVE report issue
         env:
           GH_TOKEN: ${{ github.token }}
-          TOTAL:   ${{ steps.report.outputs.total }}
+          TOTAL: ${{ steps.report.outputs.total }}
           MISSING: ${{ steps.report.outputs.missing }}
         shell: bash
         run: |

--- a/features/desktop/zed/default.nix
+++ b/features/desktop/zed/default.nix
@@ -97,8 +97,8 @@ in
           };
 
           show_edit_predictions = true;
-          features = {
-            edit_prediction_provider = "copilot";
+          edit_predictions = {
+            provider = "copilot";
           };
 
           load_direnv = "shell_hook";
@@ -119,7 +119,9 @@ in
           # AI / Agent configuration (THIS IS THE ONLY VALID AI TOP-LEVEL KEY)
           ##########################################################################
           agent = {
-            always_allow_tool_actions = true;
+            tool_permissions = {
+              default = "allow";
+            };
 
             default_model = {
               provider = "copilot_chat";

--- a/features/desktop/zed/default.nix
+++ b/features/desktop/zed/default.nix
@@ -107,6 +107,14 @@ in
           ui_font_size = 14;
           buffer_font_size = 14;
 
+          # Zed flipped the upstream default for the project / outline / git /
+          # collaboration panels to "right" (see assets/settings/default.json
+          # in zed v0.233.10). Pin the file tree back to the left.
+          project_panel.dock = "left";
+          outline_panel.dock = "left";
+          git_panel.dock = "left";
+          collaboration_panel.dock = "left";
+
           ##########################################################################
           # AI / Agent configuration (THIS IS THE ONLY VALID AI TOP-LEVEL KEY)
           ##########################################################################


### PR DESCRIPTION
## Summary
- Pin `project_panel`, `outline_panel`, `git_panel`, `collaboration_panel` to `dock = "left"`. Zed v0.233.10 flipped these upstream defaults to `"right"`, which moved the file tree on rebuild.
- Migrate two deprecated keys that triggered Zed's "settings migrated" banner on every reload:
  - `features.edit_prediction_provider` → `edit_predictions.provider` (zed migrator `m_2026_02_02`)
  - `agent.always_allow_tool_actions = true` → `agent.tool_permissions.default = "allow"` (zed migrator `m_2026_02_04`)

## Verification
- File tree returned to the left after `home-manager switch`.
- Deprecation banner did not reappear on next rebuild.