### PR TITLE
chore(flake/home-manager): `5878fdad` -> `3d4f5477`

### DIFF
--- a/features/desktop/environments/hyprland/default.nix
+++ b/features/desktop/environments/hyprland/default.nix
@@ -64,6 +64,16 @@ in
       wayland.windowManager.hyprland = {
         enable = true;
 
+        # home-manager changed the default `configType` from "hyprlang" to
+        # "lua" for stateVersion >= "26.05". Pin to "hyprlang" explicitly for
+        # now so the existing `settings` attrset (and the catppuccin.hyprland
+        # integration, which currently emits hyprlang) keep rendering as
+        # before. This also silences the migration warning that CI treats as
+        # fatal. TODO: migrate `settings` to the new lua API in a dedicated
+        # PR once catppuccin/hyprland supports it and the attrset has been
+        # reshaped for the lua serializer.
+        configType = "hyprlang";
+
         settings = {
           "$mainMod" = "SUPER";
           "$fileManager" = "yazi";

--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778609305,
-        "narHash": "sha256-muTc+WME6k3sfTr/Pvmw8hrK7zXrbl961TEF9wPeAnk=",
+        "lastModified": 1778772542,
+        "narHash": "sha256-mVZ6gS7GLy9FMVl/rx2rOICKsQ0Sb/mtlMeDdCUtPyY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5878fdadfe2cfe1b3383b38d66117f7b80696b68",
+        "rev": "3d4f5477f03e0de9f80ad0da7784d43cd386697c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`3d4f5477`](https://github.com/nix-community/home-manager/commit/3d4f5477f03e0de9f80ad0da7784d43cd386697c) | `` hyprland: remove old removed options ``                  |
| [`c3e7eb98`](https://github.com/nix-community/home-manager/commit/c3e7eb98c3c21f408039d717f5d4bdb0ecf6f158) | `` podman: fix tests ``                                     |
| [`4f9cbe43`](https://github.com/nix-community/home-manager/commit/4f9cbe4384e00cf2cf80e99741e93f12a67a8f32) | `` tailscale-systray: make theme configurable ``            |
| [`f04b141d`](https://github.com/nix-community/home-manager/commit/f04b141d1a0d6d7d62aa9678aef602dfb61e8bb1) | `` yazi: test plugin setup generation ``                    |
| [`41d5f1e5`](https://github.com/nix-community/home-manager/commit/41d5f1e504b5c5833d314991807b8a01b54d3d25) | `` yazi: add plugin setup options ``                        |
| [`9760b31d`](https://github.com/nix-community/home-manager/commit/9760b31dab3016fc6e422ca241cfeac605fb89c9) | `` hyprland: generate LuaLS config ``                       |
| [`03d2aa63`](https://github.com/nix-community/home-manager/commit/03d2aa63172be70e9488b8a795411b52c6d8a50d) | `` hyprland: submaps option lua support ``                  |
| [`acd9d8af`](https://github.com/nix-community/home-manager/commit/acd9d8af2ff46c5737cc9e76bc367e41f54645c4) | `` hyprland: migrate settings to native lua option API ``   |
| [`7654d90b`](https://github.com/nix-community/home-manager/commit/7654d90b94bab7eba3a52fd6f73b3f5a4c544fa2) | `` mailmap: map NAHO developer identity to Noah Biewesch `` |
| [`6a0bbd6b`](https://github.com/nix-community/home-manager/commit/6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a) | `` wallust: fix config location on darwin ``                |