### PR TITLE
chore(flake/nixvim): `cb0107f6` -> `7259329d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1431,11 +1431,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1779601302,
-        "narHash": "sha256-ACtB1llc5ZOJM+lxfbIudM2i/c5dFxRJVXVvhOLpjqA=",
+        "lastModified": 1779621590,
+        "narHash": "sha256-kGu+wVVqu3ltT845pu3MtOGTW40rcCUVDW3JGffSpp0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cb0107f6e18cdf7bf79a025fad154a4414c04383",
+        "rev": "7259329db1e6145842411873d23b2dab577539a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`7259329d`](https://github.com/nix-community/nixvim/commit/7259329db1e6145842411873d23b2dab577539a3) | `` flake/dev/new-plugin: type scaffold script ``              |
| [`9032ffde`](https://github.com/nix-community/nixvim/commit/9032ffde3ccec965568767b5962d8ce7107f72c9) | `` flake/dev/new-plugin: reuse plugin template in scaffold `` |