### PR TITLE
chore(flake/solaar): `f5cac914` -> `9535b887`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1761,11 +1761,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1767894877,
-        "narHash": "sha256-DB9vEEnEYilGUaHCljMRzT1embzD7uEjJugzRJgiLos=",
+        "lastModified": 1779643441,
+        "narHash": "sha256-Rav0sNMoPVp5r7sdyfBDHLNzaqkDCfkXJhlggJ2BZ0A=",
         "owner": "Svenum",
         "repo": "Solaar-Flake",
-        "rev": "f5cac914bdeeecac7fca07e99c8fee18336f5bd5",
+        "rev": "9535b8870343c54e2c08228949e2377e1fd9bbd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`9535b887`](https://github.com/Svenum/Solaar-Flake/commit/9535b8870343c54e2c08228949e2377e1fd9bbd7) | `` update to 1.1.20rc2 (#25) `` |