### PR TITLE
feat(desktop/garmin-express): add Garmin Express via Wine

### DIFF
--- a/features/desktop/default.nix
+++ b/features/desktop/default.nix
@@ -34,6 +34,7 @@ in
     ./fonts
     ./freminal
     ./frext
+    ./garmin-express
     ./ghostty
     ./githubdesktop
     ./kitty
@@ -73,6 +74,7 @@ in
       fonts.enable = true;
       freminal.enable = true;
       frext.enable = true;
+      garmin-express.enable = cfg.enable_extra;
       ghostty.enable = true;
       githubdesktop.enable = true;
       kitty.enable = true;

--- a/features/desktop/environments/hyprland/default.nix
+++ b/features/desktop/environments/hyprland/default.nix
@@ -227,6 +227,30 @@ in
           hl.animation({ leaf = "fade",        enabled = true, speed = 7,  bezier = "default" })
           hl.animation({ leaf = "workspaces",  enabled = true, speed = 6,  bezier = "default" })
 
+          -----------------------
+          ---- WINDOW RULES  ----
+          -----------------------
+
+          -- Garmin Express is a WPF/XWayland app that Hyprland consistently
+          -- places far off-screen (observed at x=-6711 on a layout whose
+          -- leftmost monitor starts at x=-2560), so the window is mapped and
+          -- "visible" but on no physical display. Express stores no window
+          -- position of its own, so this is placement, not restore. Tiling it
+          -- is the robust fix: a tiled window cannot be positioned outside a
+          -- monitor. `explorer.exe` is Wine's desktop/tray shell, which shows
+          -- up as a stray 160x20 sliver from the same prefix.
+          hl.window_rule({
+            name = "garmin-express-tile",
+            match = { class = "express.exe" },
+            float = false,
+          })
+
+          hl.window_rule({
+            name = "wine-explorer-hide",
+            match = { class = "explorer.exe" },
+            float = true,
+          })
+
           --------------------
           ---- AUTOSTART  ----
           --------------------

--- a/features/desktop/garmin-express/default.nix
+++ b/features/desktop/garmin-express/default.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  pkgs,
+  config,
+  user,
+  extraUsers ? [ ],
+  ...
+}:
+let
+  allUsers = [ user ] ++ extraUsers;
+  cfg = config.desktop.garmin-express;
+
+  # Pinned Garmin Express installer.
+  # Garmin's URL is unversioned ("latest"); when they rotate the binary the
+  # build will fail until the hash is refreshed. Refresh with:
+  #   nix-prefetch-url https://download.garmin.com/omt/express/GarminExpress.exe
+  # then convert to SRI:
+  #   nix hash convert --hash-algo sha256 --to sri <base32>
+  installer = pkgs.fetchurl {
+    url = "https://download.garmin.com/omt/express/GarminExpress.exe";
+    hash = "sha256-3R9B5WFN+24kohZgZetLnvO50UQODPPJPjDIzd4A7WE=";
+  };
+
+  garmin-express = pkgs.writeShellApplication {
+    name = "garmin-express";
+    runtimeInputs = with pkgs; [
+      wineWow64Packages.stable
+      winetricks
+      coreutils
+    ];
+    # Keep the installer reachable for first-run setup.
+    text = ''
+      export WINEPREFIX="''${XDG_DATA_HOME:-$HOME/.local/share}/wineprefixes/garmin-express"
+      export WINEARCH=win64
+      # Block Wine's Mono so real .NET can be installed by winetricks.
+      # Also disable winemenubuilder so Wine doesn't export its own duplicate
+      # .desktop entries / file associations into ~/.local/share/applications.
+      export WINEDLLOVERRIDES="mscoree=,mshtml=,winemenubuilder.exe="
+      # Garmin Express is 32-bit; installs under "Program Files (x86)".
+      EXE="$WINEPREFIX/drive_c/Program Files (x86)/Garmin/Express/express.exe"
+      MARKER="$WINEPREFIX/.garmin-express-installed"
+
+      if [ ! -f "$MARKER" ]; then
+        echo "==> First-run setup for Garmin Express. This will take 10-20 minutes." >&2
+        echo "==> Phase 1/3: Initialising Wine prefix..." >&2
+        mkdir -p "$WINEPREFIX"
+        wineboot --init
+        wineserver -w
+
+        echo "==> Phase 2/3: Installing .NET Framework 4.8 (downloads from Microsoft)..." >&2
+        # corefonts helps with installer rendering; dotnet48 is the runtime.
+        winetricks -q --force corefonts dotnet48
+        wineserver -w
+
+        echo "==> Phase 3/3: Running Garmin Express installer..." >&2
+        wine ${installer}
+        wineserver -w
+
+        if [ -f "$EXE" ]; then
+          touch "$MARKER"
+        fi
+      fi
+
+      if [ ! -f "$EXE" ]; then
+        echo "Garmin Express was not installed to the expected path:" >&2
+        echo "  $EXE" >&2
+        echo "" >&2
+        echo "To retry the installer manually:" >&2
+        echo "  WINEPREFIX=\"$WINEPREFIX\" wine ${installer}" >&2
+        echo "" >&2
+        echo "To wipe state and start over:" >&2
+        echo "  rm -rf \"$WINEPREFIX\"" >&2
+        exit 1
+      fi
+
+      # Garmin Express embeds CefSharp (Chromium). Under XWayland with GPU
+      # acceleration it renders as a black window. Disable GPU accel for the
+      # embedded browser process.
+      exec wine "$EXE" --disable-gpu --disable-gpu-compositing "$@"
+    '';
+  };
+
+  desktopItem = pkgs.makeDesktopItem {
+    name = "garmin-express";
+    desktopName = "Garmin Express";
+    exec = "garmin-express";
+    icon = "wine";
+    categories = [
+      "Utility"
+      "Network"
+    ];
+    comment = "Update maps and software for Garmin devices";
+  };
+in
+{
+  options.desktop.garmin-express = {
+    enable = lib.mkEnableOption "Garmin Express (Windows app via Wine)";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Allow user-level access to Garmin USB devices (vendor 0x091e).
+    services.udev.extraRules = ''
+      SUBSYSTEM=="usb", ATTRS{idVendor}=="091e", MODE="0666", GROUP="users"
+    '';
+
+    # MTP/auto-mount support for Garmin devices that present as storage.
+    services.gvfs.enable = true;
+
+    users.users = lib.genAttrs allUsers (_: {
+      packages = with pkgs; [
+        garmin-express
+        desktopItem
+        wineWow64Packages.stable
+        winetricks
+        simple-mtpfs
+        libmtp
+      ];
+    });
+  };
+}

