### PR TITLE
ci(lint): skip dev shell to avoid colmena rebuild; update darwin input

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,7 +58,13 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Run flake pre-commit hooks
-        run: nix develop -c pre-commit run --all-files
+        # Build the pre-commit-check derivation directly instead of entering
+        # the dev shell. The dev shell pulls in `colmena` from its flake input
+        # (not cached by cache.nixos.org), forcing CI to compile colmena and
+        # all its Cargo dependencies on every run — which is both slow and
+        # prone to transient crates.io 403s. The check derivation runs the
+        # same hooks at build time without that dependency.
+        run: nix build --no-link --print-build-logs .#checks.x86_64-linux.pre-commit-check
 
   # =====================================================================
   # Required Check Summary

--- a/flake.lock
+++ b/flake.lock
@@ -192,13 +192,13 @@
       "locked": {
         "lastModified": 1779036909,
         "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
-        "owner": "lnl7",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
         "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
-        "owner": "lnl7",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
 
     # CI: skip (macOS only)
     darwin = {
-      url = "github:lnl7/nix-darwin";
+      url = "github:nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary

- **Lint workflow:** build `.#checks.x86_64-linux.pre-commit-check` directly instead of `nix develop -c pre-commit run --all-files`. The dev shell depends on `colmena` from its flake input (not on `cache.nixos.org`), so every CI run was compiling colmena from source and pulling all its Cargo deps from crates.io — slow, and recently failing on transient 403s (see run 26547365566).
- **Flake input:** switch `darwin` from the legacy `lnl7/nix-darwin` mirror to the canonical `nix-darwin/nix-darwin` repo. The pinned revision is identical, so `flake.lock` only changes the owner field.

## Why

The pre-commit-check derivation runs the exact same hook set at build time — no colmena needed for linting. Reserving the colmena CLI for the dev shell (interactive use) keeps CI fast and removes a flaky external dependency.