### PR TITLE
chore(flake/home-manager): `e4419d31` -> `fdb2ccba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778144356,
-        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
+        "lastModified": 1778248595,
+        "narHash": "sha256-dhFgEjoeJMYN/7OY6xfxS799YB4IjbbYXTjyGIJyLpc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
+        "rev": "fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| [`fdb2ccba`](https://github.com/nix-community/home-manager/commit/fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d) | `` modular-services: document ghostunnel as a service that was not written for use as a user-level service `` |
| [`67625b8c`](https://github.com/nix-community/home-manager/commit/67625b8c313a23f23e8079c66b89399d611c452e) | `` modular-services: add `php-fpm` as a service meant to run as a user ``                                     |
| [`4fa2493b`](https://github.com/nix-community/home-manager/commit/4fa2493b307617e0f24ad6c5742212f6aaf7168c) | `` modular-services: add config files to `X-Reload-Triggers` ``                                               |
| [`61031d42`](https://github.com/nix-community/home-manager/commit/61031d425e3a415f9b68aa74ad27dc68f43381a9) | `` modular-services:rewrite `multi-user.target` to `default.target` ``                                        |
| [`1aabcdd4`](https://github.com/nix-community/home-manager/commit/1aabcdd4704f2fbe6d9284f368f6cba2ad2e8a4a) | `` modular-services: simple example using `mpd` ``                                                            |
| [`db468b48`](https://github.com/nix-community/home-manager/commit/db468b4822f2ad68a29b443aca4b6c0875847f1c) | `` modular-services: make `configdata` test use `assertFileContent` ``                                        |
| [`f77079ee`](https://github.com/nix-community/home-manager/commit/f77079ee8a7acda96819ac57fe1975e5c1bd4554) | `` modular-services: rename system-services -> home-services ``                                               |
| [`cdea7d89`](https://github.com/nix-community/home-manager/commit/cdea7d89f50d60b2e83ff5e33f55c91bcb08a2da) | `` modular-services: rename home-manager -> Home Manager ``                                                   |
| [`7eb987d1`](https://github.com/nix-community/home-manager/commit/7eb987d1a47e3a542c76f1da0bebdf3dc67a0fa0) | `` manual: fix link in modular services section ``                                                            |