### PR TITLE
chore(flake/home-manager-stable): `0585fbf6` -> `cc09c0f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777771528,
-        "narHash": "sha256-YycygK6n7KeW1YCobdFJcORWzkmrvNcp6xT+IovA0d4=",
+        "lastModified": 1777851538,
+        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0585fbf645640973e3398863bbaf3bd1ddce4a51",
+        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`cc09c0f9`](https://github.com/nix-community/home-manager/commit/cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5) | `` wlsunset: require WAYLAND_DISPLAY env var `` |
| [`76df9b63`](https://github.com/nix-community/home-manager/commit/76df9b63d15e8eb73fc856cce01f3c54bdd7959e) | `` foot: require WAYLAND_DISPLAY env var ``     |
| [`c7902887`](https://github.com/nix-community/home-manager/commit/c7902887d98738e5315911881c312865fc9d074b) | `` foot: configurable systemd target ``         |