### PR TITLE
chore(flake/home-manager): `9ce9f7f1` -> `b9311028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777733408,
-        "narHash": "sha256-lyKV2GtkMPS1Mp8bKJ8sBr7LPCzL4GnVnQQYa4e7UsQ=",
+        "lastModified": 1777780644,
+        "narHash": "sha256-CYpc+mk28rmcQWGygeM8CA+Z8SZYy8BOyQtiW18spao=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ce9f7f128c5834bb71a4f5c62232187371379b6",
+        "rev": "b9311028044a9e9b2cf27db15ef0a87d464e212d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`b9311028`](https://github.com/nix-community/home-manager/commit/b9311028044a9e9b2cf27db15ef0a87d464e212d) | `` rclone: add serve options ``                       |
| [`9c9fc936`](https://github.com/nix-community/home-manager/commit/9c9fc9368a6d9e698d03d3780d3b930ebc060334) | `` tests/anki: stub packages ``                       |
| [`b4b920d9`](https://github.com/nix-community/home-manager/commit/b4b920d9ecb7725d4f4cf4290e6e9551820f46c8) | `` tests/lutris: stub packages ``                     |
| [`1e313820`](https://github.com/nix-community/home-manager/commit/1e313820a346eb9bd8cef30f8b26e90187b7734b) | `` treewide: adapt toml generator changes ``          |
| [`7229dde6`](https://github.com/nix-community/home-manager/commit/7229dde629a635d38c5f79d252d5b22867dfd81e) | `` tests/vicinae: stub extensions ``                  |
| [`fdf4d549`](https://github.com/nix-community/home-manager/commit/fdf4d549ed5d90b3c4b89b7f1e32d27eb45df04e) | `` flake: bump nixpkgs from `68d8aa3` to `1c3fe55` `` |
| [`0379e433`](https://github.com/nix-community/home-manager/commit/0379e433a85184be523f98ffd1715d0fb4320bc9) | `` delta: configure as pager for git blame ``         |
| [`561bd674`](https://github.com/nix-community/home-manager/commit/561bd674646db26ebfccc79b4fbef89f335505db) | `` wlsunset: require WAYLAND_DISPLAY env var ``       |
| [`a53beb63`](https://github.com/nix-community/home-manager/commit/a53beb6353dab9f839b8f65d212841fb4b15ee94) | `` foot: require WAYLAND_DISPLAY env var ``           |
| [`beae317d`](https://github.com/nix-community/home-manager/commit/beae317ddb6a36e2a5a2b00653d8cb970c64c67a) | `` foot: configurable systemd target ``               |