### PR TITLE
chore(flake/nixvim): `7259329d` -> `afec1bae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1431,11 +1431,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1779621590,
-        "narHash": "sha256-kGu+wVVqu3ltT845pu3MtOGTW40rcCUVDW3JGffSpp0=",
+        "lastModified": 1779683452,
+        "narHash": "sha256-Ksx8jghpDBCPDiTaTyGhYUXG1BUwqPjf5pajl0q0cqA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7259329db1e6145842411873d23b2dab577539a3",
+        "rev": "afec1bae0e6f7983a5c03ec559f7ed2ec0e714a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`afec1bae`](https://github.com/nix-community/nixvim/commit/afec1bae0e6f7983a5c03ec559f7ed2ec0e714a9) | `` flake/dev: mark flake-compat as `flake = false` ``              |
| [`4aa27f5a`](https://github.com/nix-community/nixvim/commit/4aa27f5af04ac065971550116ecdbf05958297b9) | `` flake/dev: have nuschtosSearch systems input follow nixivm's `` |
| [`860304dd`](https://github.com/nix-community/nixvim/commit/860304dd630b69bce65b08bc38aeefd01ccb6a70) | `` flake/dev: drop dev-nixpkgs for nixvim path ref ``              |
| [`01bd2788`](https://github.com/nix-community/nixvim/commit/01bd278849f0e546aed4a90f15e81a65f9d131b4) | `` modules: drop `helpers` alias ``                                |
| [`909aa0a7`](https://github.com/nix-community/nixvim/commit/909aa0a782c2b853d2aa798eb08e89130416d3d4) | `` wrappers: pass in existing `lib.nixvim` ``                      |
| [`e71dab10`](https://github.com/nix-community/nixvim/commit/e71dab10a67868be0539168cf5e4f01efd8983b6) | `` tests/platforms: add failing test for #4341 ``                  |