### PR TITLE
chore(flake/catppuccin): `22ec0455` -> `ec7044e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778713713,
-        "narHash": "sha256-LzY4fRKC8gO6oXv5MDBDZtiteRMAyOooAz4GhMNdFkk=",
+        "lastModified": 1778836894,
+        "narHash": "sha256-vZSADE7rkRw5D5BpyXf5W4/zNJ8GvqiSeFibetYNEto=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "22ec04550dce30e65d53e3693e398176d05b6004",
+        "rev": "ec7044e195df9e00236190f13f573017d2771a26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`ec7044e1`](https://github.com/catppuccin/nix/commit/ec7044e195df9e00236190f13f573017d2771a26) | `` chore: update port sources (#930) `` |
| [`acc33999`](https://github.com/catppuccin/nix/commit/acc3399957c9776cb196b22353ee2df8c73db0f9) | `` chore: update flakes (#929) ``       |