### PR TITLE
feat(darwin): allow unfree packages (parity with Linux)

### DIFF
--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -57,6 +57,7 @@
   users.users.${user}.home = "/Users/${user}";
 
   nixpkgs.hostPlatform = lib.mkDefault "aarch64-darwin";
+  nixpkgs.config.allowUnfree = true;
 
   desktop = {
     freminal.enable = true;


### PR DESCRIPTION
## Summary
- Add \`nixpkgs.config.allowUnfree = true\` to \`profiles/darwin.nix\`. Linux has had this in \`features/common/system\` (line 62); Darwin did not.
- Surfaced by PR #1562, where unstable nixpkgs reclassified \`vimplugin-zellij.nvim\` as unfree. Linux desktops accepted it; Darwin failed evaluation.

## Verification
- One-line config addition mirrors the existing Linux setup; no behavioural change for any package that wasn't already pulled in.