### PR TITLE
fix(catppuccin): enable HM module and flip to autoEnable

### DIFF
--- a/modules/base/catppuccin.nix
+++ b/modules/base/catppuccin.nix
@@ -12,6 +12,6 @@
   # and silences the "catppuccin/nix will soon auto enroll ports" warning
   # on hosts pinned to unstable.
   // lib.optionalAttrs (options.catppuccin ? autoEnable) {
-    autoEnable = false;
+    autoEnable = true;
   };
 }

--- a/modules/base/home.nix
+++ b/modules/base/home.nix
@@ -42,11 +42,12 @@ in
   # and suppresses the "catppuccin/nix will soon auto enroll ports" warning
   # at the home-manager profile level on hosts pinned to unstable.
   catppuccin = {
+    enable = true;
     flavor = "mocha";
     accent = "lavender";
   }
   // lib.optionalAttrs (options.catppuccin ? autoEnable) {
-    autoEnable = false;
+    autoEnable = true;
   };
 
   ##########################################################################


### PR DESCRIPTION
## Summary

- Add `catppuccin.enable = true` at the home-manager level. The cf8ccac2 catppuccin/nix bump gates every port behind `config.catppuccin.enable && cfg.enable && config.programs.<x>.enable`, and the HM block never had `enable` set — so HM-scope ports (zed, brave-via-chrome, etc.) silently evaluated to false while NixOS-scope ports (sddm, hyprland, grub) kept working because `modules/base/catppuccin.nix` already had `enable = true`.
- Flip `autoEnable` from `false` to `true` on both NixOS and HM profiles to opt into upstream's new auto-enroll behavior.

## Notes

- Per-port explicit `catppuccin.<port>.enable = true` lines scattered across `features/` become harmless no-ops with autoEnable on.
- Ports we don't want themed can be opted out individually with `catppuccin.<port>.enable = false`.
- The `lib.optionalAttrs (options.catppuccin ? autoEnable)` guard is retained so release-25.11 (pre-#817) stable-input hosts still evaluate.