--- a/features/desktop/garmin-express/default.nix
+++ b/features/desktop/garmin-express/default.nix
@@ -52,12 +52,37 @@ let
         winetricks -q --force corefonts dotnet48
         wineserver -w
 
-        echo "==> Phase 3/3: Running Garmin Express installer..." >&2
-        wine ${installer}
+        # Garmin Express is a WPF app hosting CefSharp. Under Wine its WPF
+        # (Avalon / "MIL") hardware render path produces an all-black window
+        # -- the app is running and laying out text, it just composites
+        # nothing visible. Forcing WPF to its software renderer is the fix.
+        #
+        # Note this is NOT the same thing as the CEF `--disable-gpu` flags
+        # below: those only affect the embedded Chromium panes, and were
+        # verified (present in /proc/<pid>/cmdline) to leave the window black
+        # on their own. `DwmAttachMilContent` in the Wine log is the tell
+        # that the black surface belongs to WPF, not CEF.
+        echo "==> Phase 3/4: Forcing WPF software rendering..." >&2
+        wine reg add 'HKCU\Software\Microsoft\Avalon.Graphics' \
+          /v DisableHWAcceleration /t REG_DWORD /d 1 /f
         wineserver -w
+
+        echo "==> Phase 4/4: Running Garmin Express installer..." >&2
+        wine ${installer}
+
+        # The installer launches Express itself as a detached process that is
+        # NOT our child, and that process keeps wineserver alive. A blocking
+        # `wineserver -w` here would therefore hang forever and never reach
+        # the marker write below, causing the whole 20-minute .NET install to
+        # be repeated on the next launch. Kill the prefix instead: it ends
+        # the installer's Express as well, so the only instance that ever
+        # runs is the one we launch ourselves (with the flags applied).
+        wineserver -k || true
 
         if [ -f "$EXE" ]; then
           touch "$MARKER"
+        else
+          echo "==> Installer finished but express.exe is missing." >&2
         fi
       fi
 
@@ -73,9 +98,11 @@ let
         exit 1
       fi
 
-      # Garmin Express embeds CefSharp (Chromium). Under XWayland with GPU
-      # acceleration it renders as a black window. Disable GPU accel for the
-      # embedded browser process.
+      # Garmin Express embeds CefSharp (Chromium). These flags only affect the
+      # embedded browser panes -- the black-window fix is the WPF
+      # DisableHWAcceleration registry key set during first-run setup above.
+      # Kept because software rendering for the CEF panes is consistent with
+      # forcing it for WPF, and costs nothing on a page-based UI.
       exec wine "$EXE" --disable-gpu --disable-gpu-compositing "$@"
     '';
   };
