### PR TITLE
chore(flake/catppuccin): `e68cf5de` -> `d1443237`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777734189,
-        "narHash": "sha256-kbIhdhDPaTP6gxAPkcRYeB+cqPFDpTM/bnw+m+26vkI=",
+        "lastModified": 1778237125,
+        "narHash": "sha256-xL2LCN6bdjYnSFnFZ3rmLENbvXh6prT2EN7Qq6pkSr8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "e68cf5deaf1a7afed2e548835dba2ae99f5a3ccb",
+        "rev": "d1443237c8509305559880aca39d1581befec4d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                               |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`d1443237`](https://github.com/catppuccin/nix/commit/d1443237c8509305559880aca39d1581befec4d9) | `` feat(home-manager): support vscode forks (#922) `` |
| [`91160f62`](https://github.com/catppuccin/nix/commit/91160f6241735626193b1466c8b971c6aeba4693) | `` chore: update port sources (#920) ``               |
| [`3aeaf629`](https://github.com/catppuccin/nix/commit/3aeaf62936ed0c4719433b964fb2396240fff56e) | `` chore: update flakes (#919) ``                     |