### PR TITLE
chore(flake/home-manager): `1a95e2ef` -> `d0af9b8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1780347968,
+        "narHash": "sha256-I8ibSDQx+E8cgw6k3UxX6Bm7awmGoKSTXc8Gt1Zbpp4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "d0af9b8bf3b4a1d449be7034bebc9f8f9fd6ee99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`d0af9b8b`](https://github.com/nix-community/home-manager/commit/d0af9b8bf3b4a1d449be7034bebc9f8f9fd6ee99) | `` claude-code: mark hook scripts executable ``                 |
| [`5a608a62`](https://github.com/nix-community/home-manager/commit/5a608a621b001922dd708ca51a6260d5bef9e29b) | `` infat: allow customization of autoActivate ``                |
| [`8962c2a0`](https://github.com/nix-community/home-manager/commit/8962c2a0f464a5054bb77fade78eac568cd01264) | `` Translate using Weblate (Azerbaijani) ``                     |
| [`3d64f287`](https://github.com/nix-community/home-manager/commit/3d64f2875eed47965dc360a478eb03f85e599e17) | `` podman: fix container config mount on Darwin ``              |
| [`c53d0150`](https://github.com/nix-community/home-manager/commit/c53d0150e999a60c6b260695449a1ed77184085b) | `` prismlauncher: fix string escaping and hygiene ``            |
| [`16110b65`](https://github.com/nix-community/home-manager/commit/16110b65b21d29f6be9cedd3f5e70c15165ad9f5) | `` maintainers: update all-maintainers.nix ``                   |
| [`7d8127d3`](https://github.com/nix-community/home-manager/commit/7d8127d308c3fb9664f7e643eec944be74ebb37d) | `` flake: track nixpkgs-unstable ``                             |
| [`da8f8fcd`](https://github.com/nix-community/home-manager/commit/da8f8fcd69fe5a961ff75c44ea67f165c6ff6d3d) | `` ci: update release branch ``                                 |
| [`94875306`](https://github.com/nix-community/home-manager/commit/948753061a4a8d8655678aefbd6c53e6a470aeca) | `` home-manager: prepare 26.11 ``                               |
| [`61e2c965`](https://github.com/nix-community/home-manager/commit/61e2c9659324181e0f0ed911958c536333b1d4f6) | `` voxtype: initial module implementation ``                    |
| [`d17712ec`](https://github.com/nix-community/home-manager/commit/d17712ec7a9f8682919b4659a3975018e8ed9dcb) | `` Translate using Weblate (Chinese (Simplified Han script)) `` |
| [`874ae4cc`](https://github.com/nix-community/home-manager/commit/874ae4cccfbd1b4525a5459f9043449b9d944a35) | `` Translate using Weblate (Spanish) ``                         |