### PR TITLE
chore(flake/nixpkgs-stable): `26ef669c` -> `0c88e1f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1172,11 +1172,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1777673416,
-        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`2da1cd39`](https://github.com/NixOS/nixpkgs/commit/2da1cd3975a4af193ec8519007d6480797704960) | `` xen: 4.20.2 -> 4.20.3 ``                                                                            |
| [`9821996c`](https://github.com/NixOS/nixpkgs/commit/9821996c88e787175afbeefd86777821856b754d) | `` deezer-desktop: 7.1.170 -> 7.1.180 ``                                                               |
| [`9ac8a36a`](https://github.com/NixOS/nixpkgs/commit/9ac8a36a250fe6dec1aa2c37437800c030fa5260) | `` ceph: fix nixfmt ``                                                                                 |
| [`1100ff65`](https://github.com/NixOS/nixpkgs/commit/1100ff65ad783a94de661f77d3d1bee92402a657) | `` ceph: fixup build of its pyopenssl ``                                                               |
| [`6ee8f6e7`](https://github.com/NixOS/nixpkgs/commit/6ee8f6e786157347595ea8b70365afe89bbb8d5b) | `` python3Packages.aioboto3: disable DynamoDB tests with aiobotocore 3.x ``                            |
| [`84b4d3d3`](https://github.com/NixOS/nixpkgs/commit/84b4d3d3925fee845f8452b34ff98eceada05cdd) | `` nomachine-client: 9.2.18_3 -> 9.4.14_1 ``                                                           |
| [`1161322e`](https://github.com/NixOS/nixpkgs/commit/1161322e10e723fe31ac559d3db748287af24c27) | `` osu-lazer: 2026.425.0 -> 2026.429.0 ``                                                              |
| [`7202c981`](https://github.com/NixOS/nixpkgs/commit/7202c981c66da164aaf5321e4aeae89ac75ffe6e) | `` osu-lazer-bin: 2026.425.0 -> 2026.429.0 ``                                                          |
| [`4f28883d`](https://github.com/NixOS/nixpkgs/commit/4f28883d2ecbb2a05f8ec800cc4e58b58ce4870a) | `` weblate: relax on dateparser dependency ``                                                          |
| [`1f1b96bd`](https://github.com/NixOS/nixpkgs/commit/1f1b96bd99a93e9ec249ea3a88a7ed2310c3c368) | `` nixos/weblate: make wlc config file format compliant for wlc 1.17.0 ``                              |
| [`4a2e83cc`](https://github.com/NixOS/nixpkgs/commit/4a2e83ccebdd1f9164e892adad1938a540b6a559) | `` mupdf: fixup build of the vendored freeglut ``                                                      |
| [`3ec83032`](https://github.com/NixOS/nixpkgs/commit/3ec830323b8bda3d094781c66a94037d9d852e84) | `` maintainers/github-teams.json: Automated sync ``                                                    |
| [`2a0e12e0`](https://github.com/NixOS/nixpkgs/commit/2a0e12e0156a51845c143791cf6d937efb0f8841) | `` maintainers/github-teams.json: Automated sync ``                                                    |
| [`eaf135bd`](https://github.com/NixOS/nixpkgs/commit/eaf135bd907f2ace1a7faa6c4871a76949d78fe2) | `` nix: bump all versions to latest patch releases ``                                                  |
| [`c58ace3b`](https://github.com/NixOS/nixpkgs/commit/c58ace3b979ed4142225711a564ffbb8bc0c407e) | `` python3Packages.psycopg: disable slow tests ``                                                      |
| [`ab8fc92b`](https://github.com/NixOS/nixpkgs/commit/ab8fc92bef4455fb3b4a1c3e7f13092cebe9b619) | `` lix_2_95: 2.95.1 -> 2.95.2 ``                                                                       |
| [`d7f9f2d8`](https://github.com/NixOS/nixpkgs/commit/d7f9f2d869a6bb05902c5abe038516d7b5fa3233) | `` lix_2_94: 2.94.1 -> 2.94.2 ``                                                                       |
| [`c56a445e`](https://github.com/NixOS/nixpkgs/commit/c56a445e63f73e59084c209341709254e3a1c768) | `` lix_2_93: 2.93.3 -> 2.93.4 ``                                                                       |
| [`2d937793`](https://github.com/NixOS/nixpkgs/commit/2d937793875ff277730334644c239813d564191f) | `` python3Packages.astropy-iers-data: 0.2025.11.24.0.39.11 -> 0.2026.1.19.0.42.31 ``                   |
| [`b1a890ff`](https://github.com/NixOS/nixpkgs/commit/b1a890ff22830570ff50d47b7dc2e811bed045ea) | `` python3Packages.astropy-iers-data: 0.2025.8.4.0.42.59 -> 0.2025.11.24.0.39.11 ``                    |
| [`b21bb05b`](https://github.com/NixOS/nixpkgs/commit/b21bb05b8baa045e89a48877dcddb09b73e177fb) | `` python3Packages.astropy: 7.1.1 -> 7.2.0 ``                                                          |
| [`f1df17fe`](https://github.com/NixOS/nixpkgs/commit/f1df17fe1dc363eb399881eb951c5c6056f2afd5) | `` python3Packages.astropy: fix OMP_NUM_THREADS going 0 ``                                             |
| [`9e8379cc`](https://github.com/NixOS/nixpkgs/commit/9e8379ccfde2eb23ff4ea34fc2e97159b5b985e8) | `` python3Packages.astropy: 7.1.0 -> 7.1.1 ``                                                          |
| [`df866b21`](https://github.com/NixOS/nixpkgs/commit/df866b21b052729901e79de47fa8a8507a0aeeae) | `` nixos/tetrd: remove CAP_DAC_OVERRIDE ``                                                             |
| [`73268d83`](https://github.com/NixOS/nixpkgs/commit/73268d836e41916c799ab759d3a39cb032e87c6a) | `` pyrefly: 0.62.0 -> 0.63.1 ``                                                                        |
| [`9b50e661`](https://github.com/NixOS/nixpkgs/commit/9b50e661fb3030b0d1327a2a1683f7ae3ecc86c6) | `` floorp-bin-unwrapped: 12.12.2 -> 12.13.0 ``                                                         |
| [`42d20fdc`](https://github.com/NixOS/nixpkgs/commit/42d20fdcea8e74ec98d3d577c419150a8bb4716a) | `` palemoon-bin: 34.2.0 -> 34.2.2 ``                                                                   |
| [`2ef67961`](https://github.com/NixOS/nixpkgs/commit/2ef679617a9d009b247f467c033d21e0a8381f1c) | `` ocamlPackages.elpi: 3.6.2 -> 3.7.1 ``                                                               |
| [`0f024f53`](https://github.com/NixOS/nixpkgs/commit/0f024f53297de8439f6223170c5b3d501b33dad2) | `` ocamlPackages.elpi: 3.6.1 -> 3.6.2 ``                                                               |
| [`fb6bbcee`](https://github.com/NixOS/nixpkgs/commit/fb6bbceeddd7f2b8bb66d3da7c2543a384c20e83) | `` outline: 1.7.0 -> 1.7.1 ``                                                                          |
| [`0011713e`](https://github.com/NixOS/nixpkgs/commit/0011713e78b0b3da27f41b5d080e768c4eed81ff) | `` llvmPackages_git: 23.0.0-unstable-2026-04-19 -> 23.0.0-unstable-2026-05-03 ``                       |
| [`db5d76fc`](https://github.com/NixOS/nixpkgs/commit/db5d76fc2961f744b2e0299a5ac979aac2ca02bf) | `` thunderbird-latest-unwrapped: 150.0 -> 150.0.1 ``                                                   |
| [`ff1e99c1`](https://github.com/NixOS/nixpkgs/commit/ff1e99c1afd1995f7f7603eb89bed0c97cb46241) | `` jackett: 0.24.1591 -> 0.24.1807 ``                                                                  |
| [`4dfaa1cf`](https://github.com/NixOS/nixpkgs/commit/4dfaa1cf8a6059c7e5cffef2140461602061205f) | `` gitlab: use nodejs 22 ``                                                                            |
| [`93908a1d`](https://github.com/NixOS/nixpkgs/commit/93908a1de08dd0b5d3ce4f2dca67ad37a0e0c697) | `` liferea: 1.16.8 -> 1.16.9 ``                                                                        |
| [`be22f9a5`](https://github.com/NixOS/nixpkgs/commit/be22f9a50758b222dc5124fc875421f906eea694) | `` Reapply {ci,workflows}: allow multiple blocking reviews" ``                                         |
| [`5ca41422`](https://github.com/NixOS/nixpkgs/commit/5ca414228195772dd7244095bfdf0481a2c70a89) | `` gridcoin-research: migrate to pkgs by-name ``                                                       |
| [`2b78a311`](https://github.com/NixOS/nixpkgs/commit/2b78a311732e9be01519e8dc2c1e8d9903217548) | `` gridcoin-research: 5.4.9.0 -> 5.5.0.0 ``                                                            |
| [`4e7e7285`](https://github.com/NixOS/nixpkgs/commit/4e7e7285bff864f8fbc7190238fed4403f76bdb0) | `` noriskclient-launcher-unwrapped: 0.6.19 -> 0.6.20 ``                                                |
| [`8a94eae6`](https://github.com/NixOS/nixpkgs/commit/8a94eae6f3c1f7e11af6fa7497d2ef250a8c787f) | `` lrcget: 2.0.1 -> 2.1.0 ``                                                                           |
| [`f950424d`](https://github.com/NixOS/nixpkgs/commit/f950424d0e74a91ac86696cc8795c949ab7f2701) | `` lrcget: 2.0.0 -> 2.0.1 ``                                                                           |
| [`ab29237d`](https://github.com/NixOS/nixpkgs/commit/ab29237de07c0d31863a3b4a33386ffa4560d03a) | `` lrcget: 1.0.2 -> 2.0.0 ``                                                                           |
| [`b919d83e`](https://github.com/NixOS/nixpkgs/commit/b919d83ee6aeb2446b71bb574205802bf0706efb) | `` lrcget: 0.9.3 -> 1.0.2 ``                                                                           |
| [`71f087d9`](https://github.com/NixOS/nixpkgs/commit/71f087d903191b30148128b3c8e6563b638c931a) | `` vaultwarden.webvault: 2026.3.1+0 -> 2026.4.1+0 ``                                                   |
| [`b039a09a`](https://github.com/NixOS/nixpkgs/commit/b039a09a16c50a4ef627e914dac0f66b77ea4516) | `` vaultwarden: 1.35.8 -> 1.36.0 ``                                                                    |
| [`2da1cd39`](https://github.com/NixOS/nixpkgs/commit/2da1cd3975a4af193ec8519007d6480797704960) | `` xen: 4.20.2 -> 4.20.3 ``                                                                            |
| [`9821996c`](https://github.com/NixOS/nixpkgs/commit/9821996c88e787175afbeefd86777821856b754d) | `` deezer-desktop: 7.1.170 -> 7.1.180 ``                                                               |
| [`9ac8a36a`](https://github.com/NixOS/nixpkgs/commit/9ac8a36a250fe6dec1aa2c37437800c030fa5260) | `` ceph: fix nixfmt ``                                                                                 |
| [`1100ff65`](https://github.com/NixOS/nixpkgs/commit/1100ff65ad783a94de661f77d3d1bee92402a657) | `` ceph: fixup build of its pyopenssl ``                                                               |
| [`6ee8f6e7`](https://github.com/NixOS/nixpkgs/commit/6ee8f6e786157347595ea8b70365afe89bbb8d5b) | `` python3Packages.aioboto3: disable DynamoDB tests with aiobotocore 3.x ``                            |
| [`84b4d3d3`](https://github.com/NixOS/nixpkgs/commit/84b4d3d3925fee845f8452b34ff98eceada05cdd) | `` nomachine-client: 9.2.18_3 -> 9.4.14_1 ``                                                           |
| [`1161322e`](https://github.com/NixOS/nixpkgs/commit/1161322e10e723fe31ac559d3db748287af24c27) | `` osu-lazer: 2026.425.0 -> 2026.429.0 ``                                                              |
| [`7202c981`](https://github.com/NixOS/nixpkgs/commit/7202c981c66da164aaf5321e4aeae89ac75ffe6e) | `` osu-lazer-bin: 2026.425.0 -> 2026.429.0 ``                                                          |
| [`4f28883d`](https://github.com/NixOS/nixpkgs/commit/4f28883d2ecbb2a05f8ec800cc4e58b58ce4870a) | `` weblate: relax on dateparser dependency ``                                                          |
| [`1f1b96bd`](https://github.com/NixOS/nixpkgs/commit/1f1b96bd99a93e9ec249ea3a88a7ed2310c3c368) | `` nixos/weblate: make wlc config file format compliant for wlc 1.17.0 ``                              |
| [`4a2e83cc`](https://github.com/NixOS/nixpkgs/commit/4a2e83ccebdd1f9164e892adad1938a540b6a559) | `` mupdf: fixup build of the vendored freeglut ``                                                      |
| [`3ec83032`](https://github.com/NixOS/nixpkgs/commit/3ec830323b8bda3d094781c66a94037d9d852e84) | `` maintainers/github-teams.json: Automated sync ``                                                    |
| [`2a0e12e0`](https://github.com/NixOS/nixpkgs/commit/2a0e12e0156a51845c143791cf6d937efb0f8841) | `` maintainers/github-teams.json: Automated sync ``                                                    |
| [`eaf135bd`](https://github.com/NixOS/nixpkgs/commit/eaf135bd907f2ace1a7faa6c4871a76949d78fe2) | `` nix: bump all versions to latest patch releases ``                                                  |
| [`c58ace3b`](https://github.com/NixOS/nixpkgs/commit/c58ace3b979ed4142225711a564ffbb8bc0c407e) | `` python3Packages.psycopg: disable slow tests ``                                                      |
| [`ab8fc92b`](https://github.com/NixOS/nixpkgs/commit/ab8fc92bef4455fb3b4a1c3e7f13092cebe9b619) | `` lix_2_95: 2.95.1 -> 2.95.2 ``                                                                       |
| [`d7f9f2d8`](https://github.com/NixOS/nixpkgs/commit/d7f9f2d869a6bb05902c5abe038516d7b5fa3233) | `` lix_2_94: 2.94.1 -> 2.94.2 ``                                                                       |
| [`c56a445e`](https://github.com/NixOS/nixpkgs/commit/c56a445e63f73e59084c209341709254e3a1c768) | `` lix_2_93: 2.93.3 -> 2.93.4 ``                                                                       |
| [`2d937793`](https://github.com/NixOS/nixpkgs/commit/2d937793875ff277730334644c239813d564191f) | `` python3Packages.astropy-iers-data: 0.2025.11.24.0.39.11 -> 0.2026.1.19.0.42.31 ``                   |
| [`b1a890ff`](https://github.com/NixOS/nixpkgs/commit/b1a890ff22830570ff50d47b7dc2e811bed045ea) | `` python3Packages.astropy-iers-data: 0.2025.8.4.0.42.59 -> 0.2025.11.24.0.39.11 ``                    |
| [`b21bb05b`](https://github.com/NixOS/nixpkgs/commit/b21bb05b8baa045e89a48877dcddb09b73e177fb) | `` python3Packages.astropy: 7.1.1 -> 7.2.0 ``                                                          |
| [`f1df17fe`](https://github.com/NixOS/nixpkgs/commit/f1df17fe1dc363eb399881eb951c5c6056f2afd5) | `` python3Packages.astropy: fix OMP_NUM_THREADS going 0 ``                                             |
| [`9e8379cc`](https://github.com/NixOS/nixpkgs/commit/9e8379ccfde2eb23ff4ea34fc2e97159b5b985e8) | `` python3Packages.astropy: 7.1.0 -> 7.1.1 ``                                                          |
| [`df866b21`](https://github.com/NixOS/nixpkgs/commit/df866b21b052729901e79de47fa8a8507a0aeeae) | `` nixos/tetrd: remove CAP_DAC_OVERRIDE ``                                                             |
| [`73268d83`](https://github.com/NixOS/nixpkgs/commit/73268d836e41916c799ab759d3a39cb032e87c6a) | `` pyrefly: 0.62.0 -> 0.63.1 ``                                                                        |
| [`9b50e661`](https://github.com/NixOS/nixpkgs/commit/9b50e661fb3030b0d1327a2a1683f7ae3ecc86c6) | `` floorp-bin-unwrapped: 12.12.2 -> 12.13.0 ``                                                         |
| [`42d20fdc`](https://github.com/NixOS/nixpkgs/commit/42d20fdcea8e74ec98d3d577c419150a8bb4716a) | `` palemoon-bin: 34.2.0 -> 34.2.2 ``                                                                   |
| [`2ef67961`](https://github.com/NixOS/nixpkgs/commit/2ef679617a9d009b247f467c033d21e0a8381f1c) | `` ocamlPackages.elpi: 3.6.2 -> 3.7.1 ``                                                               |
| [`0f024f53`](https://github.com/NixOS/nixpkgs/commit/0f024f53297de8439f6223170c5b3d501b33dad2) | `` ocamlPackages.elpi: 3.6.1 -> 3.6.2 ``                                                               |
| [`fb6bbcee`](https://github.com/NixOS/nixpkgs/commit/fb6bbceeddd7f2b8bb66d3da7c2543a384c20e83) | `` outline: 1.7.0 -> 1.7.1 ``                                                                          |
| [`0011713e`](https://github.com/NixOS/nixpkgs/commit/0011713e78b0b3da27f41b5d080e768c4eed81ff) | `` llvmPackages_git: 23.0.0-unstable-2026-04-19 -> 23.0.0-unstable-2026-05-03 ``                       |
| [`db5d76fc`](https://github.com/NixOS/nixpkgs/commit/db5d76fc2961f744b2e0299a5ac979aac2ca02bf) | `` thunderbird-latest-unwrapped: 150.0 -> 150.0.1 ``                                                   |
| [`ff1e99c1`](https://github.com/NixOS/nixpkgs/commit/ff1e99c1afd1995f7f7603eb89bed0c97cb46241) | `` jackett: 0.24.1591 -> 0.24.1807 ``                                                                  |
| [`4dfaa1cf`](https://github.com/NixOS/nixpkgs/commit/4dfaa1cf8a6059c7e5cffef2140461602061205f) | `` gitlab: use nodejs 22 ``                                                                            |
| [`93908a1d`](https://github.com/NixOS/nixpkgs/commit/93908a1de08dd0b5d3ce4f2dca67ad37a0e0c697) | `` liferea: 1.16.8 -> 1.16.9 ``                                                                        |
| [`be22f9a5`](https://github.com/NixOS/nixpkgs/commit/be22f9a50758b222dc5124fc875421f906eea694) | `` Reapply {ci,workflows}: allow multiple blocking reviews" ``                                         |
| [`5ca41422`](https://github.com/NixOS/nixpkgs/commit/5ca414228195772dd7244095bfdf0481a2c70a89) | `` gridcoin-research: migrate to pkgs by-name ``                                                       |
| [`2b78a311`](https://github.com/NixOS/nixpkgs/commit/2b78a311732e9be01519e8dc2c1e8d9903217548) | `` gridcoin-research: 5.4.9.0 -> 5.5.0.0 ``                                                            |
| [`4e7e7285`](https://github.com/NixOS/nixpkgs/commit/4e7e7285bff864f8fbc7190238fed4403f76bdb0) | `` noriskclient-launcher-unwrapped: 0.6.19 -> 0.6.20 ``                                                |
| [`8a94eae6`](https://github.com/NixOS/nixpkgs/commit/8a94eae6f3c1f7e11af6fa7497d2ef250a8c787f) | `` lrcget: 2.0.1 -> 2.1.0 ``                                                                           |
| [`f950424d`](https://github.com/NixOS/nixpkgs/commit/f950424d0e74a91ac86696cc8795c949ab7f2701) | `` lrcget: 2.0.0 -> 2.0.1 ``                                                                           |
| [`ab29237d`](https://github.com/NixOS/nixpkgs/commit/ab29237de07c0d31863a3b4a33386ffa4560d03a) | `` lrcget: 1.0.2 -> 2.0.0 ``                                                                           |
| [`b919d83e`](https://github.com/NixOS/nixpkgs/commit/b919d83ee6aeb2446b71bb574205802bf0706efb) | `` lrcget: 0.9.3 -> 1.0.2 ``                                                                           |
| [`71f087d9`](https://github.com/NixOS/nixpkgs/commit/71f087d903191b30148128b3c8e6563b638c931a) | `` vaultwarden.webvault: 2026.3.1+0 -> 2026.4.1+0 ``                                                   |
| [`b039a09a`](https://github.com/NixOS/nixpkgs/commit/b039a09a16c50a4ef627e914dac0f66b77ea4516) | `` vaultwarden: 1.35.8 -> 1.36.0 ``                                                                    |
| [`99f9aa41`](https://github.com/NixOS/nixpkgs/commit/99f9aa41fb6cdbc7bfd7d1feb8718f4762e47d79) | `` librewolf-unwrapped: 150.0-1 -> 150.0.1-1 ``                                                        |
| [`cfdbf7b5`](https://github.com/NixOS/nixpkgs/commit/cfdbf7b5ab33103161ace42f1d292043397f1cc0) | `` somo: 1.3.2 -> 1.3.3 ``                                                                             |
| [`e1bdf649`](https://github.com/NixOS/nixpkgs/commit/e1bdf649ff2c53945e59479523c6825d446f98f5) | `` woodpecker-pipeline-transform: 0.2.0 -> 0.3.0 ``                                                    |
| [`7035b1e9`](https://github.com/NixOS/nixpkgs/commit/7035b1e9a307274606da9e7f8a2e7b0bca35a7dc) | `` .github: Bump korthout/backport-action from 4.4.0 to 4.5.0 ``                                       |
| [`a9549b63`](https://github.com/NixOS/nixpkgs/commit/a9549b6371fb772a7b7c643996d40837074c2e61) | `` dprint-plugins.dprint-plugin-biome: 0.12.8 -> 0.12.9 ``                                             |
| [`e009ca79`](https://github.com/NixOS/nixpkgs/commit/e009ca7952bcfcee7e714f8ff025d6e374aeddc5) | `` kanidm_1_10: init at 1.10.0 ``                                                                      |
| [`8002d4c8`](https://github.com/NixOS/nixpkgs/commit/8002d4c8c6631283c325a423d8b78869c3d2a6f4) | `` tandoor-recipes: use nodejs_22 for frontend ``                                                      |
| [`96b75c0b`](https://github.com/NixOS/nixpkgs/commit/96b75c0b9b9b0c0f06785f381b5b7da5b94d5893) | `` jellyfin-web: nodejs_20 EOL -> nodejs_22 ``                                                         |
| [`7de03a87`](https://github.com/NixOS/nixpkgs/commit/7de03a8711d902386ad1b0b4753ce97e0a9e700f) | `` slskd: nodejs_20 EOL -> nodejs_24 ``                                                                |
| [`f7b16a79`](https://github.com/NixOS/nixpkgs/commit/f7b16a79d6e4838eba6c4c02377c33e4733156c2) | `` prl-tools: 26.3.1-57396 -> 26.3.2-57398 ``                                                          |
| [`c2b21fb0`](https://github.com/NixOS/nixpkgs/commit/c2b21fb07e43f3f68efe6f9d25517263e5a33001) | `` python2Packages.buildPythonPackage: format expression after lib.extendMkDerivation restructuring `` |
| [`79580f83`](https://github.com/NixOS/nixpkgs/commit/79580f83ee9970c418ce5419f6651ebba2046f0f) | `` python2Packages.buildPytonPackage: restructure with lib.extendMkDerivation ``                       |
| [`96986958`](https://github.com/NixOS/nixpkgs/commit/96986958c7947c25a1f2c48dd0895bf6711ab2cf) | `` python2Packages.buildPythonPackage: remove ineffective outputs cleanAttrs ``                        |
| [`30a2aa18`](https://github.com/NixOS/nixpkgs/commit/30a2aa18dd9e9e3901bab6171b4f87a99bd50fef) | `` python2Packages.buildPythonPackage: preserve disabled after <pkg>.overrideAttrs ``                  |
| [`93b2914c`](https://github.com/NixOS/nixpkgs/commit/93b2914ce9e49020fa34c9454525d7a50632105d) | `` python2Packages.buildPythonPackage: passthru disabled ``                                            |
| [`ffc31272`](https://github.com/NixOS/nixpkgs/commit/ffc3127237318aa1711580ea954806fa135e3ba7) | `` python2Packages.buildPythonPackage: port respect user-specified passthru attrs ``                   |
| [`6cd41146`](https://github.com/NixOS/nixpkgs/commit/6cd4114682f1e661e4a88de750e54c16a11d3678) | `` python2Packages.buildPythonPackage: handle passthru with mkDerivation ``                            |
| [`01b20a6f`](https://github.com/NixOS/nixpkgs/commit/01b20a6f6540efd43fb01e258d0ff4aa3a00678e) | `` woodpecker-{agent,cli,server}: 3.12.0 -> 3.14.0 ``                                                  |
| [`dd62297c`](https://github.com/NixOS/nixpkgs/commit/dd62297c371190080c4fa53c4139ffd7e4336415) | `` linux/hardened/patches/6.12: v6.12.69-hardened1 -> v6.12.85-hardened1 ``                            |
| [`9c36f447`](https://github.com/NixOS/nixpkgs/commit/9c36f447ffc7cf7a68d30f4ba9654b1956225959) | `` siyuan: 3.6.4 -> 3.6.5 ``                                                                           |
| [`e3b66271`](https://github.com/NixOS/nixpkgs/commit/e3b66271601bd98f643e25a3d09c6a705013b929) | `` siyuan: 3.6.3 -> 3.6.4 ``                                                                           |
| [`fae6d5cd`](https://github.com/NixOS/nixpkgs/commit/fae6d5cd23cae0ee2e4aac7c9f245b8900b6c5a9) | `` siyuan: 3.6.2 -> 3.6.3 ``                                                                           |
| [`f11a8ad7`](https://github.com/NixOS/nixpkgs/commit/f11a8ad7deec432e63d0b034cc3f6dc34cb834a3) | `` exim: 4.99.1 -> 4.99.2 ``                                                                           |
| [`3439853c`](https://github.com/NixOS/nixpkgs/commit/3439853cab615779aa99755ce00d1228becf1e3a) | `` knot-resolver_6: 6.2.0 -> 6.3.0 ``                                                                  |
| [`ce76748c`](https://github.com/NixOS/nixpkgs/commit/ce76748c2b051727f7fa964509373820a8cc1067) | `` gdk-pixbuf: fixup after the last update ``                                                          |
| [`2133e713`](https://github.com/NixOS/nixpkgs/commit/2133e71351192669b4e4af1a4c52415a7f91a66f) | `` gdk-pixbuf: 2.44.5 -> 2.44.6 ``                                                                     |
| [`f3148fa7`](https://github.com/NixOS/nixpkgs/commit/f3148fa7f2205600f039e03f55f709099d251f8a) | `` j: 9.6.2 -> 9.7.1 ``                                                                                |
| [`b07ca0a5`](https://github.com/NixOS/nixpkgs/commit/b07ca0a581710fbdac8a964d08d2dad80d9c8db8) | `` osu-lazer: 2026.418.0 -> 2026.425.0 ``                                                              |
| [`d02cbd59`](https://github.com/NixOS/nixpkgs/commit/d02cbd596700cb2ebbf8d67b15688cd59ff476f6) | `` osu-lazer-bin: 2026.418.0 -> 2026.425.0 ``                                                          |
| [`f2768d4e`](https://github.com/NixOS/nixpkgs/commit/f2768d4e8c28fa7e323dadf7981e506be9bbcc7e) | `` nixos/tests/dawarich: fix points being flagged as anomalies ``                                      |
| [`c8f09439`](https://github.com/NixOS/nixpkgs/commit/c8f09439b1b5f44d611eda9955cb4785e9004f58) | `` vim: 9.2.0272 -> 9.2.0340 ``                                                                        |
| [`afd23a6b`](https://github.com/NixOS/nixpkgs/commit/afd23a6b516bd056f28b599f4280b675a4200b3c) | `` xorg.libXpm: 3.5.18 -> 3.5.19 ``                                                                    |
| [`fdc3ad69`](https://github.com/NixOS/nixpkgs/commit/fdc3ad690942ae71df83ca6b9a8d399949b333d7) | `` xorg.libXpm: 3.5.17 -> 3.5.18 ``                                                                    |
| [`ff86ebff`](https://github.com/NixOS/nixpkgs/commit/ff86ebff2cbeaa5225f629be605a9f5b944be47e) | `` python3Packages.python-multipart: add patches for CVE-2026-40347 ``                                 |
| [`597459f0`](https://github.com/NixOS/nixpkgs/commit/597459f0696d3ffba617ed6895f0dadb7f399801) | `` libarchive: 3.8.6 -> 3.8.7 ``                                                                       |
| [`23b1b7af`](https://github.com/NixOS/nixpkgs/commit/23b1b7afe6c71ec6af68f1bea5eaa1da33f3533f) | `` ngtcp2: 1.22.0 -> 1.22.1 ``                                                                         |
| [`5589935f`](https://github.com/NixOS/nixpkgs/commit/5589935f7898bf2201a29c43f65ef49fd76f5504) | `` nghttp3: 1.14.0 -> 1.15.0 ``                                                                        |
| [`4b51ce38`](https://github.com/NixOS/nixpkgs/commit/4b51ce38b699b9712e4f0187af94801864359865) | `` ngtcp2: 1.19.0 -> 1.22.0 ``                                                                         |
| [`3a1b0c75`](https://github.com/NixOS/nixpkgs/commit/3a1b0c750d7df9dd664d0627eb36b07be1ffcefe) | `` nghttp3: 1.13.1 -> 1.14.0 ``                                                                        |
| [`aa687c19`](https://github.com/NixOS/nixpkgs/commit/aa687c1922e6b28ee8daf527bf11d6473115fc0c) | `` ngtcp2: 1.18.0 -> 1.19.0 ``                                                                         |
| [`37fe379a`](https://github.com/NixOS/nixpkgs/commit/37fe379ae38132aee6bb21e82daf2f13d4084590) | `` nghttp3: 1.13.0 -> 1.13.1 ``                                                                        |
| [`54f8a254`](https://github.com/NixOS/nixpkgs/commit/54f8a254bf9bc7067e92099ae1683af256fc5a73) | `` ngtcp2: 1.17.0 -> 1.18.0 ``                                                                         |
| [`653402a3`](https://github.com/NixOS/nixpkgs/commit/653402a327680a4271a85dd5b98e732660c10247) | `` nghttp3: 1.12.0 -> 1.13.0 ``                                                                        |
| [`95908e6f`](https://github.com/NixOS/nixpkgs/commit/95908e6fc2f720a1897d6f1fdcb40d4cddcc2554) | `` nss: 3.112.3 -> 3.112.5 ``                                                                          |
| [`ad206845`](https://github.com/NixOS/nixpkgs/commit/ad206845cc359efc1eef48f36ad29ddefe01ab87) | `` libgudev: disable test-gudevdevice ``                                                               |
| [`6df8b971`](https://github.com/NixOS/nixpkgs/commit/6df8b971dd4ee39a3da70eb7218f7401fb779a0d) | `` systemd: 258.5 -> 258.7 ``                                                                          |
| [`a3cc5d38`](https://github.com/NixOS/nixpkgs/commit/a3cc5d38c8701b1eb7b8a90242908fae2460a2bd) | `` nodejs_{20,22}: disable broken openssl tests ``                                                     |
| [`6feb5735`](https://github.com/NixOS/nixpkgs/commit/6feb5735c96d084de64fc1b81f03a9ab81db2607) | `` mimir: 3.0.5 -> 3.0.6 ``                                                                            |
| [`9fb93890`](https://github.com/NixOS/nixpkgs/commit/9fb93890048d1a84fa3df67d59fe42ae9f8989ad) | `` mimir: fix escape ``                                                                                |
| [`07fddb47`](https://github.com/NixOS/nixpkgs/commit/07fddb4762c1b41af488f70748623b23f655504e) | `` mimir: 3.0.4 -> 3.0.5 ``                                                                            |
| [`c614c66d`](https://github.com/NixOS/nixpkgs/commit/c614c66d3017614b305844b845ebd2cf42ced150) | `` nixos/systemd: fix modprobe ``                                                                      |
| [`39417f53`](https://github.com/NixOS/nixpkgs/commit/39417f53bde41e6f094f7b79ac024d7108486b37) | `` cacert: 3.121 -> 3.123 ``                                                                           |
| [`c2d363f2`](https://github.com/NixOS/nixpkgs/commit/c2d363f2f2f453c9f85c2cb40d1e1319ff288fa9) | `` aws-c-event-stream: 0.5.7 -> 0.7.0, fix CVE-2026-5190 ``                                            |
| [`4484a4fe`](https://github.com/NixOS/nixpkgs/commit/4484a4feed6d950525fd90b70a87c0e29aa95e15) | `` openssh_gssapi: update patch to latest ``                                                           |
| [`8a97e77d`](https://github.com/NixOS/nixpkgs/commit/8a97e77d1b0e86e0c825ce44348090d568c62d14) | `` openssh: 10.2p1 -> 10.3p1 ``                                                                        |
| [`78f511ec`](https://github.com/NixOS/nixpkgs/commit/78f511ec5ca826464882102cad1b5d0fd5a551f5) | `` python3Packages.dateparser: 1.3.0 -> 1.4.0 ``                                                       |
| [`37f295bf`](https://github.com/NixOS/nixpkgs/commit/37f295bfd2ca1c02bd80ccf964cebe176afab8d2) | `` python3Packages.dateparser: 1.2.2 -> 1.3.0 ``                                                       |
| [`b03b9503`](https://github.com/NixOS/nixpkgs/commit/b03b950370fae8294dbdbbf5c851b59362e4abb8) | `` python3Packages.pyopenssl: backport 26.0 security fixes ``                                          |
| [`267afd61`](https://github.com/NixOS/nixpkgs/commit/267afd619efc138ac230b285ae924faec4b9bb43) | `` python3Packages.pillow: apply patch for CVE-2026-40192 ``                                           |
| [`0b72895d`](https://github.com/NixOS/nixpkgs/commit/0b72895d01294a292140cd18120ef1024c79f744) | `` jq: apply CVE patches ``                                                                            |
| [`0138ac0e`](https://github.com/NixOS/nixpkgs/commit/0138ac0e182a26cc47ef8fb3f4483ba4054af7bc) | `` imagemagick: 7.1.2-18 -> 7.1.2-19 ``                                                                |
| [`449e7da7`](https://github.com/NixOS/nixpkgs/commit/449e7da763b163a893d7cbeafe9c0ec36a4c9e2f) | `` coreutils: skip flaky du tests ``                                                                   |
| [`bdcd56c3`](https://github.com/NixOS/nixpkgs/commit/bdcd56c3d695a19326f3a9374f77ad2ba9b9fa9c) | `` mbedtls: Skip -fzero-init-padding-bits on GCC 14 ``                                                 |
| [`72fd9c16`](https://github.com/NixOS/nixpkgs/commit/72fd9c167c694817798d04cf1ac6ce5713532a5d) | `` xdg-user-dirs: re-enable xdg autostart ``                                                           |
| [`3ef7f58f`](https://github.com/NixOS/nixpkgs/commit/3ef7f58f9040a2e6ee918f02cbbd041e5253688d) | `` wolfssl: 5.9.0 -> 5.9.1 ``                                                                          |
| [`f1be0745`](https://github.com/NixOS/nixpkgs/commit/f1be07459c0e5c93ab0df20932f5992498897e1b) | `` shaka-packager: 3.7.1 -> 3.7.2 ``                                                                   |
| [`8128d184`](https://github.com/NixOS/nixpkgs/commit/8128d184ca923c86ec1d453149cf8b16018faf7b) | `` openssl: cleanup already upstreamed patches ``                                                      |
| [`69058a71`](https://github.com/NixOS/nixpkgs/commit/69058a711f5acdeb159e819b4a45a7a0573ad994) | `` openssl_3_6: 3.6.1 -> 3.6.2 ``                                                                      |
| [`e233c13c`](https://github.com/NixOS/nixpkgs/commit/e233c13cf710bc3449a6597418adff383a7ce637) | `` openssl_3: 3.0.19 -> 3.0.20 ``                                                                      |
| [`7b87ff0f`](https://github.com/NixOS/nixpkgs/commit/7b87ff0f32ddd0880014a139acac33b20eefd6e7) | `` xz: 5.8.2 -> 5.8.3 ``                                                                               |
| [`11dc9c6f`](https://github.com/NixOS/nixpkgs/commit/11dc9c6f3fe8a38fb5a58a3b20d77be7fa91dc20) | `` libjpeg8: 3.1.3 -> 3.1.4 ``                                                                         |
| [`de7f0c03`](https://github.com/NixOS/nixpkgs/commit/de7f0c031c81dcf72edcf6943728696970934869) | `` xz: 5.8.1 -> 5.8.2 ``                                                                               |
| [`b518c99f`](https://github.com/NixOS/nixpkgs/commit/b518c99fbbacc3154b91f3ef4a7850222a3df51e) | `` libjpeg8: 3.1.2 -> 3.1.3 ``                                                                         |
| [`fe3afaa4`](https://github.com/NixOS/nixpkgs/commit/fe3afaa4213dd2652cf0d920318f19e8cdd81348) | `` go_1_25: 1.25.8 -> 1.25.9 ``                                                                        |