### PR TITLE
chore(flake/nixpkgs): `549bd84d` -> `da5ad661`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1188,11 +1188,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`efdc2abe`](https://github.com/NixOS/nixpkgs/commit/efdc2abe73dfd1aca7c0367280dfe1ea87713065) | `` emmylua-ls: 0.22.0 -> 0.23.0 ``                                                           |
| [`a99e89a9`](https://github.com/NixOS/nixpkgs/commit/a99e89a942d56f76202352fbbbfdea2368f18a56) | `` python3Packages.aiolyric: migrate to finalAttrs ``                                        |
| [`cb111fb4`](https://github.com/NixOS/nixpkgs/commit/cb111fb4b8193a3f1f9d9f51ff6cd33588634d3b) | `` python3Packages.iamdata: 0.1.202605091 -> 0.1.202605101 ``                                |
| [`61976779`](https://github.com/NixOS/nixpkgs/commit/6197677924c68f332b4add8759fd3b8fb8604e06) | `` emmylua_{check,doc_cli}: use cargoHash from emmylua-ls ``                                 |
| [`27113348`](https://github.com/NixOS/nixpkgs/commit/2711334825dbc0dca8b54ce3a8b838203267d82d) | `` sendspin-go: 1.6.2 -> 1.7.0 ``                                                            |
| [`6cba2508`](https://github.com/NixOS/nixpkgs/commit/6cba250893e00c9c6d804105d2f51ea92241345c) | `` Revert "Reapply "nixos/nixpkgs.config: make use of the module defined in config.nix"" ``  |
| [`15f85d53`](https://github.com/NixOS/nixpkgs/commit/15f85d53f9a4afea29a5ce5ce612f8aa19354439) | `` naabu: 2.5.0 -> 2.6.1 ``                                                                  |
| [`4b502f0b`](https://github.com/NixOS/nixpkgs/commit/4b502f0b35f146c2ae3437e132e9201f5dd8f4bb) | `` python3Packages.victron-mqtt: 2026.4.19 -> 2026.5.0 ``                                    |
| [`aba2ddc6`](https://github.com/NixOS/nixpkgs/commit/aba2ddc61111c26f168fa538c5df64473a632f80) | `` home-assistant: update component packages ``                                              |
| [`0eaa3231`](https://github.com/NixOS/nixpkgs/commit/0eaa3231cfd0e81f9aa2d25872c1161a1abb250c) | `` python3Packages.python-duco-client: init at 0.4.1 ``                                      |
| [`869d6412`](https://github.com/NixOS/nixpkgs/commit/869d6412815ae236d313b4f242f8667ed8c7cf30) | `` treewide: replace stdenv.is* with stdenv.hostPlatform.is* ``                              |
| [`884227b3`](https://github.com/NixOS/nixpkgs/commit/884227b3a6d7db67330a22023da77cf4ad75cdaf) | `` luaPackages.luaossl: mark broken for lua 5.5 ``                                           |
| [`26cd1f58`](https://github.com/NixOS/nixpkgs/commit/26cd1f58c2d1e1a2bacf004ca80b25a3ebfbcfb6) | `` prettier-plugin-jinja-template: 2.1.0 -> 2.2.0 ``                                         |
| [`878f31c6`](https://github.com/NixOS/nixpkgs/commit/878f31c60ed2ea1eba60800c4d725d10ae520035) | `` statix: 0-unstable-2026-05-03 -> 0-unstable-2026-05-09 ``                                 |
| [`6dc6486d`](https://github.com/NixOS/nixpkgs/commit/6dc6486d7ec235ecf4f0ed462090b581ea98dbb7) | `` goverlay: 1.7.5 -> 1.8.1 ``                                                               |
| [`95cd81b9`](https://github.com/NixOS/nixpkgs/commit/95cd81b94e10b728bc3d0ae0ba9706606e6d2135) | `` python3Packages.aiolyric: 2.0.2 -> 2.1.0 ``                                               |
| [`7bc28c26`](https://github.com/NixOS/nixpkgs/commit/7bc28c26a37019e04860bba0402096ca684731ec) | `` meshlab: Add geospatial team ``                                                           |
| [`0b1ed724`](https://github.com/NixOS/nixpkgs/commit/0b1ed724dee231e0c35ee58b3797ca18740bf587) | `` velocity: 3.5.0-unstable-2026-05-01 -> 3.5.0-unstable-2026-05-09 ``                       |
| [`d65cd434`](https://github.com/NixOS/nixpkgs/commit/d65cd4342b46f71c450de867a3df55afe62ee311) | `` reaction: fix version check ``                                                            |
| [`959274ad`](https://github.com/NixOS/nixpkgs/commit/959274ad308a3e11301f7563bf1b03aa5f38f1d4) | `` mcporter: 0.10.1 -> 0.10.2 ``                                                             |
| [`d6bd5223`](https://github.com/NixOS/nixpkgs/commit/d6bd52239b607904feb26ffa35abaa8529fe042b) | `` exiftool: 13.52 -> 13.58 ``                                                               |
| [`83d419ae`](https://github.com/NixOS/nixpkgs/commit/83d419ae5eb81820910fd1edd9098d78d5404747) | `` multica-cli: 0.2.23 -> 0.2.29 ``                                                          |
| [`ea45b74e`](https://github.com/NixOS/nixpkgs/commit/ea45b74e9c91fc3e2dfea02c8398f01ccbceaaf7) | `` vim-flog: add meta.license attribute ``                                                   |
| [`49f4ea55`](https://github.com/NixOS/nixpkgs/commit/49f4ea55213c2882c5af8e5f2d9f39b22a6c844e) | `` python3Packages.elkm1-lib: 2.2.14 -> 2.2.15 ``                                            |
| [`7caf1f08`](https://github.com/NixOS/nixpkgs/commit/7caf1f085d71af70cfcb1b00c50797219eb18ed5) | `` brainflow: 5.21.0 -> 5.22.0 ``                                                            |
| [`b110b286`](https://github.com/NixOS/nixpkgs/commit/b110b28606e188a34410c036791140b0d0c87c9a) | `` gitsign: 0.15.0 -> 0.16.0 ``                                                              |
| [`c64fff91`](https://github.com/NixOS/nixpkgs/commit/c64fff91b751f8af1605e174898a89f064ced8b0) | `` rns: 1.2.4 -> 1.2.5 ``                                                                    |
| [`f81dd269`](https://github.com/NixOS/nixpkgs/commit/f81dd269cc1743aa299a13b78748089f271859b0) | `` free42: 3.3.11 -> 3.3.12 ``                                                               |
| [`2b85d4d8`](https://github.com/NixOS/nixpkgs/commit/2b85d4d8da51c4750bc75f9232da35e9024ef290) | `` mago: 1.19.0 -> 1.23.0 ``                                                                 |
| [`0894a849`](https://github.com/NixOS/nixpkgs/commit/0894a8499cced8316ef6326904f58d36f97b509d) | `` balatro-mod-manager: mark broken on aarch64-linux ``                                      |
| [`21b2bffa`](https://github.com/NixOS/nixpkgs/commit/21b2bffaaec2c2a4a722283d35713c29ba82feee) | `` jackett: 0.24.1807 -> 0.24.1831 ``                                                        |
| [`4b47adbb`](https://github.com/NixOS/nixpkgs/commit/4b47adbb8ab53819f09cb584bc7e1b140339c7b1) | `` hashlink: remove unused pcre dependency ``                                                |
| [`e0101cb9`](https://github.com/NixOS/nixpkgs/commit/e0101cb9cf4d60dbf10c50b7a214e3f09f9252f7) | `` lib/modules: make comment more clear ``                                                   |
| [`a3cf24f8`](https://github.com/NixOS/nixpkgs/commit/a3cf24f8e62cc22c933bf01da107a336b15cd25d) | `` jwt-hack: 2.0.0 -> 2.5.0 ``                                                               |
| [`9c17139e`](https://github.com/NixOS/nixpkgs/commit/9c17139e046483f7f8d3e59fe7f73ef0349f33bc) | `` gforth: 0.7.9_20260415 -> 0.7.9_20260508 ``                                               |
| [`95338e97`](https://github.com/NixOS/nixpkgs/commit/95338e9792d3a3f8adf462fa101043d2d2addbe7) | `` deck: 1.59.1 -> 1.60.0 ``                                                                 |
| [`d3c15a99`](https://github.com/NixOS/nixpkgs/commit/d3c15a99ed2174927f1f6b2fab4edf2cc0f5b6e6) | `` libretro.fbneo: 0-unstable-2026-04-30 -> 0-unstable-2026-05-09 ``                         |
| [`5f5be4cc`](https://github.com/NixOS/nixpkgs/commit/5f5be4ccdea5d69f4bacdeeba1c1a9835d934084) | `` home-assistant: update component packages ``                                              |
| [`d7409e47`](https://github.com/NixOS/nixpkgs/commit/d7409e47948ccd39f8fa020a0178b1cdd0444c70) | `` python3Packages.denon-rs232: init at 4.1.0 ``                                             |
| [`9fb89a0b`](https://github.com/NixOS/nixpkgs/commit/9fb89a0babd5ac9760d26d122834b07ef8c20938) | `` reqable: 3.0.40 -> 3.1.0 ``                                                               |
| [`4d8acc9b`](https://github.com/NixOS/nixpkgs/commit/4d8acc9b514c4d3f8a0a1e035c99f25842c69651) | `` home-assistant: update component packages ``                                              |
| [`d9693f49`](https://github.com/NixOS/nixpkgs/commit/d9693f49af2b184cc6174c2ba79223a916357a40) | `` python3Packages.earn-e-p1: init at 0.1.0 ``                                               |
| [`06379360`](https://github.com/NixOS/nixpkgs/commit/0637936092ef5a84345bbb6914696afa7d0d89f7) | `` home-assistant: update component packages ``                                              |
| [`29df146b`](https://github.com/NixOS/nixpkgs/commit/29df146b4e8dc0cfcb376edfeac2be6e1f518fb4) | `` python3Packages.eurotronic-cometblue-ha: init at 1.4.0 ``                                 |
| [`91e02a10`](https://github.com/NixOS/nixpkgs/commit/91e02a10afaaa43e60a01e2651319a58180e2b11) | `` home-assistant: update component packages ``                                              |
| [`7ea190c8`](https://github.com/NixOS/nixpkgs/commit/7ea190c8ecd1b6c686569e0a992dcbffeeeeec04) | `` python3Packages.kiosker-python-api: init at 1.2.9 ``                                      |
| [`2d26de2d`](https://github.com/NixOS/nixpkgs/commit/2d26de2d1f882168826d1899c73b23e7cf252b21) | `` home-assistant: update component packages ``                                              |
| [`acd96e1a`](https://github.com/NixOS/nixpkgs/commit/acd96e1a0e5f1f0c13fd0d02bb1031adf85ff258) | `` python3Packages.pyomie: init at 1.1.1 ``                                                  |
| [`00bd7e8c`](https://github.com/NixOS/nixpkgs/commit/00bd7e8c3b6cf4bd6e5e20660c173fdd2909ba9d) | `` checkstyle: 13.2.0 -> 13.4.2 ``                                                           |
| [`061c9ead`](https://github.com/NixOS/nixpkgs/commit/061c9ead16ed5144d8c59b50e6c1c6d9d67582a7) | `` zwave-js-ui: 11.16.2 -> 11.17.0 ``                                                        |
| [`62ffd2d1`](https://github.com/NixOS/nixpkgs/commit/62ffd2d115d0d5720df13dfa1ac0bcee2c2cbefe) | `` home-assistant: update component packages ``                                              |
| [`fbdca412`](https://github.com/NixOS/nixpkgs/commit/fbdca412f9593a58ede8ac90e50b88e84cd3f3d0) | `` python3Packages.aiopnsense: init at 1.0.8 ``                                              |
| [`197cdb60`](https://github.com/NixOS/nixpkgs/commit/197cdb60de8e88f11cdd882c9e9529f772ceb0b8) | `` motrix-next: 3.8.5 -> 3.8.9 ``                                                            |
| [`fc4a432f`](https://github.com/NixOS/nixpkgs/commit/fc4a432f24da9fe3ef7bd204bca45b02ddababca) | `` lisette: 0.1.23 -> 0.2.1 ``                                                               |
| [`d1453713`](https://github.com/NixOS/nixpkgs/commit/d145371334ead74a2ce0017b13066da5594e98e6) | `` home-assistant: update component packages ``                                              |
| [`3683a920`](https://github.com/NixOS/nixpkgs/commit/3683a920de73eed8a6f49335207d883242005e60) | `` python3Packages.python-dropbox-api: init at 0.1.3 ``                                      |
| [`dc51a6dc`](https://github.com/NixOS/nixpkgs/commit/dc51a6dcc5e523597db213718d98440b6f3d8eb4) | `` home-assistant: update component packages ``                                              |
| [`090b7d28`](https://github.com/NixOS/nixpkgs/commit/090b7d28bf46caa3da2867ff494ea5b337615b6a) | `` python3Packages.pyteleinfo: init at 0.4.0 ``                                              |
| [`be503645`](https://github.com/NixOS/nixpkgs/commit/be503645aa125b6568e29375262f6f54f32a900c) | `` open-webui: 0.9.2-> 0.9.4 ``                                                              |
| [`888eedd5`](https://github.com/NixOS/nixpkgs/commit/888eedd511007dedc86e06273092766eb4e031cd) | `` python3Packages.pyezvizapi: 1.0.4.7 -> 1.0.4.8 ``                                         |
| [`0c9a4207`](https://github.com/NixOS/nixpkgs/commit/0c9a4207abca0dd51d573ec87e2b1e8a6ffef30b) | `` chameleon-cli: 2.1.0-unstable-2026-04-19 -> 2.1.0-unstable-2026-05-08 ``                  |
| [`5e554ded`](https://github.com/NixOS/nixpkgs/commit/5e554dedcd736adb5d3193106eb9ab155dd713b9) | `` mesa: drop jdupes dependency ``                                                           |
| [`98b356ae`](https://github.com/NixOS/nixpkgs/commit/98b356ae0cbc51640aa5c1e3f798551f849763b6) | `` super-productivity: 18.4.4 -> 18.5.0 ``                                                   |
| [`01c4ab9d`](https://github.com/NixOS/nixpkgs/commit/01c4ab9d66c94cb1a2c9fd2a29caba1dbdf38dfa) | `` home-assistant-themes.material-you-theme: 5.0.1 -> 5.0.12 ``                              |
| [`c94503f3`](https://github.com/NixOS/nixpkgs/commit/c94503f39a35f13d8a59310e54927f8a6eeea8f3) | `` egctl: 1.7.2 -> 1.7.3 ``                                                                  |
| [`93374c3b`](https://github.com/NixOS/nixpkgs/commit/93374c3b798496d490b85553ce4b1af5e53c4143) | `` terraform-providers.turbot_turbot: 1.13.1 -> 1.13.3 ``                                    |
| [`ef0d4d92`](https://github.com/NixOS/nixpkgs/commit/ef0d4d924b094d8292d65ab79a7bdfca1cdc928e) | `` piliplus: 2.0.6 -> 2.0.7 ``                                                               |
| [`bbe8cd68`](https://github.com/NixOS/nixpkgs/commit/bbe8cd680a6c57cf5f21169b3197320823603fae) | `` python3Packages.piper-phonemize: mark broken on x86-64-darwin ``                          |
| [`1aea84e9`](https://github.com/NixOS/nixpkgs/commit/1aea84e9f7dd54f2a0ce7e1bd60af72b5b8dc803) | `` stdenv.mkDerivation: inherit all builtins ``                                              |
| [`13fb2f08`](https://github.com/NixOS/nixpkgs/commit/13fb2f08dc9511aae71dd4d570cf728bb23fe2f0) | `` stdenv.mkDerivation: inherit all lib variables ``                                         |
| [`789a15ef`](https://github.com/NixOS/nixpkgs/commit/789a15ef68b7c509ed7ff315ef9ea8ce0b4ac864) | `` stdenv.mkDerivation: move attrs removed for derivationArg to global scope ``              |
| [`9f278a55`](https://github.com/NixOS/nixpkgs/commit/9f278a55db99e9e575ec31f0fc555ed8c8b2cd4e) | `` stdenv.mkDerivation: store default builder args in global scope ``                        |
| [`8de09cd1`](https://github.com/NixOS/nixpkgs/commit/8de09cd1f8839e9af47ad9ce8e23028087c45438) | `` stdenv.mkDerivation: move reference checking attrs to global scope ``                     |
| [`6ca5391f`](https://github.com/NixOS/nixpkgs/commit/6ca5391f9621ba3cc3012a0bc3d91a120bf6c60e) | `` python3Packages.serialx: fix tests on darwin ``                                           |
| [`57c99d57`](https://github.com/NixOS/nixpkgs/commit/57c99d57221c89a1b2911753026b0376fb9ea1cf) | `` stdenv.mkDerivation: move list of attribute names out to global scope ``                  |
| [`fa7a5111`](https://github.com/NixOS/nixpkgs/commit/fa7a5111487f0977c48cf9ce4b839f2fd1deba96) | `` python3Packages.serialx: disable racy tests ``                                            |
| [`dfa34d93`](https://github.com/NixOS/nixpkgs/commit/dfa34d93769703cd099a0f2f86cb39c67a4d0f41) | `` stdenv.mkDerivation: move attrNames out of happy path ``                                  |
| [`2113c381`](https://github.com/NixOS/nixpkgs/commit/2113c381ea0a2b9b404a7a99aa8f39f4b9f854d8) | `` stdenv.mkDerivation: move errors variable out of happy path ``                            |
| [`95a031c3`](https://github.com/NixOS/nixpkgs/commit/95a031c36339a349f90c9d949f5c37178af6b351) | `` stdenv.mkDerivation: remove assertMsg usage ``                                            |
| [`9c145360`](https://github.com/NixOS/nixpkgs/commit/9c1453602e75fb9c4632dfabb26fe928afe18b7a) | `` stdenv.mkDerivation: only create enabledHardeningOptions variable if necessary ``         |
| [`32dc7f6f`](https://github.com/NixOS/nixpkgs/commit/32dc7f6f02e01cd844fd289d5f7b1b47ed769ea8) | `` stdenv.mkDerivation: inline hardeningDisable' ``                                          |
| [`faf7bd1d`](https://github.com/NixOS/nixpkgs/commit/faf7bd1d3868acefe7b9e82a14b5dfa906596d07) | `` stdenv.mkDerivation: move concretizeFlagImplications to global scope ``                   |
| [`4a74a811`](https://github.com/NixOS/nixpkgs/commit/4a74a811f510dbfe5d611c6933418d9fd2fc2750) | `` firefox-esr-140-unwrapped: 140.10.1esr -> 140.10.2esr ``                                  |
| [`b1e9fb0d`](https://github.com/NixOS/nixpkgs/commit/b1e9fb0d2efadbe710170f8aacdf2be0825e758f) | `` bitrise: 2.39.4 -> 2.39.5 ``                                                              |
| [`152d862b`](https://github.com/NixOS/nixpkgs/commit/152d862bb0828e191863a66c1319a83b59795932) | `` stdenv.mkDerivation: cache output checks to avoid reallocating ``                         |
| [`fc43f076`](https://github.com/NixOS/nixpkgs/commit/fc43f076bbba14e7754f7f200509b95704796674) | `` stdenv.mkDerivation: avoid listToAttrs if outputChecks will end up empty ``               |
| [`26b51ec1`](https://github.com/NixOS/nixpkgs/commit/26b51ec16dd3fa98121a02da6b34a86ad0420776) | `` stdenv.mkDerivation: avoid concat if separateDebugInfo' is false ``                       |
| [`1a0f106f`](https://github.com/NixOS/nixpkgs/commit/1a0f106fb057559f9ad647a70281bb5389a6c4e2) | `` go-font: use installFonts hook ``                                                         |
| [`14a335e2`](https://github.com/NixOS/nixpkgs/commit/14a335e23cd825909589b485d0151188acbbe565) | `` aileron: use installFonts hook ``                                                         |
| [`54b1986d`](https://github.com/NixOS/nixpkgs/commit/54b1986d4e2dab61a01311b8b3a2df0e96e10831) | `` fanwood: use installFonts hook ``                                                         |
| [`f0307e37`](https://github.com/NixOS/nixpkgs/commit/f0307e3717d472c810fe132e131b3bffddaf3ed8) | `` windsurf: 2.1.32 -> 2.2.17 ``                                                             |
| [`fde4f1c5`](https://github.com/NixOS/nixpkgs/commit/fde4f1c5a0583e00bee4a91efb675deb9d74785d) | `` stdenv.mkDerivation: check meta.mainProgram from original meta ``                         |
| [`f4513092`](https://github.com/NixOS/nixpkgs/commit/f4513092a3c0356888ed3e63d215edea5f8e4514) | `` jjui: 0.10.4 -> 0.10.5 ``                                                                 |
| [`cbd8fa59`](https://github.com/NixOS/nixpkgs/commit/cbd8fa59860e51a6833c81686dd746f809a3a8e8) | `` home-assistant-themes.material-you-theme: init at 5.0.1 ``                                |
| [`63b4d66f`](https://github.com/NixOS/nixpkgs/commit/63b4d66ff5d30a0695206d502f65578e47b97cb0) | `` nixos/home-assistant: add themes support ``                                               |
| [`81d43b57`](https://github.com/NixOS/nixpkgs/commit/81d43b573e261f520cf7be548e2425315e0bb5b7) | `` shiru: init at 6.6.0 ``                                                                   |
| [`3e516072`](https://github.com/NixOS/nixpkgs/commit/3e5160724e9794547d794af7f8b4e03d5e04261c) | `` dprint-plugins.dprint-plugin-biome: 0.12.9 -> 0.12.10 ``                                  |
| [`d5632370`](https://github.com/NixOS/nixpkgs/commit/d56323706bdd9abf44b9d97c9610d5499b164c70) | `` terraform-providers.newrelic_newrelic: 3.85.1 -> 3.87.1 ``                                |
| [`91d60064`](https://github.com/NixOS/nixpkgs/commit/91d60064ffbfb8f925fdbed414d178c9670dc66e) | `` shutter: 0.99.6 -> 0.99.7 ``                                                              |
| [`ac796e98`](https://github.com/NixOS/nixpkgs/commit/ac796e9827bd4f43fc96c2e43b62645ed9bedd29) | `` stdenv.mkDerivation: use or statement for default hardening flags ``                      |
| [`1bcc5808`](https://github.com/NixOS/nixpkgs/commit/1bcc58083cf376e0fca2693382d5f329aeac5555) | `` gemini-cli: 0.40.1 -> 0.41.2 ``                                                           |
| [`873efc6d`](https://github.com/NixOS/nixpkgs/commit/873efc6d10190b45a0f773028e4b25eab8c08ac7) | `` draupnir: 3.0.0 -> 3.1.0 ``                                                               |
| [`e2009024`](https://github.com/NixOS/nixpkgs/commit/e20090240e00ae7e511de57f2a126eeb9ca52327) | `` terraform-providers.opentelekomcloud_opentelekomcloud: 1.36.64 -> 1.36.65 ``              |
| [`fbac0dda`](https://github.com/NixOS/nixpkgs/commit/fbac0dda1c9bd068817957796d0760d5b23858cd) | `` libsForQt5.qtstyleplugin-kvantum: 1.1.6 -> 1.1.7 ``                                       |
| [`ce35986f`](https://github.com/NixOS/nixpkgs/commit/ce35986f7fa8035359a32b2c3350f875a3ad5c15) | `` stdenv/mkDerivation: only run zipAttrsWith if we have to ``                               |
| [`ec66d5fc`](https://github.com/NixOS/nixpkgs/commit/ec66d5fc09695751f00f12f17347ccf76163ee43) | `` stdenv.mkDerivation: only run fold if an invalid type or list is passed ``                |
| [`7b8b8413`](https://github.com/NixOS/nixpkgs/commit/7b8b8413eaeed0840ee56ead9143dcc383adafb6) | `` stdenv.mkDerivation: avoid checking dependency list for empty lists ``                    |
| [`ada7d723`](https://github.com/NixOS/nixpkgs/commit/ada7d723b1957d69e6235487d359abc416229bc4) | `` stdenv/darwin: remove no-ops ``                                                           |
| [`a98dc396`](https://github.com/NixOS/nixpkgs/commit/a98dc39632cb52a586aeb6da3fcfeb553a73382f) | `` arcdps-log-manager: 1.15 -> 1.15.1 ``                                                     |
| [`de8d9b21`](https://github.com/NixOS/nixpkgs/commit/de8d9b21bb6b1dbd1943e47cc5e87d150846bcb7) | `` vivaldi: 7.9.3970.60 -> 7.9.3970.64 ``                                                    |
| [`ed17e4ff`](https://github.com/NixOS/nixpkgs/commit/ed17e4ff35f07f3d063b5da854fd7ce07dda1c64) | `` kicad-testing: 10.0-2026-04-24 -> 10.0-2026-05-09 ``                                      |
| [`47562983`](https://github.com/NixOS/nixpkgs/commit/47562983a14ed8f4621186a4e999305c7754b5e4) | `` python3Packages.schedula: skip incompatible tests on py3.14 ``                            |
| [`b496b035`](https://github.com/NixOS/nixpkgs/commit/b496b03511ca9f05544dcb6f3afb61f8498f5b80) | `` uriparser: 1.0.1 -> 1.0.2 ``                                                              |
| [`9e27b8b5`](https://github.com/NixOS/nixpkgs/commit/9e27b8b54e1a21499556084c11e49a4991779b6a) | `` amp-cli: 0.0.1777624460-g8bb2f0 -> 0.0.1778343260-gb9a37d ``                              |
| [`81ca1b9f`](https://github.com/NixOS/nixpkgs/commit/81ca1b9f12c619b7aa063faab71db15e0c191ee2) | `` python3Packages.aiortc: relax av constraint ``                                            |
| [`f7e6d4f0`](https://github.com/NixOS/nixpkgs/commit/f7e6d4f07305bba11dcbc9c7475a278641fb8676) | `` python3Packages.schedula: skip form-extras test that lacks proper guard ``                |
| [`6bef12c9`](https://github.com/NixOS/nixpkgs/commit/6bef12c9f73a40d792b4f989b7defd6cd8f2dbaf) | `` python3Packages.python-discovery: 1.2.2 -> 1.3.0 ``                                       |
| [`0db97e38`](https://github.com/NixOS/nixpkgs/commit/0db97e38f8c289302e45642c4f760cd7042a4967) | `` fmd-server: 0.14.2 -> 0.15.0 ``                                                           |
| [`1dc44078`](https://github.com/NixOS/nixpkgs/commit/1dc440780f236d03dd1e515f0db6683db73d742d) | `` libretro.snes9x2010: 0-unstable-2026-04-09 -> 0-unstable-2026-05-05 ``                    |
| [`10f4e432`](https://github.com/NixOS/nixpkgs/commit/10f4e432eea8a75a0e64442269b39ffe1e14dc6f) | `` python3Packages.av: 16.1.0 -> 17.0.1 ``                                                   |
| [`d51600ad`](https://github.com/NixOS/nixpkgs/commit/d51600ad2f7d7738f6282985fe8671cf988e02c1) | `` shogihome: 1.27.1 -> 1.27.2 ``                                                            |
| [`813c0e9a`](https://github.com/NixOS/nixpkgs/commit/813c0e9ad8009603640559e4c54f15959551e921) | `` python3Packages.weaviate-client: relax grpcio bound to fix build ``                       |
| [`6192646a`](https://github.com/NixOS/nixpkgs/commit/6192646a8015be157ca0dda07273050a754b37cc) | `` zettlr: 4.4.0 -> 4.5.0 ``                                                                 |
| [`d150776c`](https://github.com/NixOS/nixpkgs/commit/d150776c3cd21df10fbc3371cb0b7d2799016d0c) | `` music-assistant: 2.8.6 -> 2.8.7 ``                                                        |
| [`52dfa814`](https://github.com/NixOS/nixpkgs/commit/52dfa81427026af7630bf141e7d131cab2f71dde) | `` openclaw: 2026.5.6 -> 2026.5.7 ``                                                         |
| [`2c3ae45d`](https://github.com/NixOS/nixpkgs/commit/2c3ae45d4ff2568acea7c40504ddb07c18b5eb3a) | `` python3Packages.aiosendspin: remove pytest-timeout ``                                     |
| [`ba57d31e`](https://github.com/NixOS/nixpkgs/commit/ba57d31e925bd5e8f3a5d136cc4339ed74c217e0) | `` dovecot: fix fts_flatcurve linking errors ``                                              |
| [`bd2b09f8`](https://github.com/NixOS/nixpkgs/commit/bd2b09f820d9693489f72e0bc78e2c22d075173b) | `` uptime-kuma: 2.3.0 -> 2.3.2 ``                                                            |
| [`07741975`](https://github.com/NixOS/nixpkgs/commit/077419755bcf010c13465fd44733729e2e93cc74) | `` linuxKernel.kernels.linux_zen: 7.0.3-zen1 -> 7.0.5-zen1 ``                                |
| [`46c1316c`](https://github.com/NixOS/nixpkgs/commit/46c1316cebd49b0bd0a74f939acd5ba83146d046) | `` cargo-deny: 0.19.4 -> 0.19.5 ``                                                           |
| [`19d0de69`](https://github.com/NixOS/nixpkgs/commit/19d0de6921aeafc024448f97e1e5a0a6c91fe023) | `` chainsaw: 2.15.0 -> 2.16.0 ``                                                             |
| [`c0e96307`](https://github.com/NixOS/nixpkgs/commit/c0e963072706254b24fdd8c59b60ba1796d6001b) | `` nixos/tests/home-assistant: restrict components that cause errors ``                      |
| [`4b117cdc`](https://github.com/NixOS/nixpkgs/commit/4b117cdc8f54a1d9ed20e24a34ecb6e3b3103f0b) | `` remnote: 1.26.0 -> 1.26.8 ``                                                              |
| [`39f064f0`](https://github.com/NixOS/nixpkgs/commit/39f064f0e36717c414bba74e9820f66b8acd6611) | `` doc/using/configuration: document NIXPKGS_CONFIG lookup order ``                          |
| [`3370de25`](https://github.com/NixOS/nixpkgs/commit/3370de254a62da6d346be7aeb5619aecd0a3c719) | `` python314Packages.pywebcopy: migrat eto finalAttrs ``                                     |
| [`ee2fd75a`](https://github.com/NixOS/nixpkgs/commit/ee2fd75ab268f45c71da186101bddb8b9724f3c7) | `` python314Packages.pywebcopy: disable failing test ``                                      |
| [`c068aafa`](https://github.com/NixOS/nixpkgs/commit/c068aafa03fe11cb59f6f3e811beaa076e84ff99) | `` nixos/home-assistant: add go2rtc to path when it is required ``                           |
| [`4f924111`](https://github.com/NixOS/nixpkgs/commit/4f924111a48eb8bda5c8ab39428ebdad606d2a3c) | `` nixos/home-assistant: add pico2wave to path when it is required ``                        |
| [`4e924087`](https://github.com/NixOS/nixpkgs/commit/4e92408750da94224fe60e3caa8d058b030e6c9a) | `` nixos/home-assistant: only add ping to path when it is required ``                        |
| [`243e97f8`](https://github.com/NixOS/nixpkgs/commit/243e97f81633966926a870e3ae88af81d2cf9812) | `` nixos/home-assistant: support packet capure in dhcp component ``                          |
| [`261d9976`](https://github.com/NixOS/nixpkgs/commit/261d997667bdb10ef569a16dee22445e41de7467) | `` redpanda-client: 26.1.6 -> 26.1.7 ``                                                      |
| [`02e51bd9`](https://github.com/NixOS/nixpkgs/commit/02e51bd9949665771cafe311cfd48f4f1377081b) | `` nixos/home-assistant: move components to the top level let in ``                          |
| [`953c17d8`](https://github.com/NixOS/nixpkgs/commit/953c17d887bb5c0a7c8ce7b1f12f2ef24293477a) | `` home-assistant-custom-components.octopus_energy: ignore pytest9 deprecation ``            |
| [`d1831504`](https://github.com/NixOS/nixpkgs/commit/d18315044c5964f7d8068ca84fb53908ff092ba0) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.329 -> 0.13.330 `` |
| [`4c72b709`](https://github.com/NixOS/nixpkgs/commit/4c72b709469116aa4afa34404126f3b0e224a0ba) | `` python314Packages.homeassistant-stubs: 2026.5.0 -> 2026.5.1 ``                            |
| [`766c0980`](https://github.com/NixOS/nixpkgs/commit/766c09803fec880a41e2adba80d61919907c4ff1) | `` home-assistant-custom-components.dreo: ignore pytest9 deprecations ``                     |
| [`712968f9`](https://github.com/NixOS/nixpkgs/commit/712968f943df7373849c1f5baf93c57a3ba715d4) | `` home-assistant-custom-components.midea_ac: disable failing tests ``                       |
| [`4bcdf05b`](https://github.com/NixOS/nixpkgs/commit/4bcdf05b452d0bb5dc049b355e30b1cef6d20ad5) | `` home-assistant: 2026.5.0 -> 2026.5.1 ``                                                   |
| [`2b95f436`](https://github.com/NixOS/nixpkgs/commit/2b95f436f79df58db8dbbfd600bfba5813339b91) | `` python3Packages.zha: 1.3.0 -> 1.3.1 ``                                                    |
| [`a872b9cc`](https://github.com/NixOS/nixpkgs/commit/a872b9cc6a5f05e9feb424cd206cf96b7599155a) | `` python3Packages.zigpy: 1.4.0 -> 1.4.1 ``                                                  |
| [`02a97aeb`](https://github.com/NixOS/nixpkgs/commit/02a97aeb5155d277ed23807316479ef7d5cda38a) | `` python314Packages.serialx: 1.7.0 -> 1.7.2 ``                                              |
| [`842e1397`](https://github.com/NixOS/nixpkgs/commit/842e1397239bdc451d52ff5894de80440adfb543) | `` python314Packages.pytibber: 0.37.4 -> 0.37.5 ``                                           |
| [`b33abb7e`](https://github.com/NixOS/nixpkgs/commit/b33abb7eb88bbf1e7bd5cde8a4e36ac4debf31c2) | `` python314Packages.python-bsblan: 5.2.0 -> 5.2.1 ``                                        |
| [`4ff944d5`](https://github.com/NixOS/nixpkgs/commit/4ff944d580a1f5f2a935ecc4287e67653c26eeb5) | `` python314Packages.pyoverkiz: 1.20.2 -> 1.20.3 ``                                          |
| [`bc262def`](https://github.com/NixOS/nixpkgs/commit/bc262def46615a95773624917eef6beef572ed48) | `` python314Packages.holidays: 0.95 -> 0.96 ``                                               |
| [`ddc1009c`](https://github.com/NixOS/nixpkgs/commit/ddc1009c732d49d800fc33cba7c2574c6f380f77) | `` python314Packages.deebot-client: 18.2.0 -> 18.3.0 ``                                      |
| [`8817cf44`](https://github.com/NixOS/nixpkgs/commit/8817cf448e43841079ce61e5228dfe792df6aa52) | `` python314Packages.blebox-uniapi: 2.5.2 -> 2.5.3 ``                                        |
| [`7bcf91f9`](https://github.com/NixOS/nixpkgs/commit/7bcf91f9203aa8382fc0c9b574dfc5d32b119fac) | `` python314Packages.axis: 69 -> 70 ``                                                       |
| [`7ba8cfca`](https://github.com/NixOS/nixpkgs/commit/7ba8cfcaca7d33c59074afdedad6f130bac9b4ce) | `` rime-wanxiang: 15.6.1 -> 15.9.12 ``                                                       |
| [`68c93c78`](https://github.com/NixOS/nixpkgs/commit/68c93c7862ddf127cc1e516b103eda0966440079) | `` polygon-cli: delete broken changelog ``                                                   |
| [`e7a51bcf`](https://github.com/NixOS/nixpkgs/commit/e7a51bcfc04c28808e8ea38e7adb08eebe5c6206) | `` python3Packages.pyopen-wakeword: mark broken on aarch64-linux ``                          |
| [`e9b39beb`](https://github.com/NixOS/nixpkgs/commit/e9b39bebbd02fdb6e1c22f68f84f8045fdb8454f) | `` python3Packages.aiosonic: migrate to finalAttrs ``                                        |
| [`9a1828d0`](https://github.com/NixOS/nixpkgs/commit/9a1828d0d878ff9ebc7afbad817a53582085aefa) | `` python3Packages.aiosonic: 0.30.1 -> 0.31.1 ``                                             |
| [`312117d9`](https://github.com/NixOS/nixpkgs/commit/312117d9fba29862e8631be2d6479104076afd43) | `` python3Packages.deebot-client: 18.2.0 -> 18.3.0 ``                                        |
| [`5c13ee53`](https://github.com/NixOS/nixpkgs/commit/5c13ee539ada072b716ddfe040365770c18e2bbf) | `` python3Packages.cf-xarray: 0.10.11 -> 0.11.0 ``                                           |
| [`595b5b9b`](https://github.com/NixOS/nixpkgs/commit/595b5b9bf2f2d09ecbb3f2f8d2c2ccdde9533292) | `` python3Packages.claude-agent-sdk: 0.1.72 -> 0.1.80 ``                                     |
| [`86a56335`](https://github.com/NixOS/nixpkgs/commit/86a563351f361dba08522e2d10bed39996fc8427) | `` nerva: 1.3.0 -> 1.4.0 ``                                                                  |
| [`ea69417c`](https://github.com/NixOS/nixpkgs/commit/ea69417c3bd1c66c07143fc1724332cf53089df5) | `` ldeep: 2.0.0 -> 2.0.2 ``                                                                  |
| [`9b9f36b0`](https://github.com/NixOS/nixpkgs/commit/9b9f36b0a4edee036a4dbc35ed60b6125153c548) | `` cdncheck: 1.2.33 -> 1.2.34 ``                                                             |
| [`708238f2`](https://github.com/NixOS/nixpkgs/commit/708238f2ff1aaad93b9a4f4dbebb1b175f01ffd7) | `` chainsaw: 2.15.0 -> 2.16.0 ``                                                             |
| [`85e6a2ab`](https://github.com/NixOS/nixpkgs/commit/85e6a2ab27734c27244ccfbd4ea28d9a3ddd7a5f) | `` checkip: 0.53.1 -> 0.53.3 ``                                                              |
| [`1d6b342c`](https://github.com/NixOS/nixpkgs/commit/1d6b342ccdf71e2e12fed6789a83810afe9f5d57) | `` dalfox: 2.12.0 -> 2.13.0 ``                                                               |
| [`8608306f`](https://github.com/NixOS/nixpkgs/commit/8608306fb48f16e453aa817540c6f7800fffe835) | `` cnspec: 13.7.0 -> 13.8.2 ``                                                               |
| [`f414aef8`](https://github.com/NixOS/nixpkgs/commit/f414aef8225ef2ffb2c7d0147b2c5163126cd59a) | `` osquery: 5.22.1 -> 5.23.0 ``                                                              |
| [`678bc94f`](https://github.com/NixOS/nixpkgs/commit/678bc94f44ad2527f3fe4b85791bb1f436332ef2) | `` python3Packages.publicsuffixlist: 1.0.2.20260507 -> 1.0.2.20260508 ``                     |
| [`e75f1c02`](https://github.com/NixOS/nixpkgs/commit/e75f1c02a7d5e56d3308ef789a2f703c13fefc40) | `` python3Packages.iamdata: 0.1.202605081 -> 0.1.202605091 ``                                |
| [`60ff9883`](https://github.com/NixOS/nixpkgs/commit/60ff9883cc1205bce44fbb3e8738a18805891193) | `` vscode-extensions.mvllow.rose-pine: 2.15.1 -> 2.15.2 ``                                   |
| [`0532c27b`](https://github.com/NixOS/nixpkgs/commit/0532c27b219c82e39d7ad77121524156afda445f) | `` evcc: 0.306.2 -> 0.306.3 ``                                                               |
| [`8ba1b756`](https://github.com/NixOS/nixpkgs/commit/8ba1b756f49ff2acc210f650dd3eece269c07ba9) | `` swagger-typescript-api: 13.7.2 -> 13.9.1 ``                                               |
| [`8162e155`](https://github.com/NixOS/nixpkgs/commit/8162e155dbddcabbc25a634622647371d98d4ebf) | `` python3Packages.speechrecognition: 3.16.0 -> 3.16.1 ``                                    |
| [`826d0927`](https://github.com/NixOS/nixpkgs/commit/826d0927516b8b53785952fb780ac91a816d982b) | `` codebook: 0.3.38 -> 0.3.39 ``                                                             |
| [`eecd1512`](https://github.com/NixOS/nixpkgs/commit/eecd15125356deec9a8ebd0fe1ec9b45be7a3db9) | `` dashy-ui: 4.0.5 -> 4.0.7 ``                                                               |
| [`6ab6ef54`](https://github.com/NixOS/nixpkgs/commit/6ab6ef542f403711636d11faf4b6819fcfbb04a2) | `` zipline: migrate from fetcherVersion = 2 to fetcherVersion = 3 ``                         |
| [`6556f2e9`](https://github.com/NixOS/nixpkgs/commit/6556f2e9dc8378ede044c4dfacc69a5674f41e44) | `` yt-dlp-ejs: migrate from fetcherVersion = 2 to fetcherVersion = 3 ``                      |
| [`cd681925`](https://github.com/NixOS/nixpkgs/commit/cd681925a9041e457104d26f688d1dc2533d03dc) | `` woodpecker-webui: migrate from fetcherVersion = 2 to fetcherVersion = 3 ``                |
| [`034a300b`](https://github.com/NixOS/nixpkgs/commit/034a300b678a08298fddeb1b53d7ee900e9b5b58) | `` voicevox: migrate from fetcherVersion = 2 to fetcherVersion = 3 ``                        |
| [`d1572af9`](https://github.com/NixOS/nixpkgs/commit/d1572af9185c1228f73eaeec80553649948edbc7) | `` vesktop: migrate from fetcherVersion = 2 to fetcherVersion = 3 ``                         |
| [`9d0aeef1`](https://github.com/NixOS/nixpkgs/commit/9d0aeef14adc91750ebb477d1e05ffe09375766a) | `` typespec: migrate from fetcherVersion = 2 to fetcherVersion = 3 ``                        |
| [`a7c31c90`](https://github.com/NixOS/nixpkgs/commit/a7c31c90054fd5be7693a88d40b10824f9480dd3) | `` svelte-language-server: migrate from fetcherVersion = 2 to fetcherVersion = 3 ``          |
| [`3eec0ac0`](https://github.com/NixOS/nixpkgs/commit/3eec0ac0dcfb134f12d0150887dcace0a135c707) | `` pkgs/test/config-nix-unit: use builtins.path with stable name ``                          |
| [`77b566aa`](https://github.com/NixOS/nixpkgs/commit/77b566aaa181bf05f6bb0932624369c6ed99c6d5) | `` eresi: fix build with gcc 15 ``                                                           |
| [`868184dd`](https://github.com/NixOS/nixpkgs/commit/868184dd203d6b150c6b1e4321df7fc829917aa6) | `` terraform-providers.nats-io_jetstream: 0.3.0 -> 0.4.0 ``                                  |
| [`205133dc`](https://github.com/NixOS/nixpkgs/commit/205133dc07d74d876248c61937e51daba08a7c9d) | `` perlPackages.CatalystPluginSession: 0.43 -> 0.44 ``                                       |
| [`da47dedd`](https://github.com/NixOS/nixpkgs/commit/da47dedd320bc32a6b367130639d2511327a9a32) | `` terraform-providers.exoscale_exoscale: 0.68.0 -> 0.69.2 ``                                |
| [`06ddcdd6`](https://github.com/NixOS/nixpkgs/commit/06ddcdd6dc380aab0fc1d523440ea3c4cf30a892) | `` nixos/lasuite-meet: add addons settings ``                                                |
| [`701a2cfa`](https://github.com/NixOS/nixpkgs/commit/701a2cfada21d18b54d2f87fdb9d85e3bfa500d3) | `` nixos/lasuite-meet: refactor ``                                                           |
| [`79ea26ed`](https://github.com/NixOS/nixpkgs/commit/79ea26ed6a4f2e91025bb05122cbb337e18de743) | `` lasuite-meet-frontend: 1.14.0 -> 1.15.0 ``                                                |
| [`d496aa0c`](https://github.com/NixOS/nixpkgs/commit/d496aa0c2adf6abf8ad0c1398e9b84e7f842e4c0) | `` lasuite-meet: 0.14.0 -> 0.15.0 ``                                                         |
| [`876ed91b`](https://github.com/NixOS/nixpkgs/commit/876ed91b2288f9f7046468bbafe3981a48172637) | `` ultrastardx: 2026.4.0 -> 2026.5.0 ``                                                      |
| [`4829bf6a`](https://github.com/NixOS/nixpkgs/commit/4829bf6a0050eebf7d4e03d60235b2ea31981353) | `` komari-agent: 1.1.93 -> 1.2.0 ``                                                          |
| [`eef66bb4`](https://github.com/NixOS/nixpkgs/commit/eef66bb462ac1445ff2bd348c8763e4cd3adb23a) | `` remarshal_0_17: fix repo, use finalAttrs, use __structuredAttrs ``                        |
| [`dfc48a35`](https://github.com/NixOS/nixpkgs/commit/dfc48a3572339daf5564db908ba73d9793038b90) | `` dictu: fix build with gcc 15 ``                                                           |
| [`2df1d676`](https://github.com/NixOS/nixpkgs/commit/2df1d67602f6d0ff4544dbc06e60eef17c3f2622) | `` postgrest: 14.8 -> 14.11 ``                                                               |
| [`b4f7d3e1`](https://github.com/NixOS/nixpkgs/commit/b4f7d3e1a7639398c91743a6b7370cc49bc0f7c4) | `` pangolin-cli: 0.8.0 -> 0.8.1 ``                                                           |
| [`6d7ba26b`](https://github.com/NixOS/nixpkgs/commit/6d7ba26b22b2892b7631f3e837becdae103136d9) | `` d-seams: fix missing cstdint include ``                                                   |
| [`72354e99`](https://github.com/NixOS/nixpkgs/commit/72354e998ac11958b7d34838363af9ebee3f8e7e) | `` terraform-providers.hashicorp_awscc: 1.82.0 -> 1.83.0 ``                                  |
| [`d181879d`](https://github.com/NixOS/nixpkgs/commit/d181879da4bd6af92f447c45245fe58d7070a46f) | `` yarn-berry: add package tests ``                                                          |
| [`50d89dd6`](https://github.com/NixOS/nixpkgs/commit/50d89dd6c15fc9fd2d4ebd9adec9ed3cdb9b35dc) | `` home-assistant-custom-lovelace-modules.horizon-card: fix for Yarn 4.14 ``                 |
| [`e8746542`](https://github.com/NixOS/nixpkgs/commit/e8746542069614eb51c4bcb77533d6b5d71f9777) | `` home-assistant-custom-lovelace-modules.advanced-camera-card: fix for Yarn 4.14 ``         |
| [`83ea488e`](https://github.com/NixOS/nixpkgs/commit/83ea488e89bbe4240245cf15b99036a11b22103f) | `` python3Packages.locust: fix for Yarn 4.14 ``                                              |
| [`e2ea1f61`](https://github.com/NixOS/nixpkgs/commit/e2ea1f618b48ef983edbe1aa2bea839f5b2b8919) | `` vultisig-cli: fix for Yarn 4.14 ``                                                        |
| [`d0461152`](https://github.com/NixOS/nixpkgs/commit/d0461152d2060f248a0cd53604f89370990d9eb4) | `` uppy-companion: fix for Yarn 4.14 ``                                                      |
| [`57f8d919`](https://github.com/NixOS/nixpkgs/commit/57f8d9191db6b4157186b98453febc9918b491b7) | `` tilt: fix for Yarn 4.14 ``                                                                |
| [`6eae1f32`](https://github.com/NixOS/nixpkgs/commit/6eae1f32572408b4971fab3bf69c56cdf935621c) | `` synapse-admin: fix for Yarn 4.14 ``                                                       |
| [`924e6e26`](https://github.com/NixOS/nixpkgs/commit/924e6e26cd4d1693a0c3e62d1db4abc4ed67da28) | `` rocketchat-desktop: fix for Yarn 4.14 ``                                                  |
| [`1cbe6ab5`](https://github.com/NixOS/nixpkgs/commit/1cbe6ab531cb26bfd78a9783f71404d38846ed8c) | `` r2modman: fix for Yarn 4.14 ``                                                            |
| [`3b80713e`](https://github.com/NixOS/nixpkgs/commit/3b80713ea8e7ee837563b293633433593538b3bc) | `` joplin-desktop: fix for Yarn 4.14 ``                                                      |
| [`3e85b9bd`](https://github.com/NixOS/nixpkgs/commit/3e85b9bd750249468db4f773f84862246d2e8096) | `` joplin-cli: fix for Yarn 4.14 ``                                                          |
| [`fb4dfe04`](https://github.com/NixOS/nixpkgs/commit/fb4dfe04b2bdfa815c1310a63396ac3e2272dc5a) | `` hedgedoc: fix for Yarn 4.14 ``                                                            |
| [`e28d4b75`](https://github.com/NixOS/nixpkgs/commit/e28d4b75e9b5368dfac682b69e2358a968803f77) | `` grafana: fix for Yarn 4.14 ``                                                             |
| [`b321ab9f`](https://github.com/NixOS/nixpkgs/commit/b321ab9f6767aa494c7ee81ea32cb062eca9ccf2) | `` element-call: fix for Yarn 4.14 ``                                                        |
| [`56efd800`](https://github.com/NixOS/nixpkgs/commit/56efd80072dc7dd8ba01dc5c62cbfda8b70046d9) | `` ansible-language-server: fix for Yarn 4.14 ``                                             |
| [`d99337c5`](https://github.com/NixOS/nixpkgs/commit/d99337c5443f56f5f4ce9f17d2c36564b7746c22) | `` anki: fix for Yarn 4.14 ``                                                                |
| [`f0e285b0`](https://github.com/NixOS/nixpkgs/commit/f0e285b0ccb348df352a44c42c27a33da5483c95) | `` affine: fix for Yarn 4.14 ``                                                              |
| [`d4a6342d`](https://github.com/NixOS/nixpkgs/commit/d4a6342d337f0326d9b97051ef2439657f2a34fc) | `` cockpit-zfs: fix for Yarn 4.14 ``                                                         |
| [`8b34fccf`](https://github.com/NixOS/nixpkgs/commit/8b34fccf2e815f8d964c2edd9074b169e3d4f78b) | `` linkwarden: fix for Yarn 4.14 ``                                                          |
| [`642c2b5c`](https://github.com/NixOS/nixpkgs/commit/642c2b5c99466e44f01a7c49313558aa405c8915) | `` mastodon: fix for Yarn 4.14 ``                                                            |
| [`bbf6afa2`](https://github.com/NixOS/nixpkgs/commit/bbf6afa2ce9e1047fa746d790b804e7eb76a3b3a) | `` peacock: fix for Yarn 4.14 ``                                                             |
| [`6d9c6c46`](https://github.com/NixOS/nixpkgs/commit/6d9c6c463fa0d32e81fe12ec832abdea87ec3177) | `` outline: fix for Yarn 4.14 ``                                                             |
| [`85eafe46`](https://github.com/NixOS/nixpkgs/commit/85eafe4615eced690eb8161e49ae75e5c454d25c) | `` ghdump: 0.1.2 -> 0.2.2 ``                                                                 |
| [`81f3f9a8`](https://github.com/NixOS/nixpkgs/commit/81f3f9a88024c504cc387efbc3dda4795f1b145d) | `` learn6502: fix for Yarn 4.14 ``                                                           |
| [`3c44cd1e`](https://github.com/NixOS/nixpkgs/commit/3c44cd1e8f93a8977e9b9c8a7f1a1e694453aab0) | `` insulator2: fix for Yarn 4.14 ``                                                          |
| [`a3ae362a`](https://github.com/NixOS/nixpkgs/commit/a3ae362a1d97c8c0022898298f9820d79d55e0f3) | `` gitbeaker-cli: fix for Yarn 4.14 ``                                                       |
| [`254f27cb`](https://github.com/NixOS/nixpkgs/commit/254f27cbe9dc6f724a3e288f8b9481e266109a25) | `` ytmdesktop: fix for Yarn 4.14 ``                                                          |
| [`104ae1c3`](https://github.com/NixOS/nixpkgs/commit/104ae1c350e3db496537c9ca49bed1f5034c99bb) | `` electron: fix for Yarn 4.14 ``                                                            |
| [`19fb21ed`](https://github.com/NixOS/nixpkgs/commit/19fb21ed1141a88d3b173e2ce6947c4b06cca176) | `` katex: fix for Yarn 4.14 ``                                                               |
| [`347023eb`](https://github.com/NixOS/nixpkgs/commit/347023eb4aaf9e775ffeea70232b3e84712dab1f) | `` eas-cli: fix for Yarn 4.14 ``                                                             |
| [`cb38921b`](https://github.com/NixOS/nixpkgs/commit/cb38921b4d659e45e326c8276bc94d18e1f87df2) | `` corepack: fix for Yarn 4.14 ``                                                            |
| [`fb00ceab`](https://github.com/NixOS/nixpkgs/commit/fb00ceabf8c4d85ac75b476c8a272d4ff1b6b1f3) | `` actual-server: fix for Yarn 4.14 ``                                                       |
| [`a37d6ae4`](https://github.com/NixOS/nixpkgs/commit/a37d6ae45d8e143b29a89095d98bc8f47b4115bb) | `` pgadmin4: fix for Yarn 4.14 ``                                                            |
| [`8a34c4ef`](https://github.com/NixOS/nixpkgs/commit/8a34c4ef05a0a81bac1b03e546dc4e6c68e1eefd) | `` prettier: fix for Yarn 4.14 ``                                                            |
| [`a93c08cd`](https://github.com/NixOS/nixpkgs/commit/a93c08cd8d3635d2304d4f39adf562c41d3cf68e) | `` yarn-berry: 4.13.0 -> 4.14.1 ``                                                           |
| [`15b85e71`](https://github.com/NixOS/nixpkgs/commit/15b85e717eacff1a71e926b998173986cb0acedb) | `` n8n: uses dart-sass instead of bundled binaries ``                                        |
| [`662355b5`](https://github.com/NixOS/nixpkgs/commit/662355b51cf8b7b34180057a89cc526298b4fce2) | `` n8n: 2.15.0 -> 2.19.5 ``                                                                  |
| [`59ce6d2a`](https://github.com/NixOS/nixpkgs/commit/59ce6d2ac18ba68ae12627638820879331ddd379) | `` alfis: 0.8.10 -> 0.8.11 ``                                                                |
| [`82b3b1b5`](https://github.com/NixOS/nixpkgs/commit/82b3b1b539b8f367e02a4208d4a83bed11bfe3d0) | `` vscode-extensions.catppuccin.catppuccin-vsc: 3.18.1 -> 3.19.0 ``                          |
| [`d754d2e4`](https://github.com/NixOS/nixpkgs/commit/d754d2e4adec0be3e3a5853da75f269784e3516e) | `` hyprutils: 0.13.0 -> 0.13.1 ``                                                            |
| [`7d124c69`](https://github.com/NixOS/nixpkgs/commit/7d124c69e15af7ac691334995fe61c0f775622ff) | `` terraform-providers.mongodb_mongodbatlas: 2.11.0 -> 2.12.0 ``                             |
| [`314519be`](https://github.com/NixOS/nixpkgs/commit/314519be4a6a3d322ba789ade65ab8ad5dff707e) | `` pixi: 0.67.2 -> 0.68.0 ``                                                                 |
| [`a6eebc84`](https://github.com/NixOS/nixpkgs/commit/a6eebc84a0b13606e88ed39c02a477355eb4a078) | `` vunnel: 0.56.0 -> 0.57.0 ``                                                               |
| [`c6341617`](https://github.com/NixOS/nixpkgs/commit/c6341617c8272655e9a9686298111927e5119d62) | `` mdwatch: 0.1.24 -> 0.2.0 ``                                                               |
| [`88b908e8`](https://github.com/NixOS/nixpkgs/commit/88b908e80e14df7d66afce6d413ad2afa9bfb0e0) | `` claude-code: 2.1.133 -> 2.1.137 ``                                                        |
| [`da44cc8a`](https://github.com/NixOS/nixpkgs/commit/da44cc8af3562f5938065a60c2d6497c47bd097d) | `` terraform-providers.digitalocean_digitalocean: 2.85.0 -> 2.85.1 ``                        |
| [`472ac0cc`](https://github.com/NixOS/nixpkgs/commit/472ac0cc4f9401781ecd05cae91f094b2a11e0ce) | `` davmail: 6.6.0 -> 6.7.0 ``                                                                |
| [`ce587ccb`](https://github.com/NixOS/nixpkgs/commit/ce587ccb9f49c4afe785d854acc67178f92554f0) | `` puppet: remove empty changelog ``                                                         |
| [`ced894df`](https://github.com/NixOS/nixpkgs/commit/ced894df79d51bf35ace6b327102f14b9b9648e2) | `` lenspect: 1.0.4 -> 1.0.5 ``                                                               |
| [`16608e26`](https://github.com/NixOS/nixpkgs/commit/16608e268bf32ecce496af9a0b1c8d6729d3d56a) | `` fna3d: 26.04 -> 26.05 ``                                                                  |
| [`24cd0d2d`](https://github.com/NixOS/nixpkgs/commit/24cd0d2de994e0193ac41cad05fee15898f6ec4c) | `` cgui: fix build with gcc15 ``                                                             |
| [`3e46802c`](https://github.com/NixOS/nixpkgs/commit/3e46802cf57d51836fcd039c4987f0e5cd7f9065) | `` creduce: migrate to by-name ``                                                            |
| [`30b6d639`](https://github.com/NixOS/nixpkgs/commit/30b6d6393a531a786ee17c31b72a77ec594527d7) | `` creduce: fix build with gcc15 ``                                                          |
| [`d4a6a1ee`](https://github.com/NixOS/nixpkgs/commit/d4a6a1ee00eca48944f95984c63c19d0315824b3) | `` nezha-agent: 2.0.2 -> 2.0.3 ``                                                            |
| [`608d6c47`](https://github.com/NixOS/nixpkgs/commit/608d6c4776c0987292adcc475800b458cf730b27) | `` xmrig-mo: 6.26.0-mo2 -> 6.26.0-mo3 ``                                                     |
| [`1226f594`](https://github.com/NixOS/nixpkgs/commit/1226f594953d1664d4b69da0235b7cd29523d982) | `` cdncheck: 1.2.33 -> 1.2.34 ``                                                             |
| [`9b9f8f82`](https://github.com/NixOS/nixpkgs/commit/9b9f8f8202f400c0619d720d29a11b05249f8665) | `` cnspec: 13.7.0 -> 13.8.2 ``                                                               |
| [`1f63447f`](https://github.com/NixOS/nixpkgs/commit/1f63447f7dcfd439d0117378f64c4e8d6cc63a56) | `` terraform-providers.linode_linode: 3.11.0 -> 3.12.0 ``                                    |
| [`569c783e`](https://github.com/NixOS/nixpkgs/commit/569c783e73ef5067bd1a225f20ac5d5102219345) | `` codex: 0.128.0 -> 0.130.0 ``                                                              |
| [`ba83e354`](https://github.com/NixOS/nixpkgs/commit/ba83e354e435c5333fae878a53206c2a3a1f4540) | `` jsonschema-cli: 0.46.3 -> 0.46.4 ``                                                       |
| [`e6823e88`](https://github.com/NixOS/nixpkgs/commit/e6823e8808c1484f1f5b5e0e39abd0fa612cb451) | `` nerva: 1.3.0 -> 1.4.0 ``                                                                  |
| [`ea9cb940`](https://github.com/NixOS/nixpkgs/commit/ea9cb940c0da04abbd7a45b23e696a8cb5b39f2b) | `` libastyle: 3.6.14 -> 3.6.15 ``                                                            |
| [`5236c263`](https://github.com/NixOS/nixpkgs/commit/5236c26383b20db4d8dede203c0a7e5c41d6a28a) | `` home-assistant-custom-components.pi-hole-v6: init at 1.17.0 ``                            |
| [`fde15f53`](https://github.com/NixOS/nixpkgs/commit/fde15f53336e3559ad072909ba6c584554b15e01) | `` home-assistant-custom-components.plant: 2026.3.2 -> 2026.5.0 ``                           |
| [`33c4942a`](https://github.com/NixOS/nixpkgs/commit/33c4942a1d298862e7d90e54afa855aad5e58ee6) | `` dns-collector: clean-up ``                                                                |
| [`316f867e`](https://github.com/NixOS/nixpkgs/commit/316f867e7d03a96e28fe6cdfa3a91e229a4ee502) | `` spacetimedb: 2.1.0 -> 2.2.0 ``                                                            |
| [`2bcfe886`](https://github.com/NixOS/nixpkgs/commit/2bcfe88606b1313be541297962398a8820b08768) | `` python3Packages.countryinfo: clean-up ``                                                  |
| [`d2b349c2`](https://github.com/NixOS/nixpkgs/commit/d2b349c2a4684d429b5195c37139bab0a3066c4f) | `` python3Packages.countryinfo: 1.0.0 -> 1.0.1 ``                                            |
| [`2f715416`](https://github.com/NixOS/nixpkgs/commit/2f715416cc4103a9921ef0ac000af4d627660a57) | `` zed-editor: 1.1.6 -> 1.1.7 ``                                                             |
| [`c7f1840d`](https://github.com/NixOS/nixpkgs/commit/c7f1840da2bfc094d3fefb97ecc448517dc0c816) | `` python3Packages.disposable-email-domains: 0.0.177 -> 0.0.181 ``                           |
| [`eb123b45`](https://github.com/NixOS/nixpkgs/commit/eb123b458b96dce745aea292be7d0deb3fc451f4) | `` python3Packages.hcloud: 2.19.0 -> 2.20.0 ``                                               |
| [`370865ad`](https://github.com/NixOS/nixpkgs/commit/370865adc5135438aa34d9f84ef20b8797451f83) | `` linux_5_15: 5.15.205 -> 5.15.206 ``                                                       |
| [`58cbdfee`](https://github.com/NixOS/nixpkgs/commit/58cbdfee0c74194bf5cf57f25aadf9a913664f7e) | `` linux_6_1: 6.1.171 -> 6.1.172 ``                                                          |
| [`7682ddab`](https://github.com/NixOS/nixpkgs/commit/7682ddab75199ec318cc42e615147e45da5db0d7) | `` kiro-cli: 2.2.0 -> 2.2.2 ``                                                               |
| [`98bd2571`](https://github.com/NixOS/nixpkgs/commit/98bd2571745fa2ba48149e2b0b09d38cf7f943f2) | `` jdupes: fix Darwin build ``                                                               |
| [`b31d77f6`](https://github.com/NixOS/nixpkgs/commit/b31d77f6e408ca9737ada25562fb29c6e90c0f88) | `` enlightenment.evisum: 1.2.3 -> 2.0.7 ``                                                   |
| [`83471e14`](https://github.com/NixOS/nixpkgs/commit/83471e14ee397a6c26bfb0d95d5dcd649d632efa) | `` nzbhydra2: 8.8.0 -> 8.8.1 ``                                                              |
| [`7b98a8ee`](https://github.com/NixOS/nixpkgs/commit/7b98a8ee2334a018e9f27d7c3362fbaa41b31902) | `` vencord: 1.14.11 -> 1.14.13 ``                                                            |
| [`9161d5f1`](https://github.com/NixOS/nixpkgs/commit/9161d5f1974127ef4e2fcf16166f90a495543647) | `` josh: 26.04.19 -> 26.05.08 ``                                                             |
| [`cbd2f72d`](https://github.com/NixOS/nixpkgs/commit/cbd2f72d5dc945e1571eef28d4fe1809f84a3ae0) | `` matlab-language-server: 1.3.10 -> 1.3.11 ``                                               |
| [`c4e699b2`](https://github.com/NixOS/nixpkgs/commit/c4e699b29282dc1ecac8d1d7db70e281da5a1fe0) | `` wasmtime: 44.0.0 -> 44.0.1 ``                                                             |
| [`546b2bf7`](https://github.com/NixOS/nixpkgs/commit/546b2bf70258d39fc796ef823270a1d8ecf70224) | `` git-xet: 0.2.0 -> 0.2.1 ``                                                                |
| [`80cb4d6d`](https://github.com/NixOS/nixpkgs/commit/80cb4d6d45812bcf5fd0cd63de4f7cd3230d541b) | `` tsshd: 0.1.6 -> 0.1.7 ``                                                                  |
| [`8347e356`](https://github.com/NixOS/nixpkgs/commit/8347e356e54549ae97588e1d7c72fb459cc060fe) | `` telegram-desktop: 6.8.0 -> 6.8.1 ``                                                       |
| [`71e0b21b`](https://github.com/NixOS/nixpkgs/commit/71e0b21b3a25e70a59988f196379a351a69cbfc7) | `` elinks: build with meson ``                                                               |
| [`b8178f50`](https://github.com/NixOS/nixpkgs/commit/b8178f50daa0dcab133a89c7c1c5cb78bcccb719) | `` {libcss, libdom}: set propagatedBuildInputs ``                                            |
| [`fd7c4558`](https://github.com/NixOS/nixpkgs/commit/fd7c4558261d1ed2bf8426ff1f61427f3c500963) | `` python3Packages.htmltools: 0.6.0 -> 0.6.1 ``                                              |
| [`228ad730`](https://github.com/NixOS/nixpkgs/commit/228ad73002e357c932aa930dacde00d21a897bce) | `` amnezia-vpn-bin: init at 4.8.15.4 ``                                                      |
| [`16ccd730`](https://github.com/NixOS/nixpkgs/commit/16ccd7307bb82d3617ec2195805ce75fa2a7dcd5) | `` sops: 3.12.2 -> 3.13.0 ``                                                                 |
| [`2d41ad2c`](https://github.com/NixOS/nixpkgs/commit/2d41ad2cf461a8452cc95ad34b47cefaf20b553e) | `` asciinema-automation: drop ``                                                             |
| [`3acc5a70`](https://github.com/NixOS/nixpkgs/commit/3acc5a705d5d0584b7af3ca4947e5f0cf654538c) | `` python3Packages.pytest-md-report: 0.7.0 -> 0.8.0 ``                                       |
| [`5b511c17`](https://github.com/NixOS/nixpkgs/commit/5b511c170c0d3680808b58ef351f569460f7dfbd) | `` ryubing: migrate to forgejo ``                                                            |
| [`26f9094d`](https://github.com/NixOS/nixpkgs/commit/26f9094d7ca7ee7acdee201a415465ed297869bb) | `` cargo-binstall: 1.18.1 -> 1.19.1 ``                                                       |
| [`e31eec38`](https://github.com/NixOS/nixpkgs/commit/e31eec3899553e5665979a4ca7ae0aeda5df8e89) | `` bird-lg: 1.4.4 -> 1.4.5 ``                                                                |
| [`019b4969`](https://github.com/NixOS/nixpkgs/commit/019b49699fa9ff11eebd8767e0e23f0b948b139e) | `` pomerium: 0.32.6 -> 0.32.7 ``                                                             |
| [`d1da3417`](https://github.com/NixOS/nixpkgs/commit/d1da3417e4351a093097bda5a297ec63969487b3) | `` rust-parallel: 1.21.0 -> 1.22.0, fix tests, use `__structuredAttrs` ``                    |
| [`6c4fbb7f`](https://github.com/NixOS/nixpkgs/commit/6c4fbb7f9a6e74f55e4166f1d53075e50e52fdb0) | `` home-assistant: update component packages ``                                              |
| [`e8137660`](https://github.com/NixOS/nixpkgs/commit/e8137660884978ee04bef4c643af92ba12130069) | `` python3Packages.autoskope-client: init at 1.4.1 ``                                        |
| [`f3ba454c`](https://github.com/NixOS/nixpkgs/commit/f3ba454c8d6b45d3c130ca8edcd61603db7e3884) | `` nixos/installation-cd-graphical-calamares-plasma6: disable qt5 integration ``             |
| [`f5ee5762`](https://github.com/NixOS/nixpkgs/commit/f5ee5762f0d76ccb3908a83f397ac182e16977e7) | `` ci/github-script/manual-file-edits: skip on PRs from one dev branch to another ``         |

*... and 1505 more commits (truncated)*