### PR TITLE
chore(flake/nixvim): `a67d9cd6` -> `7986a276`

### DIFF
--- a/features/desktop/fonts/default.nix
+++ b/features/desktop/fonts/default.nix
@@ -20,11 +20,6 @@ in
     #   pkgs.fira-code-symbols
     # ];
 
-    nixpkgs.config.allowUnfreePredicate =
-      pkg:
-      builtins.elem (lib.getName pkg) [
-        "joypixels"
-      ];
     nixpkgs.config.joypixels.acceptLicense = true;
 
     fonts = {

--- a/features/desktop/fonts/default.nix
+++ b/features/desktop/fonts/default.nix
@@ -20,6 +20,11 @@ in
     #   pkgs.fira-code-symbols
     # ];
 
+    nixpkgs.config.allowUnfreePredicate =
+      pkg:
+      builtins.elem (lib.getName pkg) [
+        "joypixels"
+      ];
     nixpkgs.config.joypixels.acceptLicense = true;
 
     fonts = {

--- a/features/shell/nvim/default.nix
+++ b/features/shell/nvim/default.nix
@@ -29,6 +29,11 @@ in
           defaultEditor = true;
           enable = true;
 
+          # Allow unfree-tagged plugins (e.g. git-conflict.nvim) in nixvim's
+          # internal pkgs instance. The host's nixpkgs.config does not propagate
+          # to nixvim's bundled nixpkgs, so this must be set explicitly here.
+          nixpkgs.config.allowUnfree = true;
+
           colorscheme = "catppuccin";
           colorschemes.catppuccin = {
             enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -307,11 +307,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777932387,
+        "narHash": "sha256-nUYVPiqrzr36ThiQOAr5MKeGHDBSDM3OFWkz0uDjOvc=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "71a3a77326609675e9f8b51084cf23d5d1945899",
         "type": "github"
       },
       "original": {
@@ -1204,11 +1204,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1777918403,
+        "narHash": "sha256-7QiZv0LcW1yIOLo2LNuCQjWon1Z1r99FwK24hbtBOF4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "afc5551119aae6eab73a95c1960891cfe63204f6",
         "type": "github"
       },
       "original": {
@@ -1369,11 +1369,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1777236345,
-        "narHash": "sha256-ALOqlq7bE30lsX4rA76hXeQ2aLLEpb44hS+D1+jWS88=",
+        "lastModified": 1777991353,
+        "narHash": "sha256-DFwjggMV+nzCZpwK6Obxj9F+P59rbLVowGqHETfctBk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a67d9cd6ff725a763afe88727aac73208ded3bf4",
+        "rev": "7986a276960b4dfaed9bb2c3c438b5ba71ae08f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`7986a276`](https://github.com/nix-community/nixvim/commit/7986a276960b4dfaed9bb2c3c438b5ba71ae08f1) | `` flake: Update ``                                                                |
| [`17922b6b`](https://github.com/nix-community/nixvim/commit/17922b6be51e335563609ba6c74656a839285e01) | `` flake: Update ``                                                                |
| [`b0d7187d`](https://github.com/nix-community/nixvim/commit/b0d7187d1d49239a5ce18d2bbf5dea5a954849a9) | `` tests/all-package-defaults: disable tests that depend on appstream on darwin `` |
| [`831b3d26`](https://github.com/nix-community/nixvim/commit/831b3d26f5310621a615d945deb93f599374122a) | `` tests/all-package-defaults: disable elm-format on darwin (because of ghc) ``    |
| [`b064eb18`](https://github.com/nix-community/nixvim/commit/b064eb18d1faee63af4d2cd690904e80a393ded3) | `` tests/all-package-defaults: re-enable nushell ``                                |
| [`1f472636`](https://github.com/nix-community/nixvim/commit/1f472636ff1b4abd3956fdda89c0369099a3bc2e) | `` tests/all-package-defaults: disable darwin failures ``                          |
| [`08d30da9`](https://github.com/nix-community/nixvim/commit/08d30da9a283d4968fa4b18440b8a683860cdcee) | `` plugins/lint: add clj-kondo ``                                                  |
| [`a4ab3092`](https://github.com/nix-community/nixvim/commit/a4ab30928bac7add15c77eb34b2b6ddbb4369dcd) | `` modules/editorconfig: remove concatLines usage ``                               |
| [`d4f718bb`](https://github.com/nix-community/nixvim/commit/d4f718bb020f98d37671a34219e723d0671e47e9) | `` plugins/refactoring: migrate to `ui-select` ``                                  |
| [`687be63e`](https://github.com/nix-community/nixvim/commit/687be63e7f338d0fbd0717dbe1fbd96dc46dac00) | `` plugins/lint: vacuum -> vacuum-go ``                                            |
| [`e64ba8b7`](https://github.com/nix-community/nixvim/commit/e64ba8b7702bb2768d368c09f6ac296f450563d4) | `` plugins/efmls-configs: add package for typos ``                                 |
| [`5b8c9e3f`](https://github.com/nix-community/nixvim/commit/5b8c9e3ffa122ec0ccc5d9701b52e2f46be35c14) | `` generated: Update ``                                                            |
| [`0056e032`](https://github.com/nix-community/nixvim/commit/0056e0324466d340f43c900f2d2bdf00b9b1f441) | `` flake: Update ``                                                                |