### PR TITLE
chore(flake/catppuccin): `823da4d4` -> `c61cab96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779741226,
-        "narHash": "sha256-2Oz1vwT1lRF16zXFpT8FoxSTF6/V6uKLsKo52Xxa0cs=",
+        "lastModified": 1779910193,
+        "narHash": "sha256-CQD/mtBC1VYQgTpKR6LhD+gPJ9S3neN6rBo/RYFWDgM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "823da4d4f1160d7ac395fe459a4e33d9dfe57bb2",
+        "rev": "c61cab9677ff7184891930a60bf8224aa81c3a31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                    |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`c61cab96`](https://github.com/catppuccin/nix/commit/c61cab9677ff7184891930a60bf8224aa81c3a31) | `` chore: prepare for 26.05 release (#956) ``              |
| [`7d283dea`](https://github.com/catppuccin/nix/commit/7d283dea9a4e25cfa9a544eb40933d256cb57957) | `` chore(shell): update nix version (#954) ``              |
| [`92c12ae6`](https://github.com/catppuccin/nix/commit/92c12ae65893d2538475ce4190122ee297e158fc) | `` feat(nixos/fish): init (#953) ``                        |
| [`96bf46de`](https://github.com/catppuccin/nix/commit/96bf46de3e35bc8e4e1040db43d57f21ae8648e2) | `` fix(hyprlock): handle pin hyprland.conf files (#951) `` |
| [`2084c545`](https://github.com/catppuccin/nix/commit/2084c545f5150584ccb5b1d03fefb345155ecb29) | `` feat(home-manager/gemini-cli): remove IFD (#948) ``     |