### PR TITLE
chore(flake/home-manager): `1768d4e4` -> `5878fdad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -767,11 +767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778594112,
-        "narHash": "sha256-VA9z90SZviIvOcA4QyatA48FIyqb8mmsmH/EsXXWAG4=",
+        "lastModified": 1778609305,
+        "narHash": "sha256-muTc+WME6k3sfTr/Pvmw8hrK7zXrbl961TEF9wPeAnk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1768d4e49860b86cb7652ee738de0e6b3050dd40",
+        "rev": "5878fdadfe2cfe1b3383b38d66117f7b80696b68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`5878fdad`](https://github.com/nix-community/home-manager/commit/5878fdadfe2cfe1b3383b38d66117f7b80696b68) | `` tests: avoid removed anime-downloader package ``           |
| [`2d53d45f`](https://github.com/nix-community/home-manager/commit/2d53d45f6b6c7b022cde84720f2b8df6c4648924) | `` tests: avoid removed acd-cli package ``                    |
| [`a5e92be8`](https://github.com/nix-community/home-manager/commit/a5e92be80314523e7a8e946046dd69fc463d55fd) | `` maintainers: drop duplicate ojsef39 entry ``               |
| [`3f640297`](https://github.com/nix-community/home-manager/commit/3f6402974019ae29a45570641ab4641bf87232f4) | `` tests: restore TOML goldens for remarshal ``               |
| [`eb3e569f`](https://github.com/nix-community/home-manager/commit/eb3e569fd44db25904c2359570b5ce7f027cb664) | `` flake: bump nixpkgs from `1c3fe55` to `da5ad66` ``         |
| [`b7e6cad3`](https://github.com/nix-community/home-manager/commit/b7e6cad33548d10e685e9a7ec18d823f45ffd5c2) | `` tests/fish: add non-handler function defined as attrset `` |
| [`755b9931`](https://github.com/nix-community/home-manager/commit/755b9931658ac6ef380b5aec0791ddc424b321ce) | `` fish: fix handler function sourcing ``                     |