### PR TITLE
Add wallpaper sources + zed CLI default open behavior

### DIFF
--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -151,6 +151,8 @@ jobs:
               [fredbar]="skip"
               [solaar]="skip"
               [walls-catppuccin]="skip"
+              [walls-zhichaoh]="skip"
+              [walls-cozypixels]="skip"
               [nixos-needsreboot]="skip"
               [colmena]="skip"
               [flake-utils]="skip"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -147,6 +147,8 @@ jobs:
               [solaar]="desktop"
               [apple-fonts]="desktop"
               [walls-catppuccin]="desktop"
+              [walls-zhichaoh]="desktop"
+              [walls-cozypixels]="desktop"
               [nixvim]="global"
               [sops-nix]="desktop"
               [nixpkgs-stable]="server"

--- a/agents.md
+++ b/agents.md
@@ -93,28 +93,30 @@ reference for that future implementation.
 
 ### Input-to-category mapping
 
-| Input                 | CI Category             | Affects                                      |
-| --------------------- | ----------------------- | -------------------------------------------- |
-| `nixpkgs`             | desktop + fredhub       | Desktops + fredhub (unstable channel)        |
-| `home-manager`        | desktop                 | Desktop home-manager configs                 |
-| `catppuccin`          | desktop                 | Desktop theming                              |
-| `niri`                | desktop                 | Niri Wayland compositor (desktop only)       |
-| `fredbar`             | desktop                 | Status bar (desktop only)                    |
-| `freminal`            | desktop                 | Terminal emulator (desktop only)             |
-| `solaar`              | desktop                 | Logitech device manager (desktop only)       |
-| `apple-fonts`         | desktop                 | Apple fonts (desktop only)                   |
-| `walls-catppuccin`    | desktop                 | Wallpapers (desktop only, `flake=false`)     |
-| `nixvim`              | global (all linux)      | Neovim config (all systems)                  |
-| `nixpkgs-stable`      | server                  | All servers (stable channel)                 |
-| `home-manager-stable` | server                  | Server home-manager configs                  |
-| `catppuccin-stable`   | server                  | Server theming                               |
-| `sops-nix-stable`     | server                  | Server secrets management                    |
-| `sops-nix`            | desktop                 | Secrets management (unstable, desktops only) |
-| `nixos-needsreboot`   | global (all linux)      | Reboot detection module (all hosts)          |
-| `darwin`              | skip (no linux rebuild) | macOS only — does not affect Linux CI        |
-| `colmena`             | skip (no linux rebuild) | Deployment tool — no effect on builds        |
-| `flake-utils`         | skip (no linux rebuild) | Utility lib — no effect on system builds     |
-| `precommit-base`      | skip (no linux rebuild) | Dev tooling only — no system builds          |
+| Input                 | CI Category             | Affects                                                    |
+| --------------------- | ----------------------- | ---------------------------------------------------------- |
+| `nixpkgs`             | desktop + fredhub       | Desktops + fredhub (unstable channel)                      |
+| `home-manager`        | desktop                 | Desktop home-manager configs                               |
+| `catppuccin`          | desktop                 | Desktop theming                                            |
+| `niri`                | desktop                 | Niri Wayland compositor (desktop only)                     |
+| `fredbar`             | desktop                 | Status bar (desktop only)                                  |
+| `freminal`            | desktop                 | Terminal emulator (desktop only)                           |
+| `solaar`              | desktop                 | Logitech device manager (desktop only)                     |
+| `apple-fonts`         | desktop                 | Apple fonts (desktop only)                                 |
+| `walls-catppuccin`    | desktop                 | Wallpapers — orangci (desktop only, `flake=false`)         |
+| `walls-zhichaoh`      | desktop                 | Wallpapers — zhichaoh mirror (desktop only, `flake=false`) |
+| `walls-cozypixels`    | desktop                 | Wallpapers — CozyPixels (desktop only, `flake=false`)      |
+| `nixvim`              | global (all linux)      | Neovim config (all systems)                                |
+| `nixpkgs-stable`      | server                  | All servers (stable channel)                               |
+| `home-manager-stable` | server                  | Server home-manager configs                                |
+| `catppuccin-stable`   | server                  | Server theming                                             |
+| `sops-nix-stable`     | server                  | Server secrets management                                  |
+| `sops-nix`            | desktop                 | Secrets management (unstable, desktops only)               |
+| `nixos-needsreboot`   | global (all linux)      | Reboot detection module (all hosts)                        |
+| `darwin`              | skip (no linux rebuild) | macOS only — does not affect Linux CI                      |
+| `colmena`             | skip (no linux rebuild) | Deployment tool — no effect on builds                      |
+| `flake-utils`         | skip (no linux rebuild) | Utility lib — no effect on system builds                   |
+| `precommit-base`      | skip (no linux rebuild) | Dev tooling only — no system builds                        |
 
 **Unknown / new inputs should default to `global`** (rebuilds all Linux hosts).
 This is the safe fallback — it may over-build but will never miss a required

