### PR TITLE
chore(flake/nixvim): `297f9341` -> `57e5355a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1315,11 +1315,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1779259093,
-        "narHash": "sha256-7DKWmH23hL2eYdkxCKeqj2i+yljTKuU+3Nk1UPHOnxc=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d99b013d5d1931ad77fe3912ed218170dec5d9a4",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {
@@ -1480,11 +1480,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1779816597,
-        "narHash": "sha256-Kgod3gZlhSp6WozZ2pFaclXbWpjs6kQLAtldoxb85Lc=",
+        "lastModified": 1780161591,
+        "narHash": "sha256-eOiIbCMsYMP9JgZXzuT/m41djqDOEHTKjMFrm5NeVHM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "297f9341476ba7f821a42d7a2805e206ef8c6ef8",
+        "rev": "57e5355a843618a717a19d43b2a726a8f27f0bd1",
         "type": "github"
       },
       "original": {
@@ -1971,15 +1971,16 @@
     },
     "systems_7": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1774449309,
+        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
+        "ref": "future-26.11",
         "repo": "default",
         "type": "github"
       }


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`57e5355a`](https://github.com/nix-community/nixvim/commit/57e5355a843618a717a19d43b2a726a8f27f0bd1) | `` flake: Update ``                                                                   |
| [`2109e940`](https://github.com/nix-community/nixvim/commit/2109e940818781efa67b21379e4442d2c29db39d) | `` lsp/servers/packages: add package for phpantom_lsp ``                              |
| [`bbadbd73`](https://github.com/nix-community/nixvim/commit/bbadbd7319055d3633607a83b7d5a21550af2657) | `` github/workflows/lint: run on Merge Queue ``                                       |
| [`9dd9795a`](https://github.com/nix-community/nixvim/commit/9dd9795ae4753e20e8191eb44a0496b67870f3a3) | `` flake: pin `systems` to `future-26.11` ``                                          |
| [`8de98e09`](https://github.com/nix-community/nixvim/commit/8de98e0940b44e7a1f800e0630cb149294b76d81) | `` maintaining: update release process docs ``                                        |
| [`e2caf02e`](https://github.com/nix-community/nixvim/commit/e2caf02e8f454c67350c23919c832c910c98caf1) | `` github/workflows/lint: run on all PRs ``                                           |
| [`a6e624a0`](https://github.com/nix-community/nixvim/commit/a6e624a04f5f2e8fcbd6700bf47759a33462c5a8) | `` maintainers: update generated/all-maintainers.nix ``                               |
| [`f3dc9319`](https://github.com/nix-community/nixvim/commit/f3dc931903e78e667473cf161d4acfe63e737d7d) | `` plugins/wildfire.nvim: init ``                                                     |
| [`dd9bd8ef`](https://github.com/nix-community/nixvim/commit/dd9bd8ef00c4beeb0347e18af79aebe885ca8fd8) | `` maintainers: add fairaldi ``                                                       |
| [`d7800d4b`](https://github.com/nix-community/nixvim/commit/d7800d4b1c420e0c2dcaaddd58038c8b662e72a8) | `` flake: Update ``                                                                   |
| [`7dbb3473`](https://github.com/nix-community/nixvim/commit/7dbb34738b94b80adf70287b5a9216bf0f66a790) | `` tests/all-package-defaults: disable ols on darwin (because of compiler-rt-libc) `` |
| [`aebff073`](https://github.com/nix-community/nixvim/commit/aebff0739062c0bed3373780ca350e003e8e6cd9) | `` plugins/efmls-configs: add package for htmlhint ``                                 |
| [`580ee314`](https://github.com/nix-community/nixvim/commit/580ee31471628564ed54e9e94ec4570bfbcf012c) | `` generated: Updated efmls-configs-sources.json ``                                   |
| [`ce82af0e`](https://github.com/nix-community/nixvim/commit/ce82af0eae30c51f73bb9a23e3f3dcb93fa703c1) | `` flake: Update ``                                                                   |