### PR TITLE
chore(flake/freminal): `c537ae15` -> `2947ba1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1776900868,
-        "narHash": "sha256-Pc2LDlrYFuC4OYyKzxvHbFpjKL/9ZpQ6Fyt/poFHRh4=",
+        "lastModified": 1779003747,
+        "narHash": "sha256-GsAptCo6Cp7pjL0RFw1XqGajgeOSWgFSyy7CO3dHkvM=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "c537ae15d0ec8652fa6fa7290957c7a6fc90d682",
+        "rev": "2947ba1cc229fcedc16148f11ecb398971732af2",
         "type": "github"
       },
       "original": {
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -1362,11 +1362,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -1536,11 +1536,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1776356478,
-        "narHash": "sha256-F8tgeptiO/pEewoVR94GGQCCoaEUKTCin5XHITqkwgM=",
+        "lastModified": 1777597424,
+        "narHash": "sha256-2szcq71hbF+FK4XrJa+sERYVo5rQVjPmxWjTMedLIXM=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "bd6364c9469a46d993e3877ee847f091cbe0916a",
+        "rev": "cb27f0e8312a14e144978fac6963d55897aa6dea",
         "type": "github"
       },
       "original": {
@@ -1617,11 +1617,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1776350315,
-        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
+        "lastModified": 1777519017,
+        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
+        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
         "type": "github"
       },
       "original": {
@@ -1638,11 +1638,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776568404,
-        "narHash": "sha256-Xng/brVgk+0+ggo/4xnaxb5v4lU82RxPpmFlMHXLGYg=",
+        "lastModified": 1778987862,
+        "narHash": "sha256-V3qGt9P1eJP/r/1ONablphfGiH0RP4agQhrRANpDYx8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e65c31bc66b9194a9fc5b5a9f97ac049523f9438",
+        "rev": "6f44d8874ac29806c8d5cae42bf8e19ebb5ce0d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`c3ac99ae`](https://github.com/fredsystems/freminal/commit/c3ac99ae6352d6cf17d45d570faf91c10e8e15b7) | `` update flakes ``                                                                    |
| [`379f68af`](https://github.com/fredsystems/freminal/commit/379f68afa77735c4109164403ad15ceacad5da01) | `` update cargo deps ``                                                                |
| [`56599469`](https://github.com/fredsystems/freminal/commit/56599469d670e686237670ae1c1e28966d81d415) | `` docs: triage bugs.txt items into v0.9.0/v0.10.0/FUTURE_PLANS ``                     |
| [`7c0a2878`](https://github.com/fredsystems/freminal/commit/7c0a2878d1e1a2547a5db77aa092c0fdbc241b5b) | `` docs(v0.8.0): mark Tasks 70 and 71 complete in plan documents ``                    |
| [`d4c21a93`](https://github.com/fredsystems/freminal/commit/d4c21a93ec345fde4b60b2906c17b3522cb75473) | `` fix(71): move first_run_complete out of config.toml into state.toml ``              |
| [`253428a0`](https://github.com/fredsystems/freminal/commit/253428a056e78eb51edf03c2c64fb4d9ea1be536) | `` fix(71): defer initial PTY spawn until after window is created ``                   |
| [`004e751f`](https://github.com/fredsystems/freminal/commit/004e751f4fd282d86c4204bb89d8aabba20872b6) | `` fix(71): surface broken layouts as a startup toast ``                               |
| [`8252da07`](https://github.com/fredsystems/freminal/commit/8252da0746ce2c63943068ba062232e30e5480c1) | `` fix(71): drain shader errors every frame, not only on subsequent window creation `` |
| [`e5ffec7c`](https://github.com/fredsystems/freminal/commit/e5ffec7c588a0df1bd659f028c6479edea5458ee) | `` fix(71): skip session restore when positional command supplied ``                   |
| [`f5d66307`](https://github.com/fredsystems/freminal/commit/f5d663076981bab318f1977cb788abf4918b9b19) | `` feat(71.20): first-run onboarding overlay ``                                        |
| [`16b28f1b`](https://github.com/fredsystems/freminal/commit/16b28f1bdb9e3bf2c19102c21f525500ce538830) | `` feat(71.19): startup layout dropdown in Settings ``                                 |
| [`ac1dfb4e`](https://github.com/fredsystems/freminal/commit/ac1dfb4ed710ff6ceb30e4c56ded9d5bb0d843f3) | `` feat(71.18): unsaved-changes guard on Settings close ``                             |
| [`e78d62e1`](https://github.com/fredsystems/freminal/commit/e78d62e19b5a0cd78d0c0510abc8cc8eac27b7d9) | `` feat(71.17): add Reload Config menu action and shared apply path ``                 |
| [`f25e8559`](https://github.com/fredsystems/freminal/commit/f25e855988edfd0ae8b991029ccd477fe9942756) | `` feat: 71.16 — cross-platform CWD readback via platform::read_cwd ``                 |
| [`459e8862`](https://github.com/fredsystems/freminal/commit/459e8862d1df13f51c9f5ae3ba62bb8e7a6c17f6) | `` feat: 71.15b — interactive recording toggle via Ctrl+Shift+R ``                     |
| [`1bf0b8d1`](https://github.com/fredsystems/freminal/commit/1bf0b8d13f3eeb34b1c8d6159343eeab6a1dfcf6) | `` refactor(71.15a): make recording handle hot-swappable ``                            |
| [`9df2d1b1`](https://github.com/fredsystems/freminal/commit/9df2d1b1eb2e9994c4515fffb0b8f7011a11c462) | `` feat(71.14): add Audio and Both bell modes ``                                       |
| [`7185c2d1`](https://github.com/fredsystems/freminal/commit/7185c2d104f1e63abb50238b388af6ebd9631785) | `` feat(71.13): add ClearScrollback keyboard action ``                                 |
| [`7130b7c3`](https://github.com/fredsystems/freminal/commit/7130b7c3827e07bb48773a5f71673f8669e63da0) | `` feat(gui): 71.12 drag-to-reorder tabs ``                                            |
| [`b7328c10`](https://github.com/fredsystems/freminal/commit/b7328c105a43df72034794064744aa07af15cea0) | `` fix(gui): release terminal focus during inline tab rename ``                        |
| [`03064de6`](https://github.com/fredsystems/freminal/commit/03064de6e49a3e30bfcf947819afae42e30f85dd) | `` docs: 71.11 — verify Task 69 search positioning fix still present ``                |
| [`d06d3c08`](https://github.com/fredsystems/freminal/commit/d06d3c087ee79895e355c1eb6f55651ef3115a65) | `` feat: 71.10 — red tint on search input when no matches ``                           |
| [`72122793`](https://github.com/fredsystems/freminal/commit/721227934927f99d372bd8f23ddc462a11729cdc) | `` feat: 71.9 — tooltips on search bar prev/next/close buttons ``                      |
| [`f020e6bc`](https://github.com/fredsystems/freminal/commit/f020e6bcc46fb943a3394acc59024abadeefef02) | `` docs: slot tentative Task 83a (Expanded Auto-Detection) into v0.10.0 ``             |
| [`430e89a8`](https://github.com/fredsystems/freminal/commit/430e89a8ff1914e45d7b9f3322055d95bc52a6cb) | `` feat: 71.7b — auto-detect plain URLs in terminal output ``                          |
| [`9bf3b1cc`](https://github.com/fredsystems/freminal/commit/9bf3b1cc99c786204e75c0be1f3228771161435b) | `` docs(plan): redesign 71.7b auto-URL detection as flatten-cache piggyback ``         |
| [`7e327327`](https://github.com/fredsystems/freminal/commit/7e327327585a129455cc0c46b8eb1e5998810f0f) | `` feat: 71.8 — case-sensitivity toggle in search bar ``                               |
| [`66df1151`](https://github.com/fredsystems/freminal/commit/66df11510ccb288f29493617c6107bb51b0d24e1) | `` feat: 71.7 — URL hover tooltip with target URL and open hint ``                     |
| [`35079d4f`](https://github.com/fredsystems/freminal/commit/35079d4f96271393f9585e3e75f9ce0d16f26801) | `` feat: 71.6 — Help menu with About, Report Issue, Keybindings ``                     |
| [`b2ca19c2`](https://github.com/fredsystems/freminal/commit/b2ca19c2a08f62647c5118f7d1ce7dda3f3b8510) | `` feat: 71.5 — Edit menu with Copy/Paste/Select All/Find ``                           |
| [`42381df9`](https://github.com/fredsystems/freminal/commit/42381df9e918e64f0a886e071de014d17302cefc) | `` feat: 71.4 — surface shader compile errors as toasts ``                             |
| [`67e69e4a`](https://github.com/fredsystems/freminal/commit/67e69e4a35f3fcb79d3be9ea65d9d5f10096ac4a) | `` feat: 71.3 — surface layout load/save failures as toasts ``                         |
| [`edb1b0b8`](https://github.com/fredsystems/freminal/commit/edb1b0b8177ce5cd47386f4d13a467ad9f21f67f) | `` feat: 71.2 — surface PTY spawn failures as toasts ``                                |
| [`6d8e451b`](https://github.com/fredsystems/freminal/commit/6d8e451bd75a090fd1e80f1d117642fe2d46b4cc) | `` feat: 71.1 — inline tab rename via double-click or RenameTab action ``              |