### PR TITLE
chore(flake/darwin): `06648f49` -> `8c62fba0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1777780666,
+        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                               |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
| [`b1737791`](https://github.com/nix-darwin/nix-darwin/commit/b1737791a9fe126a8d0e7639e00b6d6b3c8a7901) | `` tests/aerospace: adapt to new toml generator ``                                    |
| [`3510d049`](https://github.com/nix-darwin/nix-darwin/commit/3510d049d3aba0660c9563a8aace3946ba61501c) | `` homebrew: replace envHints/analytics/updateReportNew with onActivation.extraEnv `` |
| [`8f6396c0`](https://github.com/nix-darwin/nix-darwin/commit/8f6396c0dc1cc65ed83a73513aefc5e8de33a405) | `` homebrew: add envHints, analytics, and updateReportNew options ``                  |