### PR TITLE
chore(flake/home-manager): `26aaab78` -> `bd868f76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778954430,
-        "narHash": "sha256-oaNyOr05lblaQdtbkbN1wO0b2KLIL2O1LkmwDgdQp4I=",
+        "lastModified": 1779213149,
+        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26aaab785b0bab4af60a2c42b22760fa906ef22a",
+        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`bd868f76`](https://github.com/nix-community/home-manager/commit/bd868f769a69d3b6091a1da68a75cb83a181033c) | `` nushell: create if environment variable exists ``                         |
| [`93b932fd`](https://github.com/nix-community/home-manager/commit/93b932fdbb76433467b189628729839bb8a69b85) | `` rclone: extend mount unit PATH for non-NixOS fusermount ``                |
| [`fd272ce7`](https://github.com/nix-community/home-manager/commit/fd272ce76e7d2e266f82a8dbefa2b37d1f0d2e60) | `` rclone: make requiresUnit read-only on non-systemd platforms ``           |
| [`8da35b6f`](https://github.com/nix-community/home-manager/commit/8da35b6f14b01ee8da10d24c0db4d1dcd63ad604) | `` rclone: drop unused sidecarType arg from sidecar builders ``              |
| [`6cfa655a`](https://github.com/nix-community/home-manager/commit/6cfa655a2032ad1bb502d352b5ea71f1f78ea99e) | `` rclone: clarify secrets description for both Linux and Darwin ``          |
| [`2f578ccd`](https://github.com/nix-community/home-manager/commit/2f578ccd993ec5c1af0f1d5394860bb680423a7c) | `` rclone: document macFUSE requirement and Darwin requiresUnit semantics `` |
| [`6f5d4125`](https://github.com/nix-community/home-manager/commit/6f5d41250171eea5863dedfde080939e9a31d4cc) | `` rclone tests: add Darwin serve sidecar test ``                            |
| [`13e12967`](https://github.com/nix-community/home-manager/commit/13e1296711d6db1a986cc4f7d944548599f760bd) | `` rclone: add launchd mount/serve sidecar agents for Darwin ``              |
| [`d4e01575`](https://github.com/nix-community/home-manager/commit/d4e015754e4575121d9da6373f8764b79bd8be0a) | `` rclone: add launchd config agent for Darwin ``                            |
| [`fd3a68e6`](https://github.com/nix-community/home-manager/commit/fd3a68e6405635af0922b3733185046dcec6f837) | `` rclone tests: cross-platform basic-configuration gating ``                |
| [`2b6c692c`](https://github.com/nix-community/home-manager/commit/2b6c692c954268ba6aaf46752b65e893fab74453) | `` rclone: add rclone-sidecar-wrapper derivation ``                          |
| [`f99cd3d4`](https://github.com/nix-community/home-manager/commit/f99cd3d4f4986aca800c74a9a50a221aa14e4439) | `` rclone: lift config-install script to a named derivation ``               |
| [`1060e2e1`](https://github.com/nix-community/home-manager/commit/1060e2e1708a26596e86bdc6750f30df928cbcd9) | `` rclone: parameterize mkRcloneSidecars over a value builder ``             |
| [`5df5159c`](https://github.com/nix-community/home-manager/commit/5df5159c784f05d9799c48e9768fb82251291858) | `` rclone: default cache-dir to xdg.cacheHome on Darwin ``                   |
| [`16663cb1`](https://github.com/nix-community/home-manager/commit/16663cb13826d6aa519fb8c622460e3ce2a04dc1) | `` ssh: add settings.<name>.header option ``                                 |
| [`866412a1`](https://github.com/nix-community/home-manager/commit/866412a19866b4a8e32d2306a118040afa2b840c) | `` git: use absolute paths for git-lfs in config ``                          |
| [`736c2084`](https://github.com/nix-community/home-manager/commit/736c2084ea750a049ecdbdd7ff5817d2eeeef444) | `` podman: ensure openssh is available in PATH ``                            |
| [`f968ed59`](https://github.com/nix-community/home-manager/commit/f968ed5961dc72645fbed289684a2ee3f9abf0ed) | `` syncthing: support legacy config dir ``                                   |
| [`3ee415b2`](https://github.com/nix-community/home-manager/commit/3ee415b2922c3cfd3e7c64927a720178d365f513) | `` gnome-shell: use user-themes extension ``                                 |
| [`b0e20777`](https://github.com/nix-community/home-manager/commit/b0e2077789e884d66c47274b88aca4899d28b05f) | `` eww: added improvements ``                                                |
| [`fab3fd73`](https://github.com/nix-community/home-manager/commit/fab3fd7327a0ac7a1fae5095bf140377704fac7f) | `` ssh: fix ssh `enableDefaultConfig` description ``                         |
| [`936ae1b1`](https://github.com/nix-community/home-manager/commit/936ae1b1ebcf3bb81ae6b433829c7354439101d7) | `` ssh: add RFC 42 settings option ``                                        |
| [`7519f615`](https://github.com/nix-community/home-manager/commit/7519f615df36804ef40bcb03d4114f5ec9216d40) | `` ec: init module ``                                                        |
| [`74f170c6`](https://github.com/nix-community/home-manager/commit/74f170c62d57f90e656841f1f699e6bdf40f0a24) | `` maintainers: update all-maintainers.nix ``                                |
| [`0f08a37c`](https://github.com/nix-community/home-manager/commit/0f08a37c317111c7fcb53b983c0e49bf4b7fb904) | `` ci: fix module count output ``                                            |
| [`dd71501f`](https://github.com/nix-community/home-manager/commit/dd71501fb7005264feb4de78444a2e1518cd4f66) | `` treewide: move NixOS-inherited defaults to their option definitions ``    |
| [`a2c0bcaf`](https://github.com/nix-community/home-manager/commit/a2c0bcaff4414902d1b735a1f152248b3299378d) | `` fontconfig: document defaulting behavior on NixOS ``                      |
| [`08c9d014`](https://github.com/nix-community/home-manager/commit/08c9d01457badce151aa4a983c475042d9dec018) | `` hyprland: add khaneliman maintainer ``                                    |
| [`1bc2cf3e`](https://github.com/nix-community/home-manager/commit/1bc2cf3eedfed36448e809c1cb24462df93ae242) | `` hyprland: support lua variables in settings ``                            |
| [`d918d224`](https://github.com/nix-community/home-manager/commit/d918d22422c81a5a311461b663e4f5dc8e3bf857) | `` walker: add elephant integration ``                                       |
| [`84ddd33e`](https://github.com/nix-community/home-manager/commit/84ddd33ed07a119f090a050f1b1735de64eaf0ef) | `` elephant: add module ``                                                   |
| [`355734d8`](https://github.com/nix-community/home-manager/commit/355734d876f103b6f8cd38ba853b7c7d74d2a82f) | `` treewide: remove literalExpression where unneeded ``                      |
| [`917e3469`](https://github.com/nix-community/home-manager/commit/917e3469fe37f2bcabc4f5efeb8982f657edcbf8) | `` mkFirefoxModule: allow per-extension settings force ``                    |
| [`bcb774cf`](https://github.com/nix-community/home-manager/commit/bcb774cfc3268120cd61808629f9aa7dad3750a2) | `` git-credential-keepassxc: fix misplaced parentheses ``                    |