### PR TITLE
chore(flake/home-manager): `044c30c1` -> `1a95e2ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779627636,
-        "narHash": "sha256-J6JGf42zNzLo/CrRdKb5dNznpLI+eGxN/5KTLG1Mo5s=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "044c30c19550c0557997dece4ce9e54d2fa77ba1",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`1a95e2ef`](https://github.com/nix-community/home-manager/commit/1a95e2efb477959b70b4a14c51035975c0481df6) | `` home-manager: set 26.05 as stable ``               |
| [`f4df9da9`](https://github.com/nix-community/home-manager/commit/f4df9da9603acbd0deb74f97e997d7ee4c9306d5) | `` maintainers: update all-maintainers.nix ``         |
| [`612bbe3b`](https://github.com/nix-community/home-manager/commit/612bbe3b405ad5f71d7bf9edecc04b678a061652) | `` tests/darwinScrublist: add pimsync ``              |
| [`f9833292`](https://github.com/nix-community/home-manager/commit/f98332929bef04961f4ef3b2804d712d32d85d03) | `` flake: bump nixpkgs from `f83fc3c` to `2991645` `` |