### PR TITLE
chore(flake/nixpkgs-stable): `b77b3de8` -> `25f53830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1283,11 +1283,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1779467186,
-        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`a7f58c32`](https://github.com/NixOS/nixpkgs/commit/a7f58c32ffc8b048b8169cd1da3615e450a04260) | `` zipline: 4.6.0 -> 4.6.1 ``                                                                   |
| [`dea21382`](https://github.com/NixOS/nixpkgs/commit/dea21382eb85e313c2f667b56a5d11f25bcc5798) | `` zipline: 4.5.3 -> 4.6.0 ``                                                                   |
| [`f6a538e4`](https://github.com/NixOS/nixpkgs/commit/f6a538e454c7b31665f0004fd97423eff713b608) | `` firefox-bin-unwrapped: 151.0.1 -> 151.0.2 ``                                                 |
| [`ad119198`](https://github.com/NixOS/nixpkgs/commit/ad11919836bab0453b049f21c2bd701415e93004) | `` firefox-unwrapped: 151.0.1 -> 151.0.2 ``                                                     |
| [`f7fe4eb2`](https://github.com/NixOS/nixpkgs/commit/f7fe4eb2c6c0b2a69633911f1bf561d0afc88042) | `` shogihome: 1.27.2 -> 1.27.3 ``                                                               |
| [`2e2d0700`](https://github.com/NixOS/nixpkgs/commit/2e2d0700c5ad384d8aaccad77a7bfe8a7c1a7309) | `` workflows: migrate from app-id to client-id ``                                               |
| [`235987ff`](https://github.com/NixOS/nixpkgs/commit/235987ff4e75e0dc8f759cacfbe3de3dbf4e9b1b) | `` fluxcd: 2.8.7 -> 2.8.8 ``                                                                    |
| [`b0f0e993`](https://github.com/NixOS/nixpkgs/commit/b0f0e9936fbb73d4cd31253e735410d8e51de600) | `` fluxcd: 2.8.6 -> 2.8.7 ``                                                                    |
| [`12017910`](https://github.com/NixOS/nixpkgs/commit/1201791034db15b25487c717b7e96c5ca0aa8446) | `` lensfun: update lens database ``                                                             |
| [`9785571f`](https://github.com/NixOS/nixpkgs/commit/9785571fbe28d5a7ae1cedebc11105f2d52eaf4e) | `` llvmPackages_git: 23.0.0-unstable-2026-05-17 -> 23.0.0-unstable-2026-05-24 ``                |
| [`2bbc981e`](https://github.com/NixOS/nixpkgs/commit/2bbc981e95e49182322c3d16b228a1d2ea1fbdf9) | `` buildbox: 1.4.6 -> 1.4.7 ``                                                                  |
| [`62111ec9`](https://github.com/NixOS/nixpkgs/commit/62111ec9451dac465cca48cb99637d69a3081725) | `` netron: 9.0.8 -> 9.0.9 ``                                                                    |
| [`bb7f9a16`](https://github.com/NixOS/nixpkgs/commit/bb7f9a16eccc2e2ef6cbb1015ad85b0ae2aa588b) | `` maintainers: remove dsferruzza ``                                                            |
| [`de9575c1`](https://github.com/NixOS/nixpkgs/commit/de9575c19f58a24a38dcdc63dac77a9a513fe880) | `` peertube: fix security issue ``                                                              |
| [`28794d13`](https://github.com/NixOS/nixpkgs/commit/28794d13bccaf6243552f2254338d404d61e2a41) | `` jellyfin: 10.11.8 -> 10.11.10 ``                                                             |
| [`4e7fd9f9`](https://github.com/NixOS/nixpkgs/commit/4e7fd9f932f3328e5c42f684a52eb067ae61a0c4) | `` workflows/periodic-merge: update haskell-updates PR's base branch ``                         |
| [`5346b7da`](https://github.com/NixOS/nixpkgs/commit/5346b7da5e2d7447bc77a0566152b26d093932fa) | `` workflows/periodic-merge: allow testing in forks ``                                          |
| [`44402159`](https://github.com/NixOS/nixpkgs/commit/444021595338919e54b2699713f46084bb5ee9ef) | `` linuxKernel.kernels.linux_zen: 7.0.9-zen2 -> 7.0.10-zen1 ``                                  |
| [`f53acaf8`](https://github.com/NixOS/nixpkgs/commit/f53acaf82cbce73b67d050bc980c8b7661837bb6) | `` linux_5_10: 5.10.256 -> 5.10.257 ``                                                          |
| [`ddf64812`](https://github.com/NixOS/nixpkgs/commit/ddf648127a970c398577238605fbbcbca19e6342) | `` linux_5_15: 5.15.207 -> 5.15.208 ``                                                          |
| [`ff1710bd`](https://github.com/NixOS/nixpkgs/commit/ff1710bd53be3bbdf4ac96ff57a48b19c8627c31) | `` linux_6_1: 6.1.173 -> 6.1.174 ``                                                             |
| [`b7b1825e`](https://github.com/NixOS/nixpkgs/commit/b7b1825ed02099cc711aabfb0171b06606f75f2b) | `` simplex-chat-desktop: fix updates for aarch64-linux ``                                       |
| [`364704a3`](https://github.com/NixOS/nixpkgs/commit/364704a35403696e562a9c179544e79d1e1213db) | `` simplex-chat-desktop: 6.5.1 -> 6.5.2 ``                                                      |
| [`f19be595`](https://github.com/NixOS/nixpkgs/commit/f19be5955a0b8d95da187bca9f601b8d9de8b968) | `` .github: Add release-26.05 CI config ``                                                      |
| [`71a75767`](https://github.com/NixOS/nixpkgs/commit/71a75767fbbf4a7bd86b50b91dbbcf71460287a8) | `` qbz: wrap pactl and pw-metadata into PATH ``                                                 |
| [`8df0e0ba`](https://github.com/NixOS/nixpkgs/commit/8df0e0bafd8afcd1bb9e14c19da174bb7a97c7ed) | `` librewolf-unwrapped: 150.0.3-1 -> 151.0.1-2 ``                                               |
| [`df2b900e`](https://github.com/NixOS/nixpkgs/commit/df2b900e8af9a745a71cf75e3d8bb9f8a3735eed) | `` filebrowser: 2.63.3 -> 2.63.5 ``                                                             |
| [`29080319`](https://github.com/NixOS/nixpkgs/commit/290803197500895482d08271354bfa77c3c37744) | `` microsoft-edge: 148.0.3967.54 -> 148.0.3967.70 ``                                            |
| [`cfeab5a7`](https://github.com/NixOS/nixpkgs/commit/cfeab5a7f93c146bfe1006c4850bc54c24d29633) | `` linux_xanmod_latest: 7.0.9 -> 7.0.10 ``                                                      |
| [`27eb8ac8`](https://github.com/NixOS/nixpkgs/commit/27eb8ac84d5d4d85921ddd13943026cbaeac8fe5) | `` linux_xanmod: 6.18.32 -> 6.18.33 ``                                                          |
| [`ef204fe0`](https://github.com/NixOS/nixpkgs/commit/ef204fe0f6874b8f072f4405ae1c08df9d0d1a93) | `` python3Packages.nodriver: 0.48.1 -> 0.50.3 ``                                                |
| [`662e6a63`](https://github.com/NixOS/nixpkgs/commit/662e6a6392481a3c08fe1b3b35aee37b7f7a23e5) | `` pocket-id: disable checks for darwin ``                                                      |
| [`159771c2`](https://github.com/NixOS/nixpkgs/commit/159771c2b4e959e06ad6e66e2464c1e5717f4372) | `` bind: 9.20.22 -> 9.20.23 ``                                                                  |
| [`c4f0039a`](https://github.com/NixOS/nixpkgs/commit/c4f0039afccda3070e56d188af44315cd81bf46d) | `` bind: 9.20.21 -> 9.20.22 ``                                                                  |
| [`bdffc485`](https://github.com/NixOS/nixpkgs/commit/bdffc485a3294564a95f0296b5e93f5fff3746ed) | `` linux_6_6: 6.6.140 -> 6.6.141 ``                                                             |
| [`d7c4d94a`](https://github.com/NixOS/nixpkgs/commit/d7c4d94a6018e76ee46d0b2a4b453172f04b82f6) | `` linux_6_12: 6.12.90 -> 6.12.91 ``                                                            |
| [`78a05466`](https://github.com/NixOS/nixpkgs/commit/78a05466c108dc236406c23a43f6713fb07e637e) | `` linux_6_18: 6.18.32 -> 6.18.33 ``                                                            |
| [`92cccc1a`](https://github.com/NixOS/nixpkgs/commit/92cccc1a3c21f51c26f8b6ba797f50a273fe0785) | `` linux_7_0: 7.0.9 -> 7.0.10 ``                                                                |
| [`1ec93e9a`](https://github.com/NixOS/nixpkgs/commit/1ec93e9a1c6897785d735e2f0758553454d6ae0f) | `` atril: 1.28.4 -> 1.28.5 ``                                                                   |
| [`d5d06607`](https://github.com/NixOS/nixpkgs/commit/d5d06607512e93440f5c847cc36fb2ad9966b282) | `` atril: 1.28.3 -> 1.28.4 ``                                                                   |
| [`7059f048`](https://github.com/NixOS/nixpkgs/commit/7059f048ad677462075e1791aa2c954021e8ac88) | `` mate.atril: 1.28.2 -> 1.28.3 ``                                                              |
| [`827aa1a9`](https://github.com/NixOS/nixpkgs/commit/827aa1a9a0066418ef10b43a070dd3b2a7ba0dcd) | `` mate.atril: prep for top-level ``                                                            |
| [`37fcce93`](https://github.com/NixOS/nixpkgs/commit/37fcce9389403d231cb26e2a3474c31698efeeae) | `` netron: 8.8.2 -> 9.0.8 ``                                                                    |
| [`e378272d`](https://github.com/NixOS/nixpkgs/commit/e378272d2161ba67f61296e31c1afd944af79d1a) | `` xreader: 4.6.3 -> 4.6.4 ``                                                                   |
| [`ac0919c2`](https://github.com/NixOS/nixpkgs/commit/ac0919c2d5000d3059b6ba2b4a5610c815d752a6) | `` xreader: switch to finalAttrs pattern ``                                                     |
| [`5d542e0b`](https://github.com/NixOS/nixpkgs/commit/5d542e0be6b0e230669fe9cb75c4f3a81c14dd1a) | `` xreader: 4.6.2 -> 4.6.3 ``                                                                   |
| [`21aa89ca`](https://github.com/NixOS/nixpkgs/commit/21aa89ca41e1f22a024da5052446dec84242a1a3) | `` xreader: 4.6.1 -> 4.6.2 ``                                                                   |
| [`6ac4d7f8`](https://github.com/NixOS/nixpkgs/commit/6ac4d7f8407e18a4d8c6caa779b6dc08f36942b2) | `` xreader: 4.6.0 -> 4.6.1 ``                                                                   |
| [`bad4852d`](https://github.com/NixOS/nixpkgs/commit/bad4852d1e2d8e9950e6b7bdcc573d95faed54bc) | `` matrix-synapse-unwrapped: 1.152.1 -> 1.153.0 ``                                              |
| [`bdb9ba47`](https://github.com/NixOS/nixpkgs/commit/bdb9ba47c689829ee909bad71d3d202f392afb0d) | `` gnome-desktop: mark darwin as badPlatform ``                                                 |
| [`ddda3161`](https://github.com/NixOS/nixpkgs/commit/ddda31615e8d649d9f955b6e87feb11ffe6427d0) | `` nginxStable: add patch for CVE-2026-9256 ``                                                  |
| [`d3a81ed6`](https://github.com/NixOS/nixpkgs/commit/d3a81ed68f20b669165bd16f31fe4a22311cd93e) | `` nginxMainline: add patch for CVE-2026-9256 ``                                                |
| [`7edb6a99`](https://github.com/NixOS/nixpkgs/commit/7edb6a99674d33ae060fe5b522ef2acc3b45e591) | `` mattermost, mattermostLatest: 10.11.17/11.7.0 -> 10.11.18/11.7.1 ``                          |
| [`8002f528`](https://github.com/NixOS/nixpkgs/commit/8002f528f3a005b7c3736cc1ee1833680f3136b4) | `` sharkey: 2025.4.6 -> 2025.4.7 ``                                                             |
| [`cb012a12`](https://github.com/NixOS/nixpkgs/commit/cb012a129d0afa9beb07380a61b18562b2208883) | `` brave: 1.90.122 -> 1.90.124 ``                                                               |
| [`820c9628`](https://github.com/NixOS/nixpkgs/commit/820c9628a118be77a567925573f0ac70ff64b688) | `` deezer-desktop: 7.1.190 -> 7.1.200 ``                                                        |
| [`f8a2c26f`](https://github.com/NixOS/nixpkgs/commit/f8a2c26f56af1d56122d00b78c1483e74410dddc) | `` vrcx: 2026.02.11 -> 2026.05.03 ``                                                            |
| [`2eaaf171`](https://github.com/NixOS/nixpkgs/commit/2eaaf1713c808b6a88c63559147b27983d766adb) | `` cudaPackages.tensorrt: mark insecure ``                                                      |
| [`735ee55f`](https://github.com/NixOS/nixpkgs/commit/735ee55f1e62d9b1ccfe5d9214216ad0f812774c) | `` linuxKernel.kernels.linux_zen: 7.0.9-zen1 -> 7.0.9-zen2 ``                                   |
| [`1f2eb14b`](https://github.com/NixOS/nixpkgs/commit/1f2eb14ba32b4b961f76274d5a04a0a631f0a752) | `` docker: 29.4.3 -> 29.5.1 ``                                                                  |
| [`751b69dc`](https://github.com/NixOS/nixpkgs/commit/751b69dce5c829e3aa9ea90de988f2c03f709a82) | `` mautrix-signal: 26.04 -> 26.05 ``                                                            |
| [`3b781e5b`](https://github.com/NixOS/nixpkgs/commit/3b781e5bf0a896406410094d642ce23140d2beeb) | `` libsignal-ffi: 0.92.1 -> 0.93.2 ``                                                           |
| [`cc666a67`](https://github.com/NixOS/nixpkgs/commit/cc666a67552a450c3d6895f1a9403ddb3e652cc4) | `` kanidm_1_10: 1.10.2 -> 1.10.3 ``                                                             |
| [`425cdd7c`](https://github.com/NixOS/nixpkgs/commit/425cdd7cc5a06cde10ac2744ab00d8e0c2f328be) | `` thunderbird-esr-bin-unwrapped: 140.10.2esr -> 140.11.0esr ``                                 |
| [`837e9d61`](https://github.com/NixOS/nixpkgs/commit/837e9d61303079f52c21e3da2ffebbc5cdf8c91e) | `` evince: 48.1 -> 48.4 ``                                                                      |
| [`85c6cf10`](https://github.com/NixOS/nixpkgs/commit/85c6cf10a51106790c2b60bfa2bc1f10927f68b1) | `` openssh_hpn: 10.2p1 -> 10.3p1 ``                                                             |
| [`94b71330`](https://github.com/NixOS/nixpkgs/commit/94b713302207228970f10a71a01beb66d4581397) | `` dotnet/wrapper: remove nested list in test inputs ``                                         |
| [`2c02c099`](https://github.com/NixOS/nixpkgs/commit/2c02c099120eb2c6da881d4df1c2303e59188469) | `` tests.dotnet.cross-target: stop hiding dotnet output ``                                      |
| [`12161708`](https://github.com/NixOS/nixpkgs/commit/12161708504b5dee6ef791edf29978f04a789a0c) | `` tests.dotnet.cross-target: use only target runtime ``                                        |
| [`c09e979f`](https://github.com/NixOS/nixpkgs/commit/c09e979fd2315e7718a2026d8e3663814eb50e0e) | `` tests.dotnet.cross-target: override runtime pack versions ``                                 |
| [`075c27c9`](https://github.com/NixOS/nixpkgs/commit/075c27c9ec199e86cf114e5ea4022960ac640da2) | `` tests.dotnet.cross-target: include target sdk version in name ``                             |
| [`d020fe3e`](https://github.com/NixOS/nixpkgs/commit/d020fe3e792d796045b90f49438913d713824fe6) | `` dotnet: remove cross-target tests from broken SDKs ``                                        |
| [`4c52b6ce`](https://github.com/NixOS/nixpkgs/commit/4c52b6ce2d702effa0ca79ad11cc6ca73c7b13e4) | `` dotnetCorePackages.sdk_11_0: 11.0.100-preview.3.26207.106 -> 11.0.100-preview.4.26230.115 `` |
| [`58243bd8`](https://github.com/NixOS/nixpkgs/commit/58243bd898330a818d4715d3491725350e6f4a2e) | `` dotnet: may 2026 releases ``                                                                 |
| [`a3a14edd`](https://github.com/NixOS/nixpkgs/commit/a3a14edd3046c33f43da8c0de77cff6e97331509) | `` traefik: 3.6.10 -> 3.6.17 ``                                                                 |
| [`d1638882`](https://github.com/NixOS/nixpkgs/commit/d16388826dd3a685c0c8d107412960d9f993ec86) | `` element-{web,desktop}: 1.12.14 -> 1.12.18 ``                                                 |
| [`8374816e`](https://github.com/NixOS/nixpkgs/commit/8374816e457a9853d4248aa6c7b47dee477e8046) | `` boringssl: 0.20260413.0 -> 0.20260508.0 ``                                                   |
| [`68766559`](https://github.com/NixOS/nixpkgs/commit/68766559d1c7f44c064bf5d1d1b9cea959988964) | `` fluxcd: rewrite update script to use nix-update ``                                           |
| [`ecde868c`](https://github.com/NixOS/nixpkgs/commit/ecde868ccbef205f2d78949b4358a6b854a414b1) | `` fluxcd: build with CGO_ENABLED=0 to match upstream ``                                        |
| [`71e47e28`](https://github.com/NixOS/nixpkgs/commit/71e47e2880c8aba767205e163bd2a79872d7c0f5) | `` fluxcd-operator-mcp: add stealthybox as maintainer ``                                        |
| [`061cbb59`](https://github.com/NixOS/nixpkgs/commit/061cbb59e8dfe26bd2ce9d9a09c787ebb292eae5) | `` fluxcd: add superherointj as maintainer ``                                                   |
| [`37143ef9`](https://github.com/NixOS/nixpkgs/commit/37143ef9b4029d3e7ab91cbd5370bb654d79e65e) | `` fluxcd: add SchahinRohani as maintainer ``                                                   |
| [`4eecf500`](https://github.com/NixOS/nixpkgs/commit/4eecf500567e3a47f0c5dacef1c4c7e61b1fc230) | `` fluxcd: 2.7.5 -> 2.8.6 ``                                                                    |
| [`3180bfcc`](https://github.com/NixOS/nixpkgs/commit/3180bfcc6ba5fcca6cad8ad721ab53575dd85de7) | `` fluxcd: use writableTmpDirAsHomeHook ``                                                      |
| [`8ad8e3c8`](https://github.com/NixOS/nixpkgs/commit/8ad8e3c8c5d2b5a4616f7cf7a4b6f4287aea216e) | `` fluxcd: move env variable(s) into env for structuredAttrs ``                                 |
| [`f20e3cd4`](https://github.com/NixOS/nixpkgs/commit/f20e3cd49aebe6c2459d08c847266ec3f5e35968) | `` maintainers: add superherointj ``                                                            |
| [`a56a9df6`](https://github.com/NixOS/nixpkgs/commit/a56a9df642ec6fee8b850e3efd2cbf453d84f30f) | `` maintainers: add stealthybox ``                                                              |
| [`02bd18ef`](https://github.com/NixOS/nixpkgs/commit/02bd18ef8069c19768d100e71f39bf425208ea59) | `` pocket-id: fix CVE-2026-43983 ``                                                             |
| [`44f23d93`](https://github.com/NixOS/nixpkgs/commit/44f23d93dacb7a7e1c1fb6f27e8bf65da32b5c9c) | `` pocket-id: 1.15.0 -> 1.16.0 ``                                                               |
| [`8f2a297e`](https://github.com/NixOS/nixpkgs/commit/8f2a297e71d8d07b4f6eb92b3452ea4a7004c2b1) | `` nixos/netbird: fixes login not working properly on first login ``                            |
| [`39e2ee7f`](https://github.com/NixOS/nixpkgs/commit/39e2ee7fbc0e239c6f07286e33815246266f90fa) | `` nixos/netbird: moves login hardening to the hardening section ``                             |