### PR TITLE
chore(flake/nixvim): `1a380f12` -> `cb0107f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1431,11 +1431,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1779554657,
-        "narHash": "sha256-qjLcUp7DBpmSUL+nVjLymp2nEvAzeKKoAVDCRgZYxFk=",
+        "lastModified": 1779601302,
+        "narHash": "sha256-ACtB1llc5ZOJM+lxfbIudM2i/c5dFxRJVXVvhOLpjqA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1a380f12453ba97ad8cc9c60f223afb1cb8bace8",
+        "rev": "cb0107f6e18cdf7bf79a025fad154a4414c04383",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`cb0107f6`](https://github.com/nix-community/nixvim/commit/cb0107f6e18cdf7bf79a025fad154a4414c04383) | `` modules/nixpkgs: pass `lib` to config function ``                                              |
| [`a3dffa03`](https://github.com/nix-community/nixvim/commit/a3dffa03adaa03410b79f3fd36467611c2055da4) | `` modules/nixpkgs: add setting `nixpkgs.config.allowUnfreePackages = ["list" "of "packages"]` `` |
| [`ff3cd5fa`](https://github.com/nix-community/nixvim/commit/ff3cd5fa143059a09ef2e18f4051cc8c5320a97a) | `` modules/nixpkgs: top-level `pkgs` now returns `__splicedPackages` ``                           |
| [`978a8438`](https://github.com/nix-community/nixvim/commit/978a84388e53100692b52234dd6954f123f875d6) | `` Revert "modules/nixpkgs: don't assign elaborated platforms" ``                                 |
| [`06a19e07`](https://github.com/nix-community/nixvim/commit/06a19e0783536353fea5ed210fdcc9a548c825d9) | `` modules/output: assert pure rtp needs wrapper ``                                               |
| [`d82f3831`](https://github.com/nix-community/nixvim/commit/d82f383100817a140b8d4654cabc4f73667f3ac6) | `` modules/output: load wrapped config via VIMINIT ``                                             |
| [`d5bd4d4e`](https://github.com/nix-community/nixvim/commit/d5bd4d4e417787b26a8bf6f5526b341445dad551) | `` modules/doc: disable manpage docs when `config.flake` is undefined ``                          |
| [`e1ad5c4e`](https://github.com/nix-community/nixvim/commit/e1ad5c4e92ab4506d102123720d0b45fec8403f4) | `` wrappers: encapsulate access to `lib.nixvim` and lib-overlay ``                                |
| [`fca03f17`](https://github.com/nix-community/nixvim/commit/fca03f175902fe899a87872228bf69c1b43a8543) | `` lib: allow instantiating without a flake instance ``                                           |
| [`f58f0568`](https://github.com/nix-community/nixvim/commit/f58f0568829de0cac5183844e822c697dd0aeeb8) | `` modules/nixpgks: warn when `nixpkgs.source` default is incorrect ``                            |
| [`886bd8fd`](https://github.com/nix-community/nixvim/commit/886bd8fd62fc867c0d0c2cbf0bd04e9041e837f0) | `` modules/nixpkgs: `nixpkgs.source` fallback when `flake` undefined ``                           |
| [`ad628ccb`](https://github.com/nix-community/nixvim/commit/ad628ccbd2107decf84150a73d13e810291b5225) | `` nixpkgs: add file that fetches pinned revision ``                                              |