### PR TITLE
chore(flake/fredbar): `6727f8a4` -> `1f0b4cec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -270,6 +270,22 @@
     "flake-compat_5": {
       "flake": false,
       "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
         "lastModified": 1761588595,
         "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
@@ -283,7 +299,7 @@
         "type": "github"
       }
     },
-    "flake-compat_6": {
+    "flake-compat_7": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -466,6 +482,7 @@
         "ags": "ags",
         "astal": "astal_2",
         "fredcal": "fredcal",
+        "git-hooks": "git-hooks_2",
         "hyprshutdown": "hyprshutdown",
         "nixpkgs": [
           "nixpkgs"
@@ -473,11 +490,11 @@
         "precommit": "precommit_2"
       },
       "locked": {
-        "lastModified": 1778016141,
-        "narHash": "sha256-yzuDsp+HI2kr9E96NUXPHfcQybtwX5Ddto0JBy8rP1Q=",
+        "lastModified": 1778610837,
+        "narHash": "sha256-yFJ3TRKK1p4YqI69E5iMIGXbdQ/RjSw0sBK7P0gLlos=",
         "owner": "FredSystems",
         "repo": "fred-bar",
-        "rev": "6727f8a4a8e7f68b7f28c00cf94f5d01e1727250",
+        "rev": "1f0b4cecda7e56aae512a1dd08f71a5400c81f29",
         "type": "github"
       },
       "original": {
@@ -561,6 +578,29 @@
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "fredbar",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_3": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "gitignore": "gitignore_3",
+        "nixpkgs": [
+          "fredbar",
           "precommit",
           "nixpkgs"
         ]
@@ -579,10 +619,10 @@
         "type": "github"
       }
     },
-    "git-hooks_3": {
+    "git-hooks_4": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
-        "gitignore": "gitignore_3",
+        "flake-compat": "flake-compat_5",
+        "gitignore": "gitignore_4",
         "nixpkgs": [
           "freminal",
           "precommit",
@@ -603,10 +643,10 @@
         "type": "github"
       }
     },
-    "git-hooks_4": {
+    "git-hooks_5": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
-        "gitignore": "gitignore_4",
+        "flake-compat": "flake-compat_6",
+        "gitignore": "gitignore_5",
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
@@ -623,10 +663,10 @@
         "type": "github"
       }
     },
-    "git-hooks_5": {
+    "git-hooks_6": {
       "inputs": {
-        "flake-compat": "flake-compat_6",
-        "gitignore": "gitignore_5",
+        "flake-compat": "flake-compat_7",
+        "gitignore": "gitignore_6",
         "nixpkgs": [
           "precommit-base",
           "nixpkgs"
@@ -674,7 +714,6 @@
       "inputs": {
         "nixpkgs": [
           "fredbar",
-          "precommit",
           "git-hooks",
           "nixpkgs"
         ]
@@ -696,7 +735,7 @@
     "gitignore_3": {
       "inputs": {
         "nixpkgs": [
-          "freminal",
+          "fredbar",
           "precommit",
           "git-hooks",
           "nixpkgs"
@@ -719,7 +758,8 @@
     "gitignore_4": {
       "inputs": {
         "nixpkgs": [
-          "nixos-needsreboot",
+          "freminal",
+          "precommit",
           "git-hooks",
           "nixpkgs"
         ]
@@ -739,6 +779,28 @@
       }
     },
     "gitignore_5": {
+      "inputs": {
+        "nixpkgs": [
+          "nixos-needsreboot",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_6": {
       "inputs": {
         "nixpkgs": [
           "precommit-base",
@@ -1105,7 +1167,7 @@
     "nixos-needsreboot": {
       "inputs": {
         "flake-utils": "flake-utils_6",
-        "git-hooks": "git-hooks_4",
+        "git-hooks": "git-hooks_5",
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
@@ -1422,7 +1484,7 @@
     "precommit-base": {
       "inputs": {
         "flake-utils": "flake-utils_7",
-        "git-hooks": "git-hooks_5",
+        "git-hooks": "git-hooks_6",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1445,7 +1507,7 @@
     "precommit_2": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "git-hooks": "git-hooks_2",
+        "git-hooks": "git-hooks_3",
         "nixpkgs": [
           "fredbar",
           "nixpkgs"
@@ -1469,7 +1531,7 @@
     "precommit_3": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "git-hooks": "git-hooks_3",
+        "git-hooks": "git-hooks_4",
         "nixpkgs": "nixpkgs_6",
         "rust-overlay": "rust-overlay_3"
       },


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| [`1f0b4cec`](https://github.com/fredsystems/fred-bar/commit/1f0b4cecda7e56aae512a1dd08f71a5400c81f29) | `` fix(logout): resolve current user in-process for loginctl fallback ``                                      |
| [`797c4bee`](https://github.com/fredsystems/fred-bar/commit/797c4bee75947cb16dcef4283a8494a3bc06a481) | `` chore(types): enforce CI-gated tsc with portable ags type generation (C-3.5) ``                            |
| [`9db7ad8c`](https://github.com/fredsystems/fred-bar/commit/9db7ad8c0e9c8a64d926ee503994ea484c609391) | `` fix(tooltip): resolve dynamically + live-refresh on hover (C-2.9) ``                                       |
| [`3f8ef38d`](https://github.com/fredsystems/fred-bar/commit/3f8ef38df1b59d96aef234355086128abc82cd28) | `` refactor(cleanup): self-driving widget cleanup via destroy signal (C-3.2) ``                               |
| [`97ef36ce`](https://github.com/fredsystems/fred-bar/commit/97ef36ce602518a1b00f0ee53a4c67a480845d06) | `` refactor(notifications): follow-mouse popups via global state + reparenting ``                             |
| [`cecc0706`](https://github.com/fredsystems/fred-bar/commit/cecc07064c81236d6a865f70f60a0d33a06fc9d2) | `` perf(notifications): show popups on focused monitor only with shared timer (C-2.3) ``                      |
| [`a124e159`](https://github.com/fredsystems/fred-bar/commit/a124e15925629e18f9a58b10ccfdd3fb95a7ae8d) | `` perf(battery): drop redundant 2 s poll, rely on notify::* (C-2.8) ``                                       |
| [`c19f13dc`](https://github.com/fredsystems/fred-bar/commit/c19f13dcddfc693a68c85989e451ddbb78e17d5e) | `` perf(media-player): rebind on player swap instead of full rebuild (C-2.4) ``                               |
| [`0cbac310`](https://github.com/fredsystems/fred-bar/commit/0cbac310b59643d59189dac0cd7871ee5a49e585) | `` feat(tray): add per-monitor click-catcher backdrop for menu dismissal ``                                   |
| [`31a1dd8e`](https://github.com/fredsystems/fred-bar/commit/31a1dd8e4a6e8c8096e2b824f0d24612858175bd) | `` fix(tray): correct inter-icon menu transitions and toggle behavior ``                                      |
| [`43fa71c4`](https://github.com/fredsystems/fred-bar/commit/43fa71c44a8887204b1e863ce906595e5d532e3f) | `` fix(tray): bypass appmenu-glib-translator with direct dbusmenu client (C-1.16) ``                          |
| [`015f581e`](https://github.com/fredsystems/fred-bar/commit/015f581e413ee8bbd43f531cd7e6493485421d65) | `` build(flake): add gdb to dev shell for crash diagnostics ``                                                |
| [`f362a2cc`](https://github.com/fredsystems/fred-bar/commit/f362a2cc3b574fb74fd1f52e8a7a09beab03f199) | `` docs(audit): mark completed items, document C-2.9 regression and revert ``                                 |
| [`bab1410f`](https://github.com/fredsystems/fred-bar/commit/bab1410fb04bd9772ea718a46ad5449dd3a3e12a) | `` Revert "refactor(tray): resolve tooltip text dynamically (C-2.9)" ``                                       |
| [`754c6428`](https://github.com/fredsystems/fred-bar/commit/754c6428dd3d7f4e0d26e707b7a2e42df2c1273e) | `` refactor(tray): resolve tooltip text dynamically (C-2.9) ``                                                |
| [`bfa59db1`](https://github.com/fredsystems/fred-bar/commit/bfa59db12f309ca2c89b896e098e4385a1d44f80) | `` refactor(monitor): use shared getMonitorConnectorName helper (C-3.3) ``                                    |
| [`a81a7a77`](https://github.com/fredsystems/fred-bar/commit/a81a7a7780551d9b2ad3ae4af14403cb632d5560) | `` refactor(logging): introduce tagged logger with AGS_LOG_LEVEL gate (C-3.6) ``                              |
| [`b667423c`](https://github.com/fredsystems/fred-bar/commit/b667423c128f662cff90637de4cea92e8c9f48b9) | `` refactor(time-pill): key clock entries by label to avoid tzid collisions (C-3.4) ``                        |
| [`4a79fe34`](https://github.com/fredsystems/fred-bar/commit/4a79fe3486cd1f74eafabd7145f800909738920a) | `` fix(bar): click anywhere in bar dismisses open panels ``                                                   |
| [`23e31def`](https://github.com/fredsystems/fred-bar/commit/23e31def411c019e3711d6e089d26558226ecbc5) | `` refactor(services): centralise VPN polling and compositor detection (C-3.1, C-1.5, C-1.6, C-1.9, C-1.4) `` |
| [`c6557e22`](https://github.com/fredsystems/fred-bar/commit/c6557e2273788e2e028acb2dddc7b7996314e38e) | `` fix(workspaces): debounce hover collapse to break revealer oscillation (C-1.15) ``                         |
| [`4597ba5d`](https://github.com/fredsystems/fred-bar/commit/4597ba5d9886122e9310dc35ab57c4eaf96ab8c1) | `` fix(bar): close tray prefix bloat, popover hover bug, backdrop dual-add ``                                 |
| [`69e3978d`](https://github.com/fredsystems/fred-bar/commit/69e3978d940c4b7268554ed8c0ffc311e117b49b) | `` perf(niri): replace 200ms polling with niri event-stream subscription (C-2.5) ``                           |
| [`5c58b773`](https://github.com/fredsystems/fred-bar/commit/5c58b7737154eb067c4884e83b7e3d636a3f3d96) | `` perf(sliders): truly-async ddcutil detection and per-slider getvcp (C-1.7, C-1.8) ``                       |
| [`6ceeab06`](https://github.com/fredsystems/fred-bar/commit/6ceeab06cbf0317116e5a7ea6ef91e4c7d1f7395) | `` style: clear remaining biome warnings (noNonNullAssertion, useOptionalChain) ``                            |
| [`4a373613`](https://github.com/fredsystems/fred-bar/commit/4a3736133027f4702acccab19e448d2a86bd8048) | `` perf(tooltip): cache widget tree across query-tooltip callbacks (C-2.2) ``                                 |
| [`f0c5fe81`](https://github.com/fredsystems/fred-bar/commit/f0c5fe818066b75ca55f391e4d9d41ca01e038fd) | `` fix(tray): drop dropdown menu downward instead of clipping off-screen left (C-1.14) ``                     |
| [`b1783892`](https://github.com/fredsystems/fred-bar/commit/b17838928199552488a58d0e3ed8233efadbb764) | `` perf(icons): cache AppInfo enumeration and use proper themed-icon fallbacks (C-2.6, C-2.7) ``              |
| [`1e78fd11`](https://github.com/fredsystems/fred-bar/commit/1e78fd11c325fb0b916c1da0f203de5ac7f903fc) | `` refactor(timers): standardize battery/network polling on GLib.timeout_add (C-1.13) ``                      |
| [`1cd6d3c0`](https://github.com/fredsystems/fred-bar/commit/1cd6d3c0b7205199cdcf172f9bc1481c1c637a98) | `` fix(volume): collapse duplicate notify::default-speaker handler (C-1.3) ``                                 |
| [`f7b2da32`](https://github.com/fredsystems/fred-bar/commit/f7b2da320b8a8e47a9374a6a1165b1db4bbe5bd2) | `` perf(system-state): dedupe systemState poll output to suppress 4Hz rebuild churn (C-2.1) ``                |
| [`e675322c`](https://github.com/fredsystems/fred-bar/commit/e675322c50cd1b545630ecc0af8a05436374f871) | `` fix(compositors): window titles update on in-window title changes (C-1.2) ``                               |
| [`b2746af1`](https://github.com/fredsystems/fred-bar/commit/b2746af191efad36ff1e2cc605f0322f03e8b7d3) | `` fix(notifications): honor transient and x-canonical-private-synchronous hints (C-1.1) ``                   |
| [`2092d762`](https://github.com/fredsystems/fred-bar/commit/2092d762d03886d4111a0af3ad5c6f4fa6a23f44) | `` docs: add AUDIT.md cataloging correctness, perf, and architecture findings ``                              |