@@ -103,17 +130,21 @@ in
       SUBSYSTEM=="usb", ATTRS{idVendor}=="091e", MODE="0666", GROUP="users"
     '';
 
-    # MTP/auto-mount support for Garmin devices that present as storage.
-    services.gvfs.enable = true;
-
+    # Deliberately NO host-side MTP stack here (no simple-mtpfs, no libmtp,
+    # and gvfs is not force-enabled). MTP allows exactly one initiator at a
+    # time: whichever process opens the session owns the device until it
+    # closes it. A host MTP client browsing the Garmin therefore locks Wine
+    # out of it entirely. Since the whole point of this module is to let
+    # Garmin Express talk to the device, host MTP tooling is an active
+    # liability rather than a convenience. Desktops that want to browse a
+    # Garmin as a filesystem get that from the desktop environment's own
+    # gvfs, which is enabled elsewhere.
     users.users = lib.genAttrs allUsers (_: {
-      packages = with pkgs; [
+      packages = [
         garmin-express
         desktopItem
-        wineWow64Packages.stable
-        winetricks
-        simple-mtpfs
-        libmtp
+        pkgs.wineWow64Packages.stable
+        pkgs.winetricks
       ];
     });
   };


### PR DESCRIPTION
## Summary
- Adds a new \`desktop.garmin-express\` module under \`features/desktop/garmin-express/\` that runs the Windows Garmin Express app in a dedicated Wine prefix, so map and firmware updates work for Garmin devices (e.g. Edge 840) on NixOS.
- Wired into \`features/desktop/default.nix\` and gated behind \`desktop.enable_extra\` (matches the pattern used by \`ledger\` / \`trezor\`).

## Why
Garmin doesn't ship a Linux client. Native alternatives (manually copying \`.img\` files, Garmin Connect mobile) work for some cases but not for paid/preloaded TopoActive maps tied to Express. A reproducible Nix-managed Wine wrapper avoids the alternative of running a full Windows VM for one app.

## How it works
The module:
- Pins the Garmin Express installer with \`fetchurl\` (sha256). Note: Garmin's URL is unversioned; the hash will need refreshing when they rotate the binary.
- Provides a \`garmin-express\` shell wrapper that, on first launch:
  1. Initialises a dedicated Wine prefix at \`\$XDG_DATA_HOME/wineprefixes/garmin-express\`.
  2. Installs \`corefonts\` and \`dotnet48\` via \`winetricks\` (Express requires .NET Framework 4.x).
  3. Runs the Garmin Express installer interactively.
  4. Writes a \`.garmin-express-installed\` marker so subsequent launches skip setup.
- Launches \`express.exe\` (32-bit, under \`Program Files (x86)\`) with \`--disable-gpu --disable-gpu-compositing\` to work around CefSharp.Wpf rendering as a black window under XWayland.
- Adds a \`.desktop\` entry for app launchers.
- Adds a udev rule for Garmin USB vendor \`091e\` and enables \`gvfs\` for MTP support.
- Pulls in \`wineWow64Packages.stable\`, \`winetricks\`, \`jmtpfs\`, \`libmtp\`.

## Caveats
- **Reproducibility limits:** the Wine prefix is mutable state on disk; only the installer hash and Wine version are Nix-pinned. \`winetricks\` also downloads .NET from Microsoft at runtime (cached in \`~/.cache/winetricks\`). This is the unavoidable trade-off for a closed-source vendor app.
- **First-run is slow:** ~10-20 minutes to install .NET 4.8 + Garmin Express. Subsequent launches are instant.
- **GPU-accel disabled:** required to avoid the black-window issue with CefSharp.Wpf under XWayland. Verified working on Hyprland.

## Test plan
- [x] Module evaluates (\`nix-instantiate --parse\`).
- [x] Built successfully on \`fredhub\`.
- [x] First-run setup completes (.NET 4.8 + Express installer).
- [x] App launches and renders the UI with \`--disable-gpu\`.
- [ ] Edge 840 detected and map update flow tested end-to-end (next step on real hardware).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Garmin Express desktop support.
  * Provides a launcher for Garmin Express running through Wine.
  * Automatically prepares the required Windows components on first launch.
  * Adds Garmin device USB permissions for improved connectivity.
  * Integrates Garmin Express with Hyprland window management, including tiled application windows and floating Wine dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->