### PR TITLE
feat: add fish/nushell/bash shells, keybinds, yubikey fix, and misc updates

### DIFF
--- a/features/desktop/environments/hyprland/default.nix
+++ b/features/desktop/environments/hyprland/default.nix
@@ -207,6 +207,7 @@ in
             "$mainMod, E, exec, $email"
             "$mainMod, T, exec, $terminal"
             "$mainMod SHIFT, T, exec, wezterm start -- bash"
+            "$mainMod CTRL, T, exec, freminal --shell bash"
             "$mainMod, A, exec, freminal --hide-menu-bar yazi"
             "$mainMod, S, exec, ~/.config/hyprextra/scripts/idleinhibit.sh"
             "ALT, SPACE, exec, vicinae toggle"

--- a/features/desktop/environments/niri/default.nix
+++ b/features/desktop/environments/niri/default.nix
@@ -212,8 +212,7 @@ in
             "Mod+Ctrl+T".action = {
               spawn = [
                 "freminal"
-                "--"
-                "shell"
+                "--shell"
                 "bash"
               ];
             };

--- a/features/desktop/environments/niri/default.nix
+++ b/features/desktop/environments/niri/default.nix
@@ -209,6 +209,15 @@ in
               ];
             };
 
+            "Mod+Ctrl+T".action = {
+              spawn = [
+                "freminal"
+                "--"
+                "shell"
+                "bash"
+              ];
+            };
+
             "Mod+A".action = {
               spawn = [
                 "freminal"

--- a/features/desktop/yubikey/default.nix
+++ b/features/desktop/yubikey/default.nix
@@ -23,6 +23,13 @@ in
     home-manager.users = lib.genAttrs allUsers (_: {
       services.yubikey-agent.enable = true;
 
+      # home-manager's yubikey-agent module sets sshAuthSock.initialization.fish
+      # using bash parameter expansion syntax (${VAR:-default}) which fish cannot
+      # parse. Override it with valid fish syntax.
+      sshAuthSock.initialization.fish = lib.mkForce ''
+        set -x SSH_AUTH_SOCK (if test -n "$XDG_RUNTIME_DIR"; echo $XDG_RUNTIME_DIR; else; echo /run/user/(id -u); end)/yubikey-agent/yubikey-agent.sock
+      '';
+
       programs.gpg = {
         enable = true;
         settings = {

--- a/features/desktop/zed/default.nix
+++ b/features/desktop/zed/default.nix
@@ -89,6 +89,7 @@ in
           "just"
           "sql"
           "log"
+          "fish"
         ];
         mutableUserSettings = false;
         userSettings = {

--- a/features/shell/bash/default.nix
+++ b/features/shell/bash/default.nix
@@ -1,0 +1,22 @@
+{
+  user,
+  extraUsers ? [ ],
+  lib,
+  ...
+}:
+
+let
+  allUsers = [ user ] ++ extraUsers;
+in
+{
+  config = {
+    home-manager.users = lib.genAttrs allUsers (_: {
+
+      programs.bash = {
+        enable = true;
+      };
+
+      #catppuccin.bash.enable = true;
+    });
+  };
+}

--- a/features/shell/default.nix
+++ b/features/shell/default.nix
@@ -22,9 +22,9 @@ in
     ./lazygit
     ./lazynpm
     ./lsd
-    ./ohmyzsh
     ./nushell
     ./nvim
+    ./ohmyzsh
     # FIXME: pay respects appears to be fucked. It kills the terminal
     ./pay-respects
     ./starship

--- a/features/shell/default.nix
+++ b/features/shell/default.nix
@@ -14,6 +14,7 @@ in
     ./eza
     ./fastfetch
     ./fd
+    ./fish
     ./fzf
     ./gh-dash
     ./lazydocker

--- a/features/shell/default.nix
+++ b/features/shell/default.nix
@@ -25,7 +25,6 @@ in
     ./nushell
     ./nvim
     ./ohmyzsh
-    # FIXME: pay respects appears to be fucked. It kills the terminal
     ./pay-respects
     ./starship
     ./tmux

--- a/features/shell/default.nix
+++ b/features/shell/default.nix
@@ -22,6 +22,7 @@ in
     ./lazynpm
     ./lsd
     ./ohmyzsh
+    ./nushell
     ./nvim
     # FIXME: pay respects appears to be fucked. It kills the terminal
     ./pay-respects

--- a/features/shell/default.nix
+++ b/features/shell/default.nix
@@ -9,6 +9,7 @@ let
 in
 {
   imports = [
+    ./bash
     ./bat
     ./direnv
     ./eza

--- a/features/shell/direnv/default.nix
+++ b/features/shell/direnv/default.nix
@@ -12,8 +12,9 @@ in
     home-manager.users = lib.genAttrs allUsers (_: {
       programs.direnv = {
         enable = true;
+        enableBashIntegration = true;
+        enableFishIntegration = true;
         enableZshIntegration = true;
-        enableFishIntegration = false;
         # Add any additional configuration for direnv here
       };
     });

--- a/features/shell/direnv/default.nix
+++ b/features/shell/direnv/default.nix
@@ -13,7 +13,6 @@ in
       programs.direnv = {
         enable = true;
         enableBashIntegration = true;
-        enableFishIntegration = true;
         enableZshIntegration = true;
         # Add any additional configuration for direnv here
       };

--- a/features/shell/fish/default.nix
+++ b/features/shell/fish/default.nix
@@ -1,0 +1,22 @@
+{
+  user,
+  extraUsers ? [ ],
+  lib,
+  ...
+}:
+
+let
+  allUsers = [ user ] ++ extraUsers;
+in
+{
+  config = {
+    home-manager.users = lib.genAttrs allUsers (_: {
+
+      programs.fish = {
+        enable = true;
+      };
+
+      catppuccin.fish.enable = true;
+    });
+  };
+}

--- a/features/shell/nushell/default.nix
+++ b/features/shell/nushell/default.nix
@@ -1,0 +1,22 @@
+{
+  user,
+  extraUsers ? [ ],
+  lib,
+  ...
+}:
+
+let
+  allUsers = [ user ] ++ extraUsers;
+in
+{
+  config = {
+    home-manager.users = lib.genAttrs allUsers (_: {
+
+      programs.nushell = {
+        enable = true;
+      };
+
+      catppuccin.nushell.enable = true;
+    });
+  };
+}

--- a/features/shell/pay-respects/default.nix
+++ b/features/shell/pay-respects/default.nix
@@ -7,27 +7,97 @@
 }:
 let
   allUsers = [ user ] ++ extraUsers;
+  payRespectsCmd = lib.getExe pkgs.pay-respects;
 in
 {
   config = {
     home-manager.users = lib.genAttrs allUsers (_: {
-      programs.pay-respects = {
-        enable = true;
-        enableZshIntegration = false;
-      };
+      programs = {
+        nix-index = {
+          enable = true;
+          enableBashIntegration = false;
+          enableFishIntegration = false;
+          enableNushellIntegration = false;
+          enableZshIntegration = false;
+        };
 
-      # Manually add only the command_not_found_handler for zsh.
-      # The full zsh integration includes ZLE widget registration that
-      # conflicts with starship's ZLE hooks and hangs on startup.
-      programs.zsh.initContent = lib.mkOrder 1200 ''
-        function __pr_base_zsh() {
-          prefix=$(print -P "$PROMPT")
-          _PR_MODE="$1" _PR_PREFIX="$prefix" _PR_LAST_COMMAND="$2" _PR_ALIAS="`alias`" _PR_SHELL="zsh" "${lib.getExe pkgs.pay-respects}"
-        }
-        command_not_found_handler() {
-          eval $(__pr_base_zsh "cnf" "$*")
-        }
-      '';
+        pay-respects = {
+          enable = true;
+          enableZshIntegration = false;
+        };
+
+        # Inline the pay-respects zsh integration as static nix strings instead
+        # of using eval "$(pay-respects zsh --alias)". Two issues with the eval
+        # form: (1) zle -N inside an eval can trigger a ZLE redraw blocking on
+        # TTY state; (2) something in the post-init hook chain (precmd/chpwd)
+        # looks up a not-found command, invoking command_not_found_handler before
+        # the shell is fully ready, causing pay-respects to block. Fix: inline
+        # all functions statically and guard command_not_found_handler with a TTY
+        # check ([[ -t 0 && -t 1 ]]) so it only runs in a real interactive shell.
+        zsh.initContent = lib.mkOrder 1400 ''
+          alias f="__pr_main suggest"
+
+          function __pr_main() {
+            eval $(__pr_base "$1" "$(fc -ln -1)")
+          }
+
+          function __pr_base() {
+            prefix=$(print -P "$PROMPT")
+            _PR_MODE="$1" _PR_PREFIX="$prefix" _PR_LAST_COMMAND="$2" _PR_ALIAS="$(alias)" _PR_SHELL="zsh" "${payRespectsCmd}"
+          }
+
+          function __pr_inline() {
+            local input="$BUFFER"
+            local output=$(__pr_base "inline" "$input")
+            if [[ -n "$output" ]]; then
+              BUFFER="$output"
+              CURSOR=''${#BUFFER}
+            fi
+          }
+
+          function command_not_found_handler() {
+            [[ -t 0 && -t 1 ]] || return 127
+            eval $(__pr_base "cnf" "$*")
+          }
+
+          if [[ $options[zle] = on ]]; then
+            zle -N __pr_inline
+            bindkey '^X^X' __pr_inline
+          fi
+        '';
+      };
     });
+
+    # Run nix-index weekly for each user as a system timer so the database
+    # is kept fresh regardless of whether the user is logged in.
+    systemd.services = lib.listToAttrs (
+      map (u: {
+        name = "nix-index-${u}";
+        value = {
+          description = "Update nix-index database for ${u}";
+          serviceConfig = {
+            Type = "oneshot";
+            User = u;
+            ExecStart = "${lib.getExe' pkgs.nix-index "nix-index"}";
+            Nice = 19;
+            IOSchedulingClass = "idle";
+          };
+        };
+      }) allUsers
+    );
+
+    systemd.timers = lib.listToAttrs (
+      map (u: {
+        name = "nix-index-${u}";
+        value = {
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = "weekly";
+            Persistent = true;
+            RandomizedDelaySec = "4h";
+          };
+        };
+      }) allUsers
+    );
   };
 }

--- a/features/shell/pay-respects/default.nix
+++ b/features/shell/pay-respects/default.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  config,
   user,
   extraUsers ? [ ],
   lib,
@@ -72,7 +73,7 @@ in
     # is kept fresh regardless of whether the user is logged in.
     # Linux only — systemd is not available on Darwin.
   }
-  // lib.optionalAttrs pkgs.stdenv.isLinux {
+  // lib.optionalAttrs config.nixpkgs.hostPlatform.isLinux {
     systemd.services = lib.listToAttrs (
       map (u: {
         name = "nix-index-${u}";

--- a/features/shell/pay-respects/default.nix
+++ b/features/shell/pay-respects/default.nix
@@ -70,6 +70,9 @@ in
 
     # Run nix-index weekly for each user as a system timer so the database
     # is kept fresh regardless of whether the user is logged in.
+    # Linux only — systemd is not available on Darwin.
+  }
+  // lib.optionalAttrs pkgs.stdenv.isLinux {
     systemd.services = lib.listToAttrs (
       map (u: {
         name = "nix-index-${u}";

--- a/features/shell/pay-respects/default.nix
+++ b/features/shell/pay-respects/default.nix
@@ -11,13 +11,23 @@ in
 {
   config = {
     home-manager.users = lib.genAttrs allUsers (_: {
-      home.packages = with pkgs; [
-        pay-respects
-      ];
+      programs.pay-respects = {
+        enable = true;
+        enableZshIntegration = false;
+      };
 
-      # programs.pay-respects = {
-      #   enable = true;
-      # };
+      # Manually add only the command_not_found_handler for zsh.
+      # The full zsh integration includes ZLE widget registration that
+      # conflicts with starship's ZLE hooks and hangs on startup.
+      programs.zsh.initContent = lib.mkOrder 1200 ''
+        function __pr_base_zsh() {
+          prefix=$(print -P "$PROMPT")
+          _PR_MODE="$1" _PR_PREFIX="$prefix" _PR_LAST_COMMAND="$2" _PR_ALIAS="`alias`" _PR_SHELL="zsh" "${lib.getExe pkgs.pay-respects}"
+        }
+        command_not_found_handler() {
+          eval $(__pr_base_zsh "cnf" "$*")
+        }
+      '';
     });
   };
 }

--- a/features/shell/pay-respects/default.nix
+++ b/features/shell/pay-respects/default.nix
@@ -11,102 +11,66 @@ let
   payRespectsCmd = lib.getExe pkgs.pay-respects;
 in
 {
-  config = {
-    home-manager.users = lib.genAttrs allUsers (_: {
-      programs = {
-        nix-index = {
-          enable = true;
-          enableBashIntegration = false;
-          enableFishIntegration = false;
-          enableNushellIntegration = false;
-          enableZshIntegration = false;
-        };
+  # The systemd timer module only references options that exist on NixOS;
+  # nix-darwin has no `systemd` option tree, so the import itself must be
+  # conditional. `isDarwin` is a specialArg (not sourced from `config`),
+  # so referencing it here does not trigger module-system recursion.
+  imports = lib.optional (!isDarwin) ./nix-index-timer.nix;
 
-        pay-respects = {
-          enable = true;
-          enableZshIntegration = false;
-        };
-
-        # Inline the pay-respects zsh integration as static nix strings instead
-        # of using eval "$(pay-respects zsh --alias)". Two issues with the eval
-        # form: (1) zle -N inside an eval can trigger a ZLE redraw blocking on
-        # TTY state; (2) something in the post-init hook chain (precmd/chpwd)
-        # looks up a not-found command, invoking command_not_found_handler before
-        # the shell is fully ready, causing pay-respects to block. Fix: inline
-        # all functions statically and guard command_not_found_handler with a TTY
-        # check ([[ -t 0 && -t 1 ]]) so it only runs in a real interactive shell.
-        zsh.initContent = lib.mkOrder 1400 ''
-          alias f="__pr_main suggest"
-
-          function __pr_main() {
-            eval $(__pr_base "$1" "$(fc -ln -1)")
-          }
-
-          function __pr_base() {
-            prefix=$(print -P "$PROMPT")
-            _PR_MODE="$1" _PR_PREFIX="$prefix" _PR_LAST_COMMAND="$2" _PR_ALIAS="$(alias)" _PR_SHELL="zsh" "${payRespectsCmd}"
-          }
-
-          function __pr_inline() {
-            local input="$BUFFER"
-            local output=$(__pr_base "inline" "$input")
-            if [[ -n "$output" ]]; then
-              BUFFER="$output"
-              CURSOR=''${#BUFFER}
-            fi
-          }
-
-          function command_not_found_handler() {
-            [[ -t 0 && -t 1 ]] || return 127
-            eval $(__pr_base "cnf" "$*")
-          }
-
-          if [[ $options[zle] = on ]]; then
-            zle -N __pr_inline
-            bindkey '^X^X' __pr_inline
-          fi
-        '';
+  home-manager.users = lib.genAttrs allUsers (_: {
+    programs = {
+      nix-index = {
+        enable = true;
+        enableBashIntegration = false;
+        enableFishIntegration = false;
+        enableNushellIntegration = false;
+        enableZshIntegration = false;
       };
-    });
 
-    # Run nix-index weekly for each user as a system timer so the database
-    # is kept fresh regardless of whether the user is logged in.
-    # Linux only — systemd.services/timers behavior differs on Darwin
-    # (nix-darwin), so guard with mkIf using the specialArg isDarwin
-    # rather than reading pkgs/config from _module.args which causes
-    # infinite recursion when used at the top level of a `config` block.
-    systemd.services = lib.mkIf (!isDarwin) (
-      lib.listToAttrs (
-        map (u: {
-          name = "nix-index-${u}";
-          value = {
-            description = "Update nix-index database for ${u}";
-            serviceConfig = {
-              Type = "oneshot";
-              User = u;
-              ExecStart = "${lib.getExe' pkgs.nix-index "nix-index"}";
-              Nice = 19;
-              IOSchedulingClass = "idle";
-            };
-          };
-        }) allUsers
-      )
-    );
+      pay-respects = {
+        enable = true;
+        enableZshIntegration = false;
+      };
 
-    systemd.timers = lib.mkIf (!isDarwin) (
-      lib.listToAttrs (
-        map (u: {
-          name = "nix-index-${u}";
-          value = {
-            wantedBy = [ "timers.target" ];
-            timerConfig = {
-              OnCalendar = "weekly";
-              Persistent = true;
-              RandomizedDelaySec = "4h";
-            };
-          };
-        }) allUsers
-      )
-    );
-  };
+      # Inline the pay-respects zsh integration as static nix strings instead
+      # of using eval "$(pay-respects zsh --alias)". Two issues with the eval
+      # form: (1) zle -N inside an eval can trigger a ZLE redraw blocking on
+      # TTY state; (2) something in the post-init hook chain (precmd/chpwd)
+      # looks up a not-found command, invoking command_not_found_handler before
+      # the shell is fully ready, causing pay-respects to block. Fix: inline
+      # all functions statically and guard command_not_found_handler with a TTY
+      # check ([[ -t 0 && -t 1 ]]) so it only runs in a real interactive shell.
+      zsh.initContent = lib.mkOrder 1400 ''
+        alias f="__pr_main suggest"
+
+        function __pr_main() {
+          eval $(__pr_base "$1" "$(fc -ln -1)")
+        }
+
+        function __pr_base() {
+          prefix=$(print -P "$PROMPT")
+          _PR_MODE="$1" _PR_PREFIX="$prefix" _PR_LAST_COMMAND="$2" _PR_ALIAS="$(alias)" _PR_SHELL="zsh" "${payRespectsCmd}"
+        }
+
+        function __pr_inline() {
+          local input="$BUFFER"
+          local output=$(__pr_base "inline" "$input")
+          if [[ -n "$output" ]]; then
+            BUFFER="$output"
+            CURSOR=''${#BUFFER}
+          fi
+        }
+
+        function command_not_found_handler() {
+          [[ -t 0 && -t 1 ]] || return 127
+          eval $(__pr_base "cnf" "$*")
+        }
+
+        if [[ $options[zle] = on ]]; then
+          zle -N __pr_inline
+          bindkey '^X^X' __pr_inline
+        fi
+      '';
+    };
+  });
 }

--- a/features/shell/pay-respects/default.nix
+++ b/features/shell/pay-respects/default.nix
@@ -1,9 +1,9 @@
 {
   pkgs,
-  config,
   user,
   extraUsers ? [ ],
   lib,
+  isDarwin ? false,
   ...
 }:
 let
@@ -71,37 +71,42 @@ in
 
     # Run nix-index weekly for each user as a system timer so the database
     # is kept fresh regardless of whether the user is logged in.
-    # Linux only — systemd is not available on Darwin.
-  }
-  // lib.optionalAttrs config.nixpkgs.hostPlatform.isLinux {
-    systemd.services = lib.listToAttrs (
-      map (u: {
-        name = "nix-index-${u}";
-        value = {
-          description = "Update nix-index database for ${u}";
-          serviceConfig = {
-            Type = "oneshot";
-            User = u;
-            ExecStart = "${lib.getExe' pkgs.nix-index "nix-index"}";
-            Nice = 19;
-            IOSchedulingClass = "idle";
+    # Linux only — systemd.services/timers behavior differs on Darwin
+    # (nix-darwin), so guard with mkIf using the specialArg isDarwin
+    # rather than reading pkgs/config from _module.args which causes
+    # infinite recursion when used at the top level of a `config` block.
+    systemd.services = lib.mkIf (!isDarwin) (
+      lib.listToAttrs (
+        map (u: {
+          name = "nix-index-${u}";
+          value = {
+            description = "Update nix-index database for ${u}";
+            serviceConfig = {
+              Type = "oneshot";
+              User = u;
+              ExecStart = "${lib.getExe' pkgs.nix-index "nix-index"}";
+              Nice = 19;
+              IOSchedulingClass = "idle";
+            };
           };
-        };
-      }) allUsers
+        }) allUsers
+      )
     );
 
-    systemd.timers = lib.listToAttrs (
-      map (u: {
-        name = "nix-index-${u}";
-        value = {
-          wantedBy = [ "timers.target" ];
-          timerConfig = {
-            OnCalendar = "weekly";
-            Persistent = true;
-            RandomizedDelaySec = "4h";
+    systemd.timers = lib.mkIf (!isDarwin) (
+      lib.listToAttrs (
+        map (u: {
+          name = "nix-index-${u}";
+          value = {
+            wantedBy = [ "timers.target" ];
+            timerConfig = {
+              OnCalendar = "weekly";
+              Persistent = true;
+              RandomizedDelaySec = "4h";
+            };
           };
-        };
-      }) allUsers
+        }) allUsers
+      )
     );
   };
 }

--- a/features/shell/pay-respects/nix-index-timer.nix
+++ b/features/shell/pay-respects/nix-index-timer.nix
@@ -1,0 +1,46 @@
+# nix-index-timer.nix
+#
+# Linux-only sub-module: weekly nix-index database refresh per user.
+# Imported conditionally from ./default.nix (skipped on Darwin where the
+# `systemd` NixOS option tree does not exist on nix-darwin).
+{
+  pkgs,
+  user,
+  extraUsers ? [ ],
+  lib,
+  ...
+}:
+let
+  allUsers = [ user ] ++ extraUsers;
+in
+{
+  systemd.services = lib.listToAttrs (
+    map (u: {
+      name = "nix-index-${u}";
+      value = {
+        description = "Update nix-index database for ${u}";
+        serviceConfig = {
+          Type = "oneshot";
+          User = u;
+          ExecStart = "${lib.getExe' pkgs.nix-index "nix-index"}";
+          Nice = 19;
+          IOSchedulingClass = "idle";
+        };
+      };
+    }) allUsers
+  );
+
+  systemd.timers = lib.listToAttrs (
+    map (u: {
+      name = "nix-index-${u}";
+      value = {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = "weekly";
+          Persistent = true;
+          RandomizedDelaySec = "4h";
+        };
+      };
+    }) allUsers
+  );
+}

--- a/features/shell/starship/default.nix
+++ b/features/shell/starship/default.nix
@@ -14,6 +14,10 @@ in
 
       programs.starship = {
         enable = true;
+        enableZshIntegration = true;
+        enableFishIntegration = true;
+        enableBashIntegration = true;
+        enableNushellIntegration = true;
 
         settings = {
           "$schema" = "https://starship.rs/config-schema.json";

--- a/hosts/linux/maranello/configuration.nix
+++ b/hosts/linux/maranello/configuration.nix
@@ -30,11 +30,8 @@ in
     enable = true;
 
     local-llm.models = [
-      "qwen3-coder:latest"
-      "qwen2.5-coder:7b"
-      "qwen2.5-coder:32b"
-      "deepseek-coder-v2:latest"
-      "qwen3.5:9b"
+      "qwen3.6:latest"
+      "gemma4:latest"
     ];
   };
 

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -751,7 +751,7 @@
       };
 
       virtualHosts = {
-        "ai.fredhub.lan" = {
+        "ai.sdrhub.lan" = {
           locations."/" = {
             proxyPass = "http://192.168.31.14:8889";
           };

--- a/hosts/linux/sdrhub/html/index.html
+++ b/hosts/linux/sdrhub/html/index.html
@@ -59,6 +59,8 @@
     <h1>Welcome to Fred's ADSB Hub!</h1>
     <ul>
       <li><a href="http://search.sdrhub.lan/">Search</a></li>
+      <li><a href="http://ai.sdrhub.lan/">AI Interface (fredhub)</a></li>
+      <li><a href="http://localhost:8889/">AI Interface (local)</a></li>
       <li><a href="http://192.168.31.20/tar1090">Tar1090</a></li>
       <li><a href="http://192.168.31.20/dump978">dump978</a></li>
       <li><a href="http://192.168.31.20/graphs">Tar1090 Graphs</a></li>
@@ -68,8 +70,12 @@
       <li class="tower">
         <a href="http://192.168.31.20/acarshub">ACARS Hub</a>
       </li>
-      <li class="history"><a href="http://192.168.31.20/dozzle">Dozzle</a></li>
-      <li class="ad"><a href="http://192.168.31.20:3000">Ad Guard Home</a></li>
+      <li class="history">
+        <a href="http://192.168.31.20/dozzle">Dozzle</a>
+      </li>
+      <li class="ad">
+        <a href="http://192.168.31.20:3000">Ad Guard Home</a>
+      </li>
       <li class="computer">
         <a href="http://192.168.31.20/rackstation">Rackstation</a>
       </li>


### PR DESCRIPTION
## Summary

- **fish shell**: add `features/shell/fish` feature module
- **nushell**: add `features/shell/nushell` feature module; enable all starship shell integrations
- **bash**: add `features/shell/bash` feature module
- **yubikey**: fix `SSH_AUTH_SOCK` initialization for fish — home-manager's yubikey-agent module uses bash parameter expansion syntax (`${VAR:-default}`) which fish cannot parse; override `sshAuthSock.initialization.fish` with valid fish syntax
- **keybinds**: add `Mod+Ctrl+T` to launch freminal with bash in both hyprland and niri
- **zed**: add fish language support
- **maranello**: update local-llm models to `qwen3.6:latest` and `gemma4:latest`
- **sdrhub**: fix AI vhost hostname (`ai.fredhub.lan` → `ai.sdrhub.lan`); update index.html with AI interface links