### PR TITLE
chore(flake/nixpkgs-stable): `687f05a9` -> `b77b3de8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1234,11 +1234,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "lastModified": 1779467186,
+        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`77800048`](https://github.com/NixOS/nixpkgs/commit/778000485dbda6dd97489a74dd5db713b0ca1911) | `` mautrix-whatsapp: 26.04 -> 26.05 ``                                                    |
| [`870a994b`](https://github.com/NixOS/nixpkgs/commit/870a994bed128796876888716efc6808c7bc87b2) | `` radicle-desktop: 0.10.0 -> 0.11.0 ``                                                   |
| [`410551eb`](https://github.com/NixOS/nixpkgs/commit/410551ebf2a0d960399ce4add1edb983dd91905a) | `` radicle-node-unstable: 1.9.0 -> 1.9.1 ``                                               |
| [`b1d6b0ae`](https://github.com/NixOS/nixpkgs/commit/b1d6b0aeb0c83fe46d309f613b63f28a93dbcd86) | `` radicle-node: 1.9.0 -> 1.9.1 ``                                                        |
| [`cfef500d`](https://github.com/NixOS/nixpkgs/commit/cfef500d2e7afce39b7a7636ed475aee407d9d2c) | `` firefox-bin-unwrapped: 151.0 -> 151.0.1 ``                                             |
| [`9b1cb5c2`](https://github.com/NixOS/nixpkgs/commit/9b1cb5c27f7f7ada603f174c36b78dfe0ccb19df) | `` firefox-unwrapped: 151.0 -> 151.0.1 ``                                                 |
| [`bf3111e3`](https://github.com/NixOS/nixpkgs/commit/bf3111e3bbcd1a6ed7453f1ab0bc1cb62ae2118a) | `` floorp-bin-unwrapped: 12.14.0 -> 12.14.2 ``                                            |
| [`cf4e4ffb`](https://github.com/NixOS/nixpkgs/commit/cf4e4ffb354288ac1f8143cf0b60af01bee0c2ca) | `` feishin: bump electron to 40 ``                                                        |
| [`bbaf15ff`](https://github.com/NixOS/nixpkgs/commit/bbaf15ffe5a8e2f9f3efd567ffb53419323e6525) | `` feishin: 1.10.0 -> 1.11.0 ``                                                           |
| [`65c3616b`](https://github.com/NixOS/nixpkgs/commit/65c3616ba9a2f05be60b59050dcde23949e5f97d) | `` feishin: 1.9.0 -> 1.10.0 ``                                                            |
| [`1894afe5`](https://github.com/NixOS/nixpkgs/commit/1894afe52ff4a8349b9d76031e44735447401e6b) | `` feishin: 1.8.0 -> 1.9.0 ``                                                             |
| [`45252c48`](https://github.com/NixOS/nixpkgs/commit/45252c489f996d4cac31201ac0d2e29c664c2b45) | `` feishin: Clean up darwin build ``                                                      |
| [`00c44fa5`](https://github.com/NixOS/nixpkgs/commit/00c44fa54b08f5108564eeb37c9a1b9a1c41ca15) | `` feishin: 1.7.0 -> 1.8.0 ``                                                             |
| [`c9ed29e9`](https://github.com/NixOS/nixpkgs/commit/c9ed29e938d3c03c09d56c31cc39e8512399f4ef) | `` nodejs_24: 24.15.0 -> 24.16.0 ``                                                       |
| [`72f674ae`](https://github.com/NixOS/nixpkgs/commit/72f674aedeedbcac27f72cdbbdf8dce3c1498a15) | `` olivetin-3k: 3000.11.3 -> 3000.12.0 ``                                                 |
| [`6b31e3b1`](https://github.com/NixOS/nixpkgs/commit/6b31e3b14f0e9ea0d0f0a10a52fcff963f78791a) | `` vivaldi: 7.9.3970.67 -> 8.0.4033.26 ``                                                 |
| [`99f1e5d3`](https://github.com/NixOS/nixpkgs/commit/99f1e5d31f8e5c43aeabafb84fd41b33f6f6b105) | `` pdns: 4.9.14 -> 4.9.15 ``                                                              |
| [`14325f3a`](https://github.com/NixOS/nixpkgs/commit/14325f3a0115f66b859121e5fc4fa0a526dffa58) | `` mastodon: 4.5.9 -> 4.5.10 ``                                                           |
| [`e3fb530e`](https://github.com/NixOS/nixpkgs/commit/e3fb530e1e6ec66c7e1d8de8e60262132a6660a1) | `` varnish: 8.0.1 -> 8.0.2 ``                                                             |
| [`87ecac4a`](https://github.com/NixOS/nixpkgs/commit/87ecac4aa32d525ce67a91a564dc8c71e98f545e) | `` varnish60: 6.0.17 -> 6.0.18 ``                                                         |
| [`9349d784`](https://github.com/NixOS/nixpkgs/commit/9349d7841ad4715e94ef41654e0647a849a4d912) | `` firefox-devedition-unwrapped: 150.0b7 -> 152.0b1 ``                                    |
| [`cec62527`](https://github.com/NixOS/nixpkgs/commit/cec62527f94f3aa1def8cfd1137f1278bf21d320) | `` ghgrab: 1.3.2 -> 2.0.1 ``                                                              |
| [`d8cd34ff`](https://github.com/NixOS/nixpkgs/commit/d8cd34ff6ad57105209994354e850630445a0bff) | `` ghgrab: 1.3.1 -> 1.3.2 ``                                                              |
| [`a42072f6`](https://github.com/NixOS/nixpkgs/commit/a42072f6b0dee8543bdf7f69ddc2e365d5085d3b) | `` edhm-ui: 3.0.64 -> 3.0.67 ``                                                           |
| [`88182f58`](https://github.com/NixOS/nixpkgs/commit/88182f5880101db9b1cd396a8472aad0ad990cf8) | `` drupal: 11.2.11 -> 11.2.12 ``                                                          |
| [`aa019a03`](https://github.com/NixOS/nixpkgs/commit/aa019a03dce6106616ad9be5f701d3497101bdea) | `` openbao: 2.5.3 -> 2.5.4 ``                                                             |
| [`c4351148`](https://github.com/NixOS/nixpkgs/commit/c43511484e072ffc6f171fc1e080fa5e3f0c2f36) | `` mongodb-7_0: 7.0.32 -> 7.0.34 ``                                                       |
| [`bfbdb8ae`](https://github.com/NixOS/nixpkgs/commit/bfbdb8ae3f85ffdd6cb439e984001c3f63aaa2bc) | `` radicle-ci-broker: 0.27.0 -> 0.28.0 ``                                                 |
| [`3cdb49ec`](https://github.com/NixOS/nixpkgs/commit/3cdb49ece6829e3f0f797d7e6833c1da1f28c8a9) | `` ungoogled-chromium: 148.0.7778.167-1 -> 148.0.7778.178-1 ``                            |
| [`01d5e27a`](https://github.com/NixOS/nixpkgs/commit/01d5e27ac666fd05bdb3ae65a106badac7a359b6) | `` mullvad-browser: 15.0.12 -> 15.0.14 ``                                                 |
| [`248cc2cf`](https://github.com/NixOS/nixpkgs/commit/248cc2cff74b637cda7a1ea2f08bdb61d5adb169) | `` tor-browser: 15.0.13 -> 15.0.14 ``                                                     |
| [`38eae8c1`](https://github.com/NixOS/nixpkgs/commit/38eae8c1d66e9ead6c87330635d622b990511dcf) | `` osu-lazer: 2026.429.0 -> 2026.518.0 ``                                                 |
| [`2fed6ad7`](https://github.com/NixOS/nixpkgs/commit/2fed6ad71a19d3cbfeec2d2d8a0dde2a89d0f832) | `` osu-lazer-bin: 2026.429.0 -> 2026.518.0 ``                                             |
| [`367d5a57`](https://github.com/NixOS/nixpkgs/commit/367d5a57128fdb3291a13d4bcee373c6d83f7184) | `` [Backport release-25.11] sssd: 2.12.0 -> 2.13.0 ``                                     |
| [`eb0e96b8`](https://github.com/NixOS/nixpkgs/commit/eb0e96b84bbf7a2d9b869cbf34742314c6f7aec6) | `` chromium,chromedriver: 148.0.7778.167 -> 148.0.7778.178 ``                             |
| [`0340bf5d`](https://github.com/NixOS/nixpkgs/commit/0340bf5d18b38ee956514c3584783c66eef806f6) | `` radicle-node-unstable: 1.9.0-rc.3 -> 1.9.0 ``                                          |
| [`07589d59`](https://github.com/NixOS/nixpkgs/commit/07589d59ec4d97f0d00af8d246479bdb987b324a) | `` radicle-node: 1.8.0 -> 1.9.0 ``                                                        |
| [`6b160bbc`](https://github.com/NixOS/nixpkgs/commit/6b160bbcd0a3888d866a6f55238b972fe32011fc) | `` radicle-node-unstable: 1.9.0-rc.1 -> 1.9.0-rc.3 ``                                     |
| [`77a0f5f5`](https://github.com/NixOS/nixpkgs/commit/77a0f5f5a205fd8137fa77fb4573f23af485fe32) | `` radicle-node-unstable: 1.8.0 -> 1.9.0-rc.1 ``                                          |
| [`128c7c1f`](https://github.com/NixOS/nixpkgs/commit/128c7c1f4616b4e7c688270ccced58b5f72e18f3) | `` mprisence: 1.5.2 -> 1.6.0 ``                                                           |
| [`56bd39e1`](https://github.com/NixOS/nixpkgs/commit/56bd39e11bf87c59379e4153f9007329fa8097f1) | `` google-chrome: 148.0.7778.167 -> 148.0.7778.178 ``                                     |
| [`d03df731`](https://github.com/NixOS/nixpkgs/commit/d03df73102bb506531a5e9fd54779c0b75889bdd) | `` rapid-photo-downloader: change homepage to correct URL ``                              |
| [`45ae0cc8`](https://github.com/NixOS/nixpkgs/commit/45ae0cc8b220cf55eb855e895cd061218aa9081e) | `` microsoft-edge: 147.0.3912.98 -> 148.0.3967.54 ``                                      |
| [`7b4f16fd`](https://github.com/NixOS/nixpkgs/commit/7b4f16fd37cde29fdad564b8025e6d3ad0434933) | `` linux-firmware: 20260410 -> 20260519 ``                                                |
| [`b880c419`](https://github.com/NixOS/nixpkgs/commit/b880c4194d845e15da3ed832915b27f8e5600357) | `` gajim: 2.4.5 -> 2.4.6 ``                                                               |
| [`01b13b9a`](https://github.com/NixOS/nixpkgs/commit/01b13b9a9902e95b6d7cc694349c347f9a05a563) | `` jackett: 0.24.1831 -> 0.24.1879 ``                                                     |
| [`2c22d802`](https://github.com/NixOS/nixpkgs/commit/2c22d8026dd70eafaf7975e9c075d0f724d0732b) | `` electron-chromedriver: enable strictDeps, __structuredAttrs ``                         |
| [`0e8973d8`](https://github.com/NixOS/nixpkgs/commit/0e8973d893c20479f1d10a52a48484f3553376de) | `` electron_bin: enable strictDeps, __structuredAttrs ``                                  |
| [`054c8418`](https://github.com/NixOS/nixpkgs/commit/054c841809328fb90eee4b4c3d9b0abccdf04bab) | `` electron: set strictDeps to true, enable __structuredAttrs ``                          |
| [`d5bffdc6`](https://github.com/NixOS/nixpkgs/commit/d5bffdc6e009802ecb71c8f9a512cfcec2303cd8) | `` electron-chromedriver_42: 42.0.1 -> 42.1.0 ``                                          |
| [`177cdee5`](https://github.com/NixOS/nixpkgs/commit/177cdee5c5a3967802aefe2bfd7d8a6cc808fbb2) | `` electron_42-bin: 42.0.1 -> 42.1.0 ``                                                   |
| [`a5cb7eb2`](https://github.com/NixOS/nixpkgs/commit/a5cb7eb274b989bd3e64820bb261e8bb761ed77d) | `` electron-chromedriver_41: 41.5.2 -> 41.6.1 ``                                          |
| [`cedd9302`](https://github.com/NixOS/nixpkgs/commit/cedd93026e3042f5c8d6d5a8ac84162faf13e73f) | `` electron_41-bin: 41.5.2 -> 41.6.1 ``                                                   |
| [`3dd6c112`](https://github.com/NixOS/nixpkgs/commit/3dd6c112743f60b76251d5bb36435c7f1b4d6c01) | `` electron-source.electron_42: 42.0.1 -> 42.1.0 ``                                       |
| [`10ee3c7e`](https://github.com/NixOS/nixpkgs/commit/10ee3c7efadbb5f38d4207128a46ff708e661fb1) | `` electron-source.electron_41: 41.5.2 -> 41.6.1 ``                                       |
| [`8d726124`](https://github.com/NixOS/nixpkgs/commit/8d726124f667fbdcf9c2dbcde9c955035eebf3c2) | `` electron-chromedriver_42: 42.0.0 -> 42.0.1 ``                                          |
| [`99875e57`](https://github.com/NixOS/nixpkgs/commit/99875e57c71d88b92c92045e7c52d7053a5667cd) | `` electron_42-bin: 42.0.0 -> 42.0.1 ``                                                   |
| [`0832f570`](https://github.com/NixOS/nixpkgs/commit/0832f57082b76beb21911d8d40eb2a4aa93677a1) | `` electron-chromedriver_41: 41.5.0 -> 41.5.2 ``                                          |
| [`06148ec8`](https://github.com/NixOS/nixpkgs/commit/06148ec8e2b9e957dd7187b1e02a52708c3513f0) | `` electron_41-bin: 41.5.0 -> 41.5.2 ``                                                   |
| [`3b25793a`](https://github.com/NixOS/nixpkgs/commit/3b25793a4a27d2d7d7644ee7de185370621f6581) | `` electron-chromedriver_40: 40.9.3 -> 40.10.0 ``                                         |
| [`8b2370f3`](https://github.com/NixOS/nixpkgs/commit/8b2370f39ba797d2a4c6fe987835c9efd13159ee) | `` electron_40-bin: 40.9.3 -> 40.10.0 ``                                                  |
| [`0cabbb0f`](https://github.com/NixOS/nixpkgs/commit/0cabbb0ff98d28c76d003c51ac159fdd2e1e36e8) | `` electron-source.electron_42: 42.0.0 -> 42.0.1 ``                                       |
| [`b418ea84`](https://github.com/NixOS/nixpkgs/commit/b418ea8434fb3d3ab021599f23ab6955908b76a1) | `` electron-source.electron_41: 41.5.0 -> 41.5.2 ``                                       |
| [`af12f3cc`](https://github.com/NixOS/nixpkgs/commit/af12f3ccecda2be2b8a0b4363698246b4e2156ad) | `` electron-source.electron_40: 40.9.3 -> 40.10.0 ``                                      |
| [`9b76d7f0`](https://github.com/NixOS/nixpkgs/commit/9b76d7f0c88b7081684c6fa634b8f28a7a77e13d) | `` electron: update.py: fetch missing-hashes ``                                           |
| [`e07ecc21`](https://github.com/NixOS/nixpkgs/commit/e07ecc21deb54501aa4d4d54d13737a4299b901d) | `` electron-chromedriver_41: 41.3.0 -> 41.5.0 ``                                          |
| [`522eb5b3`](https://github.com/NixOS/nixpkgs/commit/522eb5b39ff4c1489ae3b553e1f7bc671fb70eba) | `` electron_41-bin: 41.3.0 -> 41.5.0 ``                                                   |
| [`4e4668c3`](https://github.com/NixOS/nixpkgs/commit/4e4668c33d211961708ca1f32d181a24a10ca5fc) | `` electron-chromedriver_40: 40.9.2 -> 40.9.3 ``                                          |
| [`a46e5dbc`](https://github.com/NixOS/nixpkgs/commit/a46e5dbc6f5a115a61a85e59b4c396f96efb1d12) | `` electron_40-bin: 40.9.2 -> 40.9.3 ``                                                   |
| [`a7b73356`](https://github.com/NixOS/nixpkgs/commit/a7b7335670e5a2ad7e04987142993a0a3e0cd1b3) | `` electron-chromedriver_39: 39.8.9 -> 39.8.10 ``                                         |
| [`b4fe821d`](https://github.com/NixOS/nixpkgs/commit/b4fe821d1d715df3a79fcaf0341488e291921300) | `` electron_39-bin: 39.8.9 -> 39.8.10 ``                                                  |
| [`8edcfb17`](https://github.com/NixOS/nixpkgs/commit/8edcfb17f68d77514b42e3f6f7275c8ae193497f) | `` electron-source.electron_39: 39.8.9 -> 39.8.10 ``                                      |
| [`db4905c2`](https://github.com/NixOS/nixpkgs/commit/db4905c24699b3a9f21fd8bf25f49eea13afeee8) | `` electron-source.electron_41: 41.3.0 -> 41.5.0 ``                                       |
| [`1860becc`](https://github.com/NixOS/nixpkgs/commit/1860becc29a7944ea6a62bf354f05d45483e931b) | `` electron-source.electron_40: 40.9.2 -> 40.9.3 ``                                       |
| [`cc89cb2b`](https://github.com/NixOS/nixpkgs/commit/cc89cb2bf6fd06cc37593207f41eeaf25f1fd9c7) | `` electron-chromedriver_42: init at 42.0.0 ``                                            |
| [`5724ee21`](https://github.com/NixOS/nixpkgs/commit/5724ee21c99be87f3c213609f9d4e5c38b763cfa) | `` electron_42-bin: init at 42.0.0 ``                                                     |
| [`d07aa655`](https://github.com/NixOS/nixpkgs/commit/d07aa65536545f133750908629ca02829d46e496) | `` electron-source.electron_42: init at 42.0.0 ``                                         |
| [`4e52ef64`](https://github.com/NixOS/nixpkgs/commit/4e52ef6480b09cd0711a53ec9d1ba3ff9219ecf9) | `` openimageio: 3.1.12.0 -> 3.1.13.1 ``                                                   |
| [`667fce87`](https://github.com/NixOS/nixpkgs/commit/667fce878161f79f6a6badc304d6389aed79f264) | `` openimageio: 3.1.11.0 -> 3.1.12.0 ``                                                   |
| [`27e6b85f`](https://github.com/NixOS/nixpkgs/commit/27e6b85f940e3016290a63f8def201fb2eed4e64) | `` nixosTests.discourse: make imap polling quieter ``                                     |
| [`5fbf78d4`](https://github.com/NixOS/nixpkgs/commit/5fbf78d491a7d11ecbbd6a87d3afb1e859fb8518) | `` discourse-mail-receiver: replace `replace` with `sd` ``                                |
| [`64b70c3a`](https://github.com/NixOS/nixpkgs/commit/64b70c3a1de59cfdd9fde9ed65764fbf2d3576ee) | `` discourse: 2026.1.3 -> 2026.1.4 ``                                                     |
| [`0a1aa563`](https://github.com/NixOS/nixpkgs/commit/0a1aa56374887f53302772e23f908ce1d9c2041d) | `` nixos/prefect: respect services.prefect.package ``                                     |
| [`9a5fe597`](https://github.com/NixOS/nixpkgs/commit/9a5fe597b0ba2ead78159497333841767ea0b6c7) | `` Revert "ci/github-script/reviewers: revoke stale review requests" ``                   |
| [`004d5487`](https://github.com/NixOS/nixpkgs/commit/004d548768be8ee5e3873a888cf1f12e549a05af) | `` Revert "ci/github-script/reviewers: keep team members when revoking stale requests" `` |
| [`4aaba361`](https://github.com/NixOS/nixpkgs/commit/4aaba36168f8aa81086a3c95e04392a13dfb9a50) | `` nextcloud33Packages: update ``                                                         |
| [`aad764ac`](https://github.com/NixOS/nixpkgs/commit/aad764ac7b958adc7fd802237f06692cd6e83a17) | `` nextcloud32Packages: update ``                                                         |
| [`a6dfbdff`](https://github.com/NixOS/nixpkgs/commit/a6dfbdff6bb224e8924c71dc02f2c18234230b5e) | `` qbz: 1.2.12 -> 1.2.13 ``                                                               |
| [`4456d8d3`](https://github.com/NixOS/nixpkgs/commit/4456d8d3bdcc82643c5e03811dd50c37cc312302) | `` ci/github-script/reviewers: keep team members when revoking stale requests ``          |
| [`69e4c3df`](https://github.com/NixOS/nixpkgs/commit/69e4c3dfd4ce046b754f36e0e98be129c4552817) | `` nextcloud33: 33.0.2 -> 33.0.3 ``                                                       |
| [`f61ebb10`](https://github.com/NixOS/nixpkgs/commit/f61ebb1008a4318c7482d4a7d2f515605c9f658c) | `` nextcloud32: 32.0.8 -> 32.0.9 ``                                                       |
| [`7851eccc`](https://github.com/NixOS/nixpkgs/commit/7851eccc52fc432f9ad8cebb55fbf358f8ce324d) | `` firefox-esr-140-unwrapped: 140.10.2esr -> 140.11.0esr ``                               |
| [`1b45af79`](https://github.com/NixOS/nixpkgs/commit/1b45af790882147d8c9b078b19771c3326632a18) | `` firefox-bin-unwrapped: 150.0.3 -> 151.0 ``                                             |
| [`5c57973e`](https://github.com/NixOS/nixpkgs/commit/5c57973ea869ccbf7f665f69f20495da6fdb6eb5) | `` firefox-unwrapped: 150.0.3 -> 151.0 ``                                                 |
| [`17fdbb17`](https://github.com/NixOS/nixpkgs/commit/17fdbb1759182b24d77d90fa769b754c996454e4) | `` github-runner: 2.333.1 -> 2.334.0 ``                                                   |
| [`7df0ddc3`](https://github.com/NixOS/nixpkgs/commit/7df0ddc300d3d87c59b87c26a084ce03a852f210) | `` wayle: 0.2.3 -> 0.3.0 ``                                                               |
| [`0bfcc128`](https://github.com/NixOS/nixpkgs/commit/0bfcc128ebed68129d1b8ea4342c78ea48591b1c) | `` obsidian: pin electron to 40 ``                                                        |
| [`798f9480`](https://github.com/NixOS/nixpkgs/commit/798f9480906378ab009c7741e514d14e20f8a389) | `` imagemagick6: 6.9.13-38 -> 6.9.13-48 ``                                                |
| [`801622e3`](https://github.com/NixOS/nixpkgs/commit/801622e34c5b0377cbb11b563adb80ba3d199b42) | `` python3Packages.nbxmpp: 7.1.0 -> 7.2.0 ``                                              |
| [`a4b6a06f`](https://github.com/NixOS/nixpkgs/commit/a4b6a06f612d8779fd52245237761d672c969c30) | `` thunderbird-latest-bin-unwrapped: 150.0.1 -> 150.0.2 ``                                |
| [`4cf8a906`](https://github.com/NixOS/nixpkgs/commit/4cf8a9063cbcd677a7791bfdeda7fd04f23bc1e3) | `` radicle-explorer: refactor ``                                                          |
| [`8c2ea766`](https://github.com/NixOS/nixpkgs/commit/8c2ea7661c6f53031537cde4622fe27af24a9c89) | `` floorp-bin-unwrapped: 12.13.0 -> 12.14.0 ``                                            |
| [`1d3dd544`](https://github.com/NixOS/nixpkgs/commit/1d3dd5448438d1d931d5761fd342da613d145adf) | `` mongodb-7_0: 7.0.31 -> 7.0.32 ``                                                       |
| [`9acd345e`](https://github.com/NixOS/nixpkgs/commit/9acd345ee70288587a989996b83f9136d7f9e342) | `` lightway: 0-unstable-2026-04-10 -> 0-unstable-2026-04-24 ``                            |
| [`bd451c74`](https://github.com/NixOS/nixpkgs/commit/bd451c748b797936c58a945ffc4637f292b1725e) | `` nix-direnv: 3.1.0 -> 3.1.1 ``                                                          |
| [`56d7d2e2`](https://github.com/NixOS/nixpkgs/commit/56d7d2e27fd4a340a4d10a83f1603689abbc5347) | `` linuxPackages.amneziawg: 1.0.20260322 -> 1.0.20260329-2 ``                             |
| [`a934bac4`](https://github.com/NixOS/nixpkgs/commit/a934bac4701b22cca031b34851c0440128cbdc18) | `` linuxPackages.amneziawg: 1.0.20251019 -> 1.0.20260322 ``                               |
| [`9cce7080`](https://github.com/NixOS/nixpkgs/commit/9cce70801261705d0b0951204717d69fe81a0b7c) | `` plexamp: 4.13.0 -> 4.13.1 ``                                                           |
| [`942dcf77`](https://github.com/NixOS/nixpkgs/commit/942dcf77b57f938797fee1862183324ab8f4971e) | `` python3Packages.modern-colorthief: 0.1.7 -> 0.1.12 ``                                  |