### PR TITLE
chore(flake/nixpkgs): `d2339023` -> `331800de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`81515c9c`](https://github.com/NixOS/nixpkgs/commit/81515c9c2e29baa8038f53d8cfd9625132750d58) | `` maintainers/github-teams.json: Automated sync ``                                                   |
| [`eeea15fb`](https://github.com/NixOS/nixpkgs/commit/eeea15fbf3240231925c9568a972599962662c80) | `` gh-gonest: init at 0-unstable-2025-12-17 ``                                                        |
| [`060ccf1e`](https://github.com/NixOS/nixpkgs/commit/060ccf1e4033fadf229bb7eee644093db8d01227) | `` mplayer: embed version, add versionCheckHook ``                                                    |
| [`35685c55`](https://github.com/NixOS/nixpkgs/commit/35685c55e8dd0bb8a4c49a9f182c862d25e42b4c) | `` mplayer: enable strictDeps and structuredAttrs ``                                                  |
| [`97950d6f`](https://github.com/NixOS/nixpkgs/commit/97950d6fecbd7018bf71d01c621d26b8f06e7892) | `` mplayer: use lib.enableFeature ``                                                                  |
| [`95aad17d`](https://github.com/NixOS/nixpkgs/commit/95aad17dc93eb4c30fdb0104312c59facfd13cc3) | `` mplayer: fix build with structuredAttrs ``                                                         |
| [`82e8d811`](https://github.com/NixOS/nixpkgs/commit/82e8d81147f9cc8921750e2fb5811830a557493a) | `` fahclient: 8.5.3 -> 8.5.6 ``                                                                       |
| [`5f81bb88`](https://github.com/NixOS/nixpkgs/commit/5f81bb887c4dda891e644d8abed1a7064145f432) | `` terraform-providers.okta_okta: 6.10.0 -> 6.11.0 ``                                                 |
| [`5230f3e0`](https://github.com/NixOS/nixpkgs/commit/5230f3e0dc760a0d3daa66bf7df8061b756cda43) | `` python3Packages.aioesphomeapi: 44.23.0 -> 44.24.1 ``                                               |
| [`ed1de9a7`](https://github.com/NixOS/nixpkgs/commit/ed1de9a708adc99e103e647b217e99b081741314) | `` python3Packages.aioesphomeapi: add version compat note ``                                          |
| [`a23a846f`](https://github.com/NixOS/nixpkgs/commit/a23a846fffb7a1f6a410cba2f43d9e417dc1259e) | `` adguardian: enable __structuredAttrs ``                                                            |
| [`9b9e0a02`](https://github.com/NixOS/nixpkgs/commit/9b9e0a021a032012a9f4fa072fcc44a1a54f8ef1) | `` nixos/kmscon: RFC42 treatment, support version 10.0.0 ``                                           |
| [`b0506757`](https://github.com/NixOS/nixpkgs/commit/b0506757dbf7cfc8609332801b0f581a05d1b80f) | `` hushboard: remove keysmashes from maintainers ``                                                   |
| [`ad2e2960`](https://github.com/NixOS/nixpkgs/commit/ad2e2960b48ba270262116b4c9cacbb4d928331a) | `` notesnook: remove keysmashes from maintainers ``                                                   |
| [`e28fcb5f`](https://github.com/NixOS/nixpkgs/commit/e28fcb5f87883f3ffb6c1d395b1f36713d823480) | `` nixos/doc: note python2 removal in 26.11 release notes ``                                          |
| [`aab86321`](https://github.com/NixOS/nixpkgs/commit/aab86321db4056d983eb2bec72450e125f60f269) | `` doc/python: drop python2 references from manual section ``                                         |
| [`34bc09dc`](https://github.com/NixOS/nixpkgs/commit/34bc09dca920b30054558948863441616cd4b069) | `` resholve: move python2-modules from oil to their folder ``                                         |
| [`574bf7de`](https://github.com/NixOS/nixpkgs/commit/574bf7de393836b40738a6443d65eabab39ec424) | `` treewide: remove isPy27 and isPy2 flags ``                                                         |
| [`cfaddae5`](https://github.com/NixOS/nixpkgs/commit/cfaddae52a3cfb8ad4362dd1a80edadbb959bda9) | `` python2: delete docs ``                                                                            |
| [`e6871d98`](https://github.com/NixOS/nixpkgs/commit/e6871d9800efed3395535a879e323b546d96feab) | `` python2: move cpython, mkPythonDerivation into resholve ``                                         |
| [`c510450a`](https://github.com/NixOS/nixpkgs/commit/c510450a30dca8cabf6f6ed480d066f9a4c797a7) | `` python2: remove from top-level ``                                                                  |
| [`a8634964`](https://github.com/NixOS/nixpkgs/commit/a86349645374aba9d6772057af03fa9fe94e4d32) | `` resholve: move python27 into its own file ``                                                       |
| [`2c87389c`](https://github.com/NixOS/nixpkgs/commit/2c87389c6f0d2833697834ea1a2003161562f12d) | `` python2-packages: move into resholve ``                                                            |
| [`5366dabe`](https://github.com/NixOS/nixpkgs/commit/5366dabecfaa57d131900918b79435f226fae038) | `` python2-packages: cleanup disabled attrs ``                                                        |
| [`761d74ba`](https://github.com/NixOS/nixpkgs/commit/761d74ba172d7e3cf64f0543ce709319557f8518) | `` Revert "python3Packages.aioesphomeapi: 44.23.0 -> 45.0.2" ``                                       |
| [`05c5c4ff`](https://github.com/NixOS/nixpkgs/commit/05c5c4ff327fe6945203f59e82af3748fb1f47e1) | `` home-assistant: construct package set with overrideScope ``                                        |
| [`e16200df`](https://github.com/NixOS/nixpkgs/commit/e16200dfea4c28e7f119710e9008c7d0132e8146) | `` rsonpath: 0.10.0 -> 0.10.1 ``                                                                      |
| [`8d818d67`](https://github.com/NixOS/nixpkgs/commit/8d818d67f78aca4a4fd095772148b19ae00e5e1f) | `` home-assistant: choose caldav_2 in component updater ``                                            |
| [`56ca2016`](https://github.com/NixOS/nixpkgs/commit/56ca20161aefcf989fdc78a1ee5f92a8e035d6f1) | `` terraform-providers.datadrivers_nexus: 2.7.1 -> 2.8.0 ``                                           |
| [`710c91cc`](https://github.com/NixOS/nixpkgs/commit/710c91cc204df5ee1e292d6fcae3983ad3d54691) | `` babl: enable strictDeps and structuredAttrs ``                                                     |
| [`dd0e79a0`](https://github.com/NixOS/nixpkgs/commit/dd0e79a00269dec86fe6a28d8512a22667e543fc) | `` nixos/tests/installer: fix clevis ZFS tests ``                                                     |
| [`b2c1ae42`](https://github.com/NixOS/nixpkgs/commit/b2c1ae428f351a55ab214de440e3e3f7b9dcbe30) | `` matcha: 0.37.0 -> 0.40.1 ``                                                                        |
| [`ba7c92db`](https://github.com/NixOS/nixpkgs/commit/ba7c92dbd89d2f3a5bd637d9f2f30171212a1bee) | `` kloak: 0.8.3-1 -> 0.8.5-1 ``                                                                       |
| [`edcd4f4e`](https://github.com/NixOS/nixpkgs/commit/edcd4f4efbd69d035ccc1a7b58dc55135128242d) | `` minizip-ng{-compat}: add kuflierl as maintainer ``                                                 |
| [`d3a32f77`](https://github.com/NixOS/nixpkgs/commit/d3a32f77d5029939b709536c4be8ed82f5511d71) | `` minizip-ng{-compat}: split compat ``                                                               |
| [`5afb67bd`](https://github.com/NixOS/nixpkgs/commit/5afb67bdacbdcd8cf32b366eea6c0c96e16ab492) | `` minizip-ng: add structuredAttrs and strictDeps ``                                                  |
| [`2a80cb20`](https://github.com/NixOS/nixpkgs/commit/2a80cb209ed8a9d0b3a18d03ff3b6185e8bf93cc) | `` sdl_gamecontrollerdb: 0-unstable-2026-05-12 -> 0-unstable-2026-05-28 ``                            |
| [`dcf83958`](https://github.com/NixOS/nixpkgs/commit/dcf839583017a638192a9cedae411d1432acc65f) | `` servo: 0.1.0 -> 0.2.0 ``                                                                           |
| [`79ecf089`](https://github.com/NixOS/nixpkgs/commit/79ecf08958d0f6bbfaf08fada07b9588cdd77641) | `` copilot-language-server: 1.495.0 -> 1.498.0 ``                                                     |
| [`cd3331e8`](https://github.com/NixOS/nixpkgs/commit/cd3331e83ccc49b5671abc91051ff1ffa6cc5f5f) | `` mieru: 3.31.0 -> 3.33.0 ``                                                                         |
| [`43fe63cd`](https://github.com/NixOS/nixpkgs/commit/43fe63cde73155c556713311d9234d1d9b3c7470) | `` catfs: drop ``                                                                                     |
| [`bbb656ba`](https://github.com/NixOS/nixpkgs/commit/bbb656bac38c0d700d00cbc41a587d80e0d6732d) | `` archivemount: migrate to fuse3 ``                                                                  |
| [`8eea5df8`](https://github.com/NixOS/nixpkgs/commit/8eea5df8373bded6421ce2d4e35c06c6134d6195) | `` obexfs: drop ``                                                                                    |
| [`2c16d74a`](https://github.com/NixOS/nixpkgs/commit/2c16d74adf262441829137f5fa2ecc793ec82e24) | `` libretro.opera: 0-unstable-2026-04-10 -> 0-unstable-2026-05-30 ``                                  |
| [`7ab05e15`](https://github.com/NixOS/nixpkgs/commit/7ab05e15d802550aaeb919bc5d2715c08ca860a7) | `` httpfs2: drop ``                                                                                   |
| [`243558ac`](https://github.com/NixOS/nixpkgs/commit/243558acc5c9644b8e91739d621023007349d210) | `` temurin-{,jre-}bin-26: init at 26.0.1 ``                                                           |
| [`e1dfe0bf`](https://github.com/NixOS/nixpkgs/commit/e1dfe0bfcfa052eff00d13542890ae4a1c970142) | `` enlightenment.efl: enable structuredAttrs and strictDeps, modernize ``                             |
| [`7bd52a96`](https://github.com/NixOS/nixpkgs/commit/7bd52a96aaf640dd19574fe6fda694e36003626f) | `` adguardian: 1.6.0 -> 1.6.1 ``                                                                      |
| [`3f776496`](https://github.com/NixOS/nixpkgs/commit/3f7764964ed996355dcbcd37cb87a8afdb732914) | `` yaziPlugins.kdeconnect-send: init at 0-unstable-2026-05-12 ``                                      |
| [`f70490ca`](https://github.com/NixOS/nixpkgs/commit/f70490cade423ec08d0973704cd569237d50528e) | `` linuxPackages.nvidiaPackages: fix gsp firmware installation in version 610 and later ``            |
| [`89aa2092`](https://github.com/NixOS/nixpkgs/commit/89aa2092d424d5c739f9216a6fee03b5200704c0) | `` linuxPackages.nvidiaPackages.new_feature: 590.48.01 -> 610.43.02 ``                                |
| [`993eaeed`](https://github.com/NixOS/nixpkgs/commit/993eaeed0589c38ecf5652a7e5f808dd1c8faadf) | `` libappimage: drop fuse input ``                                                                    |
| [`c71a0e7c`](https://github.com/NixOS/nixpkgs/commit/c71a0e7c29c30f88dca4ebd09905e0d2b322d1fc) | `` gnuradioPackages.fosphor: fix build with boost 1.89 ``                                             |
| [`cd87c827`](https://github.com/NixOS/nixpkgs/commit/cd87c82702582604b0e55fed47c56af99c0380c4) | `` cargo-feature-combinations: 0.0.52 -> 0.0.53 ``                                                    |
| [`c3deca82`](https://github.com/NixOS/nixpkgs/commit/c3deca82ebb7080b34aef27a0578e9b8b5175075) | `` afsctool: fetch submodules to enable LZFSE ``                                                      |
| [`e6a9c107`](https://github.com/NixOS/nixpkgs/commit/e6a9c10761a9279a176711b8498e91f981074407) | `` thunderkittens: 0-unstable-2026-05-22 -> 0-unstable-2026-05-27 ``                                  |
| [`bb3e3431`](https://github.com/NixOS/nixpkgs/commit/bb3e3431e640a2a071346d9baca8f93de24255ee) | `` avfs: migrate to fuse3 ``                                                                          |
| [`3b57d6e7`](https://github.com/NixOS/nixpkgs/commit/3b57d6e77ecce361aafe9209c047c776c0d33fd1) | `` aefs: drop ``                                                                                      |
| [`553e463e`](https://github.com/NixOS/nixpkgs/commit/553e463e3d0a75f4f571920f726fd2f8e6526958) | `` oku: use fuse3 ``                                                                                  |
| [`6dea6cf6`](https://github.com/NixOS/nixpkgs/commit/6dea6cf62a9ac8606f9b71941eb741d227d41b05) | `` auto-editor: 29.7.0 -> 30.3.0 ``                                                                   |
| [`a4489104`](https://github.com/NixOS/nixpkgs/commit/a44891042f07b3a87188cd4990a931519da75274) | `` amazon-cloudwatch-agent: 1.300066.0 -> 1.300069.0 ``                                               |
| [`eac07776`](https://github.com/NixOS/nixpkgs/commit/eac077768d19fa8a18661cbe44462769d5f7ffd5) | `` satisfactorymodmanager: 3.0.6 -> 3.0.7 ``                                                          |
| [`7767e8e6`](https://github.com/NixOS/nixpkgs/commit/7767e8e6f6da8726b4b879608e2727cf578e6648) | `` dblab: 0.39.0 -> 0.40.1 ``                                                                         |
| [`bc1322ea`](https://github.com/NixOS/nixpkgs/commit/bc1322ea191fe90b222af7675792cc5b418c2b53) | `` taze: 19.13.0 -> 19.14.1 ``                                                                        |
| [`43450363`](https://github.com/NixOS/nixpkgs/commit/434503630c87444ec340360759d9ea6e7fc1cedd) | `` gotenberg: 8.32.0 -> 8.33.0 ``                                                                     |
| [`8837c8d1`](https://github.com/NixOS/nixpkgs/commit/8837c8d1b57890154b59905c14a181fb269648ac) | `` octave: 11.1.0 -> 11.2.0 ``                                                                        |
| [`101e9940`](https://github.com/NixOS/nixpkgs/commit/101e9940db9101cc28554e845426e75859f77b81) | `` megacmd: use fuse3 ``                                                                              |
| [`b7768d8a`](https://github.com/NixOS/nixpkgs/commit/b7768d8a71ef7cbd9b3ea231ffb59e107380e807) | `` fwupd: 2.1.3 -> 2.1.4 ``                                                                           |
| [`96bbeb99`](https://github.com/NixOS/nixpkgs/commit/96bbeb99c5abd8046ef4c8910d3aa8b25bf0962c) | `` ocamlPackages.smtml: 0.27.0 -> 0.28.0 ``                                                           |
| [`ba4c5b31`](https://github.com/NixOS/nixpkgs/commit/ba4c5b312cf36bbedb1549a306489a4419022f17) | `` rustic: switch fuse to fuse3 ``                                                                    |
| [`58d4592e`](https://github.com/NixOS/nixpkgs/commit/58d4592e59a3ef767984130745742ae7d62c885b) | `` opencode: 1.15.12 -> 1.15.13 ``                                                                    |
| [`dd027618`](https://github.com/NixOS/nixpkgs/commit/dd027618a098074eca00171c6669c1bfe53bbbef) | `` fuse-archive: 1.10 -> 1.22 ``                                                                      |
| [`12e52333`](https://github.com/NixOS/nixpkgs/commit/12e5233307d0429889d77778f2553810820b7a70) | `` vnstat: modernise package and add choco98 as maintainer ``                                         |
| [`12d5b3fc`](https://github.com/NixOS/nixpkgs/commit/12d5b3fca210c7ef8b1a37084fcaa1f9b82b2332) | `` flint: add wegank as maintainer ``                                                                 |
| [`e537b593`](https://github.com/NixOS/nixpkgs/commit/e537b593f6e25c2e1b705a4c0fdde31283e30e82) | `` firefox-gnome-theme: 149.1 -> 150 ``                                                               |
| [`278c713e`](https://github.com/NixOS/nixpkgs/commit/278c713e17aef5af422f8dfb42036d9b8aacc878) | `` n64recomp: 0-unstable-2026-05-17 -> 0-unstable-2026-05-27 ``                                       |
| [`1d220d35`](https://github.com/NixOS/nixpkgs/commit/1d220d35d8e3cd0c5fcad2cf3fe04b970b39b406) | `` python3Packages.icalendar-compatibility: skip test failing with icalendar v7 ``                    |
| [`cecae0fe`](https://github.com/NixOS/nixpkgs/commit/cecae0fe8dfdb77ed46d1046c8101a737818ce6f) | `` python3Packages.libarchive-c: use finalAttrs ``                                                    |
| [`41665e33`](https://github.com/NixOS/nixpkgs/commit/41665e33ee4fed14bef2435870ab74c0e1ca013a) | `` python3Packages.libarchive-c: migrate to pyproject ``                                              |
| [`ad72ca16`](https://github.com/NixOS/nixpkgs/commit/ad72ca16531a1ba0aef89934283d7b2ba14e3a6e) | `` woodpecker-pipeline-transform: 0.3.0 -> 1.0.0 ``                                                   |
| [`2cac5112`](https://github.com/NixOS/nixpkgs/commit/2cac51127be84086162c49bd1994571925a9b51f) | `` python3Packages.icalendar: 6.3.2 -> 7.1.2 ``                                                       |
| [`198716e4`](https://github.com/NixOS/nixpkgs/commit/198716e4f5b28e1a3149ffbe6043ee6f26556ac2) | `` python3Packges.btrfs: add changelog ``                                                             |
| [`2f6430f5`](https://github.com/NixOS/nixpkgs/commit/2f6430f540bb5dd061cc19a626d5e296373301d2) | `` python3Packages.btrfs: use finalAttrs ``                                                           |
| [`225ea220`](https://github.com/NixOS/nixpkgs/commit/225ea2200141b16682c0fa037cce2ab0771e255b) | `` python3Packages.btrfs: modernize and migrate to pyproject ``                                       |
| [`29bbe141`](https://github.com/NixOS/nixpkgs/commit/29bbe141ea781efacad7218b7c2a0f1158e8eaa2) | `` python3Packages.pygdbmi: add changelog ``                                                          |
| [`f236a155`](https://github.com/NixOS/nixpkgs/commit/f236a15562c0d74f231a6056496e510502f8c220) | `` python3Packages.pygdbmi: use finalAttrs ``                                                         |
| [`be0d72f5`](https://github.com/NixOS/nixpkgs/commit/be0d72f58a2281032394f66f08e51152dfe8b36d) | `` python3Packages.pygdbmi: migrate to pyproject ``                                                   |
| [`30141755`](https://github.com/NixOS/nixpkgs/commit/301417557e72630d5a95dac7651ca71c50457ba0) | `` code-cursor: 3.5.17 -> 3.6.21 ``                                                                   |
| [`9e3c2da2`](https://github.com/NixOS/nixpkgs/commit/9e3c2da29cddc39bb1b3a18c70fb68c7db096843) | `` python3Packages.pyudev: add changelog ``                                                           |
| [`61fc9d6c`](https://github.com/NixOS/nixpkgs/commit/61fc9d6c92c6c05ac611694925edf154861439d5) | `` python3Packages.pyudev: use finalAttrs ``                                                          |
| [`2508c38e`](https://github.com/NixOS/nixpkgs/commit/2508c38ed56bd4b6712dfadd3dcc19a4802d7b35) | `` python3Packages.pyudev: migrate to pyproject ``                                                    |
| [`d6c26643`](https://github.com/NixOS/nixpkgs/commit/d6c26643937fd1f94bf42d097a5e7bab254cfe58) | `` ntfs3g: modernize, adopt, stop using fuse2 ``                                                      |
| [`7f650c98`](https://github.com/NixOS/nixpkgs/commit/7f650c98aad45a30e52ccbcb01b671ddc9b59d82) | `` pgdog: 0.1.41 -> 0.1.42 ``                                                                         |
| [`86db8551`](https://github.com/NixOS/nixpkgs/commit/86db85510bcd4a4511e4a775e71f01371b106094) | `` tabbyapi: 0-unstable-2026-01-20 -> 0-unstable-2026-05-29 ``                                        |
| [`3f1a5df4`](https://github.com/NixOS/nixpkgs/commit/3f1a5df48089c0840b222fd732113cd16e51deaf) | `` python3Packages.proxmoxer: use tag ``                                                              |
| [`efca1d25`](https://github.com/NixOS/nixpkgs/commit/efca1d2578a25dc72530a5292ecb00bc7e332c1d) | `` python3Packages.proxmoxer: migrate to finalAttrs ``                                                |
| [`ecd566a9`](https://github.com/NixOS/nixpkgs/commit/ecd566a91fe9349846bdd6edf611a87e47eb1b20) | `` python3Packages.exllamav2: fix build after g++ bump ``                                             |
| [`ac3f75b1`](https://github.com/NixOS/nixpkgs/commit/ac3f75b1bb68b9320680ae512243eb96aa4ba028) | `` python3Packages.exllamav3: 0.0.26 -> 0.0.38 ``                                                     |
| [`4af9872e`](https://github.com/NixOS/nixpkgs/commit/4af9872e737d9bad8baa74f73740b057cf32d968) | `` balena-cli: drop doronbehar from maintainers ``                                                    |
| [`9f8581ed`](https://github.com/NixOS/nixpkgs/commit/9f8581edf1cb23f7bc11013c03eab04acb938886) | `` home-assistant: use caldav_2 ``                                                                    |
| [`db40e3f5`](https://github.com/NixOS/nixpkgs/commit/db40e3f5c24fa5553f98da2f8f4d0ba00b3125e7) | `` python3Packages.caldav_2: init at 2.2.6 ``                                                         |
| [`7bce97a7`](https://github.com/NixOS/nixpkgs/commit/7bce97a715242a93b4708ce63a21e49832b19a89) | `` python3Packages.caldav: 2.2.6 -> 3.2.1 ``                                                          |
| [`78bea336`](https://github.com/NixOS/nixpkgs/commit/78bea3365ab0d61ba86c18c80d97c6aba4c29464) | `` home-assistant-custom-components.octopus_energy: 18.2.1 -> 18.3.0 ``                               |
| [`1aa187c4`](https://github.com/NixOS/nixpkgs/commit/1aa187c4562531730cf57fb81525c0649e3af1c0) | `` cargo-expand: 1.0.121 -> 1.0.122 ``                                                                |
| [`139bf1b6`](https://github.com/NixOS/nixpkgs/commit/139bf1b6b7edc73c1c0dd1e91431c8a2ded0d6a2) | `` vimPlugins.fff-nvim: 0.8.0 -> 0.8.4 ``                                                             |
| [`c169724f`](https://github.com/NixOS/nixpkgs/commit/c169724f5536e4330ce7665dea563581235485af) | `` mongodb-compass: 1.49.7 -> 1.49.8 ``                                                               |
| [`de8ea3f1`](https://github.com/NixOS/nixpkgs/commit/de8ea3f186d74826295e840fd3c1292be250e5bc) | `` television: 0.15.6 -> 0.15.7 ``                                                                    |
| [`362e335d`](https://github.com/NixOS/nixpkgs/commit/362e335dbe4664ac1017566a26bf0d00ace79959) | `` spice-up: drop unused libsoup 2.4 dependency, modernize ``                                         |
| [`00d4449b`](https://github.com/NixOS/nixpkgs/commit/00d4449b7b417969fe0bab5afb29862b486ca3f2) | `` manix: add iogamaster to maintainers ``                                                            |
| [`fbdf10ee`](https://github.com/NixOS/nixpkgs/commit/fbdf10eec702096767a1e62ef6db4abc79379573) | `` kubefwd: add iogamaster to maintainers ``                                                          |
| [`ada6b0da`](https://github.com/NixOS/nixpkgs/commit/ada6b0da22c7a5ed4ab179d7ffa0f8996ed3936e) | `` berk76-tetris: init at 1.1.0 ``                                                                    |
| [`cd77af62`](https://github.com/NixOS/nixpkgs/commit/cd77af625a1c47af20cc09a4c74d77e4e49c4813) | `` maintainers: add iogamaster ``                                                                     |
| [`4a736a9e`](https://github.com/NixOS/nixpkgs/commit/4a736a9e97359870c8a595cd3b6acc9991211d47) | `` ares: 147 -> 148 ``                                                                                |
| [`8ebdca12`](https://github.com/NixOS/nixpkgs/commit/8ebdca12ce8a93d13b7d805f501ed790e3f931ab) | `` uhttpmock: rename from uhttpmock_1_0 ``                                                            |
| [`55b02243`](https://github.com/NixOS/nixpkgs/commit/55b0224334f694193b901022652bd2691090e5fc) | `` python3Packages.groq: 1.3.0 -> 1.4.0 ``                                                            |
| [`d0ba6ac7`](https://github.com/NixOS/nixpkgs/commit/d0ba6ac7267f9283de024dc9d3a859805e3b6607) | `` uhttpmock: drop 0.0 abi ``                                                                         |
| [`3fc2400d`](https://github.com/NixOS/nixpkgs/commit/3fc2400dfa959ba3573bdb487c9f02b640faafa6) | `` cross-seed: 6.13.6 -> 6.13.7 ``                                                                    |
| [`dc9955b2`](https://github.com/NixOS/nixpkgs/commit/dc9955b2159cdeae8fa2f8dfd3c60a98e2895aa8) | `` vimPlugins.reactive-nvim: init at 1.2.1 ``                                                         |
| [`6bc5c115`](https://github.com/NixOS/nixpkgs/commit/6bc5c115e5fe7723ac18f265afd5bd6314bcec91) | `` aws-sso-creds: 2.0.0 -> 2.1.0 ``                                                                   |
| [`8ee83677`](https://github.com/NixOS/nixpkgs/commit/8ee83677f83fef57cc4b06846ff64c739fd4b533) | `` grantlee: migrate to pkgs/by-name ``                                                               |
| [`b95f99b7`](https://github.com/NixOS/nixpkgs/commit/b95f99b7511e9db52d2d540b3765a2ad7c789a17) | `` zztgo: init at 0-unstable-2020-05-29 ``                                                            |
| [`ffc0c4dc`](https://github.com/NixOS/nixpkgs/commit/ffc0c4dc22b8d251923e3ae864d4c870fb03c6b9) | `` opencode: disable autoupdate ``                                                                    |
| [`e8cc556d`](https://github.com/NixOS/nixpkgs/commit/e8cc556d0440b1995519af8a7b8d9dae9cf5dc30) | `` python3Packages.python-ecobee-api: 0.3.2 -> 0.4.1 ``                                               |
| [`5af0c6d3`](https://github.com/NixOS/nixpkgs/commit/5af0c6d30db3c0b2580d92fa635d37c71f652c5e) | `` Revert "mediawiki: do not clear session cache on every start" ``                                   |
| [`8e5204a9`](https://github.com/NixOS/nixpkgs/commit/8e5204a9de5cf583db0e983b65fdbc0df938d1bc) | `` proton-pass-cli: 2.1.0 -> 2.1.2 ``                                                                 |
| [`6e377eb1`](https://github.com/NixOS/nixpkgs/commit/6e377eb159d2a2552bea3d8b4e0c1d69926eb6e8) | `` terraform-providers.yandex-cloud_yandex: 0.204.0 -> 0.206.0 ``                                     |
| [`fefc9af5`](https://github.com/NixOS/nixpkgs/commit/fefc9af5ddf3997b27f9e60b83a8a799145ca6c3) | `` xdg-desktop-portal: move to by-name ``                                                             |
| [`d5436754`](https://github.com/NixOS/nixpkgs/commit/d54367545e93d361171579778141823ef804a99f) | `` obsidian: fix internal PDF viewer on Electron 40 ``                                                |
| [`76fa7a98`](https://github.com/NixOS/nixpkgs/commit/76fa7a983c807c4d5cfb631d17bfaa2eb515fadf) | `` {firehol,iprange}: move to by-name ``                                                              |
| [`75120a47`](https://github.com/NixOS/nixpkgs/commit/75120a47827f8bd347845fced8f2585f4367d024) | `` python3Packages.cloudflare: 4.3.1 -> 5.2.0 ``                                                      |
| [`f79a9444`](https://github.com/NixOS/nixpkgs/commit/f79a944433c6086f6d418ab1382588623ab1f822) | `` uutils-coreutils-noprefix: 0.8.0 -> 0.9.0 ``                                                       |
| [`70b00421`](https://github.com/NixOS/nixpkgs/commit/70b00421a8a150b8fd3c793a78d94bc231a0fcae) | `` bitwuzla: 0.9.0 -> 0.9.1 ``                                                                        |
| [`dcd4d1e0`](https://github.com/NixOS/nixpkgs/commit/dcd4d1e0d2bfe6cb13dadb5f1a9910e808a3d9d2) | `` wireless-regdb: 2026.02.04 -> 2026.05.30 ``                                                        |
| [`f755b804`](https://github.com/NixOS/nixpkgs/commit/f755b8040636238fd91eb23e99f50917c6857b96) | `` winboat: factor out electron pin ``                                                                |
| [`c9c32344`](https://github.com/NixOS/nixpkgs/commit/c9c32344ae6db87bf26a494db3a9c7be1b48980a) | `` teams-for-linux: factor out electron pin ``                                                        |
| [`52aa559e`](https://github.com/NixOS/nixpkgs/commit/52aa559ef3d1186497da48ee5e13ff6cf8097d47) | `` collectd{,-data}: move to by-name ``                                                               |
| [`eb752255`](https://github.com/NixOS/nixpkgs/commit/eb752255960162eb2c343e815dc1e02bbeed25d6) | `` python3Packages.ifcopenshell: remove pcre ``                                                       |
| [`b45dd5a3`](https://github.com/NixOS/nixpkgs/commit/b45dd5a392d51f2a7bd58bf4175c6c6655365985) | `` anystyle-cli: move to by-name ``                                                                   |
| [`69e62efb`](https://github.com/NixOS/nixpkgs/commit/69e62efb88ebb0fa3aeda9c2efa045df9513ecaf) | `` rofi-pass: move to by-name ``                                                                      |
| [`ad0f7fbb`](https://github.com/NixOS/nixpkgs/commit/ad0f7fbbe5847ca6c57e589d4b28d20b2176a134) | `` {esbuild,esbuild_netlify}: move to by-name ``                                                      |
| [`7268f0cf`](https://github.com/NixOS/nixpkgs/commit/7268f0cf39a750eb88971f671866e02af374f3b9) | `` {arduino-core,arduino-core-unwrapped}: move to by-name ``                                          |
| [`a97d4060`](https://github.com/NixOS/nixpkgs/commit/a97d406096d5181c21db3d30f47a0123edf4de3f) | `` autodock-vina: move to by-name ``                                                                  |
| [`a2e90522`](https://github.com/NixOS/nixpkgs/commit/a2e905224c8db85037d7720854a0c3c141f3ea95) | `` firefox/wrapper: quote is-packaged-app path ``                                                     |
| [`70b8785b`](https://github.com/NixOS/nixpkgs/commit/70b8785b17d77c31416e88a57678d6472450f028) | `` perlPackages.ArchiveTar: 3.02 -> 3.10 ``                                                           |
| [`25da4704`](https://github.com/NixOS/nixpkgs/commit/25da47049d5925e7d67329d642fc3fe087d24e36) | `` {lemonbar,lemonbar-xft}: move to by-name ``                                                        |
| [`7638e54a`](https://github.com/NixOS/nixpkgs/commit/7638e54a40064a0185b4e505a9347b2d5d010abe) | `` python3Packages.urllib3-future: 2.20.906 -> 2.21.900 ``                                            |
| [`fc3ed109`](https://github.com/NixOS/nixpkgs/commit/fc3ed109c13d46711b2ec9780f3053a21c7d51ff) | `` {rxvt-unicode,rxvt-unicode-unwrapped}: move to by-name ``                                          |
| [`0b223c0f`](https://github.com/NixOS/nixpkgs/commit/0b223c0f6d11cd3b990d90688627f02a6df6dfde) | `` {johnny-reborn,johnny-reborn-engine}: move to by-name ``                                           |
| [`cb65c8ca`](https://github.com/NixOS/nixpkgs/commit/cb65c8cae2edf1df502ff07d505503ee29afe56a) | `` librest: drop unused 0.8 release, rename from librest_1_0 ``                                       |
| [`71201928`](https://github.com/NixOS/nixpkgs/commit/7120192808393c57284df8fd54fbacf63139e834) | `` libchamplain: remove libsoup 2.4 variant  ``                                                       |
| [`a9b08c9f`](https://github.com/NixOS/nixpkgs/commit/a9b08c9f8d3175cdd2fca2f4d282cb3a625438aa) | `` python3Packages.remarshal: use finalAttrs ``                                                       |
| [`255175ed`](https://github.com/NixOS/nixpkgs/commit/255175edae0b7d9324edcb26052a2a88e56afd21) | `` python3Packages.remarshal: fix source ``                                                           |
| [`660bbd36`](https://github.com/NixOS/nixpkgs/commit/660bbd3662793e4ad5e7f5889d244803ebe6d86c) | `` git-branchless: 0.11.0 -> 0.11.1 ``                                                                |
| [`205c3473`](https://github.com/NixOS/nixpkgs/commit/205c347345a68b12926d6d4de7936b6607b4b62c) | `` awsebcli: relax fabric version ``                                                                  |
| [`74b33ba4`](https://github.com/NixOS/nixpkgs/commit/74b33ba41fbae2ead356807b854c80bc428c4cf8) | `` Fabric: 3.2.2 -> 3.2.3 ``                                                                          |
| [`48edc9f6`](https://github.com/NixOS/nixpkgs/commit/48edc9f66de785d7950be097172f70429708d604) | `` perlPackages.CryptX: 0.088 -> 0.089 ``                                                             |
| [`81ca8c3e`](https://github.com/NixOS/nixpkgs/commit/81ca8c3e5651ba7bc2b34404684c32c1a218b97a) | `` tinc: migrate to by-name ``                                                                        |
| [`98b7f1b2`](https://github.com/NixOS/nixpkgs/commit/98b7f1b2152517be5c91d25ee93d88a02965a4d5) | `` tinc: modernize derivation ``                                                                      |
| [`a578c315`](https://github.com/NixOS/nixpkgs/commit/a578c315bd0adeafb457394f8a8bcf1b2c014da5) | `` tinc_pre: migrate to by-name ``                                                                    |
| [`b6304a31`](https://github.com/NixOS/nixpkgs/commit/b6304a318b175d124da18b95682a515c16f55d42) | `` tinc_pre: modernize derivation ``                                                                  |
| [`942d62da`](https://github.com/NixOS/nixpkgs/commit/942d62da1c83f10178362f315f849b067acdf4cb) | `` neowall: 0.4.6 -> 0.4.7 ``                                                                         |
| [`f4da1f45`](https://github.com/NixOS/nixpkgs/commit/f4da1f458e15a76a3d8b8bf2a5c48ab5a7748a62) | `` vectorscan: drop pcre ``                                                                           |
| [`0b8e37fa`](https://github.com/NixOS/nixpkgs/commit/0b8e37fa0f402d5f3abfacf250b64a774346104b) | `` tranquil-pds: add nixos test to passthru ``                                                        |
| [`46a9ac20`](https://github.com/NixOS/nixpkgs/commit/46a9ac2071509a64184bbbd90c4b5560eae8fd19) | `` nixosTests.tranquil-pds: init ``                                                                   |
| [`56479548`](https://github.com/NixOS/nixpkgs/commit/564795482d23fccd39f39762ec2fa66ce7003c0d) | `` nixos/tranquil-pds: init module ``                                                                 |
| [`1d37a606`](https://github.com/NixOS/nixpkgs/commit/1d37a606a967cf6c09d5bb89277baea0c869f13a) | `` fwupd: 2.1.2 -> 2.1.3 ``                                                                           |
| [`6e51e9a0`](https://github.com/NixOS/nixpkgs/commit/6e51e9a041e66d04bc01cae4f7df159f9a85d785) | `` tranquil-pds-frontend: init at 0.6.3 ``                                                            |
| [`2dcfdcea`](https://github.com/NixOS/nixpkgs/commit/2dcfdcea300dfa1aced06bda2c231ee5e4d21904) | `` tranquil-pds: init at 0.6.3 ``                                                                     |
| [`a95a5069`](https://github.com/NixOS/nixpkgs/commit/a95a506991b11447a02eb5298027d40634c9ac12) | `` nixos/nginx: use structuredAttrs instead of passAsFile in writeNginxConfig ``                      |
| [`3d4bc102`](https://github.com/NixOS/nixpkgs/commit/3d4bc1021bc789975dab2bad0d5d5d7b2b82f1c1) | `` xournalpp: drop unused pcre dependency ``                                                          |
| [`c6e2474b`](https://github.com/NixOS/nixpkgs/commit/c6e2474b784130540a1e9abb1f963049a2b0114b) | `` Release NixOS 26.05 ``                                                                             |
| [`d1cd13b6`](https://github.com/NixOS/nixpkgs/commit/d1cd13b661c558c9695b9b15dda12bd142ff87cb) | `` clementine: drop unused pcre dependency ``                                                         |
| [`5142ac72`](https://github.com/NixOS/nixpkgs/commit/5142ac72496fe5938b04a25ebbeea840dc549fd7) | `` t-lang: init at 0.3.1 ``                                                                           |
| [`7fc9081f`](https://github.com/NixOS/nixpkgs/commit/7fc9081feeeb144b59ad1b4e5a039bd8efefa7b4) | `` python3Packages.amaranth-soc: 0.1a-unstable-2026-03-03 -> 0.1a-unstable-2026-05-23 ``              |
| [`ffa172d3`](https://github.com/NixOS/nixpkgs/commit/ffa172d31eae02d9396fae6abbcad76cf0d5507f) | `` transmission_4: drop unused pcre dependency ``                                                     |
| [`2002ce93`](https://github.com/NixOS/nixpkgs/commit/2002ce930b7ce6f10ac45945e2718c86faf6a5f9) | `` Revert "Release 26.05" ``                                                                          |
| [`4b8c5748`](https://github.com/NixOS/nixpkgs/commit/4b8c574878fa9f20a0e6e4118320b1446b3cea6b) | `` python3Packages.django-js-reverse: 0.10.2 -> 1.0.0 ``                                              |
| [`531cc606`](https://github.com/NixOS/nixpkgs/commit/531cc6069ec37971c945d62f7ef5ee8b512288e3) | `` fselect: 0.10.0 -> 0.10.1 ``                                                                       |
| [`2c190b59`](https://github.com/NixOS/nixpkgs/commit/2c190b59c1620c23eeec46e9c86a6e1636ae56c2) | `` various: use fetchFromCodeberg ``                                                                  |
| [`443a0b89`](https://github.com/NixOS/nixpkgs/commit/443a0b89d552c38f6b118175e4ac56759524b408) | `` luastatus: drop pcre ``                                                                            |
| [`123a2ded`](https://github.com/NixOS/nixpkgs/commit/123a2dedb2a8d201ad9585bc24c19fb437ca8c14) | `` Release 26.05 ``                                                                                   |
| [`2b4a48d5`](https://github.com/NixOS/nixpkgs/commit/2b4a48d5456349bf07fccd8693b6565f205f2c91) | `` .github/ISSUE_TEMPLATE: Mark 26.05 stable ``                                                       |
| [`4806576c`](https://github.com/NixOS/nixpkgs/commit/4806576c95ed27e0eb8194564b9ff5e05bc5f701) | `` home-assistant-custom-components.dreo: 1.9.0 -> 1.9.5 ``                                           |
| [`a7a576d5`](https://github.com/NixOS/nixpkgs/commit/a7a576d5c52df5a4eb9913faee6bd2f3e9338c6b) | `` python3Packages.unidic-lite: modernize and migrate to pyproject ``                                 |
| [`1e455c9c`](https://github.com/NixOS/nixpkgs/commit/1e455c9cb7159d0a8403c073cff848a7cdfca399) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.82.95 -> 1.82.98 ``                          |
| [`d9affaa6`](https://github.com/NixOS/nixpkgs/commit/d9affaa6862a894305b0efb81a3e0bcb6036a536) | `` doc/rl-2605: documentation fixups ``                                                               |
| [`97bc04fb`](https://github.com/NixOS/nixpkgs/commit/97bc04fb44ef38e17eb501f8a591f2eb7de103cf) | `` doc/rl-2605: Move entries from nixpkgs to nixos doc ``                                             |
| [`0f48c24e`](https://github.com/NixOS/nixpkgs/commit/0f48c24eb5ddefb7c6891867b1265dc213d9ec45) | `` doc/rl-2605: Move entries from nixos to nixpkgs doc ``                                             |
| [`0264f06d`](https://github.com/NixOS/nixpkgs/commit/0264f06d5cac7bfa3f0d6469a6e54517d154dc39) | `` doc/rl-2605: Fix broken links ``                                                                   |
| [`f154bcae`](https://github.com/NixOS/nixpkgs/commit/f154bcae55cace03dabd9a1d7ce0cd747a2e1be0) | `` doc/rl-2605: Remove a note about headplane ``                                                      |
| [`fb7fb476`](https://github.com/NixOS/nixpkgs/commit/fb7fb476cfc5bebc923e78017489ebe5fe0534b2) | `` cargo-edit: 0.13.10 -> 0.13.11 ``                                                                  |
| [`9f9e5cec`](https://github.com/NixOS/nixpkgs/commit/9f9e5cecda8417f2ff603306b9d20d144c8e8e09) | `` orcaslicer: drop unused pcre dependency ``                                                         |
| [`ea315fd7`](https://github.com/NixOS/nixpkgs/commit/ea315fd7904d2226060fba932c9180223612e71b) | `` jfrog-cli: 2.103.0 -> 2.104.1 ``                                                                   |
| [`aaeb70af`](https://github.com/NixOS/nixpkgs/commit/aaeb70af5fe63a961b75683420c33190361db06c) | `` hugo: 0.161.1 -> 0.162.1 ``                                                                        |
| [`7c7a27cf`](https://github.com/NixOS/nixpkgs/commit/7c7a27cf5c7094738a5f8ed6988cd25d9f16be20) | `` tenacity: remove unused dependency pcre ``                                                         |
| [`095b3501`](https://github.com/NixOS/nixpkgs/commit/095b3501f4fdf7f9489d0142cfb12c2287d356d3) | `` gh-skyline: 0.1.8 -> 0.1.9 ``                                                                      |
| [`e4d95caf`](https://github.com/NixOS/nixpkgs/commit/e4d95caf8d6e8bd22c29b0d0aa836f046d1aabee) | `` python3Packages.wakeonlan: 3.1.0 -> 3.3.0 ``                                                       |
| [`6a03e608`](https://github.com/NixOS/nixpkgs/commit/6a03e6089deeee22259d89ece3b941f70dcfd79e) | `` vscode-extensions.anthropic.claude-code: 2.1.156 -> 2.1.158 ``                                     |
| [`e062a191`](https://github.com/NixOS/nixpkgs/commit/e062a191667e1c067213959dad57d1c52b40edef) | `` claude-code: 2.1.156 -> 2.1.158 ``                                                                 |
| [`ebb943a8`](https://github.com/NixOS/nixpkgs/commit/ebb943a800310903ea8fc60bacdc99d732a343a3) | `` makehuman: mark broken ``                                                                          |
| [`c01c964d`](https://github.com/NixOS/nixpkgs/commit/c01c964d048c188299ab37079e7cf4704aa98f09) | `` various: use finalAttrs ``                                                                         |
| [`b310447b`](https://github.com/NixOS/nixpkgs/commit/b310447bfc91c12308f92176ec37a8fdd1dd9192) | `` sail-riscv: migrate to by-name ``                                                                  |
| [`8fc99ff7`](https://github.com/NixOS/nixpkgs/commit/8fc99ff7a4ff7a01e8541358f8505b30b7d6652e) | `` ladspaPlugins: migrate to by-name ``                                                               |
| [`dc3e5a21`](https://github.com/NixOS/nixpkgs/commit/dc3e5a21f8123be69be5ce8cee480abbfd0906fa) | `` snapcast: migrate to by-name ``                                                                    |
| [`2f2bab30`](https://github.com/NixOS/nixpkgs/commit/2f2bab306e0ba4edd35ac66a47d5b5392376d07d) | `` syncthing: migrate to by-name ``                                                                   |
| [`f7b5010a`](https://github.com/NixOS/nixpkgs/commit/f7b5010a15d0717d0fe64e0e382084fc90168f3a) | `` lysncd: migrate to by-name ``                                                                      |
| [`c99417ee`](https://github.com/NixOS/nixpkgs/commit/c99417ee25b457d6acb1bd6435a61f457aadd55a) | `` rsync: migrate to by-name ``                                                                       |
| [`61140bb1`](https://github.com/NixOS/nixpkgs/commit/61140bb1961ed610024769eef82061887d599608) | `` rrsync: migrate to by-name ``                                                                      |
| [`e7692596`](https://github.com/NixOS/nixpkgs/commit/e7692596f2abf5d6a416be8d92d13bb72612e838) | `` kbdVlock: remove redundant pkgs in path ``                                                         |
| [`85d26ae3`](https://github.com/NixOS/nixpkgs/commit/85d26ae3a5f5b6f74601091ac75eb820331ca627) | `` wesnoth: remove unused dependency pcre ``                                                          |
| [`895ab931`](https://github.com/NixOS/nixpkgs/commit/895ab9310bf51ed6b37735695870b996464d3c12) | `` cambrinary: migrate to by-name ``                                                                  |
| [`55aab24f`](https://github.com/NixOS/nixpkgs/commit/55aab24f6c159b61c1cc7a8934ff979303f1265a) | `` ola: migrate to by-name ``                                                                         |
| [`429f7911`](https://github.com/NixOS/nixpkgs/commit/429f7911570d52196fd8eee456e2793a500f033f) | `` evtest-qt: fix license ``                                                                          |
| [`7a1876a7`](https://github.com/NixOS/nixpkgs/commit/7a1876a7ad696acfa616bc9f14cdd97c66367d08) | `` twitch-chat-downloader: migrate to by-name ``                                                      |
| [`2d9ed093`](https://github.com/NixOS/nixpkgs/commit/2d9ed09301147ac8a5093a19cb27eff77b601cd2) | `` ralphex: init at 1.3.2 ``                                                                          |
| [`878d8faf`](https://github.com/NixOS/nixpkgs/commit/878d8faf4d06d68b45bc3491ecb64c4ae80387f8) | `` libretro.pcsx2: 0-unstable-2026-05-13 -> 0-unstable-2026-05-30 ``                                  |
| [`2b92feb4`](https://github.com/NixOS/nixpkgs/commit/2b92feb4d643c81e086da57eee86e12b88bc164b) | `` terraform-providers.e-breuninger_netbox: 5.3.0 -> 5.4.0 ``                                         |
| [`e883a034`](https://github.com/NixOS/nixpkgs/commit/e883a034bf45e7ca4ff5292922ce0e62f7367804) | `` python3Packages.python-socketio: 5.16.1 -> 5.16.2 ``                                               |
| [`07d5fb98`](https://github.com/NixOS/nixpkgs/commit/07d5fb982050b69268f6140a3fbdefbd2c93ab97) | `` nginx-config-formatter: add install check ``                                                       |
| [`22159ce6`](https://github.com/NixOS/nixpkgs/commit/22159ce6946cc8d8ac5f6fad31bfcae14fb6b6ca) | `` nginx-config-formatter: use tag/hash in fetcher ``                                                 |
| [`a379fabf`](https://github.com/NixOS/nixpkgs/commit/a379fabfdb60aee0cb88ab0b0246bd5da750c6e8) | `` nginx-config-formatter: enable and fix strictDeps ``                                               |
| [`e3f13cec`](https://github.com/NixOS/nixpkgs/commit/e3f13cecea2a442cc399b9918b1ea17e70c39d85) | `` python3Packages.pyvlx: 0.2.34 -> 0.2.35 ``                                                         |
| [`c6f4a239`](https://github.com/NixOS/nixpkgs/commit/c6f4a239ccbfab0771f3b026d51508721a0b1433) | `` libretro.mame2010: 0-unstable-2026-04-20 -> 0-unstable-2026-05-23 ``                               |
| [`a3c469a0`](https://github.com/NixOS/nixpkgs/commit/a3c469a0080972282d32a1112723fe8a7885ea1a) | `` taterclient-ddnet: migrate to pcre2 ``                                                             |
| [`65a3bd09`](https://github.com/NixOS/nixpkgs/commit/65a3bd09ac90adadfcef97fb7fe7fa101433cd7c) | `` terraform-providers.hetznercloud_hcloud: 1.63.0 -> 1.64.0 ``                                       |
| [`7b4ecab2`](https://github.com/NixOS/nixpkgs/commit/7b4ecab2a6d0247f54da2dd0d495135132164684) | `` qstopmotion: remove unused pcre ``                                                                 |
| [`2b706611`](https://github.com/NixOS/nixpkgs/commit/2b706611eb0a685987397837a88122706c865c3e) | `` pulseview: remove unused pcre ``                                                                   |
| [`e3299996`](https://github.com/NixOS/nixpkgs/commit/e3299996a7916f28ed1ae5f063d946a7c01fb421) | `` zapzap: 6.4.2 -> 6.5.0.0.1 ``                                                                      |
| [`47bdf7e8`](https://github.com/NixOS/nixpkgs/commit/47bdf7e849c1c0d60c7dfafe6fb5f20d138e618f) | `` hyprpaper: remove pcre ``                                                                          |
| [`025dd7a5`](https://github.com/NixOS/nixpkgs/commit/025dd7a538e8eeeeb0c93c2c8c897914568c95b4) | `` online-judge-verify-helper: remove from python3Packages ``                                         |
| [`2cc9d939`](https://github.com/NixOS/nixpkgs/commit/2cc9d939c73137efd6b6c3b79f4887991031be8d) | `` devin-cli: 2026.5.6-10 -> 2026.5.26-2 ``                                                           |
| [`d3586da6`](https://github.com/NixOS/nixpkgs/commit/d3586da606296ebc840caacf922732c3865e970c) | `` wappalyzergo: 0.2.80 -> 0.2.82 ``                                                                  |
| [`99952840`](https://github.com/NixOS/nixpkgs/commit/999528404428404ad6c2988f55ab3a203c4db59a) | `` postgresqlPackages.pg_search: 0.23.0 -> 0.23.4 ``                                                  |
| [`4fa22324`](https://github.com/NixOS/nixpkgs/commit/4fa223249966dcd3da0c275dc25fc603dd536099) | `` terraform-providers.hashicorp_aws: 6.46.0 -> 6.47.0 ``                                             |
| [`0820f8c4`](https://github.com/NixOS/nixpkgs/commit/0820f8c4f8673c16c8959949ff84d852291d4a6f) | `` thunderbird-esr-bin, thunderbird-latest-bin: fix wrapper ``                                        |
| [`0beec90b`](https://github.com/NixOS/nixpkgs/commit/0beec90b1c61d7636fe3e51f67352ea7065db892) | `` tiledb: remove postInstall rpath hack on darwin ``                                                 |
| [`56ecb9c4`](https://github.com/NixOS/nixpkgs/commit/56ecb9c425f40c41a19dc959383b6bdac3eba16f) | `` onetbb: set CMAKE_INSTALL_NAME_DIR on darwin ``                                                    |
| [`52afc653`](https://github.com/NixOS/nixpkgs/commit/52afc653e40e60be71a0e51bc297fb4e1ead0b41) | `` vdrPlugins.epgsearch: use pcre2 instead of pcre ``                                                 |
| [`05233263`](https://github.com/NixOS/nixpkgs/commit/05233263f3ff846b203da01499b298d0e9c4ab82) | `` schemat: 0.5.1 -> 0.5.2 ``                                                                         |
| [`5dcc3bbf`](https://github.com/NixOS/nixpkgs/commit/5dcc3bbf9b47c82698dac0a8661e6634a8a4e3d9) | `` antora: 3.1.14 -> 3.1.15 ``                                                                        |
| [`f10343fa`](https://github.com/NixOS/nixpkgs/commit/f10343fac9d095ff92412989aa1c4285a6a9af98) | `` doggo: 1.1.6 -> 1.1.7 ``                                                                           |
| [`0efffd86`](https://github.com/NixOS/nixpkgs/commit/0efffd86c23a2c1808a3bbb85d4fa14cb619de77) | `` dssd: 0.3.1 -> 0.3.3 ``                                                                            |
| [`1583e7b4`](https://github.com/NixOS/nixpkgs/commit/1583e7b474f2cb8d99e5634980878bf5aca1c026) | `` rasm: 3.0.9 -> 3.2.4bis ``                                                                         |
| [`eb3f5099`](https://github.com/NixOS/nixpkgs/commit/eb3f5099f570f9e8d0cba9f1369913d70c86a97f) | `` androidenv.test-suite: db5315e3cae30188 -> 2937e647936072ec ``                                     |
| [`1a3c3c6c`](https://github.com/NixOS/nixpkgs/commit/1a3c3c6c211a7ddcffb3c4bb85bdd6242f08524d) | `` python3Packages.coinbase-advanced-py: 1.8.2 -> 1.8.3 ``                                            |
| [`030cfc3e`](https://github.com/NixOS/nixpkgs/commit/030cfc3ebb708bd532538d1ee921fd775c1355df) | `` python3Packages.soco: 0.31.0 -> 0.31.1 ``                                                          |
| [`866b2441`](https://github.com/NixOS/nixpkgs/commit/866b244123ade5b59fc345d2812478beb9ec7f17) | `` dssd: init at 0.3.1 ``                                                                             |
| [`a963e240`](https://github.com/NixOS/nixpkgs/commit/a963e2408eb99af2b05583709b81afdb3597a246) | `` libretro.play: 0-unstable-2026-05-16 -> 0-unstable-2026-05-28 ``                                   |
| [`272ff98e`](https://github.com/NixOS/nixpkgs/commit/272ff98e4be1b27b2f7ae77ee4c17ec2bce9c0c6) | `` pvetui: 1.3.3 -> 1.4.0 ``                                                                          |
| [`36897b15`](https://github.com/NixOS/nixpkgs/commit/36897b15c37ef45b08dac63d358956f0eea809ad) | `` plantuml-server: 1.2026.3 -> 1.2026.5 ``                                                           |
| [`8ecf9d45`](https://github.com/NixOS/nixpkgs/commit/8ecf9d458a850128537eb4a64a1ebf65a4ce8c2a) | `` context7-mcp: 2.2.5 -> 3.0.0 ``                                                                    |
| [`1859a1a7`](https://github.com/NixOS/nixpkgs/commit/1859a1a77cec03ea37fade359b489a8bb8ab4b33) | `` pkgs-lib/formats: use buildPackages for json2x ``                                                  |
| [`a0f503ea`](https://github.com/NixOS/nixpkgs/commit/a0f503ead50c91c27893d47662165fd35b2e3be2) | `` betterleaks: 1.3.0 -> 1.3.1 ``                                                                     |
| [`2ca6de60`](https://github.com/NixOS/nixpkgs/commit/2ca6de6084f85322e03bdc9aef4739c8705894ff) | `` olivetin-3k: 3000.12.0 -> 3000.13.0 ``                                                             |
| [`bad53871`](https://github.com/NixOS/nixpkgs/commit/bad53871de59bb1cedb85ff135bf0f86bd7b87c7) | `` kicad-testing-small: 10.0-2026-05-12 -> 10.0-2026-05-30 ``                                         |
| [`6410e2dd`](https://github.com/NixOS/nixpkgs/commit/6410e2ddba53eff8fd6531f82ce35cc4dee99d4c) | `` typescript-go: 0-unstable-2026-05-20 -> 0-unstable-2026-05-29 ``                                   |
| [`017a7bbd`](https://github.com/NixOS/nixpkgs/commit/017a7bbdc8b698ff67e145154f9f54fc1b8ad688) | `` vscode-extensions.coder.coder-remote: 1.14.5 -> 1.14.6 ``                                          |
| [`635bbc2b`](https://github.com/NixOS/nixpkgs/commit/635bbc2b1781912b532c491e787dc8b090d6f5d6) | `` deezer-desktop: 7.1.200 -> 7.1.220 ``                                                              |
| [`672e4244`](https://github.com/NixOS/nixpkgs/commit/672e42448105ad36b22e6a56f5964ca1d4b638e1) | `` clojure: 1.12.5.1645 -> 1.12.5.1654 ``                                                             |
| [`4c33e80d`](https://github.com/NixOS/nixpkgs/commit/4c33e80d7d408e499e0ec474fcf9bc9dda38fae5) | `` gimp: add bddvlpr as maintainer ``                                                                 |
| [`e7912e76`](https://github.com/NixOS/nixpkgs/commit/e7912e767871a5a7d097708ca6d420ae1d6eb279) | `` gimp: 3.0.8 -> 3.2.4 ``                                                                            |
| [`cd51636f`](https://github.com/NixOS/nixpkgs/commit/cd51636fd64c28a4cb70551a07bbc372fc97083b) | `` libation: 13.3.6 -> 13.4.4 ``                                                                      |
| [`ce8a2a21`](https://github.com/NixOS/nixpkgs/commit/ce8a2a211e2eeb6e1fad0838c248b837fd89197d) | `` phpunit: 13.1.10 -> 13.1.13 ``                                                                     |
| [`a062233d`](https://github.com/NixOS/nixpkgs/commit/a062233d1e548492d422a2b59e0d9140cf431333) | `` actool: 2.0.0 -> 2.1.2 ``                                                                          |
| [`0b756ed6`](https://github.com/NixOS/nixpkgs/commit/0b756ed647e1262d65796e830fe959c6b2141343) | `` talosctl: 1.13.2 -> 1.13.3 ``                                                                      |
| [`4fa60301`](https://github.com/NixOS/nixpkgs/commit/4fa6030154df416cc64a59566a513ad625501bcc) | `` maintainers: update mshnwq ``                                                                      |
| [`66b2bb33`](https://github.com/NixOS/nixpkgs/commit/66b2bb3321e8b8ce54d7177fcfd885664cf62b78) | `` ledger-live-desktop: 4.4.0 -> 4.6.0 ``                                                             |
| [`bb39c04c`](https://github.com/NixOS/nixpkgs/commit/bb39c04c823267cc0135fa92bd730ae270b28576) | `` garmindb: 3.7.0 -> 3.8.0 ``                                                                        |
| [`8888b8ca`](https://github.com/NixOS/nixpkgs/commit/8888b8ca71aa8f47392bc5d2e4b5ed0ed0eaae58) | `` scion-apps: fix build with Darwin sandbox ``                                                       |
| [`f6164cec`](https://github.com/NixOS/nixpkgs/commit/f6164cec9b396932aa0852d227697aab7a7ff341) | `` fiddler-everywhere: 7.7.3 -> 7.8.0 ``                                                              |
| [`420f1051`](https://github.com/NixOS/nixpkgs/commit/420f10510b85c88fda8ca0f8bfd4572674864d95) | `` .github/labeler.yml: add staging-nixos to `workflow backport` ``                                   |
| [`73fac235`](https://github.com/NixOS/nixpkgs/commit/73fac2351c172c4cd0f4502a32ab9c3e7841549c) | `` python3Packages.apprise: 1.10.0 -> 1.11.0 ``                                                       |
| [`6f40befa`](https://github.com/NixOS/nixpkgs/commit/6f40befa5574f4f65f21375022ac9847b70d61c9) | `` pretalx: relax django-formtools ``                                                                 |
| [`6b003ddf`](https://github.com/NixOS/nixpkgs/commit/6b003ddfd1cb57f73d16f6dad0f9a3ce8ca4b338) | `` wakatime-cli: 2.14.5 -> 2.14.12 ``                                                                 |
| [`556d06ed`](https://github.com/NixOS/nixpkgs/commit/556d06edc30595359d51064822b2378a5ed4bc32) | `` matrix-tuwunel: 1.6.1 -> 1.7.0 ``                                                                  |
| [`e18ede29`](https://github.com/NixOS/nixpkgs/commit/e18ede29fea1cac9573793f3554b3f5ceccddee9) | `` m2r: drop as it was marked broken for 4 years ``                                                   |
| [`ff09a8b1`](https://github.com/NixOS/nixpkgs/commit/ff09a8b1ac2d0e59456c66a7600261c83b42ce7c) | `` python314Packages.chromaprint: drop as it depends on m2r ``                                        |
| [`f4495087`](https://github.com/NixOS/nixpkgs/commit/f4495087276411285fd2c01ced852969e30f7ade) | `` libagar: 1.5.0 -> 1.7.1 ``                                                                         |
| [`ddc48752`](https://github.com/NixOS/nixpkgs/commit/ddc487524d370636ff72f7b23a684aee1f3c6ff8) | `` nextcloud-client: 4.0.8 -> 33.0.5 ``                                                               |
| [`964ba4da`](https://github.com/NixOS/nixpkgs/commit/964ba4da07e6c11e219f2d22221aefea42d49fbc) | `` python3Packages.safety: 3.8.0 -> 3.8.1 ``                                                          |
| [`262da060`](https://github.com/NixOS/nixpkgs/commit/262da060ad86a806b3351b3eeb05fe4fc1733e4d) | `` vimPlugins.vim-table-mode: override license to mit ``                                              |
| [`7bb188b0`](https://github.com/NixOS/nixpkgs/commit/7bb188b05cd41aa7cf2669d84c4daf1a503f5042) | `` libphonenumber: enable strictDeps ``                                                               |
| [`96cbb0e4`](https://github.com/NixOS/nixpkgs/commit/96cbb0e4251b9e4d9daf11e6ebe19c2ab0078d22) | `` kiro: 0.12.200 -> 0.12.263 ``                                                                      |
| [`88606477`](https://github.com/NixOS/nixpkgs/commit/886064778685d920089b7bdf4e30726b57c62e28) | `` goconst: 1.8.2 -> 1.10.2 ``                                                                        |
| [`29d024e3`](https://github.com/NixOS/nixpkgs/commit/29d024e394cb85fabbc2d5e2db88c79a54ec0c1e) | `` python3Packages.fusepy: use fuse3 ``                                                               |
| [`aef2f542`](https://github.com/NixOS/nixpkgs/commit/aef2f5423288724d8774d2a5a60b1a77aed50962) | `` home-assistant-custom-components.daikin_onecta: 4.6.0 -> 4.6.2 ``                                  |
| [`f04f96a2`](https://github.com/NixOS/nixpkgs/commit/f04f96a2c2d985aff39a85e9b01c7c38d21563fd) | `` gelly: 1.3.0 -> 1.4.0 ``                                                                           |
| [`54bf6d7b`](https://github.com/NixOS/nixpkgs/commit/54bf6d7b30ba4babbb559eb10e9669a713fa4fef) | `` asciinema-agg: 1.8.1 -> 1.9.0 ``                                                                   |
| [`3ec4b8f0`](https://github.com/NixOS/nixpkgs/commit/3ec4b8f09e95093fd41e0098892e75e2ca178d88) | `` fulcrum: 1.12.0.1 -> 2.1.0 ``                                                                      |
| [`de3bda3f`](https://github.com/NixOS/nixpkgs/commit/de3bda3fa9acdb7a8e879a98e1ff41f948700d84) | `` python3Packages.aioharmony: 1.0.3 -> 1.0.8 ``                                                      |
| [`2c75c8df`](https://github.com/NixOS/nixpkgs/commit/2c75c8df4dcbde398a264c166fd032b1ee3af427) | `` python3Packages.tensordict: 0.12.3 -> 0.12.4 ``                                                    |
| [`9e7f0264`](https://github.com/NixOS/nixpkgs/commit/9e7f02648690a137b57748d06035ef0064ede68b) | `` cc-switch: init at 3.15.0 ``                                                                       |
| [`ee789afb`](https://github.com/NixOS/nixpkgs/commit/ee789afb831068d2dd8484f45ddff2f6ad86e7b2) | `` zoneminder: migrate to pcre2 ``                                                                    |
| [`c7b82f3f`](https://github.com/NixOS/nixpkgs/commit/c7b82f3fd8543eaf22738f393c744324403dd558) | `` maintainers: remove kirikaza ``                                                                    |
| [`3b4b79b2`](https://github.com/NixOS/nixpkgs/commit/3b4b79b2c195965ad644e826e25143b6fef42dd9) | `` fflogs: 9.3.17 -> 9.3.61 ``                                                                        |
| [`ecd7613d`](https://github.com/NixOS/nixpkgs/commit/ecd7613dcdb7ea21174d39f5e52c3d0ec55e8290) | `` atheme: 7.2.12 -> 7.2.12-unstable-2026-05-12 ``                                                    |
| [`666ed30f`](https://github.com/NixOS/nixpkgs/commit/666ed30fee59d3aa5dd71c746219d1d40b314a13) | `` teams-for-linux: 2.10.0 -> 2.11.1 ``                                                               |
| [`135619ca`](https://github.com/NixOS/nixpkgs/commit/135619ca9a8d352257e240de4536f5ada8157d7f) | `` go-swagger: 0.33.2 -> 0.34.0 ``                                                                    |
| [`6315ac38`](https://github.com/NixOS/nixpkgs/commit/6315ac38289edd841d7330f00b68142c6821beb3) | `` python3Packages.tinygrad: skip failing GPU tests ``                                                |
| [`8b17fd7c`](https://github.com/NixOS/nixpkgs/commit/8b17fd7c8b3e5026116504becfc810e1ba4001e3) | `` greenmask: 0.2.20 -> 0.2.21 ``                                                                     |
| [`93124525`](https://github.com/NixOS/nixpkgs/commit/93124525da6139f1d5387f9110db7f7de6ac8593) | `` python3Packages.aiopylgtv: use finalAttrs ``                                                       |
| [`08df7291`](https://github.com/NixOS/nixpkgs/commit/08df72918de3198b2ffb94c3caf4c261213045b0) | `` python3Packages.aiopylgtv: migrate to pyproject ``                                                 |
| [`69fd82a7`](https://github.com/NixOS/nixpkgs/commit/69fd82a71974c3cd463b1d88288dacea22d3cbbf) | `` python3Packages.libagent: hardcode pinentry path ``                                                |
| [`03b9e20c`](https://github.com/NixOS/nixpkgs/commit/03b9e20c2311cb30c38236315f9468b4be2fd29a) | `` python3Packages.libagent: 0.15.0 -> 0.16.1 ``                                                      |
| [`6dbf46c0`](https://github.com/NixOS/nixpkgs/commit/6dbf46c0023a2bad8cdba641792d32b77dcb2139) | `` python3Packages.ledger-agent: remove ``                                                            |
| [`2174beba`](https://github.com/NixOS/nixpkgs/commit/2174beba2a84c61a4620372fe03507b9df8df490) | `` python3Packages.keepkey-agent: remove ``                                                           |
| [`e001ff13`](https://github.com/NixOS/nixpkgs/commit/e001ff1301c594e9d7954147367523864a62bc79) | `` stirling-pdf: re-enable additional features, but make them toggleable ``                           |
| [`7de9db86`](https://github.com/NixOS/nixpkgs/commit/7de9db868dc58ee090c053d170a3804956b2c101) | `` libmowgli: fast-forward to latest commit ``                                                        |
| [`f4a52323`](https://github.com/NixOS/nixpkgs/commit/f4a52323a16f2b688c0ec00c8c4e929055cd4f97) | `` xautoclick: remove pcre ``                                                                         |
| [`6447d919`](https://github.com/NixOS/nixpkgs/commit/6447d9194ca03334ec34c9bc02522f8328946f55) | `` python3Packages.aiolookin: use finalAttrs ``                                                       |
| [`481f8049`](https://github.com/NixOS/nixpkgs/commit/481f8049a7e8843231fe60fc33d58900620d7b6e) | `` kubefwd: 1.25.14 -> 1.25.15 ``                                                                     |
| [`ccff74d3`](https://github.com/NixOS/nixpkgs/commit/ccff74d3dd0c278190e0bc7fa764b823dc011e37) | `` python3Packages.aiolookin: migrate to pyproject ``                                                 |
| [`fdf0dd13`](https://github.com/NixOS/nixpkgs/commit/fdf0dd13ad4237b1d5e3b6452622f23243fad1ed) | `` bitwarden-desktop: 2026.3.1 -> 2026.5.0 ``                                                         |
| [`d788c7fb`](https://github.com/NixOS/nixpkgs/commit/d788c7fb05569a24ed5fa7bc98644d8722662206) | `` bitwarden-cli: 2026.4.2 -> 2026.5.0 ``                                                             |
| [`6165bc30`](https://github.com/NixOS/nixpkgs/commit/6165bc30f3f03921e72f5b9c6f37e57af116b1aa) | `` proton-pass-cli: disable update checks ``                                                          |
| [`35ef5570`](https://github.com/NixOS/nixpkgs/commit/35ef5570b4cf5440a7cace8388395ea7abee0e19) | `` shibboleth-sp: fix build failure ``                                                                |
| [`8fb74995`](https://github.com/NixOS/nixpkgs/commit/8fb749953cda3153c39c54ec117061f6fb1afa92) | `` {log4shib,opensaml-cpp,shibboleth-sp,xml-security-c}: adopt ``                                     |
| [`c4404dc6`](https://github.com/NixOS/nixpkgs/commit/c4404dc66645a2d21ce6c4203d8f755d90184a90) | `` {log4shib,opensaml-cpp,shibboleth-sp,xml-security-c,xml-tooling-c}: add `passthru.updateScript` `` |
| [`fb436ebd`](https://github.com/NixOS/nixpkgs/commit/fb436ebd0ec79b6b02a72a8112ebc412a125ce79) | `` {log4shib,opensaml-cpp,shibboleth-sp,xml-security-c,xml-tooling-c}: migrate source to codeberg ``  |
| [`45230095`](https://github.com/NixOS/nixpkgs/commit/45230095f8389c5b8dd7f79c3e67b07e9b9cab6d) | `` miniflux: 2.3.0 -> 2.3.1 ``                                                                        |

*... and 5104 more commits (truncated)*