### PR TITLE
chore(flake/nixvim): `5de0b035` -> `4503b3c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1266,11 +1266,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779259093,
+        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
         "type": "github"
       },
       "original": {
@@ -1431,11 +1431,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1779231450,
-        "narHash": "sha256-5YgsQE2pzHw1YLiemIo55tQDWEeI7Og1n2D/X77kP2A=",
+        "lastModified": 1779415812,
+        "narHash": "sha256-kNCxRBKYMzX7PC4AGiHV4MV2A0SlBvP/89LJVB/mIDs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5de0b035974d6281f0bab3e8ec46015c8ffbeed9",
+        "rev": "4503b3c5e99c825ca6055a393f1bb3c95e68ba16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4503b3c5`](https://github.com/nix-community/nixvim/commit/4503b3c5e99c825ca6055a393f1bb3c95e68ba16) | `` plugins/vectorcode: add codecompanion integration ``  |
| [`291ae38d`](https://github.com/nix-community/nixvim/commit/291ae38d9e269508f040642f6e8886de02b20690) | `` plugins/claudecode: add module ``                     |
| [`7f6f92a3`](https://github.com/nix-community/nixvim/commit/7f6f92a3c9f5e1d61d417bf761b4934ac5acc401) | `` modules/lsp/onAttach: preserve event scope ``         |
| [`28eb3600`](https://github.com/nix-community/nixvim/commit/28eb36007cfc1a28257f5674425dd3bad891d220) | `` plugins/cspell: add module ``                         |
| [`a5a46c94`](https://github.com/nix-community/nixvim/commit/a5a46c944743c6e6cab2bb65d200b148471f6797) | `` dependencies: add cspell package ``                   |
| [`3ab66a1b`](https://github.com/nix-community/nixvim/commit/3ab66a1b06d019475f666ab4de2fdecd2dc00010) | `` plugins/trailblazer: add module ``                    |
| [`8236161d`](https://github.com/nix-community/nixvim/commit/8236161d3b5b86a56d3b5af402ee6bebd147fa8f) | `` plugins/live-share: add module ``                     |
| [`0ae78399`](https://github.com/nix-community/nixvim/commit/0ae783996fae0fc4929c8293ca7411dd3b042a3f) | `` plugins/codecompanion-history: add module ``          |
| [`b2f6193e`](https://github.com/nix-community/nixvim/commit/b2f6193e4e17744dfaa858d10d59a25181b51865) | `` plugins/justice: add module ``                        |
| [`b680cf0b`](https://github.com/nix-community/nixvim/commit/b680cf0ba33a0bfc7f557c68d0464a4f6a46620c) | `` plugins/just: add module ``                           |
| [`aa6fe35c`](https://github.com/nix-community/nixvim/commit/aa6fe35cff9fa17ba9b250f2c5b96dc45653e916) | `` dependencies: add just package ``                     |
| [`60cbd020`](https://github.com/nix-community/nixvim/commit/60cbd020f6e313aac5505a7b817fe4302378b78b) | `` plugins/sioyek-highlights: add module ``              |
| [`fb7de4e7`](https://github.com/nix-community/nixvim/commit/fb7de4e724f0874a253dd1e003a618a19931695d) | `` dependencies: add sioyek package deps ``              |
| [`3169a3c5`](https://github.com/nix-community/nixvim/commit/3169a3c545929f53b3b147fcda33102b7112213a) | `` generated: Update ``                                  |
| [`79872296`](https://github.com/nix-community/nixvim/commit/798722969c5435e1fef2e5a5023696021432ff9e) | `` flake: Update ``                                      |
| [`2d7cf961`](https://github.com/nix-community/nixvim/commit/2d7cf9616bfd5b8dcf1c5e4b05a8514e6803115e) | `` plugins/vectorcode: add module ``                     |
| [`5f2f6cec`](https://github.com/nix-community/nixvim/commit/5f2f6ceccae2ed7d4004d0162e4ac2e94ad135cc) | `` dependencies: add vectorcode package ``               |
| [`d633eb62`](https://github.com/nix-community/nixvim/commit/d633eb629f7bc63718df2b28db0739980d1c46a0) | `` plugins/lsp-progress: add module ``                   |
| [`e690fa93`](https://github.com/nix-community/nixvim/commit/e690fa934f06c2c407e9f3452c86a20f19e51436) | `` plugins/neotab: add module ``                         |
| [`30e1116b`](https://github.com/nix-community/nixvim/commit/30e1116b64a04256086bc1338267e26014a7bd2b) | `` plugins/codex: add module ``                          |
| [`31613daf`](https://github.com/nix-community/nixvim/commit/31613daf8791310fcd6eede8b6377316c9711ec1) | `` dependencies: add codex package ``                    |
| [`aeec62d4`](https://github.com/nix-community/nixvim/commit/aeec62d406d1203c926a158675e9a7f06f50d1ae) | `` contributing: fix table breaking syntax ``            |
| [`cfa19cd4`](https://github.com/nix-community/nixvim/commit/cfa19cd47e2f07dff5b95c5a04268b5194d96c3f) | `` contributing: fix inaccurate suggested path ``        |
| [`50dc4dc1`](https://github.com/nix-community/nixvim/commit/50dc4dc10f91650cedfdb2eb301c3333c082081c) | `` contributing: notes about creating/testing plugin ``  |
| [`c7e82d37`](https://github.com/nix-community/nixvim/commit/c7e82d37c2ed3cbddf54e36b8a13b3518ff1dc2f) | `` modules/lsp/onAttach: handle dynamic registrations `` |
| [`cf5af328`](https://github.com/nix-community/nixvim/commit/cf5af328a35c8d61a6efd29cf2e739c14330bf07) | `` flake: Update ``                                      |
| [`42dbd9f0`](https://github.com/nix-community/nixvim/commit/42dbd9f0ea9903ad415d196ba33c8cb44e85bb7a) | `` user-configs: add @allen-liaoo's config ``            |