### PR TITLE
chore(flake/nixvim): `9ad88c3f` -> `06cace83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -1266,11 +1266,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1778580735,
-        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {
@@ -1431,11 +1431,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1778682931,
-        "narHash": "sha256-6pfRbQfEBwFEkpm3ZDSi73xugqU55Ebvkt1cptJGmJk=",
+        "lastModified": 1778906310,
+        "narHash": "sha256-LqASEJRtLuKRBJd9051T1KMAEaYvsVrc6m64jhD6xbw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9ad88c3f9778cd6d16fc85a80f3045b45af749e7",
+        "rev": "06cace835d7ee727852ac789e3dcd42fc2fd360e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`06cace83`](https://github.com/nix-community/nixvim/commit/06cace835d7ee727852ac789e3dcd42fc2fd360e) | `` modules/lsp: update packages ``                          |
| [`6b4c80fc`](https://github.com/nix-community/nixvim/commit/6b4c80fccdabda4ad6b441cc37ee4f3897d24c74) | `` generated: Updated lspconfig-servers.json ``             |
| [`060bc6aa`](https://github.com/nix-community/nixvim/commit/060bc6aac01185833436442cf6c92bb60dedd7ed) | `` flake: Update ``                                         |
| [`f83231ed`](https://github.com/nix-community/nixvim/commit/f83231edf4916c284484bbfe04841cdfe36f3d5b) | `` mailmap: map NAHO developer identity to Noah Biewesch `` |
| [`40baf366`](https://github.com/nix-community/nixvim/commit/40baf3664b73c1cdde67d46a462bed9d60d8d5b3) | `` plugins/jj-nvim: rename -> jj ``                         |
| [`d885c9b7`](https://github.com/nix-community/nixvim/commit/d885c9b79b3364b8bf63f1e0cb503d7c739d401f) | `` plugins/jj-nvim: init ``                                 |
| [`e0cd240f`](https://github.com/nix-community/nixvim/commit/e0cd240ffd3f61118314881aa87bc92163393f62) | `` plugins/lsp: refactor ``                                 |
| [`90962bf4`](https://github.com/nix-community/nixvim/commit/90962bf478db8c46d6181fe5c22f1f3f63258856) | `` plugins/lsp/vue_ls: add vtslsIntegration option ``       |