--- a/features/desktop/environments/common.nix
+++ b/features/desktop/environments/common.nix
@@ -208,6 +208,11 @@ in
                 path = "~/Pictures/Background";
                 fit_mode = "cover";
                 timeout = 300;
+                # Walk subdirectories so the source-attributed layout
+                # ($out/share/backgrounds/{orangci,catppuccin,daylin,
+                # cozypixels}/...) populated by the catppuccin-wallpapers
+                # derivation is fully cycled.
+                recursive = true;
               }
             ];
           };

--- a/features/desktop/environments/common.nix
+++ b/features/desktop/environments/common.nix
@@ -213,6 +213,16 @@ in
                 # cozypixels}/...) populated by the catppuccin-wallpapers
                 # derivation is fully cycled.
                 recursive = true;
+                # Shuffle the resolved file list once at load.  Without
+                # this, hyprpaper steps through the directory in
+                # filesystem iteration order, which on a deep tree
+                # means a single leaf subdir dominates rotation for
+                # many hours before any other subtree is reached.
+                # Note: hyprpaper has a hard-coded cap of 1024 images
+                # per wallpaper entry (see ConfigManager.cpp
+                # `maxImagesCount`); files past that point are dropped
+                # regardless of order.
+                order = "random";
               }
             ];
           };

--- a/features/desktop/zed/default.nix
+++ b/features/desktop/zed/default.nix
@@ -107,6 +107,12 @@ in
           ui_font_size = 14;
           buffer_font_size = 14;
 
+          # When opening a path from the CLI (e.g. `c` -> `zed .`) while
+          # another Zed window is already open, reuse that window as a
+          # new workspace tab instead of spawning a separate window.
+          # Suppresses the "Add to existing / Open new window" prompt.
+          cli_default_open_behavior = "existing_window";
+
           # Zed flipped the upstream default for the project / outline / git /
           # collaboration panels to "right" (see assets/settings/default.json
           # in zed v0.233.10). Pin the file tree back to the left.

--- a/flake.lock
+++ b/flake.lock
@@ -1509,7 +1509,9 @@
         "solaar": "solaar",
         "sops-nix": "sops-nix",
         "sops-nix-stable": "sops-nix-stable",
-        "walls-catppuccin": "walls-catppuccin"
+        "walls-catppuccin": "walls-catppuccin",
+        "walls-cozypixels": "walls-cozypixels",
+        "walls-zhichaoh": "walls-zhichaoh"
       }
     },
     "rust-overlay": {
@@ -1933,6 +1935,38 @@
       "original": {
         "owner": "orangci",
         "repo": "walls-catppuccin-mocha",
+        "type": "github"
+      }
+    },
+    "walls-cozypixels": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772560259,
+        "narHash": "sha256-xbDUXJ/EpLc7fipKg92NM9t2j8lRulre6ja9EjubndI=",
+        "owner": "SleepyCatHey",
+        "repo": "CozyPixels",
+        "rev": "a6063c135e16d66f24e0f5bb4146247cc7904cd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SleepyCatHey",
+        "repo": "CozyPixels",
+        "type": "github"
+      }
+    },
+    "walls-zhichaoh": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661293434,
+        "narHash": "sha256-h+cFlTXvUVJPRMpk32jYVDDhHu1daWSezFcvhJqDpmU=",
+        "owner": "zhichaoh",
+        "repo": "catppuccin-wallpapers",
+        "rev": "1023077979591cdeca76aae94e0359da1707a60e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhichaoh",
+        "repo": "catppuccin-wallpapers",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,35 @@
       url = "github:orangci/walls-catppuccin-mocha";
       flake = false;
     };
