### PR TITLE
chore(flake/nixpkgs-stable): `0c88e1f2` -> `8fd9daa3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1172,11 +1172,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`6039716d`](https://github.com/NixOS/nixpkgs/commit/6039716db6478028f654263c823e942948eb3cf5) | `` librewolf-bin-unwrapped: 150.0.1-1 -> 150.0.2-1 ``                                              |
| [`ab49e74f`](https://github.com/NixOS/nixpkgs/commit/ab49e74f97d73e0e51da02461b96b86a668b11ec) | `` brave: 1.89.145 -> 1.90.121 ``                                                                  |
| [`b8435f67`](https://github.com/NixOS/nixpkgs/commit/b8435f671ec631086ed8c80e087d1bcce42038c2) | `` workflows/backport: Label failed backports ``                                                   |
| [`7a7eeecf`](https://github.com/NixOS/nixpkgs/commit/7a7eeecf6e0aa9359e7f5cc860f2d0c22ffc7904) | `` jackett: 0.24.1807 -> 0.24.1831 ``                                                              |
| [`73f93498`](https://github.com/NixOS/nixpkgs/commit/73f9349891ace7984ee4e52d0dde0f57d4a0495f) | `` dprint-plugins.dprint-plugin-biome: 0.12.9 -> 0.12.10 ``                                        |
| [`d45e4477`](https://github.com/NixOS/nixpkgs/commit/d45e4477257e9c02a6c50b07793c3982d82bd4c3) | `` firefox-esr-140-unwrapped: 140.10.1esr -> 140.10.2esr ``                                        |
| [`3343bddb`](https://github.com/NixOS/nixpkgs/commit/3343bddb715e311c48498cf5645156b799b7cc18) | `` linux/hardened/patches/6.12: init at v6.12.87-hardened1 ``                                      |
| [`b0fe6a84`](https://github.com/NixOS/nixpkgs/commit/b0fe6a84349288e20c8668831a07858bca3f13b6) | `` linux/hardened/patches/6.12: remove ``                                                          |
| [`fabe528c`](https://github.com/NixOS/nixpkgs/commit/fabe528cd3780e4dc2f2930c7d44c429e5b3cae4) | `` uriparser: 1.0.1 -> 1.0.2 ``                                                                    |
| [`c8b7ca79`](https://github.com/NixOS/nixpkgs/commit/c8b7ca79e3312189c8372a975d7c34ff0e2ca0f8) | `` vivaldi: 7.9.3970.60 -> 7.9.3970.64 ``                                                          |
| [`bc0cdc45`](https://github.com/NixOS/nixpkgs/commit/bc0cdc45b45689037f430eee38968c889e0c294f) | `` shogihome: 1.27.1 -> 1.27.2 ``                                                                  |
| [`22c30541`](https://github.com/NixOS/nixpkgs/commit/22c30541c58ac69414a9db4b41eb59f374af9ef0) | `` php84: 8.4.20 -> 8.4.21 ``                                                                      |
| [`7aaa8012`](https://github.com/NixOS/nixpkgs/commit/7aaa801291866035996e96a28305bad01ead939b) | `` nezha-agent: 2.0.2 -> 2.0.3 ``                                                                  |
| [`5cb457b1`](https://github.com/NixOS/nixpkgs/commit/5cb457b103170006e8b0a956894042540b316e99) | `` ci/github-script/manual-file-edits: skip on PRs from one dev branch to another ``               |
| [`ee084765`](https://github.com/NixOS/nixpkgs/commit/ee08476587689b12ba6782b731ca7f27c271ce4e) | `` php83: 8.3.30 -> 8.3.31 ``                                                                      |
| [`460ae3cb`](https://github.com/NixOS/nixpkgs/commit/460ae3cbd32aec3dfeaae3aede88e55afbaffab0) | `` php82: 8.2.30 -> 8.2.31 ``                                                                      |
| [`39e85acd`](https://github.com/NixOS/nixpkgs/commit/39e85acdf124866d7762fa57e848fa09f88acd6d) | `` steam-devices-udev-rules: 1.0.0.61-unstable-2026-04-14 -> 1.0.0.61-unstable-2026-04-16 ``       |
| [`368c9a3f`](https://github.com/NixOS/nixpkgs/commit/368c9a3fdb8c0c12c65efff64a97b56e0418e662) | `` perlPackages.CatalystPluginSession: 0.43 -> 0.44 ``                                             |
| [`bf6c5332`](https://github.com/NixOS/nixpkgs/commit/bf6c5332b89ae991609d1cf8774cfdaed0bc862f) | `` thunderbird-latest-bin-unwrapped: 150.0 -> 150.0.1 ``                                           |
| [`f8fd6194`](https://github.com/NixOS/nixpkgs/commit/f8fd61946e1801ab9d463548489d547d666f3335) | `` pyfa: 2.66.2 -> 2.66.3 ``                                                                       |
| [`7ac69cf5`](https://github.com/NixOS/nixpkgs/commit/7ac69cf5581b44850193b1ac71ef6c5c8bd67678) | `` librewolf-unwrapped: 150.0.1-1 -> 150.0.2-1 ``                                                  |
| [`01a6a803`](https://github.com/NixOS/nixpkgs/commit/01a6a8033f3c8f06071ea2ef5e34ea54d2023764) | `` linux_5_15: 5.15.205 -> 5.15.206 ``                                                             |
| [`c3164d96`](https://github.com/NixOS/nixpkgs/commit/c3164d96e50c47950fbe26660d4460ca3ba346ba) | `` linux_6_1: 6.1.171 -> 6.1.172 ``                                                                |
| [`d6b31f03`](https://github.com/NixOS/nixpkgs/commit/d6b31f03ecd1c8c852bb759db0ff006017a92593) | `` matrix-continuwuity: 0.5.8 -> 0.5.9 ``                                                          |
| [`d9714d9c`](https://github.com/NixOS/nixpkgs/commit/d9714d9cc43ffdfd83770cf1630da8f91eab03a6) | `` traccar: 6.12.2 -> 6.13.0 ``                                                                    |
| [`57e19356`](https://github.com/NixOS/nixpkgs/commit/57e19356ef30676dfdf6d8faa6ca8788a20ae548) | `` .github: Bump korthout/backport-action from 4.5.0 to 4.5.1 ``                                   |
| [`79fdb7f7`](https://github.com/NixOS/nixpkgs/commit/79fdb7f7ee18455af81a3d78c99647fd9c5d05db) | `` .github: Bump cachix/install-nix-action from 31.10.5 to 31.10.6 ``                              |
| [`7ca771e4`](https://github.com/NixOS/nixpkgs/commit/7ca771e4f48c25501ee4a14201bf4b87652f4d40) | `` simplex-chat-desktop: 6.4.11 -> 6.5.1 ``                                                        |
| [`1b7b2be6`](https://github.com/NixOS/nixpkgs/commit/1b7b2be632b7967f8431061349896e7ae13c698d) | `` ollama: fix build on darwin ``                                                                  |
| [`8e34acbb`](https://github.com/NixOS/nixpkgs/commit/8e34acbb5d7616dfe3e691f0c2912a57f7c553a3) | `` simplex-chat-desktop: add libnotify as a dependency ``                                          |
| [`8a729008`](https://github.com/NixOS/nixpkgs/commit/8a7290081da92c1b2d9f8d8a2f35829b501b7a28) | `` linux_5_10: 5.10.254 -> 5.10.255 ``                                                             |
| [`f94be47b`](https://github.com/NixOS/nixpkgs/commit/f94be47b20b021773022f350d96e85e721e0f2be) | `` linux_5_15: 5.15.204 -> 5.15.205 ``                                                             |
| [`85e653e3`](https://github.com/NixOS/nixpkgs/commit/85e653e38a4140716f8d02172369e0b4b72d091f) | `` linux_6_1: 6.1.170 -> 6.1.171 ``                                                                |
| [`361c5a57`](https://github.com/NixOS/nixpkgs/commit/361c5a575261fad79abb7032280b6617c31f3c76) | `` php85: 8.5.5 -> 8.5.6 ``                                                                        |
| [`e5357f57`](https://github.com/NixOS/nixpkgs/commit/e5357f57b210312ba9d9988a5ed7cac57fbcd4be) | `` weblate: mark as vulnerable ``                                                                  |
| [`ea0c10a1`](https://github.com/NixOS/nixpkgs/commit/ea0c10a1596cc92514e72e276a61160f439e171f) | `` linux_7_0: 7.0.4 -> 7.0.5 ``                                                                    |
| [`4ff9b793`](https://github.com/NixOS/nixpkgs/commit/4ff9b793ba823e8edc636c984e583d7031a73181) | `` linux_6_18: 6.18.27 -> 6.18.28 ``                                                               |
| [`e37de580`](https://github.com/NixOS/nixpkgs/commit/e37de580537b175d1c4f4eb3e69e8c06b7c6ec32) | `` linux_6_12: 6.12.86 -> 6.12.87 ``                                                               |
| [`aaa5c98b`](https://github.com/NixOS/nixpkgs/commit/aaa5c98b16ce711c47fb15331b46420e0bf15326) | `` linux_6_6: 6.6.137 -> 6.6.138 ``                                                                |
| [`4d3eefcd`](https://github.com/NixOS/nixpkgs/commit/4d3eefcd498292fe70b065d64ccf04bedc08d167) | `` go_1_26: 1.26.2 -> 1.26.3 ``                                                                    |
| [`735dd4a9`](https://github.com/NixOS/nixpkgs/commit/735dd4a9907e8f5f4136c79fb53c028e49004264) | `` linux_xanmod_latest: 7.0.2 -> 7.0.4 ``                                                          |
| [`3d604281`](https://github.com/NixOS/nixpkgs/commit/3d604281e60c7f586d7d1a1f2e5f610d7987bea4) | `` linux_xanmod: 6.18.25 -> 6.18.27 ``                                                             |
| [`c0745eec`](https://github.com/NixOS/nixpkgs/commit/c0745eece1b035baa93704e3e1b7601f2f05d4ae) | `` tor-browser: 15.0.12 -> 15.0.13 ``                                                              |
| [`e14fb992`](https://github.com/NixOS/nixpkgs/commit/e14fb992a473df38a2448dcb82130ac63577d651) | `` ungoogled-chromium: 147.0.7727.137-1 -> 148.0.7778.96-1 ``                                      |
| [`5f86df4e`](https://github.com/NixOS/nixpkgs/commit/5f86df4e8391e08cb386cc068a53dd0583ecde4d) | `` podofo_0_10: 0.10.5 -> 0.10.6 ``                                                                |
| [`393714b1`](https://github.com/NixOS/nixpkgs/commit/393714b181776a2e5f923750f91cd8022430d422) | `` tor: 0.4.9.7 -> 0.4.9.8 ``                                                                      |
| [`07997021`](https://github.com/NixOS/nixpkgs/commit/07997021eceb3f6b077bda89a73a2c71ed82d0bb) | `` mozillavpn: 2.35.0 → 2.36.0 ``                                                                  |
| [`a926a174`](https://github.com/NixOS/nixpkgs/commit/a926a17471650313bd4f6ced9131d7c36cdf749b) | `` incus: 6.23.0 -> 7.0.0 ``                                                                       |
| [`fbb2ca6d`](https://github.com/NixOS/nixpkgs/commit/fbb2ca6de1397c5c8f4dd165116aa6d8f08db27c) | `` incus: gate installShellCompletion for cross-compilation ``                                     |
| [`a8a62f30`](https://github.com/NixOS/nixpkgs/commit/a8a62f303eec4b07cfa50bf87406d6ad971f048e) | `` incus: enable use of fetchpatch2 for patches ``                                                 |
| [`ac45f522`](https://github.com/NixOS/nixpkgs/commit/ac45f522d1f6804d86e288654a29c983206fbe46) | `` nixos/minio: gate minio dependency to versions older then 7.0.0 ``                              |
| [`73ea061a`](https://github.com/NixOS/nixpkgs/commit/73ea061a7600459d01ad2bb1fc2b38f955141023) | `` matrix-synapse: 1.152.0 -> 1.152.1 ``                                                           |
| [`2564b4ea`](https://github.com/NixOS/nixpkgs/commit/2564b4ea84020a813fe95906d097aee775dec45a) | `` filebrowser: 2.63.2 -> 2.63.3 ``                                                                |
| [`870eb528`](https://github.com/NixOS/nixpkgs/commit/870eb528a136d6ad5955770759426b8af593d5de) | `` mullvad-browser: 15.0.11 -> 15.0.12 ``                                                          |
| [`cf003a89`](https://github.com/NixOS/nixpkgs/commit/cf003a89883cad470cefb58343950b47da99fb25) | `` tor-browser: 15.0.11 -> 15.0.12 ``                                                              |
| [`5d83b469`](https://github.com/NixOS/nixpkgs/commit/5d83b469e16422c97f9ff8b16c7c46e4c2cad70a) | `` chromium,chromedriver: fix building M148 by using newer Rust ``                                 |
| [`3109eba3`](https://github.com/NixOS/nixpkgs/commit/3109eba3db71247953e96f1a51b693e2dd3b07c2) | `` mbedtls_4: init at 4.1.0 ``                                                                     |
| [`fe10026d`](https://github.com/NixOS/nixpkgs/commit/fe10026d6badd96bdabae23165576c366b33a015) | `` proftpd: patch CVE-2026-44331 ``                                                                |
| [`adcfd1aa`](https://github.com/NixOS/nixpkgs/commit/adcfd1aa9203b8755c4dbe9129a3f83f96e595c5) | `` chromium,chromedriver: 147.0.7727.137 -> 148.0.7778.96 ``                                       |
| [`b52aac7f`](https://github.com/NixOS/nixpkgs/commit/b52aac7f375485b539c3371dbb8e5e94f22e2a5d) | `` kanidm_1_10: 1.10.0 -> 1.10.1 ``                                                                |
| [`c49acd40`](https://github.com/NixOS/nixpkgs/commit/c49acd40487f9078cc73ea8e92f58f11046453c7) | `` rt: fix 'Wide character in subroutine entry' crash on every request ``                          |
| [`67b71018`](https://github.com/NixOS/nixpkgs/commit/67b7101803c9313887c693e619c0cf7092f74764) | `` gerrit: 3.13.5 -> 3.13.6 ``                                                                     |
| [`c7467d63`](https://github.com/NixOS/nixpkgs/commit/c7467d63cfd6974855d5730e330fcdb7874f7ac7) | `` beets: mark as vulnerable to XSS ``                                                             |
| [`f2213c1b`](https://github.com/NixOS/nixpkgs/commit/f2213c1b42f7a54723f017a67ced289df9847f5d) | `` n8n: 1.123.27 -> 1.123.40 ``                                                                    |
| [`17e1fc6f`](https://github.com/NixOS/nixpkgs/commit/17e1fc6f3b3c941f6868e97e225f42a51f2f035e) | `` firefox-unwrapped: 150.0.1 -> 150.0.2 ``                                                        |
| [`9bd2d7de`](https://github.com/NixOS/nixpkgs/commit/9bd2d7dea3d9d1b7935866ef2994b19ae5c313c8) | `` mailmanPackages.postorius: backport security fix ``                                             |
| [`ecf5af05`](https://github.com/NixOS/nixpkgs/commit/ecf5af055549ba140126e09cdcace20317b06d17) | `` linux_6_12: 6.12.85 -> 6.12.86 ``                                                               |
| [`2778c7c1`](https://github.com/NixOS/nixpkgs/commit/2778c7c1da378c67e9cdea2269107b4bef370a3b) | `` linux_6_18: 6.18.26 -> 6.18.27 ``                                                               |
| [`85a19b9b`](https://github.com/NixOS/nixpkgs/commit/85a19b9b157b5101a679c161c54752fd3bfa4d5c) | `` linux_7_0: 7.0.3 -> 7.0.4 ``                                                                    |
| [`8f1c50c3`](https://github.com/NixOS/nixpkgs/commit/8f1c50c3f8c6ed9fdf51125b7f8d7d6de077b087) | `` redis: add hythera as maintainer ``                                                             |
| [`abfc7b78`](https://github.com/NixOS/nixpkgs/commit/abfc7b78ddcd20d9c46f1a93520890b4d5a1215b) | `` redis: 8.2.3 -> 8.6.3 ``                                                                        |
| [`a583374c`](https://github.com/NixOS/nixpkgs/commit/a583374c770f44c8968451cd8a2f88be8a93e06d) | `` [release-25.11] valkey: 8.1.6 -> 8.1.7 ``                                                       |
| [`73db3162`](https://github.com/NixOS/nixpkgs/commit/73db31620da6e186f3b1bd4176ca38ba555972fc) | `` castxml: 0.6.13 -> 0.7.0 ``                                                                     |
| [`9382e446`](https://github.com/NixOS/nixpkgs/commit/9382e44632916d70ff2c07bafb7f43cf3238465f) | `` privatebin: 2.0.3 -> 2.0.4 ``                                                                   |
| [`218a26eb`](https://github.com/NixOS/nixpkgs/commit/218a26eb7ac896390c53183ef93bc8e185581ffe) | `` Revert "[Backport release-25.11] chromium,chromedriver: 147.0.7727.137 -> 148.0.7778.96" ``     |
| [`ba4a24b7`](https://github.com/NixOS/nixpkgs/commit/ba4a24b7490abeb42547377531c797d870e68f85) | `` tor: 0.4.9.6 -> 0.4.9.7 ``                                                                      |
| [`62b1c22b`](https://github.com/NixOS/nixpkgs/commit/62b1c22b646cb11d10ba8297916d765badfb9e62) | `` apache2: 2.4.66 -> 2.4.67 ``                                                                    |
| [`129b9a5e`](https://github.com/NixOS/nixpkgs/commit/129b9a5e2d1f27a4644f6746c840f4c5d88b8647) | `` calibre-web: fix build ``                                                                       |
| [`09c9277b`](https://github.com/NixOS/nixpkgs/commit/09c9277bcba2492c9d9aa4ce37d571e8bf81dda5) | `` dawarich: 1.6.1 -> 1.7.5 ``                                                                     |
| [`d8af4361`](https://github.com/NixOS/nixpkgs/commit/d8af43614b0568a70ad400d2bbc4b19273c9e71e) | `` dawarich: remove openssl hotfix ``                                                              |
| [`92372734`](https://github.com/NixOS/nixpkgs/commit/92372734b2494e31cd51c25f1dcaf178d76ca36f) | `` zoxide: 0.9.8 -> 0.9.9 ``                                                                       |
| [`e18e989f`](https://github.com/NixOS/nixpkgs/commit/e18e989f988afadf2530ab1439cbd491a13e24be) | `` chromium,chromedriver: 147.0.7727.137 -> 148.0.7778.96 ``                                       |
| [`c470c599`](https://github.com/NixOS/nixpkgs/commit/c470c599b448316c9d44675228219fb0a869c58f) | `` onedrivegui: 1.3.0 -> 1.3.1 ``                                                                  |
| [`bf9ef959`](https://github.com/NixOS/nixpkgs/commit/bf9ef95933be66aee96845aa764bc8ee8a168daa) | `` forgejo-runner: 12.9.0 -> 12.10.1 ``                                                            |
| [`617b39bf`](https://github.com/NixOS/nixpkgs/commit/617b39bfe949fe80c18d93a1a46866a6ccde339b) | `` ci/github-script/lint-commits: confirm Git names/emails are present ``                          |
| [`93dc6a2a`](https://github.com/NixOS/nixpkgs/commit/93dc6a2ade8699f17c60c2dc2be3bde801d5b1ab) | `` magic-wormhole: 0.23.0 -> 0.24.0 ``                                                             |
| [`420a6ec9`](https://github.com/NixOS/nixpkgs/commit/420a6ec957beca6adc617f1b8e61814b434ef3eb) | `` weblate: relax on requests ``                                                                   |
| [`dc1a0fc8`](https://github.com/NixOS/nixpkgs/commit/dc1a0fc81e5899818ba09ca6658660627899e028) | `` gitlab-runner: update skipped tests to fix builds ``                                            |
| [`de6e5bac`](https://github.com/NixOS/nixpkgs/commit/de6e5bac4f9e5ce115460f8f61ded3553ff791ed) | `` pleroma: drop yayayayaka from maintainers ``                                                    |
| [`4de92e0a`](https://github.com/NixOS/nixpkgs/commit/4de92e0a0c5d8f7bbc1a4423436b76122e0f21a5) | `` matrix-authentication-service: 1.15.0 -> 1.16.0 ``                                              |
| [`10af557e`](https://github.com/NixOS/nixpkgs/commit/10af557e18213cd53a1c1fde3f4068e52eee5af6) | `` docker: 29.4.1 -> 29.4.2 ``                                                                     |
| [`f9c38e8c`](https://github.com/NixOS/nixpkgs/commit/f9c38e8c0267bc70ec2e701ce9248ac8f2949d6c) | `` mutt: 2.3.1 -> 2.3.2 ``                                                                         |
| [`be2761f7`](https://github.com/NixOS/nixpkgs/commit/be2761f709f9e55ee7518f8c6718c7960a79237b) | `` mutt: 2.3.0 -> 2.3.1 ``                                                                         |
| [`00302b51`](https://github.com/NixOS/nixpkgs/commit/00302b51d16ba2287613847bd606aa20ece035ed) | `` mutt: 2.2.16 -> 2.3.0 ``                                                                        |
| [`75f2eeed`](https://github.com/NixOS/nixpkgs/commit/75f2eeedd74419fe612ed5e2f9fb1b1c098b9d2f) | `` gitlab-runner: 18.11.1 -> 18.11.2 ``                                                            |
| [`492ffbb3`](https://github.com/NixOS/nixpkgs/commit/492ffbb3df7bf51443c285a95ed9a4dea74d20ab) | `` google-chrome: 147.0.7727.137 -> 148.0.7778.96 ``                                               |
| [`7a83b285`](https://github.com/NixOS/nixpkgs/commit/7a83b2858927b2b5302ba132fa72214d695a0b57) | `` ladybird: 0-unstable-2026-04-04 -> 0-unstable-2026-05-04 ``                                     |
| [`d918a459`](https://github.com/NixOS/nixpkgs/commit/d918a459c5d48090888ffdaba1763ad08a32ff46) | `` rocqPackages.mathcomp: rename fingroup -> finite-group and character -> group-representation `` |
| [`793487d1`](https://github.com/NixOS/nixpkgs/commit/793487d1862bc556b722ad8cc9c6dcad9113680d) | `` ocamlPackages.menhir: coqPackages -> rocqPackages ``                                            |
| [`7454847f`](https://github.com/NixOS/nixpkgs/commit/7454847fa5590fdf91a67f58337738548fc5c2a2) | `` ocamlPackages.elpi: coqPackages -> rocqPackages ``                                              |
| [`6411f2a7`](https://github.com/NixOS/nixpkgs/commit/6411f2a7df779a3548f5ffd7782bdcdefef77800) | `` coqPackages.interval: guard version check ``                                                    |
| [`a741c68f`](https://github.com/NixOS/nixpkgs/commit/a741c68f3eb75376fbdaab00fe406125da54fc27) | `` gitlab: 18.11.1 -> 18.11.12 ``                                                                  |
| [`cb4c5c52`](https://github.com/NixOS/nixpkgs/commit/cb4c5c5271f2947bcc44e24d7c3abaffff1cb637) | `` dotnetCorePackages.sdk_10_0: 10.0.202 -> 10.0.203 ``                                            |
| [`ed0c3f93`](https://github.com/NixOS/nixpkgs/commit/ed0c3f93729f8e9f2880656ab1a7ae9596feb545) | `` dotnetCorePackages.sdk_11_0: add missing release blobs ``                                       |
| [`aa519eb8`](https://github.com/NixOS/nixpkgs/commit/aa519eb80aa25d02cb50ec62e3c9578a5f6b3a66) | `` thunderbird-esr-bin-unwrapped: 140.10.0esr -> 140.10.1esr ``                                    |
| [`523d3df7`](https://github.com/NixOS/nixpkgs/commit/523d3df751bd37f090af43d5e8ec193588a76e58) | `` vale: 3.13.0 -> 3.14.1 ``                                                                       |
| [`d58dfb74`](https://github.com/NixOS/nixpkgs/commit/d58dfb74a30aac9edb88b547e0fe532b6f8b64e2) | `` affine: 0.26.2 -> 0.26.4 ``                                                                     |
| [`76628c6b`](https://github.com/NixOS/nixpkgs/commit/76628c6b627042f6b07e9446bde220ffe389c12f) | `` affine: 0.25.7 -> 0.26.2 ``                                                                     |
| [`a17cbc04`](https://github.com/NixOS/nixpkgs/commit/a17cbc0492efb42d68b9f7f5b70d4e7ec2cc8e3f) | `` affine: 0.25.6 -> 0.25.7 ``                                                                     |
| [`edd8bac9`](https://github.com/NixOS/nixpkgs/commit/edd8bac946da8b5a3b8d7a4bcc6d1ae89657f425) | `` affine: 0.25.5 -> 0.25.6 ``                                                                     |
| [`9c59307a`](https://github.com/NixOS/nixpkgs/commit/9c59307a9ebed10b7e536f8761fb057dfe4a6b00) | `` vivaldi: 7.9.3970.55 -> 7.9.3970.60 ``                                                          |
| [`77e8157e`](https://github.com/NixOS/nixpkgs/commit/77e8157eb844803f951084b5a2eca2f2f6f53d6b) | `` librewolf-bin-unwrapped: 150.0-1 -> 150.0.1-1 ``                                                |
| [`3a0508ea`](https://github.com/NixOS/nixpkgs/commit/3a0508eaeaab4c3854219ab20b1c532b31512910) | `` xorgxrdp: 0.10.4 -> 0.10.5, xrdp: 0.10.4.1 -> 0.10.6 ``                                         |
| [`e74c8e62`](https://github.com/NixOS/nixpkgs/commit/e74c8e621589eb86c841a4a2c87e4554ac818b13) | `` uriparser: 1.0.0 -> 1.0.1 ``                                                                    |
| [`bce8fdcf`](https://github.com/NixOS/nixpkgs/commit/bce8fdcf53ed6222e6488290ea5969347dd94a6c) | `` hmcl: add libxkbcommon and jdk 25, don't use system glfw by default ``                          |
| [`191cff12`](https://github.com/NixOS/nixpkgs/commit/191cff12403c72d9f252ff6638d01611ae064d13) | `` packagekit: 1.3.3 -> 1.3.5 ``                                                                   |
| [`083c6600`](https://github.com/NixOS/nixpkgs/commit/083c6600a2607a6aa733c4a1905a8287b81e84e6) | `` rollo-printer: use pkg-config instead of native cups ``                                         |
| [`900522d3`](https://github.com/NixOS/nixpkgs/commit/900522d30e46b2f315df154cddd76604a351b670) | `` rollo-printer: init at 1.8.4 ``                                                                 |
| [`375e8057`](https://github.com/NixOS/nixpkgs/commit/375e8057598f4512b10d0435c7399a90e39b6f73) | `` log4cxx: 1.6.1 -> 1.7.0 ``                                                                      |
| [`fcd57532`](https://github.com/NixOS/nixpkgs/commit/fcd575321f12daddee5d5f61cb4bf50eef1ab6ff) | `` log4cxx: 1.6.0 -> 1.6.1 ``                                                                      |
| [`cfb46cf8`](https://github.com/NixOS/nixpkgs/commit/cfb46cf81e743caf30ddbe9529eb68c57a38f4ad) | `` log4cxx: 1.5.0 -> 1.6.0 ``                                                                      |
| [`dab0e483`](https://github.com/NixOS/nixpkgs/commit/dab0e4830f1e7c0710b4cebb8ccc474af6008e08) | `` onedrive: 2.5.9 -> 2.5.10 ``                                                                    |