### PR TITLE
chore(flake/catppuccin): `229ede9c` -> `823da4d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779446167,
-        "narHash": "sha256-95gfnivOKw+zleITz2OptawwTeSs36Y9u+qeU0xdqT8=",
+        "lastModified": 1779741226,
+        "narHash": "sha256-2Oz1vwT1lRF16zXFpT8FoxSTF6/V6uKLsKo52Xxa0cs=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "229ede9cec873986144e222b2c61c2f239c16125",
+        "rev": "823da4d4f1160d7ac395fe459a4e33d9dfe57bb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                  |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`823da4d4`](https://github.com/catppuccin/nix/commit/823da4d4f1160d7ac395fe459a4e33d9dfe57bb2) | `` chore: update minver (#945) ``                                        |
| [`810d516f`](https://github.com/catppuccin/nix/commit/810d516feaf45001ec8b5feed84846dee87cf95d) | `` feat(home-manager): add support for obsidian (#941) ``                |
| [`e7bcf428`](https://github.com/catppuccin/nix/commit/e7bcf42850707d7ba30faf24651cd0b519c6ecdc) | `` docs: add 26.05 changelog (#943) ``                                   |
| [`327a473b`](https://github.com/catppuccin/nix/commit/327a473b59280b397ee447d3a71405f1bfb651a2) | `` fix(home-manger/hyprland): make compatible with lua configs (#942) `` |
| [`f62754e0`](https://github.com/catppuccin/nix/commit/f62754e0e8c13248765df49043bcb6bef842a325) | `` style: format 229ede9 ``                                              |