### PR TITLE
chore(flake/home-manager): `d9876178` -> `e4419d31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777988791,
-        "narHash": "sha256-DtbtSW5+Hls7z+D9BfsAXvFuivt5iZ0OzUXjQ8d8lB8=",
+        "lastModified": 1778144356,
+        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d987617879f613053f6fdf4491fe28ce0283d543",
+        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`e4419d31`](https://github.com/nix-community/home-manager/commit/e4419d3123b780d5f4c0bceeace450424387638c) | `` zed-editor: add zh4ngx as maintainer ``               |
| [`838330cc`](https://github.com/nix-community/home-manager/commit/838330cc25ab67312cb6963cfad842b92735e3c0) | `` zed-editor: add defaultEditor option ``               |
| [`75fac363`](https://github.com/nix-community/home-manager/commit/75fac363324f18d2b83a30fd916e509d2a02fb0e) | `` direnv: avoid duplicate fish hook ``                  |
| [`7547f894`](https://github.com/nix-community/home-manager/commit/7547f8942cd2ad9ef572d701db23b4c08bb74fae) | `` quickshell: don't throw error when package is null `` |
| [`00ed86e5`](https://github.com/nix-community/home-manager/commit/00ed86e58bb6979a7921859fd1615d19382eac5c) | `` Translate using Weblate (French) ``                   |
| [`24bac7a6`](https://github.com/nix-community/home-manager/commit/24bac7a6d399e55ded72ffe698ef3569db41946c) | `` Translate using Weblate (Russian) ``                  |
| [`02b61230`](https://github.com/nix-community/home-manager/commit/02b61230c4c24ede54d8cf6799ff35892e1253e9) | `` email: extend `mailbox.org` config flavor ``          |