### PR TITLE
chore(flake/nixpkgs): `da5ad661` -> `d2339023`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1250,11 +1250,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`e7c92d67`](https://github.com/NixOS/nixpkgs/commit/e7c92d67a28b267c85cdeef0ac0752bb9a23f68c) | `` fairywren: 0-unstable-2026-05-06 -> 0-unstable-2026-05-15 ``                           |
| [`6127880c`](https://github.com/NixOS/nixpkgs/commit/6127880c2c1856a77de19f59ea78f456eef37073) | `` mongodb-tools: 100.16.1 -> 100.17.0 ``                                                 |
| [`1ff43b72`](https://github.com/NixOS/nixpkgs/commit/1ff43b727e8497b3d10e94a42cf92e343cdca94f) | `` opencloud.web: 6.2.0 -> 7.0.0 ``                                                       |
| [`1d7a0bdd`](https://github.com/NixOS/nixpkgs/commit/1d7a0bdd876ede29930094acadb93685152f06ec) | `` opencloud: 6.1.0 -> 6.2.0 ``                                                           |
| [`a507eae9`](https://github.com/NixOS/nixpkgs/commit/a507eae9a8364d64017f5daa63db26de49addbf8) | `` python3Packages.iamdata: 0.1.202605141 -> 0.1.202605151 ``                             |
| [`1ddfc6dc`](https://github.com/NixOS/nixpkgs/commit/1ddfc6dc5ff6c78e18358045d002be489c7933fc) | `` cloud-hypervisor: 51.1 -> 52.0 ``                                                      |
| [`fe5f89d8`](https://github.com/NixOS/nixpkgs/commit/fe5f89d8356ba3c61840a736aaae4c32ff092331) | `` python3Packages.pytibber: 0.37.5 -> 0.37.6 ``                                          |
| [`070e821b`](https://github.com/NixOS/nixpkgs/commit/070e821be46816bec0639e4f37983ca5ead713bd) | `` nixos/radicale: allow changing the run user ``                                         |
| [`4f5c50df`](https://github.com/NixOS/nixpkgs/commit/4f5c50df55816520f124ef1a388778729c0a82bc) | `` draco: update maintainers ``                                                           |
| [`d08104f5`](https://github.com/NixOS/nixpkgs/commit/d08104f5730af2f75e6dd72d34c3d1882071d932) | `` draco: minimize inputs ``                                                              |
| [`9828d404`](https://github.com/NixOS/nixpkgs/commit/9828d404e425db21ffc792d729f6a7b475fbfe2b) | `` draco: modernize ``                                                                    |
| [`9221721c`](https://github.com/NixOS/nixpkgs/commit/9221721cea5b89ba40476f7e5c4be6dd5891d5e0) | `` t3code: 0.0.23 -> 0.0.24 ``                                                            |
| [`34ad60d9`](https://github.com/NixOS/nixpkgs/commit/34ad60d9a079efc00a82e62fafa4d8a2bd0b4958) | `` zizmor: 1.24.1 -> 1.25.0 ``                                                            |
| [`f823ac63`](https://github.com/NixOS/nixpkgs/commit/f823ac6343706008e3c09ef637836aa0c64cc839) | `` libretro.tgbdual: 0-unstable-2026-04-20 -> 0-unstable-2026-05-11 ``                    |
| [`7e856fa8`](https://github.com/NixOS/nixpkgs/commit/7e856fa8fe59259dd1073206041781b0a5a5f06b) | `` ly: 1.3.2 -> 1.4.1 ``                                                                  |
| [`8a9eac53`](https://github.com/NixOS/nixpkgs/commit/8a9eac53f3b12c70028e3bd32faf727bd77b0094) | `` linux_5_10: 5.10.255 -> 5.10.256 ``                                                    |
| [`c82aea2c`](https://github.com/NixOS/nixpkgs/commit/c82aea2cdb67c110669b93d5fb6668f4c2dbbdc0) | `` linux_5_15: 5.15.206 -> 5.15.207 ``                                                    |
| [`9ba008af`](https://github.com/NixOS/nixpkgs/commit/9ba008afc898b453872469f7f62c1214343382fa) | `` linux_6_1: 6.1.172 -> 6.1.173 ``                                                       |
| [`b2b4c547`](https://github.com/NixOS/nixpkgs/commit/b2b4c547e4a680785cfcea0bba387b2343b2be43) | `` linux_6_6: 6.6.138 -> 6.6.139 ``                                                       |
| [`5159bf10`](https://github.com/NixOS/nixpkgs/commit/5159bf103ff13ed0b3c34b8200fe47d8fb677615) | `` linux_6_12: 6.12.88 -> 6.12.89 ``                                                      |
| [`d728083c`](https://github.com/NixOS/nixpkgs/commit/d728083c9eee25bb8fdfc96957559016dd57e24f) | `` linux_6_18: 6.18.30 -> 6.18.31 ``                                                      |
| [`2c6bf580`](https://github.com/NixOS/nixpkgs/commit/2c6bf580d7ef708939019073a373cb44ffede28a) | `` linux_7_0: 7.0.7 -> 7.0.8 ``                                                           |
| [`d640449a`](https://github.com/NixOS/nixpkgs/commit/d640449acc6e2f4f754022e2f7ad29bd3a70a27c) | `` home-assistant-custom-components.alphaess: fix filename ``                             |
| [`291bc945`](https://github.com/NixOS/nixpkgs/commit/291bc9457b3c069f57f38f959003afb45ca95103) | `` scx.rustscheds: 1.1.0 -> 1.1.1 ``                                                      |
| [`c0518a99`](https://github.com/NixOS/nixpkgs/commit/c0518a99e56e81627facf904997eedc098e18829) | `` ty: 0.0.35 -> 0.0.36 ``                                                                |
| [`99f28c35`](https://github.com/NixOS/nixpkgs/commit/99f28c35146b6491c6f638740d3664a172fbf05a) | `` vscode-extensions.vscjava.vscode-java-dependency: 0.27.2 -> 0.27.3 ``                  |
| [`60951b1a`](https://github.com/NixOS/nixpkgs/commit/60951b1a11f0d83d7ebe07f9f055f2f4691228fc) | `` zed-editor: 1.2.3 -> 1.2.5 ``                                                          |
| [`cdfa681a`](https://github.com/NixOS/nixpkgs/commit/cdfa681a2f2b8231cc2b3c6c80cc3d1f96b28f3b) | `` home-assistant-custom-components:simple_pid_controller: init at 1.6.0 ``               |
| [`640b5e21`](https://github.com/NixOS/nixpkgs/commit/640b5e219c9d3d2f404540306b981f24ff6f432a) | `` buildHomeAssistantComponent: support finalAttrs ``                                     |
| [`f26d7967`](https://github.com/NixOS/nixpkgs/commit/f26d79676a8f4925289873958c8d27ebfda43d0c) | `` terraform-providers.spacelift-io_spacelift: 1.48.0 -> 1.49.0 ``                        |
| [`b8cdfc2c`](https://github.com/NixOS/nixpkgs/commit/b8cdfc2c9cea839d8acca59d131d5cc698b58e98) | `` python3Packages.simple-pid: init at 2.0.1 ``                                           |
| [`25665110`](https://github.com/NixOS/nixpkgs/commit/2566511049b6a9a27813c312bd806d132e89c788) | `` pixieditor: 2.0.1.19 -> 2.1.1.4 ``                                                     |
| [`81a22a2d`](https://github.com/NixOS/nixpkgs/commit/81a22a2d7f6500980cda633d41df35058b5356be) | `` python3Packages.pyportainer: 1.0.39 -> 1.0.40 ``                                       |
| [`0726a977`](https://github.com/NixOS/nixpkgs/commit/0726a9775d700a2d86568e2563986dbd6f884ddd) | `` libzim: 9.6.0 -> 9.7.0 ``                                                              |
| [`b2c4b658`](https://github.com/NixOS/nixpkgs/commit/b2c4b658ba600fe3eced275ee0f98319439d55d9) | `` terraform-providers.hashicorp_time: 0.13.1 -> 0.14.0 ``                                |
| [`ddcc30fd`](https://github.com/NixOS/nixpkgs/commit/ddcc30fdfe5142fd1594c87f68222b9a32866422) | `` retroarch-wrapper: set pname and version ``                                            |
| [`403b6dbc`](https://github.com/NixOS/nixpkgs/commit/403b6dbc02bc6f8e8ef6f4a6c0ffa4a853f7f516) | `` cloudcompare: fix build ``                                                             |
| [`f82c528d`](https://github.com/NixOS/nixpkgs/commit/f82c528d962590480a11901afeed75fadfdf3dd1) | `` terraform-providers.aliyun_alicloud: 1.277.0 -> 1.278.0 ``                             |
| [`ca4b9a33`](https://github.com/NixOS/nixpkgs/commit/ca4b9a33f70063f205ece39d65720eb3dddbfbf8) | `` python3Packages.fava-dashboards: 2.0.0b7 -> 2.0.0b8 ``                                 |
| [`1d5f2648`](https://github.com/NixOS/nixpkgs/commit/1d5f26488457578e452143de049e20d44d9250cc) | `` icm: init at 0.10.49 ``                                                                |
| [`0e0ba2f5`](https://github.com/NixOS/nixpkgs/commit/0e0ba2f5410d2ef7f85c33eb3782ce3d5b2fae6b) | `` mdbook-bib: init at 0.5.2 ``                                                           |
| [`3802340c`](https://github.com/NixOS/nixpkgs/commit/3802340c85271af6f303f4f8c2d7372ed11e8bd8) | `` maintainers: add markhakansson ``                                                      |
| [`616f8b69`](https://github.com/NixOS/nixpkgs/commit/616f8b69d69e537a2736b0daa7ac80056b560f45) | `` wasm-pack: 0.14.0 -> 0.15.0 ``                                                         |
| [`a80949e4`](https://github.com/NixOS/nixpkgs/commit/a80949e40be3ccb2185f0098e4ec64ef00f5a268) | `` python3Packages.moyopy: 0.8.0 -> 0.9.0 ``                                              |
| [`e8ddd175`](https://github.com/NixOS/nixpkgs/commit/e8ddd1751c29bef7619af863bd03c097661d3b98) | `` python3Packages.pysrdaligateway: 0.20.4 -> 0.21.0 ``                                   |
| [`883bba75`](https://github.com/NixOS/nixpkgs/commit/883bba75f2c1f2b000eaa2d3b4649f007e639c95) | `` qovery-cli: 1.158.1 -> 1.160.2 ``                                                      |
| [`51db2023`](https://github.com/NixOS/nixpkgs/commit/51db2023bdd67fb5c00bd425fdfbc6236440c299) | `` foot: 1.26.1 -> 1.27.0 ``                                                              |
| [`b8f87e55`](https://github.com/NixOS/nixpkgs/commit/b8f87e5540be040a7eecd50f35d8922510fb0eb3) | `` linuxKernel.kernels.linux_zen: 7.0.6 -> 7.0.7 ``                                       |
| [`5f525928`](https://github.com/NixOS/nixpkgs/commit/5f52592848a54fe0678f0a699ddb913167c0025d) | `` postgresqlPackages.system_stats: 4.0 -> 4.1 ``                                         |
| [`6025dfdf`](https://github.com/NixOS/nixpkgs/commit/6025dfdf3bff9494bf980e677dd885b06a6c432e) | `` opentelemetry-cpp: 1.26.0 -> 1.27.0, opentelemetry-proto: 1.8.0 -> 1.10.0 ``           |
| [`a1450861`](https://github.com/NixOS/nixpkgs/commit/a1450861dfbcd27e48415e8552d1e71dfcef0529) | `` postgresql_18: 18.3 -> 18.4 ``                                                         |
| [`ff3a971a`](https://github.com/NixOS/nixpkgs/commit/ff3a971a1bb271aee67348de40b8db3621e8f500) | `` postgresql_17: 17.9 -> 17.10 ``                                                        |
| [`d16813a3`](https://github.com/NixOS/nixpkgs/commit/d16813a3c240e476eeb9f46a8b9f82f4284026e3) | `` postgresql_16: 16.13 -> 16.14 ``                                                       |
| [`fd628675`](https://github.com/NixOS/nixpkgs/commit/fd6286751aff5db40c1f12d77afee21f4b114e0a) | `` postgresql_15: 15.17 -> 15.18 ``                                                       |
| [`624e5a42`](https://github.com/NixOS/nixpkgs/commit/624e5a428cb0cedbd7aeffa7cc6a327f834d2d46) | `` officecli: init at 1.0.92 ``                                                           |
| [`accf9233`](https://github.com/NixOS/nixpkgs/commit/accf9233beb91f89cd0eeafeb3dbadef3b2657b3) | `` brutus: 1.3.0 -> 1.4.0 ``                                                              |
| [`c3bfff7d`](https://github.com/NixOS/nixpkgs/commit/c3bfff7d3c42196579916263b060e5d418af9dec) | `` postgresql_14: 14.22 -> 14.23 ``                                                       |
| [`59633121`](https://github.com/NixOS/nixpkgs/commit/59633121bdc7fe76f78c16ea99289ed9aab65253) | `` neovimUtils.buildNeovimPlugin: fix lua c modules ``                                    |
| [`56252a05`](https://github.com/NixOS/nixpkgs/commit/56252a056179f57a6676552d5905291fd5b922de) | `` python3Packages.google-cloud-workflows: 1.21.0 -> 1.22.0 ``                            |
| [`e3332b35`](https://github.com/NixOS/nixpkgs/commit/e3332b35ae19d406cf51028105eec0b56c9af448) | `` linux_xanmod_latest: 7.0.6 -> 7.0.7 ``                                                 |
| [`c76fb7fb`](https://github.com/NixOS/nixpkgs/commit/c76fb7fb71ece6d05b3ba5b38f5a0cf363f4940b) | `` linux_xanmod: 6.18.29 -> 6.18.30 ``                                                    |
| [`46810a2a`](https://github.com/NixOS/nixpkgs/commit/46810a2a4423d42aee436dba204afd5723958514) | `` python3Packages.robotframework-pythonlibcore: 4.5.0 -> 4.6.0 ``                        |
| [`de7f0e3c`](https://github.com/NixOS/nixpkgs/commit/de7f0e3c6bcb05c29d91c874748f86b4bcdf657a) | `` labwc-tweaks-gtk: 0-unstable-2026-03-02 -> 0-unstable-2026-05-09 ``                    |
| [`35681ecd`](https://github.com/NixOS/nixpkgs/commit/35681ecd827ab6996682d6da62b7e7a9620dd228) | `` nixtamal: 1.5.3 → 1.5.4 ``                                                             |
| [`60160cbf`](https://github.com/NixOS/nixpkgs/commit/60160cbf95b4118ac7b88b822a3491684bf54efd) | `` signal-backup-deduplicator: fix build with protobuf 34 ``                              |
| [`b7a413da`](https://github.com/NixOS/nixpkgs/commit/b7a413da088ca8e408230ede029bb021ef2b4ec0) | `` python3Packages.lcn-frontend: 0.2.8 -> 0.2.9 ``                                        |
| [`c108d11b`](https://github.com/NixOS/nixpkgs/commit/c108d11b2a9c38da816d4ab5eb3fa3ec47d9657a) | `` json-sort-cli: 3.0.0 -> 3.0.1 ``                                                       |
| [`39c2e700`](https://github.com/NixOS/nixpkgs/commit/39c2e700f793b67d9d38da9eff138530274ec294) | `` vscode-extensions.cweijan.vscode-database-client2: 8.4.5 -> 8.4.6 ``                   |
| [`9105698a`](https://github.com/NixOS/nixpkgs/commit/9105698a911969d2daa8aad198e97e825f65fa66) | `` radicle-job: 0.5.2 -> 0.6.0 ``                                                         |
| [`56cf7052`](https://github.com/NixOS/nixpkgs/commit/56cf7052a691dba1ca75279143417035d7c4e0dd) | `` versatiles: 4.0.0 -> 4.1.0 ``                                                          |
| [`39c19c6d`](https://github.com/NixOS/nixpkgs/commit/39c19c6d08e14dd94b773f6b6d96b3da4d53bb6f) | `` terraform-providers.hashicorp_random: 3.8.1 -> 3.9.0 ``                                |
| [`2d5e4549`](https://github.com/NixOS/nixpkgs/commit/2d5e45497b2d551efd9578b5c449407a58668469) | `` orbiton: 2.73.1 -> 2.74.0 ``                                                           |
| [`94fda3c5`](https://github.com/NixOS/nixpkgs/commit/94fda3c5d0e9fc729f40ccbf63518d40eb4206af) | `` ghc: fix c++ linkage and c standard for < 9.10 on darwin ``                            |
| [`9b902050`](https://github.com/NixOS/nixpkgs/commit/9b9020502685535a0ea87a7a9ecb14828eb6f8a1) | `` Revert "sbcl: remove broken run-program test" ``                                       |
| [`c2303eef`](https://github.com/NixOS/nixpkgs/commit/c2303eef09e1320b52a46a6063798bd52ee129fe) | `` harbor-cli: 0.0.19 -> 0.0.20 ``                                                        |
| [`6cbc3fdf`](https://github.com/NixOS/nixpkgs/commit/6cbc3fdf49bce747f85fc4be5ae25269d5b5ab18) | `` ruqola: 2.7.1 -> 2.7.2 ``                                                              |
| [`4d2449a2`](https://github.com/NixOS/nixpkgs/commit/4d2449a21d55ecdde6c3ae53e5fa5afb82d41656) | `` macaulay2: modified tests for aarch64 compatibility ``                                 |
| [`ebbffd5a`](https://github.com/NixOS/nixpkgs/commit/ebbffd5a61e043c2d0a1d208f0c7d30d4a3258e0) | `` lldpd: 1.0.21 -> 1.0.22 ``                                                             |
| [`a57b1a93`](https://github.com/NixOS/nixpkgs/commit/a57b1a93a3b3a84fcafc32ff5df426e4405f6483) | `` astyle: 3.6.15 -> 3.6.16 ``                                                            |
| [`6f953b13`](https://github.com/NixOS/nixpkgs/commit/6f953b139d61d65db6dc947c6ab851863d51656c) | `` kazumi: 2.1.0 -> 2.1.1 ``                                                              |
| [`ec45f1b5`](https://github.com/NixOS/nixpkgs/commit/ec45f1b5dcc97f10273167238eca0bec19c186a1) | `` home-assistant-custom-components.entity-notes: init at 3.3.4 ``                        |
| [`5519e397`](https://github.com/NixOS/nixpkgs/commit/5519e3979f2ac964ae02ab4aeb11779faa451685) | `` cgit: 1.3 -> 1.3.1 ``                                                                  |
| [`dfdfca2e`](https://github.com/NixOS/nixpkgs/commit/dfdfca2e30047b4252fdcb725b7d488cc01544db) | `` python3Packages.frigidaire: 0.18.29 -> 0.18.43 ``                                      |
| [`56f31fbe`](https://github.com/NixOS/nixpkgs/commit/56f31fbe42bb4deeeda56badf087aa80763a2f5b) | `` python3Packages.checkdmarc: 5.13.4 -> 5.15.4 ``                                        |
| [`748479d0`](https://github.com/NixOS/nixpkgs/commit/748479d0e8753c277c0b46e841f779d62b60d893) | `` postgresqlPackages.pg_textsearch: 1.1.0 -> 1.2.0 ``                                    |
| [`4f17b3a8`](https://github.com/NixOS/nixpkgs/commit/4f17b3a897b2243b71f27d3a9d3b18c0bec2f5f8) | `` python3Packages.fyta-cli: migrate to finalAttrs ``                                     |
| [`bcb2f7c0`](https://github.com/NixOS/nixpkgs/commit/bcb2f7c039f642791cdafee40f34522b899c02b9) | `` python3Packages.thermopro-ble: migrate to finalAttrs ``                                |
| [`25b8a88c`](https://github.com/NixOS/nixpkgs/commit/25b8a88ced726e9a60b2113c0c02d03fc2828648) | `` python3Packages.fyta-cli: 0.7.2 -> 0.7.3 ``                                            |
| [`2e153b3b`](https://github.com/NixOS/nixpkgs/commit/2e153b3b14c442c6e52171352d14d820e6ae2103) | `` libretro.mupen64plus: 0-unstable-2026-04-02 -> 0-unstable-2026-05-12 ``                |
| [`f4d93d08`](https://github.com/NixOS/nixpkgs/commit/f4d93d083eb26498b1be4c43f3a2fbaa3828dfcd) | `` bliss: 0.73 -> 0.77 ``                                                                 |
| [`ed5d3af0`](https://github.com/NixOS/nixpkgs/commit/ed5d3af0a8cbc4b1260255d52d0d63dba916a44f) | `` python3Packages.easyenergy: 3.0.0 -> 3.0.1 ``                                          |
| [`f6c0b876`](https://github.com/NixOS/nixpkgs/commit/f6c0b8761011d4e3487ca985b9996cece43cbd11) | `` python3Packages.cf-xarray: 0.11.0 -> 0.11.1 ``                                         |
| [`ff43bb47`](https://github.com/NixOS/nixpkgs/commit/ff43bb4775356d5fc1cd50330aa0d0994344006f) | `` python3Packages.aiotankerkoenig: 0.5.2 -> 0.5.3 ``                                     |
| [`d42481ad`](https://github.com/NixOS/nixpkgs/commit/d42481add3f9ca855f78fe08d0fe09e75b1dfaa0) | `` python3Packages.jupyter-docprovider: 2.3.0 -> 2.4.0 ``                                 |
| [`26e279bc`](https://github.com/NixOS/nixpkgs/commit/26e279bcf94307300704aad940ef01aca36f0dc0) | `` terraform-providers.metio_migadu: 2026.3.5 -> 2026.5.14 ``                             |
| [`0d5f2ff2`](https://github.com/NixOS/nixpkgs/commit/0d5f2ff2934e43d7baf9a174e99a6d6a9e086b19) | `` python3Packages.bleak-esphome: 3.7.3 -> 3.7.4 ``                                       |
| [`fb2b25fe`](https://github.com/NixOS/nixpkgs/commit/fb2b25fe92abc7512897a8c6688d483c63c6e0e1) | `` python3Packages.thermopro-ble: 1.1.3 -> 1.1.4 ``                                       |
| [`95adba84`](https://github.com/NixOS/nixpkgs/commit/95adba845c43d15921cbce28dba8e7153590ed65) | `` python3Packages.lxmf: 0.9.6 -> 0.9.8 ``                                                |
| [`9731b3f5`](https://github.com/NixOS/nixpkgs/commit/9731b3f55001096c22dc35f9062cbee91953b0e5) | `` goshs: 2.0.7 -> 2.0.8 ``                                                               |
| [`d382ea20`](https://github.com/NixOS/nixpkgs/commit/d382ea20a5e23ba816e24488467a2a1c6c9da77f) | `` exploitdb: 2026-05-08 -> 2026-05-14 ``                                                 |
| [`db952528`](https://github.com/NixOS/nixpkgs/commit/db95252870a834f6332d5d4dd833a158adac91a9) | `` python3Packages.publicsuffixlist: 1.0.2.20260508 -> 1.0.2.20260514 ``                  |
| [`774ae231`](https://github.com/NixOS/nixpkgs/commit/774ae2311ec4ddaec3b922e2669b862fe77a2452) | `` home-assistant-custom-components.bodymiscale: 2026.4.5 -> 2026.5.5 ``                  |
| [`4c2bdc6c`](https://github.com/NixOS/nixpkgs/commit/4c2bdc6cde3c7feb5e14dcea50a4d0649cbdcbbd) | `` sandbox-runtime: 0.0.50 -> 0.0.51 ``                                                   |
| [`31ce586a`](https://github.com/NixOS/nixpkgs/commit/31ce586a5d3d3c77c1dc32db0bc6b07dc094df65) | `` python3Packages.wyoming: 1.8.0 -> 1.9.0 ``                                             |
| [`5d9aa3e6`](https://github.com/NixOS/nixpkgs/commit/5d9aa3e6fbc9142465cd5da8a6dda8c3354124bf) | `` uv: 0.11.13 -> 0.11.14 ``                                                              |
| [`917d2f92`](https://github.com/NixOS/nixpkgs/commit/917d2f92e5ab3925b595b61add65afb8dbe35e8e) | `` matrix-authentication-service: fix cross compilation ``                                |
| [`ca236da1`](https://github.com/NixOS/nixpkgs/commit/ca236da116ce8cc52ca7bf080f42a02973d48d83) | `` python3Packages.tencentcloud-sdk-python: 3.1.95 -> 3.1.97 ``                           |
| [`5172763e`](https://github.com/NixOS/nixpkgs/commit/5172763eb0ddd9505be973c2ebb22fe2d09cc2f2) | `` python3Packages.iamdata: 0.1.202605131 -> 0.1.202605141 ``                             |
| [`a54cd4f6`](https://github.com/NixOS/nixpkgs/commit/a54cd4f6ce1e8a373fac72bf11342405f28bf8f2) | `` ocm: 1.0.14 -> 1.0.15 ``                                                               |
| [`8f5a476c`](https://github.com/NixOS/nixpkgs/commit/8f5a476cd55a802b800fb38358fabeac7b435659) | `` terraform-providers.terraform-lxd_lxd: 2.7.0 -> 2.7.1 ``                               |
| [`652c3827`](https://github.com/NixOS/nixpkgs/commit/652c38273be7056649c7ff19c968f118d9a4920f) | `` slurm: 25-11-5-1 -> 25-11-6-1 ``                                                       |
| [`b84d94c9`](https://github.com/NixOS/nixpkgs/commit/b84d94c976e3c94e8d749e9f29ab554a2819c7d4) | `` aliases: enhance 'kwalletcli' removal message with Qt6 info ``                         |
| [`309a1ce6`](https://github.com/NixOS/nixpkgs/commit/309a1ce6a8d828b52c511b91d336589f2fbdbc03) | `` opentofu: 1.11.7 -> 1.11.8 ``                                                          |
| [`0db12f62`](https://github.com/NixOS/nixpkgs/commit/0db12f62d09370274d4b8efa0b4448373da89759) | `` lasuite-docs{,-frontend,-collaboration-server}: 5.0.0 -> 5.1.0 ``                      |
| [`e77ead02`](https://github.com/NixOS/nixpkgs/commit/e77ead024d953d4b2c9e54fdd44786f31734b5c5) | `` terraform-providers.rootlyhq_rootly: 5.13.0 -> 5.15.1 ``                               |
| [`77003235`](https://github.com/NixOS/nixpkgs/commit/77003235d6b9edd386961a3e01b026809c2ef2ee) | `` keyd: add pygobject3 and dbus-python to keyd-application-mapper script dependencies `` |
| [`eb2731dc`](https://github.com/NixOS/nixpkgs/commit/eb2731dc6eaf54a967ab795ead2d56ba1bf614f1) | `` xdg-ninja: 0-unstable-2026-04-29 -> 0-unstable-2026-05-10 ``                           |
| [`43b664bf`](https://github.com/NixOS/nixpkgs/commit/43b664bf083d8bb50dbd0a30f7783f39be3db735) | `` hyprutils: add meta.changelog ``                                                       |
| [`c5b803f1`](https://github.com/NixOS/nixpkgs/commit/c5b803f16c7a32a8d047c03c2707ff39cc7562f6) | `` hyprsunset: add meta.changelog ``                                                      |
| [`9cb94ca8`](https://github.com/NixOS/nixpkgs/commit/9cb94ca89a22e38a8c810b02d4c42df401a154f4) | `` hyprshutdown: add meta.changelog ``                                                    |
| [`895506d2`](https://github.com/NixOS/nixpkgs/commit/895506d23106579198a74cb74aef2d462a75dbd4) | `` hyprpicker: add meta.changelog ``                                                      |
| [`c06292d2`](https://github.com/NixOS/nixpkgs/commit/c06292d21bed079d63628315b36d959d9a53be2b) | `` hyprlock: add meta.changelog ``                                                        |
| [`b5a4803c`](https://github.com/NixOS/nixpkgs/commit/b5a4803c718feeecc12bc053b37de5038da5d7c3) | `` hyprland: add meta.changelog ``                                                        |
| [`31d43f45`](https://github.com/NixOS/nixpkgs/commit/31d43f453450be433f12959588ce186752492c11) | `` hypridle: add meta.changelog ``                                                        |
| [`a96d98ea`](https://github.com/NixOS/nixpkgs/commit/a96d98ea6f290936eda271e9b6017164cd6f27ac) | `` vicinae: 0.20.15 -> 0.21.0 ``                                                          |
| [`391fe6db`](https://github.com/NixOS/nixpkgs/commit/391fe6dba7901626994e40eddafcad9004d64b94) | `` pgrok: 1.4.6 -> 1.5.0 ``                                                               |
| [`240b3ef9`](https://github.com/NixOS/nixpkgs/commit/240b3ef980e068454bde43746dbc260ba9686ebc) | `` lutgen-studio: 0.3.0 -> 0.4.0 ``                                                       |
| [`bf9367d4`](https://github.com/NixOS/nixpkgs/commit/bf9367d4b5185478b83fc38dad0caace02f2dd54) | `` hyprgraphics: add meta.changelog ``                                                    |
| [`544929eb`](https://github.com/NixOS/nixpkgs/commit/544929eb58063a6ee90f921f5df0ee533bb163bb) | `` protoc-gen-go-grpc: 1.6.1 -> 1.6.2 ``                                                  |
| [`e404b46c`](https://github.com/NixOS/nixpkgs/commit/e404b46c6db038c57b3c3300b31a40e81337de3b) | `` lutgen: 1.0.1 -> 1.1.1 ``                                                              |
| [`8ea34767`](https://github.com/NixOS/nixpkgs/commit/8ea34767f3ecd524dc25d1b6617fdaab85a4b596) | `` yaziPlugins.compress: add meta.changelog ``                                            |
| [`6d8af4f4`](https://github.com/NixOS/nixpkgs/commit/6d8af4f476bf70cf4a359214e03cb2f6d0f39695) | `` yaziPlugins.sshfs: add meta.changelog ``                                               |
| [`ee169328`](https://github.com/NixOS/nixpkgs/commit/ee1693283d87c0cde710e8f7af3633bd21778e54) | `` yaziPlugins.yatline: add meta.changelog ``                                             |
| [`e2b6d8e3`](https://github.com/NixOS/nixpkgs/commit/e2b6d8e3f4015f52fc8ac3ae1a9347e65bcd071b) | `` yazi: add meta.changelog ``                                                            |
| [`07bdf442`](https://github.com/NixOS/nixpkgs/commit/07bdf442ed328255c1995c5c4731bbf0f9121d69) | `` python3Packages.wandb: 0.26.1 -> 0.27.0 ``                                             |
| [`eb64cfcb`](https://github.com/NixOS/nixpkgs/commit/eb64cfcb6c953e5ae18fe08cdf1c25f5ab744efd) | `` grav: 1.5.50.3 -> 1.7.52 ``                                                            |
| [`4eadca76`](https://github.com/NixOS/nixpkgs/commit/4eadca769746deabecb89ea4b15b59378a144fcc) | `` vscode-extensions.oxc.oxc-vscode: init at 1.55.0 ``                                    |
| [`25675d9b`](https://github.com/NixOS/nixpkgs/commit/25675d9b352c020af14bc55a58b39d492bdf7453) | `` qgis: 4.0.1 -> 4.0.2 ``                                                                |
| [`3def199c`](https://github.com/NixOS/nixpkgs/commit/3def199cc18637ec6f70e39886eb313d17c1c204) | `` vscode-extensions.sonarsource.sonarlint-vscode: 5.2.1 -> 5.2.3 ``                      |
| [`06a3e335`](https://github.com/NixOS/nixpkgs/commit/06a3e335086169e9aa0bad44b00472e547b1317d) | `` kubernetes: 1.36.0 -> 1.36.1 ``                                                        |
| [`4e24e520`](https://github.com/NixOS/nixpkgs/commit/4e24e520f2df8c6c6d8b658a7870fcd8c3311c8c) | `` material-maker: package metadata and icon files ``                                     |
| [`e0892a72`](https://github.com/NixOS/nixpkgs/commit/e0892a72016721b30e65ac2ac3303cbf694dc738) | `` qgis-ltr: 3.44.9 -> 3.44.10 ``                                                         |
| [`e93bd807`](https://github.com/NixOS/nixpkgs/commit/e93bd80765e2397740d919a135afba321fb673c4) | `` dwproton-bin: dwproton-10.0-26 -> dwproton-11.0-1 ``                                   |
| [`96a8fdc3`](https://github.com/NixOS/nixpkgs/commit/96a8fdc303e089b386a20ff56e2c9b490bb82280) | `` netbird: 0.70.4 -> 0.70.5 ``                                                           |
| [`4801114e`](https://github.com/NixOS/nixpkgs/commit/4801114e4d25dd75f3bea588b216e31087385f74) | `` zellij: 0.44.2 -> 0.44.3 ``                                                            |
| [`e62fc63f`](https://github.com/NixOS/nixpkgs/commit/e62fc63ff760c1624ea221f7389b423843b9039b) | `` mirrord: 3.209.1 -> 3.210.0 ``                                                         |
| [`78520aa5`](https://github.com/NixOS/nixpkgs/commit/78520aa5744c73270252123b37c1be35f1544787) | `` smartcat: remove v prefix in meta.changelog ``                                         |
| [`05329fd6`](https://github.com/NixOS/nixpkgs/commit/05329fd6baaa6c708e241ca114b0f7d96708da6c) | `` ardour: 9.2 -> 9.4 ``                                                                  |
| [`cd350ecf`](https://github.com/NixOS/nixpkgs/commit/cd350ecf66bb439a80f7dbdf10c9a7f3d9ad1704) | `` linux_6_12: 6.12.87 -> 6.12.88 ``                                                      |
| [`0a692ddf`](https://github.com/NixOS/nixpkgs/commit/0a692ddf9c8cedd5cb53db0009186ad8f5e4ff44) | `` linux_6_18: 6.18.29 -> 6.18.30 ``                                                      |
| [`4b3f8d02`](https://github.com/NixOS/nixpkgs/commit/4b3f8d029c16a276486b23c634def14e9280e9c2) | `` linux_7_0: 7.0.6 -> 7.0.7 ``                                                           |
| [`2e23db98`](https://github.com/NixOS/nixpkgs/commit/2e23db9859355fac394c1b94d821c64bc9245258) | `` nixpkgs-review: depends on nix-eval-jobs ``                                            |
| [`a69e459d`](https://github.com/NixOS/nixpkgs/commit/a69e459d2b4eca23a2210a5e3026cb0b06189982) | `` warpgate: 0.23.1 -> 0.23.4 ``                                                          |
| [`394455c8`](https://github.com/NixOS/nixpkgs/commit/394455c87d7a43b6d188b58d04869c26012b2138) | `` grafana: 13.0.1 -> 13.0.1+security-01 ``                                               |
| [`14b47267`](https://github.com/NixOS/nixpkgs/commit/14b4726797bda9b9b8e8946ba89c4f397b197b4b) | `` raycast-beta: init at 0.60.0.0 ``                                                      |
| [`a8df69b3`](https://github.com/NixOS/nixpkgs/commit/a8df69b3780e304cee8fca39c8986f870ca5d81c) | `` radicale: 3.7.2 -> 3.7.3 ``                                                            |
| [`a03ff8b3`](https://github.com/NixOS/nixpkgs/commit/a03ff8b358dcf5dc1ecb9c417dcb2000fa00d63c) | `` librearp-lv2: 2.4 -> 2.5 ``                                                            |
| [`7e571ea1`](https://github.com/NixOS/nixpkgs/commit/7e571ea12b316ea3af79ad7b3f95ca0fd9e71a0d) | `` librearp: 2.4 -> 2.5 ``                                                                |
| [`c309644b`](https://github.com/NixOS/nixpkgs/commit/c309644bb79cf23b2d1ae1c48a61dd5479e00851) | `` ruff: 0.15.12 -> 0.15.13 ``                                                            |
| [`85198639`](https://github.com/NixOS/nixpkgs/commit/851986399093c7b3e2fcb81b56b8c13d345eb369) | `` raycast: 1.104.10 -> 1.104.17 ``                                                       |
| [`bcf71190`](https://github.com/NixOS/nixpkgs/commit/bcf71190d6c57e95377ec09abc148f6d60d9043c) | `` yaziPlugins: support finalAttrs pattern ``                                             |
| [`4845d8d8`](https://github.com/NixOS/nixpkgs/commit/4845d8d807b8e7a9e3db80b2b0b09fd760c3dadf) | `` extra-cmake-modules: mark as dropped ``                                                |
| [`6b45d0cc`](https://github.com/NixOS/nixpkgs/commit/6b45d0ccb5b5135be899040f7c7d7c4d143b7f6f) | `` nixos/lasuite-docs: add warnings for renamed LaSuite Docs options ``                   |
| [`055f26d8`](https://github.com/NixOS/nixpkgs/commit/055f26d8e97b6768f9c5b5a5e4c83127b215dc4f) | `` lasuite-docs{,-collaboration-server,-frontend}: 4.8.6 -> 5.0.0 ``                      |
| [`b91a7632`](https://github.com/NixOS/nixpkgs/commit/b91a763229a4b223c1b20b74f62d277977efa42c) | `` netatalk: 4.4.2 -> 4.4.3 ``                                                            |
| [`6930b84a`](https://github.com/NixOS/nixpkgs/commit/6930b84a3af911d749226b111e48f75d5e487c4f) | `` jankyborders: add meta.changelog ``                                                    |
| [`2f2cce5b`](https://github.com/NixOS/nixpkgs/commit/2f2cce5b7d2a92911dd4edb6703190426b20083e) | `` jankyborders: 1.8.4 -> 1.9.0 ``                                                        |
| [`67f915df`](https://github.com/NixOS/nixpkgs/commit/67f915df60108086e4657c7630d97cbe67eaa584) | `` wttrbar: 0.14.4 -> 0.14.5 ``                                                           |
| [`70e5fa5f`](https://github.com/NixOS/nixpkgs/commit/70e5fa5f6145d44ed697290c2404826b7103b616) | `` vscode-extensions.jnoortheen.nix-ide: 0.5.5 -> 0.5.9 ``                                |
| [`b4f3b3e0`](https://github.com/NixOS/nixpkgs/commit/b4f3b3e04dcbe66fbd52b916bdd13c3fc587d16c) | `` python3Packages.mat2: fix tests under python 3.14 ``                                   |
| [`37e5237f`](https://github.com/NixOS/nixpkgs/commit/37e5237f7dac0bbb17911b228e4b1f5838adbe7b) | `` tageditor: 3.9.9 -> 3.9.10 ``                                                          |
| [`eb9b81b7`](https://github.com/NixOS/nixpkgs/commit/eb9b81b7d6185d26cbd0a71d3869f3aca31775b9) | `` qt6Packages.qtutilities: 6.21.0 -> 6.21.1 ``                                           |
| [`cf408430`](https://github.com/NixOS/nixpkgs/commit/cf4084302d32b96cdda33bed6afc850ab921d9aa) | `` kdePackages.plasma-wayland-protocols: 1.20.0 -> 1.21.0 ``                              |
| [`0648ef88`](https://github.com/NixOS/nixpkgs/commit/0648ef88910fcbc1935aff581bdb0f6db479552f) | `` tagparser: 12.5.2 -> 12.5.3 ``                                                         |
| [`418b97e3`](https://github.com/NixOS/nixpkgs/commit/418b97e309c61d82a3e270cc7f5584d769c9fe9f) | `` canaille: stabilize fetchpatch2 hashes ``                                              |
| [`da526453`](https://github.com/NixOS/nixpkgs/commit/da526453fc44bf086abe5356759bdd111636e051) | `` python3Packages.highdicom: stabilize fetchpatch2 hash ``                               |
| [`d4bb86d2`](https://github.com/NixOS/nixpkgs/commit/d4bb86d24ef26ac4aaa0b036a26a8ee8ff71c759) | `` sdl_gamecontrollerdb: 0-unstable-2026-04-29 -> 0-unstable-2026-05-12 ``                |
| [`ca034330`](https://github.com/NixOS/nixpkgs/commit/ca034330a94336bdea829257687fd94b8e24556a) | `` bumpp: 11.0.1 -> 11.1.0 ``                                                             |
| [`2c413d05`](https://github.com/NixOS/nixpkgs/commit/2c413d05740678d93be64aff4539a14411490fcc) | `` vscode-extensions.gitlab.gitlab-workflow: 6.75.3 -> 6.78.1 ``                          |
| [`c88511f7`](https://github.com/NixOS/nixpkgs/commit/c88511f77917ed39a00dfdb27849eb8d19f033f9) | `` ytt: 0.54.0 -> 0.55.0 ``                                                               |
| [`61343927`](https://github.com/NixOS/nixpkgs/commit/613439273eafcd38be05044322f8d41903d14dfa) | `` otel-tui: 0.7.2 -> 0.7.3 ``                                                            |
| [`370b8e27`](https://github.com/NixOS/nixpkgs/commit/370b8e27d1525219e8494d26f2c128633508f283) | `` v2ray-domain-list-community: 20260505033347 -> 20260514020130 ``                       |
| [`fc3a27e5`](https://github.com/NixOS/nixpkgs/commit/fc3a27e5878e675fd8d4044f015e3bedf0739b51) | `` python3Packages.http-sf: 1.2.0 -> 1.2.1 ``                                             |
| [`9e7f39a7`](https://github.com/NixOS/nixpkgs/commit/9e7f39a7c0466eb378314a90178be232a351ca06) | `` python3Packages.cwsandbox: init at 0.23.0 ``                                           |
| [`9cdaf9b7`](https://github.com/NixOS/nixpkgs/commit/9cdaf9b7628834f4b5b272cfe828411f2a8bcbd0) | `` copilot-language-server: 1.480.0 -> 1.487.0 ``                                         |
| [`78bcabd2`](https://github.com/NixOS/nixpkgs/commit/78bcabd2709d5eb684365356089e126d88618cd6) | `` python3Packages.pyghidra: 3.0.2 -> 3.1.0 ``                                            |
| [`01e03ca5`](https://github.com/NixOS/nixpkgs/commit/01e03ca565b82aefd7856d3d44a99c926c10ef06) | `` hidapitester: 0.5 -> 0.6 ``                                                            |
| [`b267376c`](https://github.com/NixOS/nixpkgs/commit/b267376cacbebbeb3a5013519cfa59662d8b3a4e) | `` zed-editor: 1.1.7 -> 1.2.3 ``                                                          |
| [`2b484757`](https://github.com/NixOS/nixpkgs/commit/2b484757b2a9dfa3ec7872d5c2f948e0fc1f55f8) | `` uutils-procps: 0.0.1-unstable-2026-05-01 -> 0.0.1-unstable-2026-05-13 ``               |
| [`e931463c`](https://github.com/NixOS/nixpkgs/commit/e931463c8836ebc8c70a30f0806bd323173f21aa) | `` pulseeffects-legacy: fix build ``                                                      |
| [`2f8ff5b2`](https://github.com/NixOS/nixpkgs/commit/2f8ff5b25811cf463acda39030be01e6d3397820) | `` uutils-acl: 0.0.1-unstable-2026-05-01 -> 0.0.1-unstable-2026-05-12 ``                  |
| [`b5f5db55`](https://github.com/NixOS/nixpkgs/commit/b5f5db55de169fcc927457996ec7d2c71ac165a3) | `` python3Packages.reqif: 0.0.49 -> 0.0.50 ``                                             |
| [`8a62462a`](https://github.com/NixOS/nixpkgs/commit/8a62462a67c9c30b311da868e0c66935a8a1ed09) | `` hyprland: 0.55.0 -> 0.55.1 ``                                                          |
| [`8dffa8ae`](https://github.com/NixOS/nixpkgs/commit/8dffa8aea66d3e25c47293d70d2714b5a2fb1d97) | `` web-eid-app: 2.8.0 -> 2.9.0 ``                                                         |
| [`b64244ed`](https://github.com/NixOS/nixpkgs/commit/b64244edbc0c11c9c4c73275ea7761c4710a4706) | `` wiki-go: 1.8.8 -> 1.8.9 ``                                                             |
| [`125cefdb`](https://github.com/NixOS/nixpkgs/commit/125cefdb07fc0ad888ea9467b3df3010e1a2df45) | `` bottles-unwrapped: fix vulkan detection by adding vulkan-tools ``                      |
| [`c90ae6b8`](https://github.com/NixOS/nixpkgs/commit/c90ae6b8b4ce2f02347a1ddf794ed2313cdd576d) | `` python3Packages.jupyter-server-ydoc: 2.3.0 -> 2.4.0 ``                                 |
| [`8c76429a`](https://github.com/NixOS/nixpkgs/commit/8c76429a435020c299ae3651d6166c265fb90a0a) | `` thunderkittens: 0-unstable-2026-04-29 -> 0-unstable-2026-05-11 ``                      |
| [`f9a63546`](https://github.com/NixOS/nixpkgs/commit/f9a63546e61614e86d41b1fd387cc02a202b560c) | `` fzf-zsh-plugin: 1.0.0-unstable-2026-03-03 -> 1.0.0-unstable-2026-05-06 ``              |
| [`378b6f4d`](https://github.com/NixOS/nixpkgs/commit/378b6f4dfd1f1f895631105eaecc90332a3344fe) | `` slade-unstable: 3.2.12-unstable-2026-04-27 -> 3.2.12-unstable-2026-05-08 ``            |
| [`12a87ca1`](https://github.com/NixOS/nixpkgs/commit/12a87ca1297a880789dd5176180df075bcf3a395) | `` home-assistant-custom-components.oref_alert: 6.18.1 -> 6.18.2 ``                       |
| [`06561906`](https://github.com/NixOS/nixpkgs/commit/06561906e08798f8635257b34be84a06ee09a4c2) | `` unity-test: fix clang build ``                                                         |
| [`7c8ee3e7`](https://github.com/NixOS/nixpkgs/commit/7c8ee3e7538079c8f25adbd8aa08663f7ca62ec7) | `` vscode-extensions.anthropic.claude-code: 2.1.140 -> 2.1.141 ``                         |
| [`0554c538`](https://github.com/NixOS/nixpkgs/commit/0554c538990459146d525c8a6c96eaa5ef51b02f) | `` claude-code: 2.1.140 -> 2.1.141 ``                                                     |
| [`131ea269`](https://github.com/NixOS/nixpkgs/commit/131ea269087074822611d0d82fc5442e7f385331) | `` oh-my-posh: 29.12.0 -> 29.13.1 ``                                                      |
| [`ede12b87`](https://github.com/NixOS/nixpkgs/commit/ede12b87a906213ce4ed74865fe506c42bd8c749) | `` flashmq: 1.26.1 -> 1.26.2 ``                                                           |
| [`6b0df07f`](https://github.com/NixOS/nixpkgs/commit/6b0df07fa7d59452baa47066934841a19bfc2ed2) | `` kanidm_1_10: 1.10.1 -> 1.10.2 ``                                                       |
| [`3a965d09`](https://github.com/NixOS/nixpkgs/commit/3a965d0941ec786acfdea366148bddb0792ac2f7) | `` kanidm_1_9: 1.9.3 -> 1.9.4 ``                                                          |
| [`d6afc0fc`](https://github.com/NixOS/nixpkgs/commit/d6afc0fc97a7c88ab55f5e48da81c523840c298b) | `` circumflex: 4.0 -> 4.1 ``                                                              |
| [`83ebb801`](https://github.com/NixOS/nixpkgs/commit/83ebb8014fdb7ce0a7b61fa81e6b19f89eb8193f) | `` pantheon.gala: 8.5.0 -> 8.5.1 ``                                                       |
| [`5b82a034`](https://github.com/NixOS/nixpkgs/commit/5b82a03445b7aad96b791d5f8634538428c39313) | `` chiri: 0.8.0 -> 0.8.1 ``                                                               |
| [`6357c90c`](https://github.com/NixOS/nixpkgs/commit/6357c90cfa908ad7d590efcae9ae996038483bd9) | `` langgraph-cli: 0.4.25 -> 0.4.26 ``                                                     |
| [`3b4444dc`](https://github.com/NixOS/nixpkgs/commit/3b4444dc0beb0f0b95006cbc7c3d1d2a1524e35d) | `` dtop: 0.7.4 -> 0.7.6 ``                                                                |
| [`845657b2`](https://github.com/NixOS/nixpkgs/commit/845657b29d680ab3b5d1fb977f0b3840b9ea7dcc) | `` flexget: 3.19.16 -> 3.19.17 ``                                                         |
| [`edf61b9a`](https://github.com/NixOS/nixpkgs/commit/edf61b9acb835a4bd455822b370fc9189f9e6404) | `` ovito: 3.15.2 -> 3.15.4 ``                                                             |
| [`ba6e5008`](https://github.com/NixOS/nixpkgs/commit/ba6e50088e790a0d73a303243476059b9eae0cdf) | `` python3Packages.homematicip: 2.9.0 -> 2.11.0 ``                                        |
| [`23bb500a`](https://github.com/NixOS/nixpkgs/commit/23bb500a1b433fa26d98fc844ac6522647fb0427) | `` nnd: 0.73 -> 0.74 ``                                                                   |
| [`eb8143a5`](https://github.com/NixOS/nixpkgs/commit/eb8143a5be09353ba4ab4bd19a85c78e40931b92) | `` talhelper: 3.1.9 -> 3.1.10 ``                                                          |
| [`9ccfca52`](https://github.com/NixOS/nixpkgs/commit/9ccfca520b9a439f3fb14f926d6f511c3844a5a2) | `` runpodctl: 2.2.0 -> 2.3.0 ``                                                           |
| [`30aa1629`](https://github.com/NixOS/nixpkgs/commit/30aa16295f49deea44bee947552d9ddf9a11d2a1) | `` home-assistant-custom-lovelace-modules.horizon-card: fix entrypoint ``                 |
| [`ce8b542d`](https://github.com/NixOS/nixpkgs/commit/ce8b542d33a09e3fa40598ec8a759f2348d4a5da) | `` python3Packages.copier: 9.15.0 -> 9.15.1 ``                                            |
| [`b8669052`](https://github.com/NixOS/nixpkgs/commit/b8669052e486881f9d4920fdf08e040d51fdb1ce) | `` various: migrate to pkgs/by-name ``                                                    |
| [`d44ee59e`](https://github.com/NixOS/nixpkgs/commit/d44ee59e860a137261ea304e4e6168f26f989a0a) | `` various: convert some callPackage uses in all-packages.nix to overrides ``             |
| [`03c6dfdf`](https://github.com/NixOS/nixpkgs/commit/03c6dfdfa0ddb20bf72243e54335e4ebd2b9160b) | `` grpc-client-cli: 1.24.3 -> 1.24.4 ``                                                   |
| [`01d17016`](https://github.com/NixOS/nixpkgs/commit/01d170164d9f0c8c1b64bb6a4e36aa263c3233ea) | `` buildEnv: use concatMap, avoid piping ``                                               |
| [`e9b4b40d`](https://github.com/NixOS/nixpkgs/commit/e9b4b40df78ad55c9dec4635ed1c5b527495777f) | `` pcre: migrate to pkgs/by-name ``                                                       |
| [`4b9182f6`](https://github.com/NixOS/nixpkgs/commit/4b9182f6376eb1ff8ec32e09ac3eff97cc4f94ee) | `` zsnes2: 2.1.0 -> 2.1.1 ``                                                              |
| [`55e3a8bb`](https://github.com/NixOS/nixpkgs/commit/55e3a8bb622db058d79f87bc19b3cf0b0f830e7d) | `` python3Packages.kestra: 1.2.0 -> 1.3.0 ``                                              |
| [`8d353626`](https://github.com/NixOS/nixpkgs/commit/8d35362651e9c08f57cac421e31756dc2c9c79f3) | `` nix: fix withMimalloc ``                                                               |
| [`b24dfb93`](https://github.com/NixOS/nixpkgs/commit/b24dfb93d1ca27afb4f896483cef35a8084f9624) | `` python3Packages.pydantic-ai-slim: 1.95.0 -> 1.95.1 ``                                  |
| [`b59456b1`](https://github.com/NixOS/nixpkgs/commit/b59456b166dc079f13c22e4d5bb14be1cdbfd4bd) | `` cpm-cmake: 0.42.1 -> 0.42.3 ``                                                         |
| [`80224151`](https://github.com/NixOS/nixpkgs/commit/8022415151c79352b5d34f52dd04c8daeefca259) | `` python3Packages.pydantic-graph: 1.95.0 -> 1.95.1 ``                                    |
| [`4322b22a`](https://github.com/NixOS/nixpkgs/commit/4322b22aa2d753f638817fd4678a011f6fe187c5) | `` wasm-bindgen-cli: enable __structuredAttrs ``                                          |
| [`5a71c7cd`](https://github.com/NixOS/nixpkgs/commit/5a71c7cdef40248a52ff95350e4853095d2fd9eb) | `` zfs_2_3: 2.3.6 -> 2.3.7 ``                                                             |
| [`3b309571`](https://github.com/NixOS/nixpkgs/commit/3b309571891dd7985f32b2c1b755aead316ebe08) | `` zfs_2_4: 2.4.1 -> 2.4.2 ``                                                             |
| [`ff5cca89`](https://github.com/NixOS/nixpkgs/commit/ff5cca89acf5340d493e2fa9d841201e6cfc2e4f) | `` python3Packages.sentry-sdk: 2.59.0 -> 2.60.0 ``                                        |
| [`c2fbcba7`](https://github.com/NixOS/nixpkgs/commit/c2fbcba7596d4feea84e360900605c1c754e6e08) | `` python3Packages.imap-tools: 1.12.1 -> 1.13.0 ``                                        |
| [`b1845cf9`](https://github.com/NixOS/nixpkgs/commit/b1845cf91fb2cc413207372930ed008873286892) | `` wasm-bindgen-cli: 0.2.117 -> 0.2.121 ``                                                |
| [`05abc40d`](https://github.com/NixOS/nixpkgs/commit/05abc40d459c5d23d12e2e0d13bdf0594d846d1d) | `` wasm-bindgen-cli_0_2_121: init at 0.2.121 ``                                           |
| [`13e7331a`](https://github.com/NixOS/nixpkgs/commit/13e7331a5f679455d5b6d7f788dec2cf0e8b5589) | `` python3Packages.pynetbox: 7.6.1 -> 7.7.0 ``                                            |
| [`f183eb1a`](https://github.com/NixOS/nixpkgs/commit/f183eb1a2403f89824fb75de2191b4c712db50f3) | `` nixos/tor: Remove IFD from key reading function ``                                     |
| [`4b45e5c7`](https://github.com/NixOS/nixpkgs/commit/4b45e5c778fab0f68932d649ad391401a8986d17) | `` nixosTests.zfs: Test installer with systemd stage 1 ``                                 |
| [`f165a42e`](https://github.com/NixOS/nixpkgs/commit/f165a42ec0ce7c7542542e058e4a019dff36df74) | `` nixosTests.zfs: Fix broken tests ``                                                    |
| [`10d3bafe`](https://github.com/NixOS/nixpkgs/commit/10d3bafe233aeebd8811731885b6c6ecbf603b14) | `` openzwave: drop ``                                                                     |
| [`07373fb3`](https://github.com/NixOS/nixpkgs/commit/07373fb303af60a17e203c23f5b8aab2a94f34b7) | `` python3Packages.python-openzwave: drop ``                                              |
| [`59a76463`](https://github.com/NixOS/nixpkgs/commit/59a764634d522057ec9d1992308060bbd8b09b11) | `` secretspec: 0.8.2 -> 0.10.1 ``                                                         |
| [`d011285c`](https://github.com/NixOS/nixpkgs/commit/d011285c5a3add26f79064aa312a7eb66bbf5127) | `` nodejs_22: 22.22.2 -> 22.22.3 ``                                                       |
| [`3e77b27f`](https://github.com/NixOS/nixpkgs/commit/3e77b27f7e62301c01413490cec4380221eebedd) | `` python3Packages.boto3-stubs: 1.43.6 -> 1.43.7 ``                                       |
| [`47c5dd57`](https://github.com/NixOS/nixpkgs/commit/47c5dd575bcaad6a2ff1279f61a7b65305ed2945) | `` nixos/tests/nginx-etag: fix aarch64-linux compat ``                                    |
| [`975f58e0`](https://github.com/NixOS/nixpkgs/commit/975f58e0d12c8c89f61b6faaeae77bcf6ea0e061) | `` python3Packages.mypy-boto3-stepfunctions: 1.43.0 -> 1.43.7 ``                          |
| [`9c06eeee`](https://github.com/NixOS/nixpkgs/commit/9c06eeeeb1aedc6d5e192bebf307799dec2f3bc1) | `` python3Packages.mypy-boto3-sagemaker: 1.43.5 -> 1.43.7 ``                              |
| [`7b78c5fe`](https://github.com/NixOS/nixpkgs/commit/7b78c5fe48bf869c4a4374f2b5ecd798b01a3bc3) | `` python3Packages.mypy-boto3-redshift: 1.43.0 -> 1.43.7 ``                               |
| [`dcbd5e85`](https://github.com/NixOS/nixpkgs/commit/dcbd5e852c93f7ff2351c2240487248af7016689) | `` python3Packages.mypy-boto3-quicksight: 1.43.2 -> 1.43.7 ``                             |
| [`4e81b5fb`](https://github.com/NixOS/nixpkgs/commit/4e81b5fb80a0299b7e4769ee481cbfd946366e54) | `` python3Packages.mypy-boto3-opensearch: 1.43.4 -> 1.43.7 ``                             |
| [`1e36d453`](https://github.com/NixOS/nixpkgs/commit/1e36d4531bc14cebea57431292c59a29734e6e17) | `` python3Packages.mypy-boto3-lightsail: 1.43.0 -> 1.43.7 ``                              |
| [`e036a264`](https://github.com/NixOS/nixpkgs/commit/e036a26445f8547ce86cc55022ca5850e14d3abc) | `` python3Packages.mypy-boto3-glue: 1.43.5 -> 1.43.7 ``                                   |
| [`250601b2`](https://github.com/NixOS/nixpkgs/commit/250601b27679fd8f6151f22bbd98ba19e97c31b2) | `` python3Packages.mypy-boto3-es: 1.43.0 -> 1.43.7 ``                                     |
| [`431ba0e4`](https://github.com/NixOS/nixpkgs/commit/431ba0e4dec26c9c7e8747c03e8b8e83e7fd386a) | `` python3Packages.mypy-boto3-ec2: 1.43.6 -> 1.43.7 ``                                    |
| [`a4409757`](https://github.com/NixOS/nixpkgs/commit/a440975718312e005a7657ffc1f3f746079b17b4) | `` python3Packages.mypy-boto3-connectcases: 1.43.0 -> 1.43.7 ``                           |
| [`19c13979`](https://github.com/NixOS/nixpkgs/commit/19c13979d2bef052ab06948cf4f8b8ad602ed6b8) | `` python3Packages.mypy-boto3-connect: 1.43.0 -> 1.43.7 ``                                |
| [`34639e71`](https://github.com/NixOS/nixpkgs/commit/34639e71e03c51b609f08d9ca38035402d41d473) | `` python3Packages.mypy-boto3-billingconductor: 1.43.0 -> 1.43.7 ``                       |
| [`35889a4a`](https://github.com/NixOS/nixpkgs/commit/35889a4a72bc83083bb29f67fda7a54e9f8272e0) | `` python3Packages.mypy-boto3-batch: 1.43.0 -> 1.43.7 ``                                  |
| [`f69daf75`](https://github.com/NixOS/nixpkgs/commit/f69daf75e71a98aa0faf35ae143afd6ae3aa8edb) | `` various: move to pkgs/by-name ``                                                       |
| [`0102d452`](https://github.com/NixOS/nixpkgs/commit/0102d452a3615f9de6753a7e9350da534870837f) | `` ob-xf: set strictDeps and __structuredAttrs ``                                         |
| [`504fdfe0`](https://github.com/NixOS/nixpkgs/commit/504fdfe0f542ddad237708b7112a7d500e67298b) | `` tmuxPlugins: set __structuredAttrs = true; ``                                          |
| [`617eac4c`](https://github.com/NixOS/nixpkgs/commit/617eac4cdc7f340aa41f0d82c1681785606ea89f) | `` python3Packages.supabase: fix meta.description typo ``                                 |
| [`12046cc4`](https://github.com/NixOS/nixpkgs/commit/12046cc453a3870d9b05aeddb67da062580e68e7) | `` keyd: remove unused systemd dependency ``                                              |
| [`8e934730`](https://github.com/NixOS/nixpkgs/commit/8e934730aa805394cea47274b56357d258718802) | `` python3Packages.jupyterhub: disable tests that fail to connect on Darwin ``            |
| [`dbed408e`](https://github.com/NixOS/nixpkgs/commit/dbed408e8cff423af800f35dd5bbb2f924f4f5c0) | `` xdg-desktop-portal-wlr: replace systemd dependency with systemdLibs ``                 |
| [`a8244813`](https://github.com/NixOS/nixpkgs/commit/a8244813090f0b095209dba50956a4116ce869dd) | `` python3Packages.beets-alternatives: 0.14.0 -> 0.14.1 ``                                |
| [`5c9008c2`](https://github.com/NixOS/nixpkgs/commit/5c9008c2b9e9778cb814afc0a579c35638201cc6) | `` devenv: 2.1.1 -> 2.1.2 ``                                                              |
| [`a80c30e6`](https://github.com/NixOS/nixpkgs/commit/a80c30e6a50751857a838d9ad7f769632d651610) | `` nixos/stage-1: Fix inconsistency with fonts and no earlySetup ``                       |
| [`31d8f91d`](https://github.com/NixOS/nixpkgs/commit/31d8f91d1396665885b45aa7e603b89e2cd88eab) | `` meilisearch: 1.43.0 -> 1.43.1 ``                                                       |
| [`7fda83d3`](https://github.com/NixOS/nixpkgs/commit/7fda83d316291d4fafeef9ef1d83bbec0c571741) | `` Revert "nixos/console: Fix systemd-vconsole-setup" ``                                  |
| [`df5a55cc`](https://github.com/NixOS/nixpkgs/commit/df5a55cc47b1bf1618c6c7d4c8a26ef4ae8b82cc) | `` python3Packages.tencentcloud-sdk-python: 3.1.93 -> 3.1.95 ``                           |
| [`a24ff184`](https://github.com/NixOS/nixpkgs/commit/a24ff1840780bc66b589d8ddec0bff947eeeb9c7) | `` python3Packages.iamdata: 0.1.202605121 -> 0.1.202605131 ``                             |
| [`d3c9b942`](https://github.com/NixOS/nixpkgs/commit/d3c9b94215ec0bcddf9a5e8352addbd55a49c105) | `` maintainers: update email address for vuks (#51289041) ``                              |
| [`f37fda22`](https://github.com/NixOS/nixpkgs/commit/f37fda229af8a1e1e2b0bf5bda7aba31b5de9e2b) | `` ungoogled-chromium: 148.0.7778.96-1 -> 148.0.7778.167-1 ``                             |
| [`792131c5`](https://github.com/NixOS/nixpkgs/commit/792131c5c7002aca44557066168c88b106c0c661) | `` nixos/doc/rl-2405: remove dangling link to pqos-wrapper ``                             |
| [`fc62e28f`](https://github.com/NixOS/nixpkgs/commit/fc62e28f2fcbe8e1e7a0d457c58e8a5103d57572) | `` picocrypt-ng: 2.08 -> 2.09 ``                                                          |
| [`9e822089`](https://github.com/NixOS/nixpkgs/commit/9e822089b854b65dd492af3fcf7f382f56396cd1) | `` nixos/transmission: update systemd service based on upstream ``                        |
| [`dfd7b7c8`](https://github.com/NixOS/nixpkgs/commit/dfd7b7c871e3ec0fb48e3564362b91a275cbceb2) | `` nixos/doc/rl-2611: mention `programs.pqos-wrapper` removal ``                          |
| [`a13fcf3b`](https://github.com/NixOS/nixpkgs/commit/a13fcf3bd21c4f9f6f3cb0031e6a25ff6a248501) | `` nixos/pqos-wrapper: remove broken wrapper ``                                           |
| [`fd154a9e`](https://github.com/NixOS/nixpkgs/commit/fd154a9e0e3c352a6352385800696205e011f286) | `` doc/rl-2611: mention `pqos-wrapper` removal ``                                         |
| [`7cea44b8`](https://github.com/NixOS/nixpkgs/commit/7cea44b86b8f3c46701cc1da2875e343010e4e41) | `` brave: 1.90.121 -> 1.90.122 ``                                                         |
| [`cf15d20c`](https://github.com/NixOS/nixpkgs/commit/cf15d20cd7110bb5881054f5a323baa6c38926e3) | `` pgdog: 0.1.39 -> 0.1.40 ``                                                             |
| [`7610c350`](https://github.com/NixOS/nixpkgs/commit/7610c350aaf504c175800157d9e187b6cf08de2a) | `` ratty: 0.2.0 -> 0.3.0 ``                                                               |
| [`977b1c7d`](https://github.com/NixOS/nixpkgs/commit/977b1c7d4a7319fc4f815d0fe6cc77680ba3eb28) | `` pqos-wrapper: remove unmaintained package ``                                           |
| [`5c7ff687`](https://github.com/NixOS/nixpkgs/commit/5c7ff6878be024512f3acd793f9f5133ff2f6809) | `` zeroclaw: skip wiremock tests that fail in darwin sandbox ``                           |
| [`a8212a1a`](https://github.com/NixOS/nixpkgs/commit/a8212a1ab771579cf27b586867ec69a397ff836a) | `` zeroclaw-web: use patch file for api-generated.ts stub ``                              |
| [`e810c5fe`](https://github.com/NixOS/nixpkgs/commit/e810c5feb0e8730e19f6628f0c379a989fc4b4dc) | `` zeroclaw: add nixosclaw as co-maintainer ``                                            |
| [`ae5f64c4`](https://github.com/NixOS/nixpkgs/commit/ae5f64c4c974389cc02c7c1c21ab65b45bfa8516) | `` zeroclaw: 0.5.1 -> 0.7.5 ``                                                            |
| [`efc5fd4c`](https://github.com/NixOS/nixpkgs/commit/efc5fd4c8b0336100d65bb294cd275d222576199) | `` pkarr: 5.0.5 -> 6.0.0 ``                                                               |
| [`f0bd65fd`](https://github.com/NixOS/nixpkgs/commit/f0bd65fd5583d0423e887babc6827f6e271b0ac0) | `` nginxMainline: 1.29.7 -> 1.31.0 ``                                                     |
| [`562cb7f3`](https://github.com/NixOS/nixpkgs/commit/562cb7f3e87436ad01a414bd96167409d0c6bfad) | `` nginx: 1.30.0 -> 1.30.1 ``                                                             |
| [`eba989c0`](https://github.com/NixOS/nixpkgs/commit/eba989c00e047942c0a6df2e5217ba9cff3dc265) | `` python3Packages.jupyter-server: disable flaky test_execution_state on all platforms `` |
| [`7372590a`](https://github.com/NixOS/nixpkgs/commit/7372590a440726afc70784af498d99f3ed9046b7) | `` notmuch: fix darwin build ``                                                           |
| [`81e4f2eb`](https://github.com/NixOS/nixpkgs/commit/81e4f2ebb15a1c1cbec9d55f0bfd5d7861d12ab7) | `` jenkins: 2.555.1 -> 2.555.2 ``                                                         |
| [`b5612f66`](https://github.com/NixOS/nixpkgs/commit/b5612f66097582fcb1efef0111284cc6dec1811a) | `` singular: fix aarch64-darwin build ``                                                  |
| [`5402ad11`](https://github.com/NixOS/nixpkgs/commit/5402ad11deddeebc0d1721dfd135b3da36c00d44) | `` phpPackages.composer: 2.9.7 -> 2.9.8 ``                                                |
| [`cef175d5`](https://github.com/NixOS/nixpkgs/commit/cef175d5225d2a1fd9f34f01cefc3ec85c250ecf) | `` python314Packages.jaxlib: update homepage ``                                           |
| [`2059f74a`](https://github.com/NixOS/nixpkgs/commit/2059f74acd03767be9bd0149b904c6585146bb8f) | `` libz: fix dylib rpath on darwin ``                                                     |
| [`68ce3bba`](https://github.com/NixOS/nixpkgs/commit/68ce3bba239b83d35e8f44dd40f6168c55ee4642) | `` frobby: fix dylib rpath on darwin ``                                                   |
| [`7f9e77bc`](https://github.com/NixOS/nixpkgs/commit/7f9e77bc789741deeb12e9024f6ec03d07b25e73) | `` python314Packages.uarray: remove unused astunparse dependency ``                       |
| [`469aac9e`](https://github.com/NixOS/nixpkgs/commit/469aac9eccebc1c878eaf9cc1b5b12528cf08727) | `` fritzing: fix ngspice path on darwin ``                                                |
| [`f41050b1`](https://github.com/NixOS/nixpkgs/commit/f41050b1877deeb0e86017ddb40ccf06658eed08) | `` beeper: 4.2.785 -> 4.2.808 ``                                                          |
| [`653bf82c`](https://github.com/NixOS/nixpkgs/commit/653bf82c4d7758fbb5088e6fc7cfc2c1d1fab331) | `` devcontainer: 0.86.0 -> 0.87.0 ``                                                      |
| [`b8ceba86`](https://github.com/NixOS/nixpkgs/commit/b8ceba8652dc7acc94db0ebda2c2930270920708) | `` mongodb-compass: 1.49.5 -> 1.49.7 ``                                                   |
| [`0e9155c1`](https://github.com/NixOS/nixpkgs/commit/0e9155c1b818e816278c3d972316ec22ccb72290) | `` typescript-language-server: 5.1.3 -> 5.2.0 ``                                          |
| [`557eeaab`](https://github.com/NixOS/nixpkgs/commit/557eeaab332dd61aae28d7defefa97106cbe8223) | `` fflogs: 9.3.6 -> 9.3.17 ``                                                             |
| [`1aa19474`](https://github.com/NixOS/nixpkgs/commit/1aa1947487815288fa26f8b2f7cd0bf86bb20fb4) | `` lib.types: Fix biggest/smallest supported int comment ``                               |
| [`66921255`](https://github.com/NixOS/nixpkgs/commit/6692125526fe8834de3f21c243432b719f623d04) | `` python3Packages.pydo: 0.33.0 -> 0.34.0 ``                                              |
| [`c93bd4ab`](https://github.com/NixOS/nixpkgs/commit/c93bd4ab442ce10dd64c7b613fa9402368da8467) | `` python3Packages.groq: 1.2.0 -> 1.3.0 ``                                                |
| [`23a84878`](https://github.com/NixOS/nixpkgs/commit/23a848786bea609a5ab2d99d073f34c4c9d17740) | `` pocket-id: 2.6.2 -> 2.7.0 ``                                                           |
| [`978128d0`](https://github.com/NixOS/nixpkgs/commit/978128d01bcbe3adf1651c1de1ae2cdc30772bd7) | `` python3Packages.langchain: disable timing-sensitive tests ``                           |
| [`6351c0ca`](https://github.com/NixOS/nixpkgs/commit/6351c0caeaf43ac7685b6b6bb91e5c9a4cc386d8) | `` win2xcur: 0.2.0 -> 0.2.1 ``                                                            |
| [`f002d602`](https://github.com/NixOS/nixpkgs/commit/f002d602089973d1959f449c00eb6c35ba9e8176) | `` fastfetch: add enlightment support ``                                                  |
| [`5a9a35ff`](https://github.com/NixOS/nixpkgs/commit/5a9a35ff4863d2672e8ef2812257b400c5d54ed4) | `` python3Packages.transformer-engine: 2.14 -> 2.15 ``                                    |
| [`ad016daf`](https://github.com/NixOS/nixpkgs/commit/ad016daf9a28dc4384583dce5e1a6c206ee4a63a) | `` imapgoose: 0.5.2 -> 0.5.3 ``                                                           |
| [`449567c0`](https://github.com/NixOS/nixpkgs/commit/449567c05c88a04b9a78873f9ce7d81cd4b9a753) | `` fastfetch: 2.62.1 -> 2.63.1 ``                                                         |
| [`3cc30074`](https://github.com/NixOS/nixpkgs/commit/3cc30074a144e3008a08a118d16a95497267bc32) | `` terraform-providers.yandex-cloud_yandex: 0.201.0 -> 0.202.0 ``                         |
| [`dc18288e`](https://github.com/NixOS/nixpkgs/commit/dc18288e1a9a830963b372fdca1a876b3d22d5b8) | `` yaziPlugins: fix versioning scheme ``                                                  |
| [`7a181136`](https://github.com/NixOS/nixpkgs/commit/7a1811364626eb0667d619ebd75243f6db455aad) | `` yaziPlugins: update on 2026-05-13 ``                                                   |
| [`33a7bfa0`](https://github.com/NixOS/nixpkgs/commit/33a7bfa0e848173bdb1a0ecb2ec8e86705398db7) | `` yaziPlugins.updater: leverage nixpkgs-plugin-update ``                                 |
| [`7033a4c2`](https://github.com/NixOS/nixpkgs/commit/7033a4c2cc2de4598b122329ab628b1c6532105d) | `` rclone: 1.74.0 -> 1.74.1 ``                                                            |
| [`f99bb4b9`](https://github.com/NixOS/nixpkgs/commit/f99bb4b96943e250c8004434bbf32fbc192ce2cb) | `` perlPackages.YAMLSyck: 1.36 -> 1.45 ``                                                 |
| [`87098591`](https://github.com/NixOS/nixpkgs/commit/8709859128676d4a07b9829cbbbb3a91ce920b85) | `` python3Packages.langchain-aws: 1.4.5 -> 1.4.6 ``                                       |
| [`62a601c6`](https://github.com/NixOS/nixpkgs/commit/62a601c66b6c216aa91e8fa85b54d6ea6cf8f8d0) | `` mitmproxy: 12.2.2 -> 12.2.3 ``                                                         |
| [`a9db3731`](https://github.com/NixOS/nixpkgs/commit/a9db373198851c11f8f8c09617599740ef690255) | `` python3Packages.language-tool-python: 3.3.0 -> 3.3.1 ``                                |
| [`800de38b`](https://github.com/NixOS/nixpkgs/commit/800de38ba72b8ecd4531a90e4c96b701aa98d245) | `` nixos/gitea-actions-runner: set module maintainers to match package ``                 |
| [`f6962f6b`](https://github.com/NixOS/nixpkgs/commit/f6962f6b28d038f3994c74c6213f63c3c36a9a10) | `` gitea-actions-runner: add superherointj as maintainer ``                               |
| [`26792f8e`](https://github.com/NixOS/nixpkgs/commit/26792f8eb45f263bfd7b545731baef47917ad642) | `` python3Packages.urllib3-future: 2.20.902 -> 2.20.904 ``                                |
| [`a2baf7bb`](https://github.com/NixOS/nixpkgs/commit/a2baf7bb693c314782b07c5e649b41bf979eb325) | `` cudaPackages.libcusolvermp: fix build ``                                               |
| [`61b1c302`](https://github.com/NixOS/nixpkgs/commit/61b1c3028e1cf0e68d7e6a7b845af5cd055068a3) | `` jj-starship: 0.7.0 -> 0.7.1 ``                                                         |
| [`d5d80f1c`](https://github.com/NixOS/nixpkgs/commit/d5d80f1c29faa51e80f041cb3e8164d56e9bff8a) | `` k8sgpt: 0.4.32 -> 0.4.33 ``                                                            |
| [`02bcac37`](https://github.com/NixOS/nixpkgs/commit/02bcac37b37641e0988d861a233608a7cd0ebb5b) | `` kubeone: 1.13.4 -> 1.13.5 ``                                                           |
| [`f7d81ced`](https://github.com/NixOS/nixpkgs/commit/f7d81cede9004757910cc44d2e78267d490cf77c) | `` zlcompressor: 0.4.0 -> 0.5.0 ``                                                        |
| [`dbf04679`](https://github.com/NixOS/nixpkgs/commit/dbf046794801529b3c1338deea49cfa9be1407c3) | `` libdigidocpp: 4.3.0 -> 4.4.0 ``                                                        |
| [`8e03d5e6`](https://github.com/NixOS/nixpkgs/commit/8e03d5e6b5a0e49eaa2955abe43b40eb54f6f39b) | `` mpsolve: make GUI optional ``                                                          |
| [`14d90bda`](https://github.com/NixOS/nixpkgs/commit/14d90bda744de71c888c5d2eca62543ce97ed7ba) | `` mpsolve: run checks ``                                                                 |

*... and 1213 more commits (truncated)*