### PR TITLE
chore(flake/niri): `8994a3e5` -> `f525d3b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1035,11 +1035,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1778512904,
-        "narHash": "sha256-GmJZE3/rjeVwB364IGClx4TV50T5ey5V+48f0t8AUD4=",
+        "lastModified": 1778600236,
+        "narHash": "sha256-jWlIT+uKqKZoz6rNweobs/h6FfI5dKnC5OO7/3T7Tdw=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "8994a3e53989f8ce9e6f16c29da15c08e0056402",
+        "rev": "f525d3b0a684d463dc9cf5c59359b9e67a372939",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`f525d3b0`](https://github.com/sodiboo/niri-flake/commit/f525d3b0a684d463dc9cf5c59359b9e67a372939) | `` Update flake.lock `` |