### PR TITLE
chore(flake/catppuccin): `d1443237` -> `f656000a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778237125,
-        "narHash": "sha256-xL2LCN6bdjYnSFnFZ3rmLENbvXh6prT2EN7Qq6pkSr8=",
+        "lastModified": 1778336446,
+        "narHash": "sha256-axlSmUkHgMSnHitMgIWH8iNfU9Ej39Th50KD8NePjac=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d1443237c8509305559880aca39d1581befec4d9",
+        "rev": "f656000aa5e6dc2664f71bc57ce00bf68dc65366",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                         |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`f656000a`](https://github.com/catppuccin/nix/commit/f656000aa5e6dc2664f71bc57ce00bf68dc65366) | `` chore(vscode): update (#923) ``              |
| [`06d19f2e`](https://github.com/catppuccin/nix/commit/06d19f2e8c7ade5b150555615ddf6909819b80d2) | `` chore(deps): update astro monorepo (#916) `` |