+
+    # CI: desktop
+    # Community-maintained mirror of the (taken-down) catppuccin/wallpapers
+    # repo. Provides the original 11 categories (dithered, flatppuccin,
+    # gradients, landscapes, mandelbrot, minimalistic, misc, os, patterns,
+    # solids, waves).
+    walls-zhichaoh = {
+      url = "github:zhichaoh/catppuccin-wallpapers";
+      flake = false;
+    };
+
+    # CI: desktop
+    # Curated cozy/aesthetic collection. We only consume the Catppuccin/
+    # subtree from this repo (it also ships Nord and One Dark variants).
+    walls-cozypixels = {
+      url = "github:SleepyCatHey/CozyPixels";
+      flake = false;
+    };
+
+    # NOTE: daylinmorgan/catppuccin-wallpapers is NOT a flake input.
+    # It is fetched as a release tarball via pkgs.fetchurl inside
+    # flake/dev/packages.nix because:
+    #   1. The upstream repo ships only SVG sources + a Python+Inkscape
+    #      generator — generating PNGs at build time would pull a ~500MB
+    #      Inkscape closure for only 4 base designs.
+    #   2. The pre-generated PNGs are released as .tar.gz on the v2022.05.02
+    #      release.  The repo has been dormant since 2022, so a pinned
+    #      release tarball is fully equivalent to (and cheaper than)
+    #      tracking the git source.
   };
 
   outputs =
@@ -159,6 +188,8 @@
       niri,
       darwin,
       walls-catppuccin,
+      walls-zhichaoh,
+      walls-cozypixels,
       solaar,
       colmena,
       freminal,
@@ -256,6 +287,8 @@
           solaar
           colmena
           walls-catppuccin
+          walls-zhichaoh
+          walls-cozypixels
           freminal
           ;
       };

--- a/flake/dev/packages.nix
+++ b/flake/dev/packages.nix
@@ -9,25 +9,150 @@
   ...
 }:
 let
