### PR TITLE
chore(flake/home-manager): `3d4f5477` -> `26aaab78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778772542,
-        "narHash": "sha256-mVZ6gS7GLy9FMVl/rx2rOICKsQ0Sb/mtlMeDdCUtPyY=",
+        "lastModified": 1778954430,
+        "narHash": "sha256-oaNyOr05lblaQdtbkbN1wO0b2KLIL2O1LkmwDgdQp4I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3d4f5477f03e0de9f80ad0da7784d43cd386697c",
+        "rev": "26aaab785b0bab4af60a2c42b22760fa906ef22a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`26aaab78`](https://github.com/nix-community/home-manager/commit/26aaab785b0bab4af60a2c42b22760fa906ef22a) | `` claude-code: fixes enableMcpIntegration option docstring ``               |
| [`d5ece85b`](https://github.com/nix-community/home-manager/commit/d5ece85b6d3d6b5ab5a514b2785fb952b629bfea) | `` zsh: guard session variables under nounset ``                             |
| [`32b42d71`](https://github.com/nix-community/home-manager/commit/32b42d71b4b22c4465963285bb6e462d7c93d45e) | `` discord: add option for different config locations ``                     |
| [`1772e8fb`](https://github.com/nix-community/home-manager/commit/1772e8fb838e26f9b0f07bcbc5118c62af314d85) | `` qt: pass negative KDE settings as values ``                               |
| [`f63af17f`](https://github.com/nix-community/home-manager/commit/f63af17f47af7e11ab526ccc02eb661ede5f3629) | `` podman: quote Quadlet labels with spaces ``                               |
| [`92a87361`](https://github.com/nix-community/home-manager/commit/92a8736142944ed3b2c4aba8b364583b6fda15a5) | `` ci: quote some shell variables ``                                         |
| [`3c71cec0`](https://github.com/nix-community/home-manager/commit/3c71cec05da50f0e61b779345b16fe0093636c3c) | `` ci: use `grep -c` instead of `grep|wc -l` ``                              |
| [`c7fad819`](https://github.com/nix-community/home-manager/commit/c7fad8197070948d8aa02cb8922240ee129cab2e) | `` sherlock: update `aliases` example to use the official NixOS Wiki link `` |
| [`ca77575d`](https://github.com/nix-community/home-manager/commit/ca77575d39c908de876c10f93704532689df546f) | `` t3code: add module ``                                                     |
| [`1bedcc87`](https://github.com/nix-community/home-manager/commit/1bedcc8740b9aa2f7d3e1312a6c88baf00909f54) | `` exwm: add module ``                                                       |
| [`2cb4f4db`](https://github.com/nix-community/home-manager/commit/2cb4f4db37c13bb51a4c61911aaa210de6525ece) | `` maintainers: add garklein ``                                              |
| [`e7a7c550`](https://github.com/nix-community/home-manager/commit/e7a7c550e22ae631cd738db9dcd317a9544962e3) | `` claude-code: add `configDir` option ``                                    |
| [`3e707f5f`](https://github.com/nix-community/home-manager/commit/3e707f5f93d7be40fd3e4182ed977446bdf2e2c3) | `` eww: remove shell integration ``                                          |
| [`9846abe1`](https://github.com/nix-community/home-manager/commit/9846abe15e7d0d36b8acbd4d05f2b87461744c92) | `` Translate using Weblate (Toki Pona) ``                                    |
| [`c68d2a24`](https://github.com/nix-community/home-manager/commit/c68d2a24376da3860ef161373d91348b1542356b) | `` ssh-tpm-agent: add extraArgs option ``                                    |
| [`2809b9e3`](https://github.com/nix-community/home-manager/commit/2809b9e3f83c5eea8818452424ec90386ced1407) | `` ssh: allow explicit "no" for identitiesOnly in matchBlocks ``             |