### PR TITLE
chore(flake/home-manager): `503480e5` -> `feda4150`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777498633,
-        "narHash": "sha256-+3xXjfFz7y1gNG/9tQgjdxFKsQZYcDUxz1RbzmdgXj8=",
+        "lastModified": 1777655179,
+        "narHash": "sha256-Rx7RvgxgFeoaJUddpuVbJ2jaaAp7qH6wV9PwBmLvfz4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "503480e51357c7beca8c19bde560af1491a372d0",
+        "rev": "feda41500ec53fcd4e3131de7b0441bce08fd3e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`feda4150`](https://github.com/nix-community/home-manager/commit/feda41500ec53fcd4e3131de7b0441bce08fd3e9) | `` github-copilot-cli: add context, agents, and skills ``  |
| [`9a3efa07`](https://github.com/nix-community/home-manager/commit/9a3efa079c3a91567c4bedeadc9a58f47244ef4b) | `` maintainers: update all-maintainers.nix ``              |
| [`d181e6ac`](https://github.com/nix-community/home-manager/commit/d181e6ac2ad01e50c914220d7478fed50b1dbf68) | `` treewide: support store path strings for skills dirs `` |
| [`94db0286`](https://github.com/nix-community/home-manager/commit/94db02863273736b57b9dcb1b5c4e873705c64c0) | `` Translate using Weblate (French) ``                     |
| [`f92dc916`](https://github.com/nix-community/home-manager/commit/f92dc91642acc19f0c4e17cbdb8699f2d9578e24) | `` Translate using Weblate (Arabic) ``                     |
| [`e6613dd6`](https://github.com/nix-community/home-manager/commit/e6613dd625122fa1d545611805859ee1d8cdd467) | `` codex: keep managed skills under CODEX_HOME ``          |
| [`899c08a1`](https://github.com/nix-community/home-manager/commit/899c08a15beae5da51a5cecd6b2b994777a948da) | `` github-copilot-cli: fix mcp integration ``              |
| [`2e54a938`](https://github.com/nix-community/home-manager/commit/2e54a938cdd4c8e414b2518edc3d82308027c670) | `` exo: add module ``                                      |
| [`7a45713b`](https://github.com/nix-community/home-manager/commit/7a45713b5df3f7225c6c22b139bb3d3b82aae04b) | `` maintainers: add dsqr ``                                |