### PR TITLE
chore(flake/home-manager): `feda4150` -> `9ce9f7f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777655179,
-        "narHash": "sha256-Rx7RvgxgFeoaJUddpuVbJ2jaaAp7qH6wV9PwBmLvfz4=",
+        "lastModified": 1777733408,
+        "narHash": "sha256-lyKV2GtkMPS1Mp8bKJ8sBr7LPCzL4GnVnQQYa4e7UsQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "feda41500ec53fcd4e3131de7b0441bce08fd3e9",
+        "rev": "9ce9f7f128c5834bb71a4f5c62232187371379b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`9ce9f7f1`](https://github.com/nix-community/home-manager/commit/9ce9f7f128c5834bb71a4f5c62232187371379b6) | `` shell: support boolean sessionVariables ``                     |
| [`7c28dd52`](https://github.com/nix-community/home-manager/commit/7c28dd52cb15a106cc358ec8fbfad707b99c74b4) | `` macchina: fix palette spacing config being missing ``          |
| [`9cb587ad`](https://github.com/nix-community/home-manager/commit/9cb587ade2aa1b4a7257f0238d41072690b0ca4f) | `` launchd: use bootout --wait to wait for the service to stop `` |
| [`5c1b7490`](https://github.com/nix-community/home-manager/commit/5c1b74905c7261e8280dcda3623dbe677a1bc158) | `` keynav: add tests ``                                           |
| [`d955574e`](https://github.com/nix-community/home-manager/commit/d955574ea4f371988c658027ed02eab4fc6a5cd8) | `` keynav: add configuration option ``                            |
| [`edf3f599`](https://github.com/nix-community/home-manager/commit/edf3f59954f4ea31bfb08d09f5c2a392286ce2f6) | `` github-copilot-cli: add lsp server support ``                  |