-  inherit (inputs) nixpkgs walls-catppuccin;
+  inherit (inputs)
+    nixpkgs
+    walls-catppuccin
+    walls-zhichaoh
+    walls-cozypixels
+    ;
 in
 {
   packages = forAllSystems (
     system:
     let
       pkgs = import nixpkgs { inherit system; };
+
+      # Pinned release tarball of procedurally-generated catppuccin
+      # wallpapers from daylinmorgan/catppuccin-wallpapers.  See the
+      # comment in flake.nix (walls-cozypixels block) for the rationale
+      # for using a release tarball instead of a flake input.
+      walls-daylin-tarball = pkgs.fetchurl {
+        url = "https://github.com/daylinmorgan/catppuccin-wallpapers/releases/download/v2022.05.02/all.tar.gz";
+        hash = "sha256-kMpqJhr1sR/xhifKCp0IwmmfQ6SqKsWMRW34Nn8n2y8=";
+      };
     in
     {
+      # Aggregate catppuccin wallpaper collection.
+      #
+      # Layout under $out/share/backgrounds/:
+      #   orangci/      - github:orangci/walls-catppuccin-mocha
+      #   catppuccin/   - github:zhichaoh/catppuccin-wallpapers
+      #                   (mirror of the original catppuccin/wallpapers,
+      #                    11 categories preserved as subdirs)
+      #   daylin/       - daylinmorgan/catppuccin-wallpapers v2022.05.02
+      #                   release tarball (procedurally-generated PNGs
+      #                   across the catppuccin palette)
+      #   cozypixels/   - SleepyCatHey/CozyPixels Catppuccin/ subtree
+      #                   (subdirs renamed to remove spaces & ampersands)
+      #
+      # Consumers (e.g. hyprpaper) must enable recursive scanning to
+      # walk into the source-attributed subdirectories.
       catppuccin-wallpapers = pkgs.stdenvNoCC.mkDerivation {
         pname = "catppuccin-wallpapers";
-        version = "git";
+        version = "2026-05-05";
 
-        src = walls-catppuccin;
+        # Pass the four sources through the env so the install phase
+        # can reference each one.
+        srcs = [
+          walls-catppuccin
+          walls-zhichaoh
+          walls-cozypixels
+          walls-daylin-tarball
+        ];
+
+        # We have multiple unrelated sources; skip the default
+        # unpackPhase and lay them out manually.
+        dontUnpack = true;
+
+        nativeBuildInputs = [ pkgs.gzip ];
 
         installPhase = ''
-          mkdir -p $out/share/backgrounds
-          cp -r . $out/share/backgrounds/
+          runHook preInstall
+
+          out_bg="$out/share/backgrounds"
+          mkdir -p "$out_bg"
+
+          ##################################################################
+          # 1. orangci/walls-catppuccin-mocha
+          #    Flat collection of images at the repo root.
+          ##################################################################
+          mkdir -p "$out_bg/orangci"
+          cp -r ${walls-catppuccin}/. "$out_bg/orangci/"
+
+          ##################################################################
+          # 2. zhichaoh/catppuccin-wallpapers
+          #    Preserve the 11 category subdirs.  Drop repo metadata
+          #    files so only image content lands in the output.
+          ##################################################################
+          mkdir -p "$out_bg/catppuccin"
+          cp -r ${walls-zhichaoh}/. "$out_bg/catppuccin/"
+          rm -f \
+            "$out_bg/catppuccin/.editorconfig" \
+            "$out_bg/catppuccin/LICENSE" \
+            "$out_bg/catppuccin/README.md"
+
+          ##################################################################
+          # 3. SleepyCatHey/CozyPixels — Catppuccin/ subtree only.
+          #    The upstream subdirs use spaces and ampersands (e.g.
+          #    "Anime & Gaming") which are awkward in shell paths.
+          #    Rename to lowercase-with-hyphens during install.
+          ##################################################################
+          mkdir -p "$out_bg/cozypixels"
+          cp -r "${walls-cozypixels}/Catppuccin/." "$out_bg/cozypixels/"
+          # Files copied from another store path are read-only; make
+          # them writable so subsequent rename/delete steps succeed.
+          chmod -R u+w "$out_bg/cozypixels"
+          # Normalise subdir names: lowercase, spaces -> '-', drop '&'.
+          while IFS= read -r -d "" dir; do
+            base="$(basename "$dir")"
+            parent="$(dirname "$dir")"
+            new="$(printf '%s' "$base" \
+              | tr '[:upper:] ' '[:lower:]-' \
+              | tr -d '&' \
+              | tr -s '-')"
+            new="''${new%-}"
+            if [ "$base" != "$new" ]; then
+              mv "$dir" "$parent/$new"
+            fi
+          done < <(find "$out_bg/cozypixels" -mindepth 1 -maxdepth 1 -type d -print0)
+          # Normalise file extensions: upstream contains DOS-truncated
+          # ".WEB" files (real WebP images) which hyprpaper's extension
+          # filter would skip.  Rename to lowercase ".webp".
+          find "$out_bg/cozypixels" -type f -name '*.WEB' -print0 \
+            | while IFS= read -r -d "" f; do
+                mv "$f" "''${f%.WEB}.webp"
+              done
+          # Drop any non-image stragglers (e.g. Dolphin ".comments"
+          # metadata, hidden dotfiles) that may slip in from upstream.
+          find "$out_bg/cozypixels" -type f \
+            ! -iname '*.png' \
+            ! -iname '*.jpg' \
+            ! -iname '*.jpeg' \
+            ! -iname '*.webp' \
+            ! -iname '*.gif' \
+            -delete
+
+          ##################################################################
+          # 4. daylinmorgan/catppuccin-wallpapers release tarball.
+          #    Tarball top-level layout: pngs/{caffeine,cat,lines,tux}/...
+          #    Some files are stored as <name>.png.gz; gunzip them.
+          ##################################################################
+          mkdir -p "$out_bg/daylin"
+          tar -xzf ${walls-daylin-tarball} -C "$out_bg/daylin" --strip-components=1
+          # Decompress any .png.gz files in place.
+          find "$out_bg/daylin" -type f -name '*.png.gz' -print0 \
+            | while IFS= read -r -d "" f; do
+                gunzip -f "$f"
+              done
+
+          runHook postInstall
         '';
+
+        meta = with pkgs.lib; {
+          description = "Aggregated catppuccin wallpaper collection (orangci, zhichaoh, daylinmorgan, CozyPixels)";
+          license = licenses.mit;
+          platforms = platforms.all;
+        };
       };
     }
   );

--- a/flake/dev/packages.nix
+++ b/flake/dev/packages.nix
@@ -21,6 +21,7 @@ in
     system:
     let
       pkgs = import nixpkgs { inherit system; };
+      inherit (pkgs) lib;
 
       # Pinned release tarball of procedurally-generated catppuccin
       # wallpapers from daylinmorgan/catppuccin-wallpapers.  See the
@@ -31,7 +32,10 @@ in
         hash = "sha256-kMpqJhr1sR/xhifKCp0IwmmfQ6SqKsWMRW34Nn8n2y8=";
       };
     in
