### PR TITLE
chore(flake/home-manager): `bd868f76` -> `509ed3c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779213149,
-        "narHash": "sha256-Cf+p/T4Z3n9Sw0TiR3kQaIwQI+/hfvLJcoTzeq6yS3E=",
+        "lastModified": 1779507042,
+        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd868f769a69d3b6091a1da68a75cb83a181033c",
+        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`509ed3c6`](https://github.com/nix-community/home-manager/commit/509ed3c603349a9d43de9e2ae6613baea6bd5b34) | `` Translate using Weblate (Dutch) ``         |
| [`928d7237`](https://github.com/nix-community/home-manager/commit/928d72376949e222ea4f07b44828a55b0136422e) | `` dunst: support ordered settings ``         |
| [`374742ad`](https://github.com/nix-community/home-manager/commit/374742adb6d5102f95af65af7d52c26b530abe23) | `` maintainers: update all-maintainers.nix `` |
| [`62b325b4`](https://github.com/nix-community/home-manager/commit/62b325b47cebe02bbeb670d460e9517899091ec8) | `` fish: add SunOfLife1 as a maintainer ``    |
| [`f9be3dd4`](https://github.com/nix-community/home-manager/commit/f9be3dd495e5af37095f5385ab2f170456bffd23) | `` maintainers: add SunOfLife1 ``             |