### PR TITLE
chore(flake/home-manager): `6e92bf09` -> `23703a32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779580960,
-        "narHash": "sha256-/EG2rRahtxdoKKzGPGqaymVB96kBBYhygatEAbsoqaM=",
+        "lastModified": 1779592288,
+        "narHash": "sha256-pVZwRFVFdHS3D3G07MiZQcSPENnv1xlYCJtfabkqd3Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e92bf094d45bc33d754e2b0f75d9ca1827cc363",
+        "rev": "23703a32ef3d7803a2f1bb9909a3f46fc5185e37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`23703a32`](https://github.com/nix-community/home-manager/commit/23703a32ef3d7803a2f1bb9909a3f46fc5185e37) | `` betterlockscreen: drop sebtm ``                    |
| [`50aaf8f2`](https://github.com/nix-community/home-manager/commit/50aaf8f2841d8ff6624aa957cf7ce8533c32a3ef) | `` tests/darwinScrublist: add intelli-shell ``        |
| [`64f1f8dd`](https://github.com/nix-community/home-manager/commit/64f1f8dd8dbe10704e8ea0b7efa3c727365af2a3) | `` flake: bump nixpkgs from `da5ad66` to `f83fc3c` `` |