### PR TITLE
chore(flake/catppuccin): `f656000a` -> `a0fa2f1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778336446,
-        "narHash": "sha256-axlSmUkHgMSnHitMgIWH8iNfU9Ej39Th50KD8NePjac=",
+        "lastModified": 1778406663,
+        "narHash": "sha256-jGOtlDJAe0MFoOErIxSFs3TQZ7WaCpUt1qnjJ0HhLfw=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f656000aa5e6dc2664f71bc57ce00bf68dc65366",
+        "rev": "a0fa2f1b901473d8aefb2e3026396e3562c1782c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                     |
| ----------------------------------------------------------------------------------------------- | --------------------------- |
| [`a0fa2f1b`](https://github.com/catppuccin/nix/commit/a0fa2f1b901473d8aefb2e3026396e3562c1782c) | `` perf & cleanup (#924) `` |