### PR TITLE
chore(flake/home-manager): `2f419037` -> `1768d4e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778365864,
-        "narHash": "sha256-ImoT/wqmgMImf2dAC+E0MverAdA4QXsedOeES9B7Ezw=",
+        "lastModified": 1778594112,
+        "narHash": "sha256-VA9z90SZviIvOcA4QyatA48FIyqb8mmsmH/EsXXWAG4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f419037039a152448c5f4ae9494154753d1b399",
+        "rev": "1768d4e49860b86cb7652ee738de0e6b3050dd40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`1768d4e4`](https://github.com/nix-community/home-manager/commit/1768d4e49860b86cb7652ee738de0e6b3050dd40) | `` chromium: add Microsoft Edge ``                                              |
| [`b3de8ada`](https://github.com/nix-community/home-manager/commit/b3de8ada63521fc16c6e535172085f0863b611f9) | `` maintainers: update all-maintainers.nix ``                                   |
| [`b659c7ff`](https://github.com/nix-community/home-manager/commit/b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab) | `` hyprland: update documentation links ``                                      |
| [`5b73f949`](https://github.com/nix-community/home-manager/commit/5b73f949a1765ee018fa402521a5d0e280b7e656) | `` systemd: install systemd files when user is root (revert c2aa831) (#9274) `` |
| [`bc63bedc`](https://github.com/nix-community/home-manager/commit/bc63bedcab3454f11c79fcdbcf90301deb562b6c) | `` email: add warning to documentation of `useStartTls` ``                      |
| [`85ba629c`](https://github.com/nix-community/home-manager/commit/85ba629c79449badf4338117c27f0ee92b4b9f1a) | `` rofi: change configPath type to nonEmptyStr ``                               |
| [`c0729fa3`](https://github.com/nix-community/home-manager/commit/c0729fa3f060008080b2124fd0c3b9285d53b393) | `` kanshi: Remove myself from the maintainers ``                                |
| [`dcebe66f`](https://github.com/nix-community/home-manager/commit/dcebe66f958673729896eec2de4abfd86ef22d21) | `` atuin: precompute fish init script ``                                        |