### PR TITLE
chore(flake/nixpkgs-stable): `a4bf0661` -> `755f5aa9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1172,11 +1172,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1777077449,
-        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`b6184609`](https://github.com/NixOS/nixpkgs/commit/b6184609474fae79b32e99341117194a1a4645ad) | `` chromium,chromedriver: 147.0.7727.116 -> 147.0.7727.137 ``                       |
| [`6277515b`](https://github.com/NixOS/nixpkgs/commit/6277515b34cedf609dd2552731726d4dd5330485) | `` ueransim: 3.2.6 -> 3.2.8 ``                                                      |
| [`dcf8e2f3`](https://github.com/NixOS/nixpkgs/commit/dcf8e2f328801ead6213ee61db898a702ec2803e) | `` talosctl: remove myself from maintainers ``                                      |
| [`21526929`](https://github.com/NixOS/nixpkgs/commit/21526929c3c66039688c17feb75cfa74f50bcdeb) | `` talosctl: 1.12.5 -> 1.12.6 ``                                                    |
| [`aa41eb83`](https://github.com/NixOS/nixpkgs/commit/aa41eb839a3b524378ef6771509abe3bbf1f7146) | `` talosctl: add johanot as maintainer ``                                           |
| [`9ad0193d`](https://github.com/NixOS/nixpkgs/commit/9ad0193d37b85659afab4b639ae3664d92a91364) | `` talosctl: 1.12.4 -> 1.12.5 ``                                                    |
| [`468ea456`](https://github.com/NixOS/nixpkgs/commit/468ea456c1530b53c5032778a0975ae5e0c98e96) | `` talosctl: 1.12.3 -> 1.12.4 ``                                                    |
| [`6b82ffa6`](https://github.com/NixOS/nixpkgs/commit/6b82ffa613ff16eb27979b868e1c0592bb329832) | `` talosctl: 1.12.2 -> 1.12.3 ``                                                    |
| [`fa780b40`](https://github.com/NixOS/nixpkgs/commit/fa780b402aea2876f22ae2ec7a8427c62c8960ac) | `` various: switch buildGoModule packages to use finalAttrs ``                      |
| [`d3564785`](https://github.com/NixOS/nixpkgs/commit/d356478501d096aadfb8fab7dc79da9f475b8364) | `` talosctl: 1.12.0 -> 1.12.2 ``                                                    |
| [`662352b7`](https://github.com/NixOS/nixpkgs/commit/662352b7a5f83d43ce1430ffb58e72db0b670eaf) | `` talosctl: 1.11.6 -> 1.12.0 ``                                                    |
| [`e6a5312a`](https://github.com/NixOS/nixpkgs/commit/e6a5312ae8bf5abef071a940434afe6583be88c1) | `` talosctl: 1.11.5 -> 1.11.6 ``                                                    |
| [`82ae2f55`](https://github.com/NixOS/nixpkgs/commit/82ae2f551cab1aa04dbd06da222b44a29d5b9abf) | `` ueransim: backport `gcc-15` fix ``                                               |
| [`890545d1`](https://github.com/NixOS/nixpkgs/commit/890545d183b02a21997be93f120c8590f0c36563) | `` mullvad-browser: 15.0.10 -> 15.0.11 ``                                           |
| [`109b34f5`](https://github.com/NixOS/nixpkgs/commit/109b34f5e578b1ab2c83e2c24d03d1506ffa736f) | `` firefox-bin-unwrapped: 150.0 -> 150.0.1 ``                                       |
| [`a106b4b2`](https://github.com/NixOS/nixpkgs/commit/a106b4b20aab1e360789b6df4371a68b82c4c507) | `` firefox-unwrapped: 150.0 -> 150.0.1 ``                                           |
| [`8564bda3`](https://github.com/NixOS/nixpkgs/commit/8564bda374aa9425f586026388edd4a768a40936) | `` victoriametrics: 1.140.0 -> 1.141.0 ``                                           |
| [`8ec433ff`](https://github.com/NixOS/nixpkgs/commit/8ec433ffbc9989a70b7c7dd514789a429e13e42e) | `` brave: 1.89.137 -> 1.89.143 ``                                                   |
| [`4ea21e0e`](https://github.com/NixOS/nixpkgs/commit/4ea21e0e45a158914c8ee648fbbfc6c35960a903) | `` perlPackages.CryptX: 0.087 -> 0.088 ``                                           |
| [`2512095e`](https://github.com/NixOS/nixpkgs/commit/2512095e28d871d0c8284794a5aaeb33e1b257e2) | `` drupal: 11.2.8 -> 11.2.11 ``                                                     |
| [`8d618900`](https://github.com/NixOS/nixpkgs/commit/8d6189008c3f43368dc4a94b55bafe0b8622d037) | `` mattermost-desktop: 6.1.1 -> 6.1.2 ``                                            |
| [`d6e02e9c`](https://github.com/NixOS/nixpkgs/commit/d6e02e9ce8eb10bcd35c016cf7fa430706f179a3) | `` linux_6_6: 6.6.135 -> 6.6.136 ``                                                 |
| [`f17294da`](https://github.com/NixOS/nixpkgs/commit/f17294da63cd429c2defccb2243fafc2e6dbbd6f) | `` linux_6_12: 6.12.83 -> 6.12.84 ``                                                |
| [`6e7da333`](https://github.com/NixOS/nixpkgs/commit/6e7da33329d89b52d83c141f0dcee854fee69614) | `` linux_6_18: 6.18.24 -> 6.18.25 ``                                                |
| [`ac73ef74`](https://github.com/NixOS/nixpkgs/commit/ac73ef74b49fd5fc0dcc42d694930a8184abf879) | `` linux_7_0: 7.0.1 -> 7.0.2 ``                                                     |
| [`55e28d69`](https://github.com/NixOS/nixpkgs/commit/55e28d6925ba570d9b4fac873e140f51fa905e99) | `` wayle: 0.2.1 -> 0.2.3 ``                                                         |
| [`147a3fcc`](https://github.com/NixOS/nixpkgs/commit/147a3fcc0ddf557796e8c6f57e72ea6c26088996) | `` gleam: 1.15.4 -> 1.16.0 ``                                                       |
| [`a0475215`](https://github.com/NixOS/nixpkgs/commit/a0475215f5a39f70b1527275923ff8355cf2ff02) | `` nixos/modules/profiles/nix-builder-vm: remove suffix from system version ``      |
| [`95abfd84`](https://github.com/NixOS/nixpkgs/commit/95abfd84d1cb3b1f7de8e5a8934d41e74649ef6c) | `` modrinth-app-unwrapped: 0.12.6 -> 0.13.3 ``                                      |
| [`cafc0693`](https://github.com/NixOS/nixpkgs/commit/cafc06934eb29765dbde88bc0da8e3f9abc82ccf) | `` moonlight: 2026.3.3 -> 2026.4.0 ``                                               |
| [`299f55b7`](https://github.com/NixOS/nixpkgs/commit/299f55b767cac910877da3bb021d165f38f1a3ee) | `` vaultwarden.webvault: 2026.2.0+0 -> 2026.3.1+0 ``                                |
| [`47025c47`](https://github.com/NixOS/nixpkgs/commit/47025c47019c28a6f78c5ecfcd6ff7206efd3e64) | `` vaultwarden: 1.35.7 -> 1.35.8 ``                                                 |
| [`55f27dbe`](https://github.com/NixOS/nixpkgs/commit/55f27dbecc3686f983095250242a7b86de8476ef) | `` signal-desktop: 8.6.1 -> 8.8.0 ``                                                |
| [`51a1e4bb`](https://github.com/NixOS/nixpkgs/commit/51a1e4bb3b777bb81c5e684d981f8646a7605ee6) | `` chatzone-desktop: 5.6.0 -> 5.6.1 ``                                              |
| [`1d60e8a9`](https://github.com/NixOS/nixpkgs/commit/1d60e8a957769c8bcccfcb0626cf11e7902331b4) | `` wayle: init at 0.2.1 ``                                                          |
| [`78308ed6`](https://github.com/NixOS/nixpkgs/commit/78308ed6f36f2c89ae2c8b87e0c0e1b232a5bb32) | `` rpcs3: update `meta.license` ``                                                  |
| [`01e7601d`](https://github.com/NixOS/nixpkgs/commit/01e7601dcdac2bc5ef6d5835f979d5b7dcfd71d3) | `` forge-mtg: 2.0.11 -> 2.0.12 ``                                                   |
| [`0093c2a3`](https://github.com/NixOS/nixpkgs/commit/0093c2a3322e747e7779a7aa86305b54dff1b45d) | `` python3Packages.authlib: 1.6.9 -> 1.6.11 ``                                      |
| [`d7d55982`](https://github.com/NixOS/nixpkgs/commit/d7d55982d5cd96e0a46b852ae16457508501bea5) | `` floorp-bin-unwrapped: 12.12.1 -> 12.12.2 ``                                      |
| [`814aebf0`](https://github.com/NixOS/nixpkgs/commit/814aebf0fa07097ce4b11f156a1cbb19791ebfcc) | `` resources: 1.9.0 -> 1.9.1 ``                                                     |
| [`9397cf6f`](https://github.com/NixOS/nixpkgs/commit/9397cf6ff5e28ce1acc8f49f56680165400d7161) | `` [Backport release-25.11] ollama: 0.12.11 -> 0.21.1 ``                            |
| [`cc7107b4`](https://github.com/NixOS/nixpkgs/commit/cc7107b4dd7a4ff365748d1cc69b5edf4982243e) | `` liferea: 1.16.7 -> 1.16.8 ``                                                     |
| [`4faef223`](https://github.com/NixOS/nixpkgs/commit/4faef2236e17e51a8ba2ffe691731bdd8a4de951) | `` liferea: 1.16.6 -> 1.16.7 ``                                                     |
| [`1183cb02`](https://github.com/NixOS/nixpkgs/commit/1183cb027673ea27eee16ed1ddc0ceab56b5410e) | `` impression: 3.5.4 -> 3.5.5 ``                                                    |
| [`ae8faece`](https://github.com/NixOS/nixpkgs/commit/ae8faecef97e9112694c0e3feecd110a425c963c) | `` elastic: 1.0.1 -> 1.0.2 ``                                                       |
| [`15bf6575`](https://github.com/NixOS/nixpkgs/commit/15bf657547839cdef32ab1c49f86e0a741d8440f) | `` mattermost-desktop: add yayayayaka to maintainers ``                             |
| [`45eaa760`](https://github.com/NixOS/nixpkgs/commit/45eaa76051c302a75401d23b887a6d29e72ed714) | `` msolve: guard SIMD instructions ``                                               |
| [`4dc5ab97`](https://github.com/NixOS/nixpkgs/commit/4dc5ab978c53593001446f4fbbf7f729e2829f9c) | `` nh: 4.3.1 -> 4.3.2 ``                                                            |
| [`bc1db5c8`](https://github.com/NixOS/nixpkgs/commit/bc1db5c8a8d6b595bcaca257c0f7af41fc4ccd2f) | `` nh: 4.3.0 -> 4.3.1 ``                                                            |
| [`c32e399a`](https://github.com/NixOS/nixpkgs/commit/c32e399a37e5ac0cb4353f290c5e22ccfc368e10) | `` nh: fix postInstall cleanup ``                                                   |
| [`f989230d`](https://github.com/NixOS/nixpkgs/commit/f989230df8af429ca4bd38f8303d4a489344203a) | `` qtcreator: 19.0.0 -> 19.0.1 ``                                                   |
| [`faa60c5d`](https://github.com/NixOS/nixpkgs/commit/faa60c5d45e92dc26946a03e5a4d53a63e000192) | `` python3Packages.pypdf: 6.10.0 -> 6.10.2 ``                                       |
| [`7796a99d`](https://github.com/NixOS/nixpkgs/commit/7796a99d3cd6c15ed5d9b6e5e91276990e6b4052) | `` openlist: 4.1.10 -> 4.2.1 ``                                                     |
| [`201c0206`](https://github.com/NixOS/nixpkgs/commit/201c02065028c70f6c315c49c9a37570846df980) | `` openlist.frontend: switch to buildNpmPackage ``                                  |
| [`cbf444c4`](https://github.com/NixOS/nixpkgs/commit/cbf444c485413ddebb6b34a529ecce6a2c158e61) | `` nixos: Set mmap ASLR entropy to a safe default on AArch64 ``                     |
| [`28d15edf`](https://github.com/NixOS/nixpkgs/commit/28d15edf5fb7e662fee4c940eecc3526bd9d94f6) | `` modrinth-app-unwrapped: 0.12.4 -> 0.12.6 ``                                      |
| [`f89ae877`](https://github.com/NixOS/nixpkgs/commit/f89ae877242a64bb7d58a99e9efb6e9963a794e1) | `` mattermost: 10.11.14 -> 10.11.15 ``                                              |
| [`662ce039`](https://github.com/NixOS/nixpkgs/commit/662ce039e8f419f9a72eb3aa1a1de6f07910c3be) | `` thunderbird-esr-bin-unwrapped: 140.9.1esr -> 140.10.0esr ``                      |
| [`b5ed8059`](https://github.com/NixOS/nixpkgs/commit/b5ed8059b80eef304f20d2f5e4f05a1840768346) | `` rustPlatform.fetchCargoVendor: use static.crates.io in v2 ``                     |
| [`0fb82de3`](https://github.com/NixOS/nixpkgs/commit/0fb82de3fbc378e21d67a8657f8afe3aae8dae16) | `` rustPlatform.fetchCargoVendor: set custom User-Agent in v2 ``                    |
| [`de211187`](https://github.com/NixOS/nixpkgs/commit/de2111877214b8e059df101f72f27f0401de4466) | `` rustPlatform.fetchCargoVendor: copy fetch-cargo-vendor-util.py for v2 ``         |
| [`8bb44436`](https://github.com/NixOS/nixpkgs/commit/8bb444365863da508d30e724c3765ea469215f26) | `` linux_6_19: remove ``                                                            |
| [`797719cb`](https://github.com/NixOS/nixpkgs/commit/797719cbd52150b75547c8d99214a51f137e5701) | `` ci/github-script/merge: clarify maintainership is based on target branch ``      |
| [`ccbaaf1d`](https://github.com/NixOS/nixpkgs/commit/ccbaaf1da6125b9002480a195a88ec83bab63a47) | `` daisydisk: 4.33.2 -> 4.33.3 ``                                                   |
| [`4303bd71`](https://github.com/NixOS/nixpkgs/commit/4303bd71004144d4eff58b920d734d0287649663) | `` daisydisk: 4.32 -> 4.33.2 ``                                                     |
| [`7d5b45a1`](https://github.com/NixOS/nixpkgs/commit/7d5b45a13bcf73ac777903460822c90008f9a674) | `` daisydisk: 4.3.1 -> 4.3.2 ``                                                     |
| [`5c85ff75`](https://github.com/NixOS/nixpkgs/commit/5c85ff7596003f4f202e491995c9732678d42da5) | `` pyrefly: 0.60.0 -> 0.62.0 ``                                                     |
| [`8e838372`](https://github.com/NixOS/nixpkgs/commit/8e838372e0f75bc4271d5170c233481846a73768) | `` ci/eval/compare: set NixOS test rebuild label on all PRs that do so ``           |
| [`e5403068`](https://github.com/NixOS/nixpkgs/commit/e54030689e9c5e66c8a6a1ff052bf68266570045) | `` mautrix-signal: 26.03 -> 26.04 ``                                                |
| [`a0095848`](https://github.com/NixOS/nixpkgs/commit/a0095848d1f787300cccdc585ca6c5cb78268f3c) | `` libsignal-ffi: 0.87.5 -> 0.92.1 ``                                               |
| [`fcb7f687`](https://github.com/NixOS/nixpkgs/commit/fcb7f6870cf1c8a1f8e9868ffc7c98c04c9e2dfd) | `` mautrix-whatsapp: 26.03 -> 26.04 ``                                              |
| [`0f76682a`](https://github.com/NixOS/nixpkgs/commit/0f76682a756ee2a082fdc5e2bb74e4af13098d6a) | `` qpwgraph: 1.0.0 -> 1.0.1 ``                                                      |
| [`a011879c`](https://github.com/NixOS/nixpkgs/commit/a011879c38e14897e23fbd25d2ebd8b75259a8c0) | `` uutils-coreutils: symlink multicall aliases to fix closure size ``               |
| [`e2b6c84c`](https://github.com/NixOS/nixpkgs/commit/e2b6c84c838feb2955fd153761f17bd53d52deca) | `` uutils-coreutils: 0.7.0 -> 0.8.0 ``                                              |
| [`92d46e9b`](https://github.com/NixOS/nixpkgs/commit/92d46e9b3453e913fb8a515fc82dd7af6be614e9) | `` uutils-coreutils: fix static build ``                                            |
| [`f71b66e0`](https://github.com/NixOS/nixpkgs/commit/f71b66e04dfc1c7ce2f6a722caa9bdc1ef05dc32) | `` uutils-coreutils: 0.6.0 -> 0.7.0 ``                                              |
| [`dffadd78`](https://github.com/NixOS/nixpkgs/commit/dffadd784fdb587447506beee6be204d2bd97ba2) | `` python3Packages.nbconvert: use upstream's style.css ``                           |
| [`c68798dd`](https://github.com/NixOS/nixpkgs/commit/c68798ddf34d99a40acfffa9376292c5b4b43c24) | `` python3Packages.nbconvert: 7.16.6 -> 7.17.1 ``                                   |
| [`fd3f35b7`](https://github.com/NixOS/nixpkgs/commit/fd3f35b74fe7ba63db8b36a5f7461c4983c2f1e3) | `` gitlab: 18.10.3 -> 18.11.1 ``                                                    |
| [`47203643`](https://github.com/NixOS/nixpkgs/commit/47203643b87ca7240d98cf54104d9872052a9ce1) | `` gitlab: fix update.py ``                                                         |
| [`110057d1`](https://github.com/NixOS/nixpkgs/commit/110057d1500aaa98e2cbcdfe06bbc3016068dcb4) | `` bitcoin: 30.2 -> 31.0 ``                                                         |
| [`71733406`](https://github.com/NixOS/nixpkgs/commit/71733406251e8b00f97e36674c9bd1ef7b20b743) | `` bitcoin: Remove libsodium transistive dependency from bitcoin ``                 |
| [`164e6373`](https://github.com/NixOS/nixpkgs/commit/164e6373e4fc566d31ea81d88ad4423e0af75ddc) | `` mattermost-desktop: disable update checking ``                                   |
| [`ac010069`](https://github.com/NixOS/nixpkgs/commit/ac01006974670989b345bfc434cb77aa68fe1a02) | `` librewolf-bin-unwrapped: 149.0.2-2 -> 150.0-1 ``                                 |
| [`0d8229ae`](https://github.com/NixOS/nixpkgs/commit/0d8229ae06b3fa6fc0dff85977c1ff91205d467b) | `` firefly-iii-data-importer: 2.2.2 -> 2.2.3 ``                                     |
| [`d94bf91c`](https://github.com/NixOS/nixpkgs/commit/d94bf91c4cc6139cc6916da86c0790b8be13c0ec) | `` nuclei: 3.7.1 -> 3.8.0 ``                                                        |
| [`b1b1bbf3`](https://github.com/NixOS/nixpkgs/commit/b1b1bbf3a57f3fa0caf405c21fd1760799d71d23) | `` nuclei: 3.7.0 -> 3.7.1 ``                                                        |
| [`9489638d`](https://github.com/NixOS/nixpkgs/commit/9489638d244d4e9b308a0ad508f02819704919ce) | `` nuclei: migrate to finalAttrs ``                                                 |
| [`8fd5a12b`](https://github.com/NixOS/nixpkgs/commit/8fd5a12b79820cb83fd14f48613eea23ee5aae34) | `` nuclei: 3.6.2 -> 3.7.0 ``                                                        |
| [`12a73a88`](https://github.com/NixOS/nixpkgs/commit/12a73a88d73bbc1e68c9622154853f16e62d00d8) | `` nuclei: 3.6.1 -> 3.6.2 ``                                                        |
| [`9c533f7a`](https://github.com/NixOS/nixpkgs/commit/9c533f7a5117e148458de5c3ec4079b24a5c53b6) | `` nuclei: 3.6.0 -> 3.6.1 ``                                                        |
| [`3ec6e0e7`](https://github.com/NixOS/nixpkgs/commit/3ec6e0e78617f000f8ad432fdd7fc4391c0af512) | `` nuclei: 3.5.1 -> 3.6.0 ``                                                        |
| [`ffd48eed`](https://github.com/NixOS/nixpkgs/commit/ffd48eed5a8c8821cbd2621ba6d529919be79bf5) | `` phpunit: 12.5.6 -> 12.5.8 ``                                                     |
| [`d094b038`](https://github.com/NixOS/nixpkgs/commit/d094b038c48403ff1701f730fc8cda91eedc2f3d) | `` phpunit: 12.5.4 -> 12.5.6 ``                                                     |
| [`d0019a5c`](https://github.com/NixOS/nixpkgs/commit/d0019a5cdd464fb3e8726d65d08146ed7afa6a9a) | `` phpunit: 12.5.1 -> 12.5.4 ``                                                     |
| [`48931c5f`](https://github.com/NixOS/nixpkgs/commit/48931c5fe703e57e759693f5368527ee900bbf1a) | `` phpunit: 12.4.4 -> 12.5.1 ``                                                     |
| [`05c5e60b`](https://github.com/NixOS/nixpkgs/commit/05c5e60b22ae1928000bd35296206dd921981995) | `` phpunit: 12.4.3 -> 12.4.4 ``                                                     |
| [`1b3d44a0`](https://github.com/NixOS/nixpkgs/commit/1b3d44a0265e3ffcf06d211c5cb8989154976358) | `` source2viewer-cli: init at 19.1 ``                                               |
| [`ccbb8955`](https://github.com/NixOS/nixpkgs/commit/ccbb89559302533980045a16bc329708fe731f66) | `` obsidian: add prince213 as maintainer ``                                         |
| [`254992f3`](https://github.com/NixOS/nixpkgs/commit/254992f32782aaca369eb0d4cbcc9214ada014a0) | `` obsidian: pin electron to 39 ``                                                  |
| [`463fb18f`](https://github.com/NixOS/nixpkgs/commit/463fb18f8d321b747e93726e25e0fe9f9f937452) | `` kamailio: 6.0.5 -> 6.0.6 ``                                                      |
| [`51007ee9`](https://github.com/NixOS/nixpkgs/commit/51007ee91eabec450e917ec183041a8c6ba2500a) | `` kamailio: 6.0.4 -> 6.0.5 ``                                                      |
| [`3a4bb658`](https://github.com/NixOS/nixpkgs/commit/3a4bb658c53cd75d8b2a30b8e5f2dc6402521642) | `` kamailio: 6.0.3 -> 6.0.4 ``                                                      |
| [`c9dc6d33`](https://github.com/NixOS/nixpkgs/commit/c9dc6d33f1966591fa0567e727d838d23ab04b7c) | `` freetube: 0.23.15 -> 0.24.0 ``                                                   |
| [`98c3297c`](https://github.com/NixOS/nixpkgs/commit/98c3297c87f3ed6d965c07e7c1d13dcbc1b6f8ab) | `` tangram: 3.4 -> 3.5 ``                                                           |
| [`31bace5e`](https://github.com/NixOS/nixpkgs/commit/31bace5ec43be5e12c315a431ad09aa2effa3fa5) | `` tangram: 3.3 -> 3.4 ``                                                           |
| [`2eacab23`](https://github.com/NixOS/nixpkgs/commit/2eacab2370e6df6374af8328b2ef90e7bf19f4c4) | `` switcheroo: 2.2.0 -> 2.5.2 ``                                                    |
| [`633b1e2b`](https://github.com/NixOS/nixpkgs/commit/633b1e2ba9b9cc1a0e78e2bac89ced248060b99c) | `` komikku: 1.105.0 -> 50.0.1 ``                                                    |
| [`3082e83f`](https://github.com/NixOS/nixpkgs/commit/3082e83ff3bd9172e9d2f9ee21092e4686db576f) | `` komikku: 1.103.0 -> 1.105.0 ``                                                   |
| [`799cbea3`](https://github.com/NixOS/nixpkgs/commit/799cbea3e590a49e81268443ae595a78ef99e7b3) | `` komikku: 1.102.0 -> 1.103.0 ``                                                   |
| [`4b0435be`](https://github.com/NixOS/nixpkgs/commit/4b0435bee634b981b7e464100317404f517a46e6) | `` komikku: 1.101.0 -> 1.102.0 ``                                                   |
| [`345f1795`](https://github.com/NixOS/nixpkgs/commit/345f1795c433d5ad49782bcfa916e90f9cb6d27d) | `` junction: 1.9 -> 1.12 ``                                                         |
| [`6288154e`](https://github.com/NixOS/nixpkgs/commit/6288154e8525c8b5cb5bb520b39614315ad9de63) | `` iotas: 0.12.5 -> 0.12.7 ``                                                       |
| [`86807033`](https://github.com/NixOS/nixpkgs/commit/86807033890dc7e4f48a1aa643b00763d4d4ab06) | `` gnome-secrets: 12.0 -> 12.3 ``                                                   |
| [`87094dea`](https://github.com/NixOS/nixpkgs/commit/87094dea4ff7aa898f7bd620ddcd4c0b28c911e6) | `` gnome-graphs: 1.8.4 -> 1.8.7 ``                                                  |
| [`ba81b201`](https://github.com/NixOS/nixpkgs/commit/ba81b20137fc70658a262542fbbdf05797280a62) | `` gnome-decoder: 0.8.0 -> 0.8.1 ``                                                 |
| [`0200c324`](https://github.com/NixOS/nixpkgs/commit/0200c324816532de9203178d7d414abc15f14d53) | `` exercise-timer: fix dependencies ``                                              |
| [`4bd152a8`](https://github.com/NixOS/nixpkgs/commit/4bd152a80435fc2145f5b46ca2622155b91d6e37) | `` exercise-timer: 1.8.5 -> 1.9.1 ``                                                |
| [`66eeb11f`](https://github.com/NixOS/nixpkgs/commit/66eeb11fa9cf390eca6f476af07d1eec9d918b52) | `` elastic: 0.1.9 -> 1.0.1 ``                                                       |
| [`3083e585`](https://github.com/NixOS/nixpkgs/commit/3083e5856188e6d81bdd5235950f5ac1c6b5f326) | `` curtail: 1.14.0 -> 1.15.0 ``                                                     |
| [`87710a24`](https://github.com/NixOS/nixpkgs/commit/87710a249112a2bf03f55024a9415ec67430de52) | `` curtail: 1.13.0 -> 1.14.0 ``                                                     |
| [`9483a313`](https://github.com/NixOS/nixpkgs/commit/9483a31324a8277f841d5b55f39aa9ea27aa0f8d) | `` commit: 4.4 -> 4.5 ``                                                            |
| [`8e42097e`](https://github.com/NixOS/nixpkgs/commit/8e42097ee3642aa08b20402b7d8e0fc0ba1c334b) | `` clairvoyant: 3.1.10 -> 3.1.12 ``                                                 |
| [`771e707b`](https://github.com/NixOS/nixpkgs/commit/771e707b734861d18b982139968c36b15a3b5725) | `` grocy: Add config abilities to module ``                                         |
| [`9be8d89c`](https://github.com/NixOS/nixpkgs/commit/9be8d89cadb78625ee4f64f03c518e5e61466e67) | `` grocy: 4.5.0 -> 4.6.0 ``                                                         |
| [`bc06dead`](https://github.com/NixOS/nixpkgs/commit/bc06dead629503f04902926073ae538b98abca8b) | `` modrinth-app-unwrapped: 0.10.30 -> 0.12.4 ``                                     |
| [`d5c7424c`](https://github.com/NixOS/nixpkgs/commit/d5c7424cdbd1b0198c12893b97f75ed8d3060f4b) | `` modrinth-app-unwrapped: migrate from fetcherVersion = 1 to fetcherVersion = 3 `` |