### PR TITLE
chore(flake/catppuccin): `e82c195f` -> `a199649e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777505151,
-        "narHash": "sha256-ul1iRBfVX2vc971tHHhVtxX2hycU3nVwgO005OcOKnw=",
+        "lastModified": 1777637913,
+        "narHash": "sha256-IV0MJUCncmFUpcRRoHR11gK6VR+hpN/Vtaz91+dsPPE=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "e82c195f2276825b0a08024fdaff80f965edcd69",
+        "rev": "a199649e9941490ab712aa891c144e305d165ef8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`a199649e`](https://github.com/catppuccin/nix/commit/a199649e9941490ab712aa891c144e305d165ef8) | `` fix: convert lastModified to string (#914) ``                                        |
| [`62382bcc`](https://github.com/catppuccin/nix/commit/62382bccfce7ddd67d7419fb90cc5b3cd437b17f) | `` chore: update flakes (#911) ``                                                       |
| [`0085b57b`](https://github.com/catppuccin/nix/commit/0085b57b51028a9d5fb789068b9f3a2f2e654505) | `` chore: update port sources (#912) ``                                                 |
| [`b2d0b8cc`](https://github.com/catppuccin/nix/commit/b2d0b8ccbe1f3af05252716d5069364fb88e0386) | `` fix(home-manager/wezterm): add settings & handle programs.wezterm.settings (#910) `` |