### PR TITLE
chore(flake/home-manager): `b9311028` -> `d9876178`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780644,
-        "narHash": "sha256-CYpc+mk28rmcQWGygeM8CA+Z8SZYy8BOyQtiW18spao=",
+        "lastModified": 1777988791,
+        "narHash": "sha256-DtbtSW5+Hls7z+D9BfsAXvFuivt5iZ0OzUXjQ8d8lB8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b9311028044a9e9b2cf27db15ef0a87d464e212d",
+        "rev": "d987617879f613053f6fdf4491fe28ce0283d543",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`d9876178`](https://github.com/nix-community/home-manager/commit/d987617879f613053f6fdf4491fe28ce0283d543) | `` generic-linux-gpu: don't pass kernel ``                                              |
| [`5a155051`](https://github.com/nix-community/home-manager/commit/5a15505146ffd149dd88126562209028220c93e3) | `` Revert "sshAuthSock: assert that at most one agent is enabled" ``                    |
| [`7ef1c04d`](https://github.com/nix-community/home-manager/commit/7ef1c04d11f7ef69fd946b118c768c32de0b89a5) | `` rclone: rename remote directory to fix failing tests ``                              |
| [`5be632da`](https://github.com/nix-community/home-manager/commit/5be632dab0be072deadd69ebced5bc7366d71bb8) | `` gpu: use tmpfiles.d to set up the /run/opengl-driver symlink ``                      |
| [`a89686d1`](https://github.com/nix-community/home-manager/commit/a89686d115e970e200eb2caa7603f3673050e00c) | `` git: avoid implicit signing config ``                                                |
| [`0ecfc72c`](https://github.com/nix-community/home-manager/commit/0ecfc72c7c882bdafe60fe3c5cdf58088801f2a2) | `` docs: explain file collision handling ``                                             |
| [`938311a3`](https://github.com/nix-community/home-manager/commit/938311a3bde90dc1356e5c55f1fe864ce79d9bed) | `` docs: clarify package overrides with flakes ``                                       |
| [`c3387b41`](https://github.com/nix-community/home-manager/commit/c3387b41c96033eb22ed1ab4202483ed9da592d2) | `` docs: document unstable packages with flakes ``                                      |
| [`e70904b3`](https://github.com/nix-community/home-manager/commit/e70904b3af1d362da9de52023f9f661e78c5db53) | `` docs: clarify update and upgrade workflows ``                                        |
| [`d6c1bb35`](https://github.com/nix-community/home-manager/commit/d6c1bb355fe57e5660704bb274e0ea5357f5a154) | `` maintainers: update all-maintainers.nix ``                                           |
| [`fb6a0c6d`](https://github.com/nix-community/home-manager/commit/fb6a0c6d398179f746ac6636d1acdf757e19eded) | `` modules: add modular services support ``                                             |
| [`9c6f1307`](https://github.com/nix-community/home-manager/commit/9c6f1307e1d76a2285d8001e1b8bc281bfe15dac) | `` kitty/fix-git-integration: fix typo trustExistCode -> trustExitCode ``               |
| [`c909892d`](https://github.com/nix-community/home-manager/commit/c909892de502b4de9e92838a503c09a9c8ebe4aa) | `` vscode: warn when package is a known fork and remove `pname` option ``               |
| [`80ab64bb`](https://github.com/nix-community/home-manager/commit/80ab64bb796a89c6e73056fb98381c18c0a76d73) | `` vscode: add dedicated modules for VSCode forks ``                                    |
| [`26412a22`](https://github.com/nix-community/home-manager/commit/26412a220b7da23fe5c419716ae81c47753c33f1) | `` vscode: extract mkVscodeModule factory function ``                                   |
| [`71ad4614`](https://github.com/nix-community/home-manager/commit/71ad461413b8ee86f7a616014b3febb270a6ad0f) | `` man-db: add assertion for man.man-db.extraConfig when man.generateCaches is false `` |
| [`1b4806c5`](https://github.com/nix-community/home-manager/commit/1b4806c50b2cb337083b35962d960340c6a1c85a) | `` news: add news entry for programs.man.{man-db,mandoc} ``                             |
| [`7914f8d7`](https://github.com/nix-community/home-manager/commit/7914f8d7d7948b5c217ccf8ba59b7004f085795d) | `` tests/man: add tests for man-db/mandoc ``                                            |
| [`f02e422b`](https://github.com/nix-community/home-manager/commit/f02e422b3ed060b7aca83c27391326f1208a7152) | `` man: add mandoc and man-db option ``                                                 |
| [`4625f262`](https://github.com/nix-community/home-manager/commit/4625f26228f4f7ea3cf65eee3023359a8221fcff) | `` neovim: Support configuring plugins using Fennel ``                                  |
| [`b5e86c1b`](https://github.com/nix-community/home-manager/commit/b5e86c1b19f178a8ee10f7cb747325e02e3d3991) | `` treewide: remove network-online.target ``                                            |