### PR TITLE
chore(flake/catppuccin): `c61cab96` -> `cf8ccac2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779910193,
-        "narHash": "sha256-CQD/mtBC1VYQgTpKR6LhD+gPJ9S3neN6rBo/RYFWDgM=",
+        "lastModified": 1780154910,
+        "narHash": "sha256-aaGjVFEAJQWB69kok/AthcXpT/9yA5Ag2uYDwdbbj5c=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "c61cab9677ff7184891930a60bf8224aa81c3a31",
+        "rev": "cf8ccac24e24a2a78fe6f36de9c5d5e9860299a4",
         "type": "github"
       },
       "original": {

--- a/flake/lib/mk-darwin-system.nix
+++ b/flake/lib/mk-darwin-system.nix
@@ -74,16 +74,11 @@ darwin.lib.darwinSystem {
           ]
           ++ hmModules;
 
-          catppuccin = {
-            enable = true;
-            # Opt out of the new global auto-enroll behavior introduced in
-            # catppuccin/nix #817 — per-port enables remain explicit in the
-            # feature modules. Silences the "catppuccin/nix will soon auto
-            # enroll ports" home-manager warning.
-            autoEnable = false;
-            flavor = "mocha";
-            accent = "lavender";
-          };
+          # `enable`, `flavor`, `accent`, and (when present on the input)
+          # `autoEnable` are set by ../../modules/base/home.nix. Only the
+          # NixOS-side system module sets `enable = true` automatically;
+          # Darwin needs it set explicitly here at the HM level.
+          catppuccin.enable = true;
         };
 
         extraSpecialArgs = {

--- a/flake/lib/mk-darwin-system.nix
+++ b/flake/lib/mk-darwin-system.nix
@@ -76,6 +76,11 @@ darwin.lib.darwinSystem {
 
           catppuccin = {
             enable = true;
+            # Opt out of the new global auto-enroll behavior introduced in
+            # catppuccin/nix #817 — per-port enables remain explicit in the
+            # feature modules. Silences the "catppuccin/nix will soon auto
+            # enroll ports" home-manager warning.
+            autoEnable = false;
             flavor = "mocha";
             accent = "lavender";
           };

--- a/modules/base/catppuccin.nix
+++ b/modules/base/catppuccin.nix
@@ -1,12 +1,17 @@
+{ lib, options, ... }:
 {
   catppuccin = {
     enable = true;
-    # Opt out of the new global auto-enroll behavior introduced in
-    # catppuccin/nix #817. We keep per-port enables explicit across the
-    # feature modules, so set this to `false` to preserve current behavior
-    # and silence the "catppuccin/nix will soon auto enroll ports" warning.
-    autoEnable = false;
     flavor = "mocha";
     accent = "lavender";
+  }
+  # `autoEnable` was introduced in catppuccin/nix #817 (post-25.11). The
+  # release-25.11 input used by server hosts does not have this option yet,
+  # so guard the assignment on its presence. Setting it to `false` preserves
+  # current behavior (per-port enables stay explicit in feature modules)
+  # and silences the "catppuccin/nix will soon auto enroll ports" warning
+  # on hosts pinned to unstable.
+  // lib.optionalAttrs (options.catppuccin ? autoEnable) {
+    autoEnable = false;
   };
 }

--- a/modules/base/catppuccin.nix
+++ b/modules/base/catppuccin.nix
@@ -1,6 +1,11 @@
 {
   catppuccin = {
     enable = true;
+    # Opt out of the new global auto-enroll behavior introduced in
+    # catppuccin/nix #817. We keep per-port enables explicit across the
+    # feature modules, so set this to `false` to preserve current behavior
+    # and silence the "catppuccin/nix will soon auto enroll ports" warning.
+    autoEnable = false;
     flavor = "mocha";
     accent = "lavender";
   };

--- a/modules/base/home.nix
+++ b/modules/base/home.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  options,
   isDarwin,
   inputs,
   verbose_name,
@@ -34,15 +35,18 @@ in
   ##########################################################################
   ## catppuccin (home-manager)
   ##########################################################################
-  # Opt out of the new global auto-enroll behavior introduced in
-  # catppuccin/nix #817. Each port is explicitly enabled in its feature
-  # module, so setting `autoEnable = false` preserves current behavior and
-  # suppresses the "catppuccin/nix will soon auto enroll ports" warning at
-  # the home-manager profile level.
+  # `autoEnable` was introduced in catppuccin/nix #817 (post-25.11). The
+  # release-25.11 input used by server hosts does not have this option yet,
+  # so guard the assignment on its presence. Setting it to `false` keeps
+  # current behavior (per-port enables remain explicit in feature modules)
+  # and suppresses the "catppuccin/nix will soon auto enroll ports" warning
+  # at the home-manager profile level on hosts pinned to unstable.
   catppuccin = {
-    autoEnable = false;
     flavor = "mocha";
     accent = "lavender";
+  }
+  // lib.optionalAttrs (options.catppuccin ? autoEnable) {
+    autoEnable = false;
   };
 
   ##########################################################################

--- a/modules/base/home.nix
+++ b/modules/base/home.nix
@@ -32,6 +32,20 @@ in
   ++ lib.optional isLinux ./home-linux.nix;
 
   ##########################################################################
+  ## catppuccin (home-manager)
+  ##########################################################################
+  # Opt out of the new global auto-enroll behavior introduced in
+  # catppuccin/nix #817. Each port is explicitly enabled in its feature
+  # module, so setting `autoEnable = false` preserves current behavior and
+  # suppresses the "catppuccin/nix will soon auto enroll ports" warning at
+  # the home-manager profile level.
+  catppuccin = {
+    autoEnable = false;
+    flavor = "mocha";
+    accent = "lavender";
+  };
+
+  ##########################################################################
   ## .gitconfig — fully generated
   ##########################################################################
   home.file.".gitconfig".text = ''


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`cf8ccac2`](https://github.com/catppuccin/nix/commit/cf8ccac24e24a2a78fe6f36de9c5d5e9860299a4) | `` chore: update port sources (#958) ``                                                   |
| [`b58bc1e6`](https://github.com/catppuccin/nix/commit/b58bc1e6e3e006853e2eecf11da0ba3d9430dbad) | `` chore: update flakes (#957) ``                                                         |
| [`6a10ed7a`](https://github.com/catppuccin/nix/commit/6a10ed7aeceb3e7d81b5763e6b9144e672706e91) | `` feat!(nixos/sddm): drop accentColor removal (#966) ``                                  |
| [`22b36c36`](https://github.com/catppuccin/nix/commit/22b36c36ebe70a1d8f6d02bae743c7fa415c5c7f) | `` feat!(home-manager/gtk): drop removal warning (#965) ``                                |
| [`74a76c78`](https://github.com/catppuccin/nix/commit/74a76c78738fa5f61750d6ad29aaa72100810145) | `` feat(global): add `autoEnable` and make `enable = false` disable all modules (#817) `` |
| [`6cfdd6fb`](https://github.com/catppuccin/nix/commit/6cfdd6fbfa5c13cda26aad39c708c7d396f6d609) | `` Revert "feat(home-manager/gemini-cli): remove IFD" (#962) ``                           |
| [`08442687`](https://github.com/catppuccin/nix/commit/084426878f3fc8d3ebecb903eea1424ee5932dd1) | `` fix(pkgs/firefox): appease absolute path lint (#959) ``                                |