### PR TITLE
chore(flake/home-manager-stable): `0d02ec1d` -> `0585fbf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775425411,
-        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
+        "lastModified": 1777771528,
+        "narHash": "sha256-YycygK6n7KeW1YCobdFJcORWzkmrvNcp6xT+IovA0d4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
+        "rev": "0585fbf645640973e3398863bbaf3bd1ddce4a51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`0585fbf6`](https://github.com/nix-community/home-manager/commit/0585fbf645640973e3398863bbaf3bd1ddce4a51) | `` tests/vicinae: stub extensions ``                  |
| [`3a93da85`](https://github.com/nix-community/home-manager/commit/3a93da858fa9f8a81ec10e317249660cc6f9809b) | `` flake: bump nixpkgs from `bcd464c` to `755f5aa` `` |