### PR TITLE
chore(flake/home-manager-stable): `389b8300` -> `e1fd7350`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778401693,
-        "narHash": "sha256-OVHdCqXXUF5UdGkH+FF2ZL06OLZjj2kvP2dIUmzVWoo=",
+        "lastModified": 1778606796,
+        "narHash": "sha256-P2krpSkFVYJ89bgsnAZ9RtQiGwiTW77sfSJp9SEDscM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "389b83002efc26f1145e89a6a8e6edc5a6435948",
+        "rev": "e1fd7350f4410972bcb8c42a697d8c924ffe642a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`e1fd7350`](https://github.com/nix-community/home-manager/commit/e1fd7350f4410972bcb8c42a697d8c924ffe642a) | `` wayle: add module ``                               |
| [`e29db51c`](https://github.com/nix-community/home-manager/commit/e29db51cc034dca8a2397aed65bcea9f6a6ef2f0) | `` flake: bump nixpkgs from `0c88e1f` to `8fd9daa` `` |