### PR TITLE
chore(flake/nixpkgs-stable): `8fd9daa3` -> `d7a713c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1234,11 +1234,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1778430510,
-        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`f065c1fe`](https://github.com/NixOS/nixpkgs/commit/f065c1feecbe34e20fd0899ca1b3974022036ba2) | `` anytype: fix desktop entry ``                                                      |
| [`b96631d9`](https://github.com/NixOS/nixpkgs/commit/b96631d9dca512def1747b1f922af5b78ed82cbd) | `` maintainers: add xmnlz ``                                                          |
| [`d99b4163`](https://github.com/NixOS/nixpkgs/commit/d99b416321c99a1e632889a80159799e3bfb40e2) | `` nixos/tests/nginx-etag: fix aarch64-linux compat ``                                |
| [`654a4ee5`](https://github.com/NixOS/nixpkgs/commit/654a4ee5b33995bc18c8ed193e95790c69fcbc69) | `` tirith: 0.2.12 -> 0.3.1 ``                                                         |
| [`bbe64516`](https://github.com/NixOS/nixpkgs/commit/bbe645169ef8be38011aaaa0a45e64236266fdc3) | `` deezer-desktop: 7.1.180 -> 7.1.190 ``                                              |
| [`fea42eff`](https://github.com/NixOS/nixpkgs/commit/fea42eff30fe8dcec4a545c6e7ec2657b3772e4c) | `` audiobookshelf: 2.33.2 -> 2.34.0 ``                                                |
| [`cb15ee63`](https://github.com/NixOS/nixpkgs/commit/cb15ee63184ef03a1cff24dcc456c7488edcbeec) | `` audiobookshelf: 2.33.1 -> 2.33.2 ``                                                |
| [`74379da8`](https://github.com/NixOS/nixpkgs/commit/74379da80ac41e073e6563fe4152853b2e3fb954) | `` audiobookshelf: 2.33.0 -> 2.33.1 ``                                                |
| [`3e9b3167`](https://github.com/NixOS/nixpkgs/commit/3e9b3167dcde0d3434686ca86b0361e4cdbe0574) | `` audiobookshelf: 2.32.1 -> 2.33.0 ``                                                |
| [`cfcd3d6e`](https://github.com/NixOS/nixpkgs/commit/cfcd3d6eb9591e0fb62a816803e94a251694985a) | `` audiobookshelf: use Node.js 22 to resolve build failure ``                         |
| [`0e78b008`](https://github.com/NixOS/nixpkgs/commit/0e78b008859b02a22e6886ae22536920b593e513) | `` audiobookshelf: 2.32.0 -> 2.32.1 ``                                                |
| [`e2b2a022`](https://github.com/NixOS/nixpkgs/commit/e2b2a022337a20d426b3f9c8fe202eb264638ae4) | `` ungoogled-chromium: 148.0.7778.96-1 -> 148.0.7778.167-1 ``                         |
| [`7cc73d12`](https://github.com/NixOS/nixpkgs/commit/7cc73d12f14a0ac677c9ee9945a7541c12cce6b9) | `` microcode-intel: 20260227 -> 20260512 ``                                           |
| [`0af27bce`](https://github.com/NixOS/nixpkgs/commit/0af27bce79c14e9fbfb74d3c9260dc422ea8938f) | `` qbz: 1.2.10 -> 1.2.12 ``                                                           |
| [`fc7e9d2c`](https://github.com/NixOS/nixpkgs/commit/fc7e9d2ca420a8cf428bb539baefd5d5b6819d9e) | `` scrcpy: 3.3.4 -> 4.0 ``                                                            |
| [`6035e056`](https://github.com/NixOS/nixpkgs/commit/6035e0565a53f3f874a0fe1fb6d0c99495e2b7c3) | `` rucio: 38.5.1 -> 38.5.5 ``                                                         |
| [`6840ca6e`](https://github.com/NixOS/nixpkgs/commit/6840ca6e55bff6b289f3484c6a1751a8b9dd994e) | `` python3Packages.granian: 2.7.2 -> 2.7.4 ``                                         |
| [`0285c0fb`](https://github.com/NixOS/nixpkgs/commit/0285c0fbc074ffdba92c03733210c72f5f9c93bb) | `` python3Packages.granian: 2.6.1 -> 2.7.2 ``                                         |
| [`bcfbf8a4`](https://github.com/NixOS/nixpkgs/commit/bcfbf8a41e893084a6ee261e8349bb231477e992) | `` python3Packages.granian: 2.6.0 -> 2.6.1 ``                                         |
| [`aca82bd6`](https://github.com/NixOS/nixpkgs/commit/aca82bd682f95a5800ba4507ca0e8ddc30ddbfa0) | `` python313Packages.granian: skip tests ``                                           |
| [`8e5bf65b`](https://github.com/NixOS/nixpkgs/commit/8e5bf65baa715228957547884495b8e58471b9a3) | `` python3Packages.granian: 2.5.6 -> 2.6.0 ``                                         |
| [`f4f49a11`](https://github.com/NixOS/nixpkgs/commit/f4f49a114c549fcd3b4495d203777c485df78df5) | `` kata-runtime: 3.21.0 -> 3.29.0 ``                                                  |
| [`336f2c23`](https://github.com/NixOS/nixpkgs/commit/336f2c23b9afb5abcaae12e17ab6ef7f6072ca4e) | `` kata-runtime: 3.16.0 -> 3.21.0 ``                                                  |
| [`5a94af3e`](https://github.com/NixOS/nixpkgs/commit/5a94af3e1fef8f0063c0cbb512c837ea94348e11) | `` discord: don't put icon in not spec-compliant location ``                          |
| [`324d8f72`](https://github.com/NixOS/nixpkgs/commit/324d8f72ded2f73e208cf046191a3cf6ecd6b83d) | `` discord{-ptb,-canary,-development}: quote client mods on darwin ``                 |
| [`ef07a308`](https://github.com/NixOS/nixpkgs/commit/ef07a3082c55a34d9e2f140d98af64d98390bf14) | `` discord: enable strictDeps ``                                                      |
| [`e802280d`](https://github.com/NixOS/nixpkgs/commit/e802280d6b1fee7952e34b6486c2b445c2e2b87c) | `` discord-development: fix darwin hash ``                                            |
| [`ee3e6a8f`](https://github.com/NixOS/nixpkgs/commit/ee3e6a8f5aac7aa047af2915e7d6c65d83fc7177) | `` linuxKernel.kernels.linux_zen: 7.0.5-zen1 -> 7.0.6-zen1 ``                         |
| [`f1294e21`](https://github.com/NixOS/nixpkgs/commit/f1294e21923f4d8064651dc6a7f65988df4f8cc8) | `` chromium,chromedriver: 148.0.7778.96 -> 148.0.7778.167 ``                          |
| [`26245264`](https://github.com/NixOS/nixpkgs/commit/262452644a96229743c0d02386db04de1bf26ca5) | `` google-chrome: 148.0.7778.96 -> 148.0.7778.167 ``                                  |
| [`621588f9`](https://github.com/NixOS/nixpkgs/commit/621588f9a418efd36f17b12581a60d0b1ca5ddb8) | `` librewolf-unwrapped: 150.0.2 -> 150.0.3 ``                                         |
| [`c42cabe0`](https://github.com/NixOS/nixpkgs/commit/c42cabe09351a385e881764a4912e6a50aadfb18) | `` nixos/tests/caddy: bump caddy.withPlugins test caddyserver/replace-response dep `` |
| [`7a48ae15`](https://github.com/NixOS/nixpkgs/commit/7a48ae15f01d2089e56db81cfdcb068b2eb40c1d) | `` caddy: 2.11.2 -> 2.11.3 ``                                                         |
| [`b001f28b`](https://github.com/NixOS/nixpkgs/commit/b001f28bb14176687e3a01d145d98ce36c8e5ad0) | `` firefox-bin-unwrapped: 150.0.1 -> 150.0.3 ``                                       |
| [`086f73bb`](https://github.com/NixOS/nixpkgs/commit/086f73bb3125754d6b747a71099aa0e03a778f62) | `` firefox-unwrapped: 150.0.2 -> 150.0.3 ``                                           |
| [`25c3ce5b`](https://github.com/NixOS/nixpkgs/commit/25c3ce5bbd090939347200ee5fe91aea6c574693) | `` synology-drive-client: 4.0.2-17889 -> 4.0.3-17892 ``                               |
| [`18083202`](https://github.com/NixOS/nixpkgs/commit/1808320207af995bcb4f3c52a625059527384d75) | `` thunderbird-latest-unwrapped: 150.0.1 -> 150.0.2 ``                                |
| [`3d2192d0`](https://github.com/NixOS/nixpkgs/commit/3d2192d02288e270e808a7ae7f83ee4fe9f33596) | `` forgejo-lts: 11.0.13 -> 11.0.14 ``                                                 |
| [`e8a010fa`](https://github.com/NixOS/nixpkgs/commit/e8a010fa9d95390200490239e94def2465cde169) | `` forgejo: 15.0.1 -> 15.0.2 ``                                                       |
| [`b96d3a42`](https://github.com/NixOS/nixpkgs/commit/b96d3a42e8b322a34d3c3b8c2e231f64938b94fd) | `` woodpecker-{agent,cli,server}: 3.14.0 -> 3.14.1 ``                                 |
| [`03ba7e99`](https://github.com/NixOS/nixpkgs/commit/03ba7e99afedfdf0f1f51d06fe8efa9f90b226f5) | `` dotnet: build only source-build-reference-packages in fetch-deps ``                |
| [`730edf74`](https://github.com/NixOS/nixpkgs/commit/730edf74982d56f0a7b2e644a3c08671074115b0) | `` dotnet: reduce update time ``                                                      |
| [`9a4c87c6`](https://github.com/NixOS/nixpkgs/commit/9a4c87c65e08082729671e096e75a70535c827e6) | `` dotnet: don't evaluate missing packages ``                                         |
| [`cf1f8520`](https://github.com/NixOS/nixpkgs/commit/cf1f85205d4ee4793811303ae62d62f90a40c689) | `` dotnet: fix indentation in update scripts ``                                       |
| [`0655574b`](https://github.com/NixOS/nixpkgs/commit/0655574beb7ef2c7e3dbca8807505b8080ca5c11) | `` ocamlPackages.ca-certs: 1.0.1 → 1.0.3 ``                                           |
| [`26c14ae2`](https://github.com/NixOS/nixpkgs/commit/26c14ae21a12b6e8218b5090b1787704bea20f25) | `` victoriametrics: 1.142.0 -> 1.143.0 ``                                             |
| [`529d631f`](https://github.com/NixOS/nixpkgs/commit/529d631fc68760a74473bac577f08dc33f8015ff) | `` maintainers/github-teams.json: Automated sync ``                                   |
| [`527fdf2f`](https://github.com/NixOS/nixpkgs/commit/527fdf2f25fcb1802722a734309418f55e032dc0) | `` valkey: skip test integration/dual-channel-replication ``                          |
| [`2a0eaf04`](https://github.com/NixOS/nixpkgs/commit/2a0eaf046e9be9c78f5fdd5b7838a8729d43295a) | `` bcachefs-tools: 1.38.0 -> 1.38.2 ``                                                |
| [`ca945792`](https://github.com/NixOS/nixpkgs/commit/ca945792cfd32084c7d8477240a54360cb9eda22) | `` mysql84: 8.4.8 -> 8.4.9 ``                                                         |
| [`3f52df10`](https://github.com/NixOS/nixpkgs/commit/3f52df108876bd583cbbf251b08ff654a43b7bae) | `` anki: 25.09.2 -> 25.09.3 ``                                                        |
| [`eb066e53`](https://github.com/NixOS/nixpkgs/commit/eb066e53b532326a3d14c89ed78256cb6af42cfb) | `` linux_xanmod_latest: 7.0.4 -> 7.0.6 ``                                             |
| [`cd74d56f`](https://github.com/NixOS/nixpkgs/commit/cd74d56f657313c9a67f5bd48a88051466a3ce7f) | `` linux_xanmod: 6.18.27 -> 6.18.29 ``                                                |
| [`42459387`](https://github.com/NixOS/nixpkgs/commit/42459387d798d124f27ccd18a5396b7374575031) | `` tomcat10: 10.1.52 -> 10.1.54 ``                                                    |
| [`dc5118bf`](https://github.com/NixOS/nixpkgs/commit/dc5118bf40c4a0139808d59ce7e1899c8080267e) | `` tomcat9: 9.0.115 -> 9.0.117 ``                                                     |
| [`03ec10e0`](https://github.com/NixOS/nixpkgs/commit/03ec10e0519b1af6ad3cd6cb510db2eb94bf1bc6) | `` tyrolienne: 1.2.0 -> 1.2.2 ``                                                      |
| [`d937b2d5`](https://github.com/NixOS/nixpkgs/commit/d937b2d5c46b6f1d574bbbd17ac2cc72289f4a0d) | `` pgbouncer: 1.25.1 -> 1.25.2 ``                                                     |
| [`3861cea0`](https://github.com/NixOS/nixpkgs/commit/3861cea0534b8e081d0da60672ef84bd9e2cfb25) | `` istioctl: 1.28.3 -> 1.28.6 ``                                                      |
| [`531d5167`](https://github.com/NixOS/nixpkgs/commit/531d516796c14ec781f47ef32226832bae2ad799) | `` perlPackages.NetCIDRLite: 0.23 -> 0.24 ``                                          |
| [`2bcebefd`](https://github.com/NixOS/nixpkgs/commit/2bcebefd1dd748dc2dcc4f03b59c92a5bee05e2f) | `` dnsmasq: 2.92 -> 2.92rel2 ``                                                       |
| [`e1e3a6ee`](https://github.com/NixOS/nixpkgs/commit/e1e3a6eecbf6775ef18041f48ffa3490999173e3) | `` llvmPackages_git: 23.0.0-unstable-2026-05-03 -> 23.0.0-unstable-2026-05-10 ``      |
| [`61ec2226`](https://github.com/NixOS/nixpkgs/commit/61ec2226b33a90b0f65fc473d70755d49a83d1b5) | `` workflows/periodic-merges: integrate with staging-26.05 ``                         |
| [`9b4c29bc`](https://github.com/NixOS/nixpkgs/commit/9b4c29bca63a065eb2a9e328abe0e0f838cb355d) | `` html2pdf: 0.8.2 -> 0.8.3 ``                                                        |
| [`f1dbaef1`](https://github.com/NixOS/nixpkgs/commit/f1dbaef15837d2a4d7fd94c317bdc5e24af950c7) | `` linux_6_18: 6.18.28 -> 6.18.29 ``                                                  |
| [`5f324327`](https://github.com/NixOS/nixpkgs/commit/5f324327fc2a6ef942d000264302ed3bdf47a1d0) | `` linux_7_0: 7.0.5 -> 7.0.6 ``                                                       |
| [`0ab832ca`](https://github.com/NixOS/nixpkgs/commit/0ab832cab15c18c454a8bb8bce84f01589de0ce3) | `` linux_testing: 7.1-rc2 -> 7.1-rc3 ``                                               |
| [`67b3a13e`](https://github.com/NixOS/nixpkgs/commit/67b3a13e699c1409f0d0c0602604a2c4ba55eebd) | `` linux_testing: 7.1-rc1 -> 7.1-rc2 ``                                               |
| [`84e51fc3`](https://github.com/NixOS/nixpkgs/commit/84e51fc351e680d4fee9fb2d714d2450d7345913) | `` linux/common-config: leave FOU options to defaults ``                              |
| [`0b6f82dc`](https://github.com/NixOS/nixpkgs/commit/0b6f82dca4bd45ebf69fc45230634fd178856283) | `` linux_testing: 7.0-rc7 -> 7.1-rc1 ``                                               |
| [`00fe4c67`](https://github.com/NixOS/nixpkgs/commit/00fe4c672fe680071e7c3e9ef5633c224395980b) | `` linux/common-config: update for 7.1 ``                                             |
| [`2f4c94ce`](https://github.com/NixOS/nixpkgs/commit/2f4c94ce072659408cea9ad1db57e507016264e4) | `` linux/common-config: Make Nova depend on Rust support ``                           |
| [`2b373a41`](https://github.com/NixOS/nixpkgs/commit/2b373a41363b0b179094e6d53c761dcde8b8f4b8) | `` python3Packages.willow: disable flaky test ``                                      |
| [`ab4a4faa`](https://github.com/NixOS/nixpkgs/commit/ab4a4faa6bfbb831be46fce8320e5680420b0f0a) | `` python3Packages.pillow-heif: patch CVE-2026-28231 ``                               |
| [`18f6d80e`](https://github.com/NixOS/nixpkgs/commit/18f6d80ecbc34031a0e9279f5b177843cd05ca41) | `` python3Packages.gitpython: 3.1.46 -> 3.1.50 ``                                     |
| [`b39189b1`](https://github.com/NixOS/nixpkgs/commit/b39189b105c942ac720b8bafd8b15e16a5237f3f) | `` python313Packages.gitpython: migrate to finalAttrs ``                              |
| [`92ef6468`](https://github.com/NixOS/nixpkgs/commit/92ef6468a948b173b8daa0a959cc94bf6a4442ae) | `` python3Packages.gitpython: 3.1.45 -> 3.1.46 ``                                     |
| [`a31d53a9`](https://github.com/NixOS/nixpkgs/commit/a31d53a90c3b77ddb171265cac7f62f347907611) | `` python313Packages.gitpython: modernize ``                                          |
| [`02916e4f`](https://github.com/NixOS/nixpkgs/commit/02916e4f1967500fa31ab2ddbc3ed8d5e231356c) | `` .github: Bump actions/labeler from 6.0.1 to 6.1.0 ``                               |
| [`0e6c3fa7`](https://github.com/NixOS/nixpkgs/commit/0e6c3fa7705c203ecaa6cf9caa0fa5a839bcf842) | `` chatzone-desktop: 5.6.1 -> 5.6.2 ``                                                |
| [`3b0a140e`](https://github.com/NixOS/nixpkgs/commit/3b0a140edaab4d01d99351304f46a3ed719dd4bb) | `` exiftool: 13.52 -> 13.58 ``                                                        |
| [`41afcded`](https://github.com/NixOS/nixpkgs/commit/41afcded512511fc3f4253db75faebca2727ed99) | `` gscan2pdf: disable a failing test ``                                               |
| [`2cb012a4`](https://github.com/NixOS/nixpkgs/commit/2cb012a4d3b9ad95ff76c9b4dbf6440312854ff6) | `` istioctl: 1.28.2 -> 1.28.3 ``                                                      |
| [`61e58ed4`](https://github.com/NixOS/nixpkgs/commit/61e58ed47fd07f16029a63496b13cf0109ffd6c5) | `` istioctl: 1.28.1 -> 1.28.2 ``                                                      |
| [`ae3003cc`](https://github.com/NixOS/nixpkgs/commit/ae3003cc4a47fb0c530e3dbad8f85caa44f369c8) | `` istioctl: 1.28.0 -> 1.28.1 ``                                                      |
| [`135095bd`](https://github.com/NixOS/nixpkgs/commit/135095bd0e2ff1b8a2fdd3950ab15a92d6966151) | `` linuxKernel.kernels.linux_zen: 7.0.3-zen1 -> 7.0.5-zen1 ``                         |
| [`ac195944`](https://github.com/NixOS/nixpkgs/commit/ac1959449244ccf734532c856c10c4508b608a83) | `` irpf: 2026-1.1 -> 2026-1.2 ``                                                      |
| [`b0e81fc7`](https://github.com/NixOS/nixpkgs/commit/b0e81fc7aea862c5c4d70d1bf8b1feb34365e821) | `` lx-music-desktop: 2.12.1 -> 2.12.2 ``                                              |
| [`58e13599`](https://github.com/NixOS/nixpkgs/commit/58e135991eac74db6dd6dc15d9b13f037e6e94ed) | `` pika-backup: 0.7.5 -> 0.7.6 ``                                                     |
| [`348af665`](https://github.com/NixOS/nixpkgs/commit/348af6653ffacae2bd74387fb88bb4ee175ea484) | `` nixos/acme: Make the maximum jitter configurable ``                                |