### PR TITLE
chore(flake/darwin): `8c62fba0` -> `56c666e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                     |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`905fe609`](https://github.com/nix-darwin/nix-darwin/commit/905fe60936949d4f0ab1cb8880b217774cafa147) | `` add reverseSplitBindings option ``                       |
| [`4ec530e8`](https://github.com/nix-darwin/nix-darwin/commit/4ec530e8b5a1358ce875cf95ccbdddd7926fca4d) | `` tmux: update key binding ``                              |
| [`09b3575c`](https://github.com/nix-darwin/nix-darwin/commit/09b3575c2db953574da6a742a2727dcece2e885e) | `` Revert "tests/aerospace: adapt to new toml generator" `` |
| [`1e2d8fbb`](https://github.com/nix-darwin/nix-darwin/commit/1e2d8fbb375432a32b19bd9af8759b3f86f00541) | `` darwin-rebuild: support --log-format ``                  |
| [`a0a51c56`](https://github.com/nix-darwin/nix-darwin/commit/a0a51c56f0de06d48b862eaacf0b5f9a847a35fa) | `` nixpkgs.config: Add allowUnfreePackages option ``        |