### PR TITLE
chore(flake/nixvim): `06cace83` -> `5de0b035`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1266,11 +1266,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1778794387,
-        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -1431,11 +1431,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1778906310,
-        "narHash": "sha256-LqASEJRtLuKRBJd9051T1KMAEaYvsVrc6m64jhD6xbw=",
+        "lastModified": 1779231450,
+        "narHash": "sha256-5YgsQE2pzHw1YLiemIo55tQDWEeI7Og1n2D/X77kP2A=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "06cace835d7ee727852ac789e3dcd42fc2fd360e",
+        "rev": "5de0b035974d6281f0bab3e8ec46015c8ffbeed9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`5de0b035`](https://github.com/nix-community/nixvim/commit/5de0b035974d6281f0bab3e8ec46015c8ffbeed9) | `` flake: Update ``                                                |
| [`13ba3f7c`](https://github.com/nix-community/nixvim/commit/13ba3f7ca9da3d49e959745f6d0d1e7a662c1984) | `` plugins/jdtls: prefer vim.lsp config registration ``            |
| [`72d07973`](https://github.com/nix-community/nixvim/commit/72d07973badc9449733e4f7da2ba08e642943965) | `` plugins/lazy: allow `pkg` option in `pluginType` to be null. `` |
| [`3643cc52`](https://github.com/nix-community/nixvim/commit/3643cc52c29e3c7d28be560f70476bc1aed47e4c) | `` plugins/direnv: fix `settingsOptions` ``                        |
| [`9b28a7e6`](https://github.com/nix-community/nixvim/commit/9b28a7e6e3e6f61b114a550941abfc9fce0645cc) | `` maintainers: update generated/all-maintainers.nix ``            |
| [`13673158`](https://github.com/nix-community/nixvim/commit/1367315826ebda2bebbf896029f44ac05df523f5) | `` flake: Update ``                                                |
| [`2e60ad95`](https://github.com/nix-community/nixvim/commit/2e60ad952a9f4b0a1c275a79a1a44c8e3a088789) | `` ci: bump actions/download-artifact from 7 to 8 ``               |
| [`0d05726b`](https://github.com/nix-community/nixvim/commit/0d05726bfb060f6559f6d64c1d427f3663dba178) | `` flake: Update ``                                                |