### PR TITLE
chore(flake/home-manager-stable): `d1686dc7` -> `3ee51fbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778905220,
-        "narHash": "sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8=",
+        "lastModified": 1779506708,
+        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d1686dc7d36cbd1234cb226ad6ef97e882716acb",
+        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`3ee51fbd`](https://github.com/nix-community/home-manager/commit/3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f) | `` flake: bump nixpkgs from `d7a713c` to `687f05a` `` |