-    {
+    # The aggregate wallpaper bundle is a Linux-desktop-only asset
+    # (consumed by hyprpaper).  Skip it on Darwin so the 1.4 GB closure
+    # is never built or surfaced there.
+    lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
       # Aggregate catppuccin wallpaper collection.
       #
       # Layout under $out/share/backgrounds/:
@@ -151,7 +155,7 @@ in
         meta = with pkgs.lib; {
           description = "Aggregated catppuccin wallpaper collection (orangci, zhichaoh, daylinmorgan, CozyPixels)";
           license = licenses.mit;
-          platforms = platforms.all;
+          platforms = platforms.linux;
         };
       };
     }


### PR DESCRIPTION
## Summary

- Aggregate the catppuccin wallpaper collection with three new sources alongside `walls-catppuccin` (orangci): `walls-zhichaoh` (mirror of the original `catppuccin/wallpapers`), `walls-cozypixels` (`Catppuccin/` subtree), and a pinned `daylinmorgan/catppuccin-wallpapers` release tarball via `pkgs.fetchurl`.
- Lay them out under `$out/share/backgrounds/{orangci,catppuccin,daylin,cozypixels}/` and enable `recursive = true` on the hyprpaper wallpaper entry so the cycle picks files from every subdir.
- Set `cli_default_open_behavior = "existing_window"` in zed user settings so `c` (alias for `zed .`) reuses the focused window instead of prompting.

## Notes

- Total derivation size ~1.4 GB (1252 wallpapers). CozyPixels alone is ~709 MB; happy to trim if that's too much.
- Install phase normalizes CozyPixels subdir names (lowercase, `&` removed, spaces -> `-`), renames `.WEB` -> `.webp`, drops non-image stragglers, and decompresses daylin `.png.gz` files in place.
- Verified: `nix flake check` passes, `nix build .#catppuccin-wallpapers` succeeds, hyprpaper picked `catppuccin/gradients/red_peach.png` after rebuild (confirms `recursive` works).
- CI: both new inputs categorized as `desktop` (linux) / `skip` (darwin); `agents.md` input table updated.