### PR TITLE
chore(flake/sops-nix): `8eaee5c4` -> `c591bf66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1717,11 +1717,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777338324,
-        "narHash": "sha256-bc+ZZCmOTNq86/svGnw0tVpH7vJaLYvGLLKFYP08Q8E=",
+        "lastModified": 1777944972,
+        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8eaee5c45428b28b8c47a83e4c09dccec5f279b5",
+        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                          |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`9be8324e`](https://github.com/Mic92/sops-nix/commit/9be8324eae725fa3972916d780986e3fcf6c6c18) | `` update vendorHash ``                          |
| [`329f6488`](https://github.com/Mic92/sops-nix/commit/329f64889c7e1a702bffe2f1c6c073096ae8f4ea) | `` Bump gopkg.in/ini.v1 from 1.67.1 to 1.67.2 `` |