### PR TITLE
chore(flake/catppuccin): `ec7044e1` -> `86996e2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778836894,
-        "narHash": "sha256-vZSADE7rkRw5D5BpyXf5W4/zNJ8GvqiSeFibetYNEto=",
+        "lastModified": 1779125773,
+        "narHash": "sha256-F34zmAgMQXHwvFb9SpCilX4cAIfF4+KvpzrJqnkNLJE=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "ec7044e195df9e00236190f13f573017d2771a26",
+        "rev": "86996e2c4ee6a091fddb10de56dd21a1a5972bcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                       |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`86996e2c`](https://github.com/catppuccin/nix/commit/86996e2c4ee6a091fddb10de56dd21a1a5972bcb) | `` chore(docs): update (#935) ``              |
| [`502f50d7`](https://github.com/catppuccin/nix/commit/502f50d7d7e63d05a86a2a01cc18ce2925e99997) | `` fix(vscode): correct vendor hash (#936) `` |