### PR TITLE
chore(flake/nixpkgs-stable): `755f5aa9` -> `26ef669c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1172,11 +1172,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1777673416,
+        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                         |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b9e64fef`](https://github.com/NixOS/nixpkgs/commit/b9e64fef39ad5c81a439d291b47af262533b0433) | `` lomiri.lomiri-mediaplayer-app: Fix links in meta ``          |
| [`49e6324b`](https://github.com/NixOS/nixpkgs/commit/49e6324b4459366690271e84e1369576af4d862e) | `` littlegptracker: update source hash ``                       |
| [`7b1b69d0`](https://github.com/NixOS/nixpkgs/commit/7b1b69d02cf1a2941721a9586b71ea61d9fb4927) | `` matrix-synapse: 1.151.0 -> 1.152.0 ``                        |
| [`28e54549`](https://github.com/NixOS/nixpkgs/commit/28e54549dc45d788248775865405b1ea45c631fc) | `` tshark: fix hash ``                                          |
| [`66db3c4b`](https://github.com/NixOS/nixpkgs/commit/66db3c4b1ed4e3f088787100387812ae259f7040) | `` wireshark: fix meta.changelog ``                             |
| [`2baa48ff`](https://github.com/NixOS/nixpkgs/commit/2baa48ffe847e9e9ed244fdf345cafc10a042879) | `` tshark: 4.6.4 -> 4.6.5 ``                                    |
| [`461ac7c2`](https://github.com/NixOS/nixpkgs/commit/461ac7c20cfc544c9f2387282753233f7dc0c7a4) | `` firefox-esr-140-unwrapped: 140.10.0esr -> 140.10.1esr ``     |
| [`2c542ff2`](https://github.com/NixOS/nixpkgs/commit/2c542ff24007b4102a79b0bfb75be6062bf2bf95) | `` linuxKernel.kernels.linux_zen: 6.19.12-zen1 -> 7.0.3-zen1 `` |
| [`01a4e14e`](https://github.com/NixOS/nixpkgs/commit/01a4e14e5f6c13a21291a4768b45ef1bfa198ccb) | `` grocy: fix vendorHash ``                                     |
| [`410d9f60`](https://github.com/NixOS/nixpkgs/commit/410d9f6047be51d6282bc246076ffba690805dd1) | `` shogihome: 1.27.0 -> 1.27.1 ``                               |
| [`0325ad32`](https://github.com/NixOS/nixpkgs/commit/0325ad32a6070fdc4d5ce175e5f713fc018e396a) | `` rgx: 0.12.0 -> 0.12.1 ``                                     |
| [`ce983e72`](https://github.com/NixOS/nixpkgs/commit/ce983e72382e51f7d99882a7ce55ea71398efaf5) | `` kdePackages.dolphin: cherry-pick security fix ``             |
| [`6bac6293`](https://github.com/NixOS/nixpkgs/commit/6bac6293c0ec381ff7e1aa7ebc9fefb709850fb2) | `` kdePackages.kcoreaddons: cherry-pick security fix ``         |
| [`c1e8623b`](https://github.com/NixOS/nixpkgs/commit/c1e8623bd4485111cf29abf7b3436cf077babed5) | `` lazyhetzner: 1.2.0 -> 1.3.0 ``                               |
| [`70bdd222`](https://github.com/NixOS/nixpkgs/commit/70bdd2221c5471a88312731c610065933746b176) | `` qbz: 1.2.8 -> 1.2.10 ``                                      |
| [`2a9a9442`](https://github.com/NixOS/nixpkgs/commit/2a9a94423a930c5bf38e678be57c6e6346dddabf) | `` unofficial-homestuck-collection: 2.8.0 -> 2.8.1 ``           |
| [`8a418be3`](https://github.com/NixOS/nixpkgs/commit/8a418be36cdf81151c60dcabbdec81fa8358eaf1) | `` matrix-continuwuity: 0.5.7 -> 0.5.8 ``                       |
| [`bb991d9f`](https://github.com/NixOS/nixpkgs/commit/bb991d9fadea04e80a72c5d7f93fa1a0417c495c) | `` dioxus-cli: 0.7.5 -> 0.7.6 ``                                |
| [`af77d0bd`](https://github.com/NixOS/nixpkgs/commit/af77d0bdc0c3b63ddeae67081c190db7be2f52ca) | `` winbox4: remove Scrumplex from maintainers ``                |
| [`d49a716a`](https://github.com/NixOS/nixpkgs/commit/d49a716a9717f8481c598f56842f82d408a4e3fa) | `` nbd: apply patch updating test certificate expiry dates ``   |
| [`ee299675`](https://github.com/NixOS/nixpkgs/commit/ee2996757370b9a6ae8c5bd81eab309909b2cc83) | `` ungoogled-chromium: 147.0.7727.116-1 -> 147.0.7727.137-1 ``  |
| [`f080dc3d`](https://github.com/NixOS/nixpkgs/commit/f080dc3d573815fb3719fce1beebbbc8f6605a96) | `` signal-desktop: install policy templates on linux ``         |
| [`9637f49a`](https://github.com/NixOS/nixpkgs/commit/9637f49a5f027d485a3aa78a59151124e772dd84) | `` buildbox: 1.4.4 -> 1.4.5 ``                                  |
| [`9e31294a`](https://github.com/NixOS/nixpkgs/commit/9e31294a83cf689a9fe7736a56fa442e717a7ff4) | `` kanidm_1_9: 1.9.2 -> 1.9.3 ``                                |
| [`aaae007a`](https://github.com/NixOS/nixpkgs/commit/aaae007a556c0fa49a735865103f49673b6e8cc1) | `` kanidm_1_8: mark unsupported ``                              |
| [`1fea7636`](https://github.com/NixOS/nixpkgs/commit/1fea7636ac7ce6f6c5b92248ba7a6f52c45b8991) | `` linux_5_10: 5.10.253 -> 5.10.254 ``                          |
| [`037cff1c`](https://github.com/NixOS/nixpkgs/commit/037cff1ce5a2e01918eb0e92523471b2a1bae498) | `` linux_5_15: 5.15.203 -> 5.15.204 ``                          |
| [`9e6c843a`](https://github.com/NixOS/nixpkgs/commit/9e6c843af8cf29169132624cf21abdd49d99bd76) | `` linux_6_1: 6.1.169 -> 6.1.170 ``                             |
| [`a39bcab5`](https://github.com/NixOS/nixpkgs/commit/a39bcab5bbb327bb4fde95101630819bfd9a9e2d) | `` linux_6_6: 6.6.136 -> 6.6.137 ``                             |
| [`248336e3`](https://github.com/NixOS/nixpkgs/commit/248336e3492990904b0dea2fb2e5149bfe367b56) | `` linux_6_12: 6.12.84 -> 6.12.85 ``                            |
| [`b28c3409`](https://github.com/NixOS/nixpkgs/commit/b28c3409f62caffdad758056b33aec35d5a4c917) | `` linux_6_18: 6.18.25 -> 6.18.26 ``                            |
| [`dab16d6f`](https://github.com/NixOS/nixpkgs/commit/dab16d6f5978fb43cf94fc7fa6a6e7cf11aeefeb) | `` linux_7_0: 7.0.2 -> 7.0.3 ``                                 |
| [`c8cbf60b`](https://github.com/NixOS/nixpkgs/commit/c8cbf60b259b89d792b37d83bd438ccc45687e9b) | `` brave: 1.89.143 -> 1.89.145 ``                               |
| [`2f59a185`](https://github.com/NixOS/nixpkgs/commit/2f59a185defdecf0763c90d51056935be5f3c3cc) | `` thunderbird-latest-bin-unwrapped: 149.0.2 -> 150.0 ``        |
| [`04a3e024`](https://github.com/NixOS/nixpkgs/commit/04a3e024b5ae61691c0d08fa5b11f2a722fe1cc2) | `` edhm-ui: 3.0.63 -> 3.0.64 ``                                 |
| [`c500a634`](https://github.com/NixOS/nixpkgs/commit/c500a634b5b8579d2e9f3fe6d22569d5b3fb4abf) | `` perlPackages.Plack: 1.0050 -> 1.0053 ``                      |
| [`22d22adf`](https://github.com/NixOS/nixpkgs/commit/22d22adfb06949e9a085373b406632c2de3e9440) | `` google-chrome: 147.0.7727.116 -> 147.0.7727.137 ``           |
| [`a3931144`](https://github.com/NixOS/nixpkgs/commit/a3931144c8180846fb5019cac11120b25961a449) | `` tor-browser: 15.0.10 -> 15.0.11 ``                           |
| [`7997de39`](https://github.com/NixOS/nixpkgs/commit/7997de39712cbdca876db4ea879199183411ce00) | `` nuget-to-json: don't add packages with only contentHash ``   |
| [`e9302388`](https://github.com/NixOS/nixpkgs/commit/e9302388d8a3a2bc90dc73e2e2174dea9bcc7f20) | `` forgejo-lts: 11.0.12 -> 11.0.13 ``                           |
| [`7ff4c00a`](https://github.com/NixOS/nixpkgs/commit/7ff4c00a5f03da4020106b9e30a8e4d914219ccd) | `` perlPackages.TextCSV_XS: 1.52 -> 1.62 ``                     |
| [`467f0bf6`](https://github.com/NixOS/nixpkgs/commit/467f0bf6807917e33d100ef59b9c49191938f5f4) | `` forgejo: 15.0.0 -> 15.0.1 ``                                 |
| [`db4d888b`](https://github.com/NixOS/nixpkgs/commit/db4d888b09c4f02a0c0ae1245b8ebe9095847825) | `` linux_xanmod_latest: 6.19.14 -> 7.0.2 ``                     |
| [`42cb026b`](https://github.com/NixOS/nixpkgs/commit/42cb026b2d8d0f68210039924263ebbbb5ea1524) | `` linux_xanmod: 6.18.24 -> 6.18.25 ``                          |
| [`4a148832`](https://github.com/NixOS/nixpkgs/commit/4a1488322e3e35228e623bc1274b2a94019d4608) | `` victoriametrics: 1.141.0 -> 1.142.0 ``                       |
| [`6f9bb06b`](https://github.com/NixOS/nixpkgs/commit/6f9bb06b57014385538ab1b0bd251060c79a77ea) | `` proftpd: 1.3.9 -> 1.3.9a ``                                  |
| [`66fb330b`](https://github.com/NixOS/nixpkgs/commit/66fb330b5464719e7d9bbebd2e9a6cbd0c83b418) | `` python3Packages.requests-hardened: 1.2.0 -> 1.2.2 ``         |
| [`ee3b3410`](https://github.com/NixOS/nixpkgs/commit/ee3b3410c9a1ba12cdfcc1343e19553af9c640a2) | `` modrinth-app-unwrapped: 0.13.3 -> 0.13.6 ``                  |
| [`b2226a07`](https://github.com/NixOS/nixpkgs/commit/b2226a07358c6412058fc39246da52f9e9a478b4) | `` perlPackages.Starman: 0.4017 -> 0.4018 ``                    |
| [`bcf53527`](https://github.com/NixOS/nixpkgs/commit/bcf53527afe89304ca5fab11aa0bca6f0e290707) | `` outline: 1.6.1 -> 1.7.0 ``                                   |
| [`ff22f8f2`](https://github.com/NixOS/nixpkgs/commit/ff22f8f26045dbe4f2483eac29da22a76523544b) | `` docker: 29.4.0 -> 29.4.1 ``                                  |
| [`84cda446`](https://github.com/NixOS/nixpkgs/commit/84cda4461c4b12026a9e81d4936b23a30c283c24) | `` librechat: mark vulnerable ``                                |
| [`5ed5cf69`](https://github.com/NixOS/nixpkgs/commit/5ed5cf694683efe806493f5fee748aca539737bf) | `` thunderbird-latest-unwrapped: 149.0.2 -> 150.0 ``            |
| [`75c1c7f2`](https://github.com/NixOS/nixpkgs/commit/75c1c7f237e3f266c8ecc6c1b82d519b6493eed1) | `` wasm-pack: add hythera as maintainer ``                      |
| [`7e6010d4`](https://github.com/NixOS/nixpkgs/commit/7e6010d4f5072101fc6e3194267a5b1be396adf1) | `` wasm-pack: 0.13.1 -> 0.14.0 ``                               |
| [`fca096b7`](https://github.com/NixOS/nixpkgs/commit/fca096b7a3791bd9caf0d1a29065d0c772f8002c) | `` deezer-desktop: 7.1.150 -> 7.1.170 ``                        |
| [`50a9f7be`](https://github.com/NixOS/nixpkgs/commit/50a9f7be85627acb333c023750183071398bc729) | `` vesktop: 1.6.4 -> 1.6.5 ``                                   |
| [`2575700a`](https://github.com/NixOS/nixpkgs/commit/2575700af4fe3eaf2aff8ec363c6a0996d718e87) | `` littlegptracker: 1.4.2 -> 1.5.0 ``                           |