### PR TITLE
chore(flake/nixpkgs-stable): `d7a713c0` -> `687f05a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1234,11 +1234,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
| [`dc7706d5`](https://github.com/NixOS/nixpkgs/commit/dc7706d5b3a95e7031daee26398df0535a151843) | `` vivaldi: 7.9.3970.64 -> 7.9.3970.67 ``                                                                                 |
| [`e4704809`](https://github.com/NixOS/nixpkgs/commit/e470480942475f234784228bf833c30652c651db) | `` asciinema-agg: 1.7.0 -> 1.8.1 ``                                                                                       |
| [`211bf102`](https://github.com/NixOS/nixpkgs/commit/211bf102c758d78e8040c083192ddf9f020eb37a) | `` linux_xanmod_latest: 7.0.8 -> 7.0.9 ``                                                                                 |
| [`b054dd77`](https://github.com/NixOS/nixpkgs/commit/b054dd7700261b1af6e1c0fa2051f93603fcd0ca) | `` linux_xanmod: 6.18.31 -> 6.18.32 ``                                                                                    |
| [`86e668d9`](https://github.com/NixOS/nixpkgs/commit/86e668d9b98cd07f68e29908cdc1c0af53b5a04d) | `` mailpit: disallow building nixos tests on darwin ``                                                                    |
| [`6c893f96`](https://github.com/NixOS/nixpkgs/commit/6c893f96ed9b07a75272a86cf72df04355334eca) | `` mailpit: 1.29.7 -> 1.30.0 ``                                                                                           |
| [`7ad7af81`](https://github.com/NixOS/nixpkgs/commit/7ad7af81946d55bfd3db14826c6521bf45924802) | `` spamassassin: skip the problematic test ``                                                                             |
| [`04e69f48`](https://github.com/NixOS/nixpkgs/commit/04e69f48e197846c2f7d78b14a517269935cfeb3) | `` linuxKernel.kernels.linux_zen: 7.0.8-zen1 -> 7.0.9-zen1 ``                                                             |
| [`37bf1b9b`](https://github.com/NixOS/nixpkgs/commit/37bf1b9b9c08d1181367f24393573bed1fd1f627) | `` llvmPackages_git: 23.0.0-unstable-2026-05-10 -> 23.0.0-unstable-2026-05-17 ``                                          |
| [`6c32334f`](https://github.com/NixOS/nixpkgs/commit/6c32334f99eea3be0fc484013dfd02be35631426) | `` mailpit: 1.29.6 -> 1.29.7 ``                                                                                           |
| [`df70c858`](https://github.com/NixOS/nixpkgs/commit/df70c8585c14a2990c1162d52e4faf8fa582311f) | `` sogo: 5.12.7 -> 5.12.8 ``                                                                                              |
| [`1d2c9a5a`](https://github.com/NixOS/nixpkgs/commit/1d2c9a5af222ed82bf3c5bfe90d0086e004473a8) | `` sope: 5.12.7 -> 5.12.8 ``                                                                                              |
| [`0481c95d`](https://github.com/NixOS/nixpkgs/commit/0481c95d86bfb0b31ddd7edf85af75a221654032) | `` dprint-plugins.dprint-plugin-biome: 0.12.10 -> 0.12.11 ``                                                              |
| [`c9a679eb`](https://github.com/NixOS/nixpkgs/commit/c9a679eb7750f3164b4f91741bee8cb07d4342a0) | `` linux_6_6: 6.6.139 -> 6.6.140 ``                                                                                       |
| [`188c517f`](https://github.com/NixOS/nixpkgs/commit/188c517ff30716d0825f5ff0e6592c0a254c06f8) | `` linux_6_12: 6.12.89 -> 6.12.90 ``                                                                                      |
| [`dc7706d5`](https://github.com/NixOS/nixpkgs/commit/dc7706d5b3a95e7031daee26398df0535a151843) | `` vivaldi: 7.9.3970.64 -> 7.9.3970.67 ``                                                                                 |
| [`e4704809`](https://github.com/NixOS/nixpkgs/commit/e470480942475f234784228bf833c30652c651db) | `` asciinema-agg: 1.7.0 -> 1.8.1 ``                                                                                       |
| [`211bf102`](https://github.com/NixOS/nixpkgs/commit/211bf102c758d78e8040c083192ddf9f020eb37a) | `` linux_xanmod_latest: 7.0.8 -> 7.0.9 ``                                                                                 |
| [`b054dd77`](https://github.com/NixOS/nixpkgs/commit/b054dd7700261b1af6e1c0fa2051f93603fcd0ca) | `` linux_xanmod: 6.18.31 -> 6.18.32 ``                                                                                    |
| [`86e668d9`](https://github.com/NixOS/nixpkgs/commit/86e668d9b98cd07f68e29908cdc1c0af53b5a04d) | `` mailpit: disallow building nixos tests on darwin ``                                                                    |
| [`6c893f96`](https://github.com/NixOS/nixpkgs/commit/6c893f96ed9b07a75272a86cf72df04355334eca) | `` mailpit: 1.29.7 -> 1.30.0 ``                                                                                           |
| [`7ad7af81`](https://github.com/NixOS/nixpkgs/commit/7ad7af81946d55bfd3db14826c6521bf45924802) | `` spamassassin: skip the problematic test ``                                                                             |
| [`04e69f48`](https://github.com/NixOS/nixpkgs/commit/04e69f48e197846c2f7d78b14a517269935cfeb3) | `` linuxKernel.kernels.linux_zen: 7.0.8-zen1 -> 7.0.9-zen1 ``                                                             |
| [`37bf1b9b`](https://github.com/NixOS/nixpkgs/commit/37bf1b9b9c08d1181367f24393573bed1fd1f627) | `` llvmPackages_git: 23.0.0-unstable-2026-05-10 -> 23.0.0-unstable-2026-05-17 ``                                          |
| [`6c32334f`](https://github.com/NixOS/nixpkgs/commit/6c32334f99eea3be0fc484013dfd02be35631426) | `` mailpit: 1.29.6 -> 1.29.7 ``                                                                                           |
| [`df70c858`](https://github.com/NixOS/nixpkgs/commit/df70c8585c14a2990c1162d52e4faf8fa582311f) | `` sogo: 5.12.7 -> 5.12.8 ``                                                                                              |
| [`1d2c9a5a`](https://github.com/NixOS/nixpkgs/commit/1d2c9a5af222ed82bf3c5bfe90d0086e004473a8) | `` sope: 5.12.7 -> 5.12.8 ``                                                                                              |
| [`0481c95d`](https://github.com/NixOS/nixpkgs/commit/0481c95d86bfb0b31ddd7edf85af75a221654032) | `` dprint-plugins.dprint-plugin-biome: 0.12.10 -> 0.12.11 ``                                                              |
| [`c9a679eb`](https://github.com/NixOS/nixpkgs/commit/c9a679eb7750f3164b4f91741bee8cb07d4342a0) | `` linux_6_6: 6.6.139 -> 6.6.140 ``                                                                                       |
| [`188c517f`](https://github.com/NixOS/nixpkgs/commit/188c517ff30716d0825f5ff0e6592c0a254c06f8) | `` linux_6_12: 6.12.89 -> 6.12.90 ``                                                                                      |
| [`ddb3a486`](https://github.com/NixOS/nixpkgs/commit/ddb3a486dda98196608ec20dc84e862387cb7b49) | `` linux_6_18: 6.18.31 -> 6.18.32 ``                                                                                      |
| [`b9fb458d`](https://github.com/NixOS/nixpkgs/commit/b9fb458dce9a839ff129a71c2209f54bbd4ca9fa) | `` linux_7_0: 7.0.8 -> 7.0.9 ``                                                                                           |
| [`35a9fe8b`](https://github.com/NixOS/nixpkgs/commit/35a9fe8bf381b043482a456a824f5965e191fa1e) | `` linux_testing: 7.1-rc3 -> 7.1-rc4 ``                                                                                   |
| [`bbcf1b76`](https://github.com/NixOS/nixpkgs/commit/bbcf1b76c7673e320f3ce4635acb67570b66def1) | `` github/workflows: build nixos manual on PRs targeting staging-nixos ``                                                 |
| [`f06eefe5`](https://github.com/NixOS/nixpkgs/commit/f06eefe594f750a3acf576132708ac7f8c45fe9e) | `` ci/github-script/reviewers: revoke stale review requests ``                                                            |
| [`85846548`](https://github.com/NixOS/nixpkgs/commit/858465487d05bd53b39765fb8d92ba7b7b57dd0d) | `` cinny-unwrapped: add ryand56 as maintainer ``                                                                          |
| [`562b6bb4`](https://github.com/NixOS/nixpkgs/commit/562b6bb45bb159861105b4f1adee08391ec90bc8) | `` cinny{-unwrapped,-desktop}: 4.11.1 -> 4.12.1 ``                                                                        |
| [`52fa912f`](https://github.com/NixOS/nixpkgs/commit/52fa912f18111f0dcb21f05bab73e2b73b9e8af6) | `` ci/github-script: update npm versions ``                                                                               |
| [`92b8eb82`](https://github.com/NixOS/nixpkgs/commit/92b8eb829c5d3ce62f11a9bb0d9b0b6eafe00d2c) | `` ci/github-script/check-target-branch: disable review for xanmod kernels ``                                             |
| [`b604ce27`](https://github.com/NixOS/nixpkgs/commit/b604ce274da295dd36a5b37ada6d7cf2137e30d9) | `` buildbox: 1.4.5 -> 1.4.6 ``                                                                                            |
| [`c3eca25a`](https://github.com/NixOS/nixpkgs/commit/c3eca25ab66a09c17aac0b72b45723d90abad992) | `` hath-rust: 1.16.1 -> 1.17.0 ``                                                                                         |
| [`1f66e225`](https://github.com/NixOS/nixpkgs/commit/1f66e2259f5cc0f349ccc49fc97d6552108426dc) | `` sope: 5.12.3 -> 5.12.7 ``                                                                                              |
| [`5e5775c4`](https://github.com/NixOS/nixpkgs/commit/5e5775c412b68418ef07c0b729a176db5ac731c5) | `` sogo: 5.12.4 -> 5.12.7 ``                                                                                              |
| [`2e815c21`](https://github.com/NixOS/nixpkgs/commit/2e815c214a996c58a55858111a64fc06e23526b1) | `` mattermost, mattermostLatest: 10.11.15/11.5.3 -> 10.11.17/11.7.0 ``                                                    |
| [`158d6fd4`](https://github.com/NixOS/nixpkgs/commit/158d6fd4198eede22dba0a9c8800aba0fe880af4) | `` linuxKernel.kernels.linux_zen: 7.0.7-zen2 -> 7.0.8-zen1 ``                                                             |
| [`1ed0c1de`](https://github.com/NixOS/nixpkgs/commit/1ed0c1def4f803bac2ec7bdfa00362cdec8ab220) | `` shellhub-agent: 0.21.7 -> 0.24.2 ``                                                                                    |
| [`9f31f35d`](https://github.com/NixOS/nixpkgs/commit/9f31f35dcb77e771620b3fad334070d893bce6bd) | `` shellhub-agent: 0.24.1 -> 0.21.7 ``                                                                                    |
| [`ec876583`](https://github.com/NixOS/nixpkgs/commit/ec8765834df90b3614c2377b3729fa7a62d6bf7f) | `` shellhub-agent: 0.24.0 -> 0.24.1 ``                                                                                    |
| [`4f0d3ec3`](https://github.com/NixOS/nixpkgs/commit/4f0d3ec30dfd2ea12fefca8831a405ddc443822b) | `` shellhub-agent: 0.22.0 -> 0.24.0 ``                                                                                    |
| [`cf93330f`](https://github.com/NixOS/nixpkgs/commit/cf93330f228faf339d5386c3a0e43b922af33525) | `` shellhub-agent: 0.21.5 -> 0.22.0 ``                                                                                    |
| [`6278bd4b`](https://github.com/NixOS/nixpkgs/commit/6278bd4bffa0f529f9944ffeb7cef483167d6b0a) | `` miniflux: 2.2.19 -> 2.3.0 ``                                                                                           |
| [`b79d4ea7`](https://github.com/NixOS/nixpkgs/commit/b79d4ea7be0ab18cbab7338b9faa6ecb12019d94) | `` turbo-unwrapped: 2.9.6 -> 2.9.14 ``                                                                                    |
| [`122bd60c`](https://github.com/NixOS/nixpkgs/commit/122bd60cf5c4e6c0f75df4b5ac22a935f7d10d8a) | `` libmodsecurity: 3.0.14 -> 3.0.15 ``                                                                                    |
| [`358bd2f7`](https://github.com/NixOS/nixpkgs/commit/358bd2f7e18e23fae8e3630afec67baa255a7507) | `` logseq: pin electron to electron_39 to fix plugin loading ``                                                           |
| [`71c635e7`](https://github.com/NixOS/nixpkgs/commit/71c635e7347fac07f46d48b149d17974dd7c6e80) | `` gitlab: 18.11.2 -> 18.11.3 ``                                                                                          |
| [`087f7cb9`](https://github.com/NixOS/nixpkgs/commit/087f7cb920051007d0e4bfbe112d7851cffb6438) | `` openimageio: 3.1.10.0 -> 3.1.11.0 ``                                                                                   |
| [`647a83f3`](https://github.com/NixOS/nixpkgs/commit/647a83f389392dd053b105ee851647685079f549) | `` linux_xanmod_latest: 7.0.7 -> 7.0.8 ``                                                                                 |
| [`500ab82c`](https://github.com/NixOS/nixpkgs/commit/500ab82caf01a1e6f44b11a7d9c645e306e176ef) | `` linux_xanmod: 6.18.30 -> 6.18.31 ``                                                                                    |
| [`806dc1de`](https://github.com/NixOS/nixpkgs/commit/806dc1de0d2587e0f7c71c2a8a628f20b2968817) | `` openimageio: 3.1.9.0 -> 3.1.10.0 ``                                                                                    |
| [`19c1da01`](https://github.com/NixOS/nixpkgs/commit/19c1da012be7801ebb4d5ad84c051b0903dc2be3) | `` openimageio: 3.1.7.0 -> 3.1.9.0 ``                                                                                     |
| [`69ba92a2`](https://github.com/NixOS/nixpkgs/commit/69ba92a2ed4f48a92ec569a4d9060cea46097de4) | `` workflows/pull-request-target: don't try to use secrets in pull_request context on Dependabot PRs ``                   |
| [`6a2b7142`](https://github.com/NixOS/nixpkgs/commit/6a2b7142f06ed8439c0c92428d1d36c36ceb56b7) | `` ci/github-script: npm audit fix ``                                                                                     |
| [`104b8731`](https://github.com/NixOS/nixpkgs/commit/104b87317bdc94ede0089a24e7a06e5ea37d0a78) | `` ci/github-script/prepare: fix review dismissals ``                                                                     |
| [`44614377`](https://github.com/NixOS/nixpkgs/commit/4461437716f7419781b8ab4075885d99dd9334aa) | `` .github: Bump cachix/cachix-action ``                                                                                  |
| [`851f500f`](https://github.com/NixOS/nixpkgs/commit/851f500f163044651b89c11f0e548e320ece1fb1) | `` podofo_1_0: 1.0.3 -> 1.0.4, fix CVE-2026-44348 ``                                                                      |
| [`b5ae75e5`](https://github.com/NixOS/nixpkgs/commit/b5ae75e5eddc0eceadf360206d96d471439c682a) | `` signal-desktop: 8.8.0 -> 8.9.1 ``                                                                                      |
| [`61757373`](https://github.com/NixOS/nixpkgs/commit/61757373023c0c5c05dfec93c6032c5ec9dfb1f2) | `` .github: Bump actions/create-github-app-token from 3.1.1 to 3.2.0 ``                                                   |
| [`39dc21ae`](https://github.com/NixOS/nixpkgs/commit/39dc21ae3102abb380062dbba33ef88b76d02ae1) | `` .github: Bump korthout/backport-action from 4.5.1 to 4.5.2 ``                                                          |
| [`4174b434`](https://github.com/NixOS/nixpkgs/commit/4174b4344f6892c19d66e8cc68561c2a69b1604a) | `` octodns-providers.ddns: 0.3.0 -> 0.4.0 ``                                                                              |
| [`fba23c6e`](https://github.com/NixOS/nixpkgs/commit/fba23c6e0a764837a3203756fa86a5f0924e528f) | `` nss_latest: 3.123.1 -> 3.124 ``                                                                                        |
| [`9ac7d574`](https://github.com/NixOS/nixpkgs/commit/9ac7d5748a58153df284f989a8979fc8c1472c19) | `` cloud-hypervisor: 51.1 -> 52.0 ``                                                                                      |
| [`4e903a1d`](https://github.com/NixOS/nixpkgs/commit/4e903a1db0df0825e14ea672cd46f77bda1dcb6f) | `` cloud-hypervisor: 51.0 → 51.1 ``                                                                                       |
| [`a2169fce`](https://github.com/NixOS/nixpkgs/commit/a2169fcedb767ae71a70e58d2845a8326a3da502) | `` cloud-hypervisor: 50.2 -> 51.0 ``                                                                                      |
| [`3ac6f7f1`](https://github.com/NixOS/nixpkgs/commit/3ac6f7f1fdaea9e97700885413ed20512d583bf7) | `` radicle-job: 0.5.2 -> 0.6.0 ``                                                                                         |
| [`e4afe891`](https://github.com/NixOS/nixpkgs/commit/e4afe891b85509676c1bf7fdd3fb88157fd305e1) | `` macaulay2: modified tests for aarch64 compatibility ``                                                                 |
| [`4238c8ce`](https://github.com/NixOS/nixpkgs/commit/4238c8ce3ad344990db3ffe0ea2ef6393e6b45c3) | `` zabbix72: Mark as EOL ``                                                                                               |
| [`2adf4fc9`](https://github.com/NixOS/nixpkgs/commit/2adf4fc9aa5dbc4cd7cd4af131973ed3378d4d1e) | `` brave: 1.90.121 -> 1.90.122 ``                                                                                         |
| [`013b524b`](https://github.com/NixOS/nixpkgs/commit/013b524bd6c622854a043852dd460215d465994a) | `` zabbix74: 7.4.7 -> 7.4.8 ``                                                                                            |
| [`0055368c`](https://github.com/NixOS/nixpkgs/commit/0055368c43ae594329b54e22524d3f12f64f9726) | `` zabbix: 6.0.44 -> 6.0.45 ``                                                                                            |
| [`171dba4b`](https://github.com/NixOS/nixpkgs/commit/171dba4b97e6742b9578e1b599893b7a4d53cf0c) | `` zabbix70: 7.0.23 -> 7.0.24 ``                                                                                          |
| [`9bb1c2d8`](https://github.com/NixOS/nixpkgs/commit/9bb1c2d89d586c938e3d189ff138058329bc74c3) | `` zabbix74: 7.4.6 -> 7.4.7 ``                                                                                            |
| [`f098f563`](https://github.com/NixOS/nixpkgs/commit/f098f563086126c8c4b1385d287b90aa3cdb924f) | `` zabbix: 6.0.43 -> 6.0.44 ``                                                                                            |
| [`d1169faa`](https://github.com/NixOS/nixpkgs/commit/d1169faae4e67037f4e98799b8ffdec7ebe89f45) | `` zabbix70: 7.0.22 -> 7.0.23 ``                                                                                          |
| [`7987fc2c`](https://github.com/NixOS/nixpkgs/commit/7987fc2ce730329218dd80c981c3d2f1a3aaa3bd) | `` jenkins: 2.555.1 -> 2.555.2 ``                                                                                         |
| [`9ae2bc82`](https://github.com/NixOS/nixpkgs/commit/9ae2bc82b9dbe3df73c6e3c2dd0a8c8189b138e3) | `` wasm-pack: 0.14.0 -> 0.15.0 ``                                                                                         |
| [`fd3a429a`](https://github.com/NixOS/nixpkgs/commit/fd3a429a5397a9359e310b4801d337f89f2737cc) | `` linux_5_10: 5.10.255 -> 5.10.256 ``                                                                                    |
| [`54064d4c`](https://github.com/NixOS/nixpkgs/commit/54064d4c27384d8b4ddcf523da7dfe33a066b456) | `` linux_5_15: 5.15.206 -> 5.15.207 ``                                                                                    |
| [`fe6b92ee`](https://github.com/NixOS/nixpkgs/commit/fe6b92ee67f5ff9c53cb6b5c6ca8b005b727e85d) | `` linux_6_1: 6.1.172 -> 6.1.173 ``                                                                                       |
| [`85fba605`](https://github.com/NixOS/nixpkgs/commit/85fba605db90633099dea495f2b2a2afd6abc240) | `` linux_6_6: 6.6.138 -> 6.6.139 ``                                                                                       |
| [`cd4bba43`](https://github.com/NixOS/nixpkgs/commit/cd4bba436ef50bb65d359fb60055d1c5f8068517) | `` linux_6_12: 6.12.88 -> 6.12.89 ``                                                                                      |
| [`fde7d267`](https://github.com/NixOS/nixpkgs/commit/fde7d26762e8412f0a0add0694b887ba39973e64) | `` linux_6_18: 6.18.30 -> 6.18.31 ``                                                                                      |
| [`fb6033b1`](https://github.com/NixOS/nixpkgs/commit/fb6033b118ba24be64110ca140a03cf75c87ce56) | `` linux_7_0: 7.0.7 -> 7.0.8 ``                                                                                           |
| [`5c68f5c0`](https://github.com/NixOS/nixpkgs/commit/5c68f5c07eabac8802428ae59544d7e5f5356544) | `` linuxKernel.kernels.linux_zen: 7.0.6 -> 7.0.7 ``                                                                       |
| [`9783061b`](https://github.com/NixOS/nixpkgs/commit/9783061bf1276da0d42c1deab03ef0154f8bb4ae) | `` lldpd: fix oob heap read ``                                                                                            |
| [`b02b773c`](https://github.com/NixOS/nixpkgs/commit/b02b773c3f8f995e6128e28cfa03cd42adfda35f) | `` linux_xanmod_latest: 7.0.6 -> 7.0.7 ``                                                                                 |
| [`ff5b6efd`](https://github.com/NixOS/nixpkgs/commit/ff5b6efd92153e6f0b3d81b619e5b78cfc14407d) | `` linux_xanmod: 6.18.29 -> 6.18.30 ``                                                                                    |
| [`261b1a9d`](https://github.com/NixOS/nixpkgs/commit/261b1a9db049e69ace24429c27ad6080159f5302) | `` postgresql_18: 18.3 -> 18.4 ``                                                                                         |
| [`29ad1ea1`](https://github.com/NixOS/nixpkgs/commit/29ad1ea1ef30fbd6a53de0a759b406074c353147) | `` postgresql_17: 17.9 -> 17.10 ``                                                                                        |
| [`6e1467d0`](https://github.com/NixOS/nixpkgs/commit/6e1467d03b12059a82da5f2f8f012b111dccdaa1) | `` postgresql_16: 16.13 -> 16.14 ``                                                                                       |
| [`26d2cc8f`](https://github.com/NixOS/nixpkgs/commit/26d2cc8f642cc3f9a4bc1f5ed98fc8edc546f312) | `` postgresql_15: 15.17 -> 15.18 ``                                                                                       |
| [`35f2249b`](https://github.com/NixOS/nixpkgs/commit/35f2249bc92a6777ab0f8da82195af7af493659e) | `` postgresql_14: 14.22 -> 14.23 ``                                                                                       |
| [`6df107b9`](https://github.com/NixOS/nixpkgs/commit/6df107b9a39bd8765a247fedefe72f2f17501ef8) | `` buildMozillaMach: revert macOS sdk 26.4 update and minimize patches ``                                                 |
| [`02e12dbf`](https://github.com/NixOS/nixpkgs/commit/02e12dbf32b12ff07613c0c10d2fa58e1bd26112) | `` anki: 25.09.3 -> 25.09.4 ``                                                                                            |
| [`8f7e8171`](https://github.com/NixOS/nixpkgs/commit/8f7e8171915b60fc55531651d271c29d477708ed) | `` phpPackages.composer: 2.9.7 -> 2.9.8, fix CVE-2026-45793 ``                                                            |
| [`10808cda`](https://github.com/NixOS/nixpkgs/commit/10808cdafe24e641835a74af07c31729c8510f27) | `` linux_6_12: 6.12.87 -> 6.12.88 ``                                                                                      |
| [`10e05bcf`](https://github.com/NixOS/nixpkgs/commit/10e05bcf8d6b51f53106b613e2de047c23fffb3c) | `` linux_6_18: 6.18.29 -> 6.18.30 ``                                                                                      |
| [`8d349883`](https://github.com/NixOS/nixpkgs/commit/8d3498835f44e3d0e472ef8be133c22570c54773) | `` linux_7_0: 7.0.6 -> 7.0.7 ``                                                                                           |
| [`7c4f3d90`](https://github.com/NixOS/nixpkgs/commit/7c4f3d907c0747c61d07c5fdde915ad8c22c314c) | `` grafana: 12.3.6 -> 12.3.6+security-01 ``                                                                               |
| [`ffe0f095`](https://github.com/NixOS/nixpkgs/commit/ffe0f095c053e66b9b16e8f8961d2bcf4328d5f0) | `` perlPackages.YAMLSyck: 1.36 -> 1.45 ``                                                                                 |
| [`f01a94c4`](https://github.com/NixOS/nixpkgs/commit/f01a94c44b5fb216ddc2bd9de19806d25f76663d) | `` nginxMainline: patch CVE-2026-42926, CVE-2026-40460, CVE-2026-40701, CVE-2026-42934, CVE-2026-42945, CVE-2026-42946 `` |
| [`4a904ff4`](https://github.com/NixOS/nixpkgs/commit/4a904ff44a190a211342d16408ea9702c56106b0) | `` nginxStable: patch CVE-2026-40460, CVE-2026-40701, CVE-2026-42934, CVE-2026-42945, CVE-2026-42946 ``                   |
| [`a8cfe4df`](https://github.com/NixOS/nixpkgs/commit/a8cfe4dff9097a472d3383cc004170654ecbae9c) | `` kanidm_1_10: 1.10.1 -> 1.10.2 ``                                                                                       |
| [`e6b033a4`](https://github.com/NixOS/nixpkgs/commit/e6b033a421389ad98400b8035ad1478d27fca775) | `` kanidm_1_9: 1.9.3 -> 1.9.4 ``                                                                                          |
| [`66993381`](https://github.com/NixOS/nixpkgs/commit/6699338179db98d5ddbacd42919726835c24dade) | `` zfs_2_3: 2.3.6 -> 2.3.7 ``                                                                                             |
| [`423cbdea`](https://github.com/NixOS/nixpkgs/commit/423cbdea48d1f0141d2cb8f7208dd931247cc313) | `` zfs_2_4: 2.4.1 -> 2.4.2 ``                                                                                             |
| [`451405fd`](https://github.com/NixOS/nixpkgs/commit/451405fdcf20310079bfb33d0339478c9e765551) | `` nixosTests.zfs: Test installer with systemd stage 1 ``                                                                 |
| [`f68846ad`](https://github.com/NixOS/nixpkgs/commit/f68846ad48f5884318ccd42be1edd5d727b9a686) | `` nixosTests.zfs: Fix broken tests ``                                                                                    |
| [`f09bb011`](https://github.com/NixOS/nixpkgs/commit/f09bb0119c924c15a20cc569a233f7423285f123) | `` zfs_unstable: 2.4.0 -> 2.4.1 ``                                                                                        |
| [`b5601e9b`](https://github.com/NixOS/nixpkgs/commit/b5601e9be7644d6f24ad5673c41f7467030e7a5a) | `` claude-code: fix voice mode native module load on Linux ``                                                             |
| [`5dcf984e`](https://github.com/NixOS/nixpkgs/commit/5dcf984ea13ac4a01d8ab2ebbe5d51175f9c923a) | `` vscode-extensions.anthropic.claude-code: 2.1.138 -> 2.1.140 ``                                                         |
| [`ed9dd65e`](https://github.com/NixOS/nixpkgs/commit/ed9dd65e4d7283f362b9fc911e6ecf4a4ef93e23) | `` claude-code: 2.1.138 -> 2.1.140 ``                                                                                     |
| [`0aace1a4`](https://github.com/NixOS/nixpkgs/commit/0aace1a40cc99f3fef52214ed03e09e1a7cd7030) | `` vscode-extensions.anthropic.claude-code: 2.1.133 -> 2.1.138 ``                                                         |
| [`9f10359d`](https://github.com/NixOS/nixpkgs/commit/9f10359d0fcaa4d67b2a5e59c3de0933cb7d899b) | `` claude-code: 2.1.137 -> 2.1.138 ``                                                                                     |
| [`fc200aea`](https://github.com/NixOS/nixpkgs/commit/fc200aeae2efb79966b80551e2daf025840b6644) | `` claude-code: 2.1.133 -> 2.1.137 ``                                                                                     |
| [`f97e6ff8`](https://github.com/NixOS/nixpkgs/commit/f97e6ff8666feec51531f4a59e242ee8510ac23f) | `` vscode-extensions.anthropic.claude-code: 2.1.131 -> 2.1.133 ``                                                         |
| [`a098d45f`](https://github.com/NixOS/nixpkgs/commit/a098d45fb81906cd4e282f46f8c87606f0049eee) | `` claude-code: 2.1.131 -> 2.1.133 ``                                                                                     |
| [`d801def1`](https://github.com/NixOS/nixpkgs/commit/d801def14795347c6bed16b3dc4aa461da84d975) | `` vscode-extensions.anthropic.claude-code: 2.1.128 -> 2.1.131 ``                                                         |
| [`a384fee1`](https://github.com/NixOS/nixpkgs/commit/a384fee102492d904968e87a01a156133364d7cb) | `` claude-code: 2.1.128 -> 2.1.131 ``                                                                                     |
| [`78ef1b15`](https://github.com/NixOS/nixpkgs/commit/78ef1b15cd50ad2456a6dcdea02c91b1e1c9f466) | `` frobby: fix dylib rpath on darwin ``                                                                                   |
| [`4dd95148`](https://github.com/NixOS/nixpkgs/commit/4dd9514893702031da2bbb4486f9628687bd6b8b) | `` macaulay2: init at 1.26.05 ``                                                                                          |
| [`c969219b`](https://github.com/NixOS/nixpkgs/commit/c969219b0c085df74c62eab405444f2da088562f) | `` mathicgb: init at 1.3 ``                                                                                               |
| [`531c0bcc`](https://github.com/NixOS/nixpkgs/commit/531c0bccf3409afd98357bb012672cb8e90a5cce) | `` mathic: init at 1.3 ``                                                                                                 |
| [`d8ead35c`](https://github.com/NixOS/nixpkgs/commit/d8ead35c02c3183aeb2a19d3d723846afb482db9) | `` frobby: init at 0.9.9 ``                                                                                               |
| [`36160449`](https://github.com/NixOS/nixpkgs/commit/36160449fff708bc51ff64ca82d2e6eacc31168d) | `` cohomcalg: init at 0.32 ``                                                                                             |
| [`b6b60bdf`](https://github.com/NixOS/nixpkgs/commit/b6b60bdfb755b5aebde9680a1bf3a952df86106a) | `` memtailor: init at 1.3 ``                                                                                              |
| [`a16f886f`](https://github.com/NixOS/nixpkgs/commit/a16f886f04a845389834a6046fb9a96dd6b50fc9) | `` topcom: init at 1.1.2 ``                                                                                               |
| [`d82bbff1`](https://github.com/NixOS/nixpkgs/commit/d82bbff13d110b3c8fda3e5449fd1d147bebf634) | `` maintainers: add coolcuber ``                                                                                          |
| [`a9fcac44`](https://github.com/NixOS/nixpkgs/commit/a9fcac44eae71e160c715ccc5d4221d3f9517c85) | `` _4ti2: patch in absolute patch to `which` ``                                                                           |
| [`dc033778`](https://github.com/NixOS/nixpkgs/commit/dc033778d15b99be3f684265c66230aca12134eb) | `` docker: 29.4.2 -> 29.4.3 ``                                                                                            |
| [`32d5eb2c`](https://github.com/NixOS/nixpkgs/commit/32d5eb2c16ba9d01b8bd6f6213fee8616556b892) | `` pocketbase: 0.37.4 -> 0.37.5 ``                                                                                        |
| [`e61e8c95`](https://github.com/NixOS/nixpkgs/commit/e61e8c95eb517232aba8e8e718ff9330b929bef8) | `` pocketbase: 0.37.3 -> 0.37.4 ``                                                                                        |
| [`caac2739`](https://github.com/NixOS/nixpkgs/commit/caac2739f7275bac9933afb7cd4e90da8a88d977) | `` pocketbase: 0.36.9 -> 0.37.3 ``                                                                                        |
| [`e5cbe2dc`](https://github.com/NixOS/nixpkgs/commit/e5cbe2dc2c0cdf5afc73d299ded32fc78cdb7f35) | `` pocketbase: 0.36.8 -> 0.36.9 ``                                                                                        |
| [`4c58603e`](https://github.com/NixOS/nixpkgs/commit/4c58603ef8ffcbc1516cab5fe4ced2ac91c76f12) | `` pocketbase: 0.36.7 -> 0.36.8 ``                                                                                        |
| [`1d7cbd01`](https://github.com/NixOS/nixpkgs/commit/1d7cbd013ea9ac0f371f6bcf428d35fb7775ac00) | `` pocketbase: 0.36.6 -> 0.36.7 ``                                                                                        |
| [`292050b6`](https://github.com/NixOS/nixpkgs/commit/292050b670a977036a188298121809c87a1a7812) | `` pocketbase: 0.36.5 -> 0.36.6 ``                                                                                        |
| [`21e6e1fe`](https://github.com/NixOS/nixpkgs/commit/21e6e1fe32fef4e0df82c8738b6e95b6d9d1e7c8) | `` pocketbase: 0.36.4 -> 0.36.5 ``                                                                                        |
| [`ee33a561`](https://github.com/NixOS/nixpkgs/commit/ee33a56185a88e31d3cffb6275b200d86316d924) | `` pocketbase: 0.36.2 -> 0.36.4 ``                                                                                        |
| [`3bcc03f6`](https://github.com/NixOS/nixpkgs/commit/3bcc03f675f9702800dea18372b3c3649f9bd5be) | `` pocketbase: 0.36.1 -> 0.36.2 ``                                                                                        |
| [`9c0c61ea`](https://github.com/NixOS/nixpkgs/commit/9c0c61ea634a3915dddf8aac4c63cbff5c257166) | `` pocketbase: 0.36.0 -> 0.36.1 ``                                                                                        |
| [`8537a4f9`](https://github.com/NixOS/nixpkgs/commit/8537a4f92c6cf2c42ff480ac6025811a1728e1cd) | `` pocketbase: 0.35.0 -> 0.36.0 ``                                                                                        |
| [`1282d9f2`](https://github.com/NixOS/nixpkgs/commit/1282d9f2189cc950f2440a6bbfb461e433c8a2a6) | `` pocketbase: 0.34.2 -> 0.35.0 ``                                                                                        |
| [`624ccf6e`](https://github.com/NixOS/nixpkgs/commit/624ccf6e107a617d79bfe2b25236f5ae4f56855e) | `` pocketbase: 0.34.0 -> 0.34.2 ``                                                                                        |
| [`9cbb99bc`](https://github.com/NixOS/nixpkgs/commit/9cbb99bc217055fb3675469868417143f4e7ea8d) | `` pocketbase: 0.33.0 -> 0.34.0 ``                                                                                        |
| [`d90f5075`](https://github.com/NixOS/nixpkgs/commit/d90f50751afcdd710c57cb93ef3d144e6b4d23f9) | `` thunderbird-esr-bin-unwrapped: 140.10.1esr -> 140.10.2esr ``                                                           |
| [`8944452f`](https://github.com/NixOS/nixpkgs/commit/8944452fd1285c43805fdc83d42ee6026f8df742) | `` firefox-beta-unwrapped: 150.0b9 -> 151.0b9 ``                                                                          |
| [`106fe7f8`](https://github.com/NixOS/nixpkgs/commit/106fe7f83a6eab2765673d35b7a0dbb38ec61dde) | `` gitsign: 0.15.0 -> 0.16.0 ``                                                                                           |
| [`3465bd0b`](https://github.com/NixOS/nixpkgs/commit/3465bd0b5138c3b4de03674091f777b1b414999d) | `` gitsign: 0.14.0 -> 0.15.0 ``                                                                                           |
| [`6e9e7237`](https://github.com/NixOS/nixpkgs/commit/6e9e72378ead347bf061cef3e365027b1c4ae74f) | `` gitsign: 0.13.0 -> 0.14.0 ``                                                                                           |
| [`73dcdc09`](https://github.com/NixOS/nixpkgs/commit/73dcdc09f169f78918e46c4cb31d848c7fcb8163) | `` pihole-ftl: 6.4.1 -> 6.6.1 ``                                                                                          |
| [`e7fd76c3`](https://github.com/NixOS/nixpkgs/commit/e7fd76c32fff3cf6b0efb7cf1f6a5931e7c1de14) | `` pihole-ftl: cleanup ``                                                                                                 |
| [`271780af`](https://github.com/NixOS/nixpkgs/commit/271780af9830f9eb679c36ff696a6ae1dfa0b660) | `` pihole-ftl: fix build ``                                                                                               |
| [`b30b3fc3`](https://github.com/NixOS/nixpkgs/commit/b30b3fc3dc7162ddcfa37f5a8e8220a8fe953186) | `` pihole-ftl: 6.2.3 -> 6.4.1 ``                                                                                          |
| [`ded51486`](https://github.com/NixOS/nixpkgs/commit/ded514864de8836173c1cbc48389d0dd2515bafc) | `` teleport: Use pnpm fetcherVersion 3; teleport_17: 17.7.20 -> 17.7.23; teleport_18: 18.7.2 -> 18.7.6 ``                 |
| [`16f1ee85`](https://github.com/NixOS/nixpkgs/commit/16f1ee852646fa24ac53765256604ac48a59bc96) | `` vscode-extensions.anthropic.claude-code: 2.1.123 -> 2.1.128 ``                                                         |
| [`07d96378`](https://github.com/NixOS/nixpkgs/commit/07d96378cde8a20b1574bba83f73a2b5b7a8b868) | `` claude-code: 2.1.123 -> 2.1.128 ``                                                                                     |
| [`6cdc9a56`](https://github.com/NixOS/nixpkgs/commit/6cdc9a56e04cee72ee4ca19238b777f1ae8a303f) | `` vscode-extensions.anthropic.claude-code: fix bundled binary on NixOS ``                                                |
| [`e6cff52c`](https://github.com/NixOS/nixpkgs/commit/e6cff52ccbff289243fada8e09659c42e3729201) | `` vscode-extensions.anthropic.claude-code: 2.1.121 -> 2.1.123 ``                                                         |
| [`11716129`](https://github.com/NixOS/nixpkgs/commit/117161294660044a3a4313b0a393c8563e93d37c) | `` claude-code: 2.1.121 -> 2.1.123 ``                                                                                     |
| [`f7e37599`](https://github.com/NixOS/nixpkgs/commit/f7e375998faded18d896bd77885b2307815e458a) | `` vscode-extensions.anthropic.claude-code: 2.1.119 -> 2.1.121 ``                                                         |
| [`437b1ecd`](https://github.com/NixOS/nixpkgs/commit/437b1ecd4e8e6e1dcd19517bb6753855974fd6c6) | `` claude-code: 2.1.119 -> 2.1.121 ``                                                                                     |
| [`f7674910`](https://github.com/NixOS/nixpkgs/commit/f76749105490917484b7269f1d7b1fccdf1d5885) | `` vscode-extensions.anthropic.claude-code: use platform-specific VSIXs ``                                                |
| [`7d2cb1ed`](https://github.com/NixOS/nixpkgs/commit/7d2cb1ed848a929775231a88df452af214dfceac) | `` vscode-extensions.anthropic.claude-code: 2.1.118 -> 2.1.119 ``                                                         |
| [`270ed746`](https://github.com/NixOS/nixpkgs/commit/270ed746e3644309ba69bed86ba59328349f6cb4) | `` claude-code: 2.1.118 -> 2.1.119 ``                                                                                     |
| [`fd69cfdc`](https://github.com/NixOS/nixpkgs/commit/fd69cfdc8e6cb4fd0c80af9cdb17439cb27c3a07) | `` vscode-extensions.anthropic.claude-code: 2.1.114 -> 2.1.118 ``                                                         |
| [`396e7de8`](https://github.com/NixOS/nixpkgs/commit/396e7de85040293b94e3745aa5b22847a360e3f5) | `` claude-code: 2.1.114 -> 2.1.118 ``                                                                                     |
| [`c7f74a2b`](https://github.com/NixOS/nixpkgs/commit/c7f74a2b24e136b49355adcffc76fbc037575cd7) | `` claude-code: replace npm source package with native binary dist ``                                                     |
| [`df1f35c1`](https://github.com/NixOS/nixpkgs/commit/df1f35c1be3f81e246c7ed42de2276b105238610) | `` vscode-extensions.anthropic.claude-code: 2.1.112 -> 2.1.114 ``                                                         |
| [`7d0c1e89`](https://github.com/NixOS/nixpkgs/commit/7d0c1e89e8e691e056d9fdbc09af6cbda90b1310) | `` claude-code-bin: 2.1.112 -> 2.1.114 ``                                                                                 |
| [`75701bb4`](https://github.com/NixOS/nixpkgs/commit/75701bb4088757e671bf2ee3c53ff660ab9b4d4b) | `` claude-code: 2.1.111 -> 2.1.112 ``                                                                                     |
| [`78eca6ae`](https://github.com/NixOS/nixpkgs/commit/78eca6ae61bf2703cffa3a6a4a531cc794ffb0d3) | `` vscode-extensions.anthropic.claude-code: 2.1.111 -> 2.1.112 ``                                                         |
| [`efdae85c`](https://github.com/NixOS/nixpkgs/commit/efdae85ceee9e5ab57f67999ce9b431246f285b1) | `` claude-code-bin: 2.1.111 -> 2.1.112 ``                                                                                 |
| [`1f9a40a5`](https://github.com/NixOS/nixpkgs/commit/1f9a40a55849729394822d113e3ea0d1b0da1a86) | `` claude-code,claude-code-bin: add oskarwires as maintainer ``                                                           |
| [`c583dca4`](https://github.com/NixOS/nixpkgs/commit/c583dca4b66a7834b6128eaf1ed1882a13e7ef86) | `` claude-code: 2.1.107 -> 2.1.111 ``                                                                                     |
| [`4ebd4b20`](https://github.com/NixOS/nixpkgs/commit/4ebd4b20449f8f615e6259102317a00e86785d26) | `` vscode-extensions.anthropic.claude-code: 2.1.107 -> 2.1.111 ``                                                         |
| [`38828b72`](https://github.com/NixOS/nixpkgs/commit/38828b72f0015c160e1d1dc9c3bb6a5312e36a90) | `` claude-code-bin: 2.1.107 -> 2.1.111 ``                                                                                 |
| [`8c9f962d`](https://github.com/NixOS/nixpkgs/commit/8c9f962dffca0d1fa8fd3a564479a528d0d59a6d) | `` claude-code: 2.1.104 -> 2.1.107 ``                                                                                     |
| [`12812a8a`](https://github.com/NixOS/nixpkgs/commit/12812a8a56a3969bdd198b9316da4905f9bbbdad) | `` vscode-extensions.anthropic.claude-code: 2.1.101 -> 2.1.107 ``                                                         |
| [`40c22445`](https://github.com/NixOS/nixpkgs/commit/40c22445addd37620b42eed79771ad117169d20b) | `` claude-code-bin: 2.1.104 -> 2.1.107 ``                                                                                 |
| [`dc622984`](https://github.com/NixOS/nixpkgs/commit/dc6229847df7d370ebbdad8b032f708e030a052a) | `` vscode-extensions.anthropic.claude-code: 2.1.96 -> 2.1.101 ``                                                          |
| [`dfa10a9c`](https://github.com/NixOS/nixpkgs/commit/dfa10a9c776f8569be55890c62df138329c10004) | `` claude-code-bin: 2.1.97 -> 2.1.104 ``                                                                                  |