### PR TITLE
chore(flake/nixpkgs-kernel): `26ef669c` -> `25f53830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1251,11 +1251,11 @@
     },
     "nixpkgs-kernel": {
       "locked": {
-        "lastModified": 1777673416,
-        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
| [`a7f58c32`](https://github.com/NixOS/nixpkgs/commit/a7f58c32ffc8b048b8169cd1da3615e450a04260) | `` zipline: 4.6.0 -> 4.6.1 ``                                                                                             |
| [`dea21382`](https://github.com/NixOS/nixpkgs/commit/dea21382eb85e313c2f667b56a5d11f25bcc5798) | `` zipline: 4.5.3 -> 4.6.0 ``                                                                                             |
| [`f6a538e4`](https://github.com/NixOS/nixpkgs/commit/f6a538e454c7b31665f0004fd97423eff713b608) | `` firefox-bin-unwrapped: 151.0.1 -> 151.0.2 ``                                                                           |
| [`ad119198`](https://github.com/NixOS/nixpkgs/commit/ad11919836bab0453b049f21c2bd701415e93004) | `` firefox-unwrapped: 151.0.1 -> 151.0.2 ``                                                                               |
| [`f7fe4eb2`](https://github.com/NixOS/nixpkgs/commit/f7fe4eb2c6c0b2a69633911f1bf561d0afc88042) | `` shogihome: 1.27.2 -> 1.27.3 ``                                                                                         |
| [`2e2d0700`](https://github.com/NixOS/nixpkgs/commit/2e2d0700c5ad384d8aaccad77a7bfe8a7c1a7309) | `` workflows: migrate from app-id to client-id ``                                                                         |
| [`235987ff`](https://github.com/NixOS/nixpkgs/commit/235987ff4e75e0dc8f759cacfbe3de3dbf4e9b1b) | `` fluxcd: 2.8.7 -> 2.8.8 ``                                                                                              |
| [`b0f0e993`](https://github.com/NixOS/nixpkgs/commit/b0f0e9936fbb73d4cd31253e735410d8e51de600) | `` fluxcd: 2.8.6 -> 2.8.7 ``                                                                                              |
| [`12017910`](https://github.com/NixOS/nixpkgs/commit/1201791034db15b25487c717b7e96c5ca0aa8446) | `` lensfun: update lens database ``                                                                                       |
| [`9785571f`](https://github.com/NixOS/nixpkgs/commit/9785571fbe28d5a7ae1cedebc11105f2d52eaf4e) | `` llvmPackages_git: 23.0.0-unstable-2026-05-17 -> 23.0.0-unstable-2026-05-24 ``                                          |
| [`2bbc981e`](https://github.com/NixOS/nixpkgs/commit/2bbc981e95e49182322c3d16b228a1d2ea1fbdf9) | `` buildbox: 1.4.6 -> 1.4.7 ``                                                                                            |
| [`62111ec9`](https://github.com/NixOS/nixpkgs/commit/62111ec9451dac465cca48cb99637d69a3081725) | `` netron: 9.0.8 -> 9.0.9 ``                                                                                              |
| [`bb7f9a16`](https://github.com/NixOS/nixpkgs/commit/bb7f9a16eccc2e2ef6cbb1015ad85b0ae2aa588b) | `` maintainers: remove dsferruzza ``                                                                                      |
| [`de9575c1`](https://github.com/NixOS/nixpkgs/commit/de9575c19f58a24a38dcdc63dac77a9a513fe880) | `` peertube: fix security issue ``                                                                                        |
| [`28794d13`](https://github.com/NixOS/nixpkgs/commit/28794d13bccaf6243552f2254338d404d61e2a41) | `` jellyfin: 10.11.8 -> 10.11.10 ``                                                                                       |
| [`4e7fd9f9`](https://github.com/NixOS/nixpkgs/commit/4e7fd9f932f3328e5c42f684a52eb067ae61a0c4) | `` workflows/periodic-merge: update haskell-updates PR's base branch ``                                                   |
| [`5346b7da`](https://github.com/NixOS/nixpkgs/commit/5346b7da5e2d7447bc77a0566152b26d093932fa) | `` workflows/periodic-merge: allow testing in forks ``                                                                    |
| [`44402159`](https://github.com/NixOS/nixpkgs/commit/444021595338919e54b2699713f46084bb5ee9ef) | `` linuxKernel.kernels.linux_zen: 7.0.9-zen2 -> 7.0.10-zen1 ``                                                            |
| [`f53acaf8`](https://github.com/NixOS/nixpkgs/commit/f53acaf82cbce73b67d050bc980c8b7661837bb6) | `` linux_5_10: 5.10.256 -> 5.10.257 ``                                                                                    |
| [`ddf64812`](https://github.com/NixOS/nixpkgs/commit/ddf648127a970c398577238605fbbcbca19e6342) | `` linux_5_15: 5.15.207 -> 5.15.208 ``                                                                                    |
| [`ff1710bd`](https://github.com/NixOS/nixpkgs/commit/ff1710bd53be3bbdf4ac96ff57a48b19c8627c31) | `` linux_6_1: 6.1.173 -> 6.1.174 ``                                                                                       |
| [`b7b1825e`](https://github.com/NixOS/nixpkgs/commit/b7b1825ed02099cc711aabfb0171b06606f75f2b) | `` simplex-chat-desktop: fix updates for aarch64-linux ``                                                                 |
| [`364704a3`](https://github.com/NixOS/nixpkgs/commit/364704a35403696e562a9c179544e79d1e1213db) | `` simplex-chat-desktop: 6.5.1 -> 6.5.2 ``                                                                                |
| [`f19be595`](https://github.com/NixOS/nixpkgs/commit/f19be5955a0b8d95da187bca9f601b8d9de8b968) | `` .github: Add release-26.05 CI config ``                                                                                |
| [`71a75767`](https://github.com/NixOS/nixpkgs/commit/71a75767fbbf4a7bd86b50b91dbbcf71460287a8) | `` qbz: wrap pactl and pw-metadata into PATH ``                                                                           |
| [`8df0e0ba`](https://github.com/NixOS/nixpkgs/commit/8df0e0bafd8afcd1bb9e14c19da174bb7a97c7ed) | `` librewolf-unwrapped: 150.0.3-1 -> 151.0.1-2 ``                                                                         |
| [`df2b900e`](https://github.com/NixOS/nixpkgs/commit/df2b900e8af9a745a71cf75e3d8bb9f8a3735eed) | `` filebrowser: 2.63.3 -> 2.63.5 ``                                                                                       |
| [`29080319`](https://github.com/NixOS/nixpkgs/commit/290803197500895482d08271354bfa77c3c37744) | `` microsoft-edge: 148.0.3967.54 -> 148.0.3967.70 ``                                                                      |
| [`cfeab5a7`](https://github.com/NixOS/nixpkgs/commit/cfeab5a7f93c146bfe1006c4850bc54c24d29633) | `` linux_xanmod_latest: 7.0.9 -> 7.0.10 ``                                                                                |
| [`27eb8ac8`](https://github.com/NixOS/nixpkgs/commit/27eb8ac84d5d4d85921ddd13943026cbaeac8fe5) | `` linux_xanmod: 6.18.32 -> 6.18.33 ``                                                                                    |
| [`ef204fe0`](https://github.com/NixOS/nixpkgs/commit/ef204fe0f6874b8f072f4405ae1c08df9d0d1a93) | `` python3Packages.nodriver: 0.48.1 -> 0.50.3 ``                                                                          |
| [`662e6a63`](https://github.com/NixOS/nixpkgs/commit/662e6a6392481a3c08fe1b3b35aee37b7f7a23e5) | `` pocket-id: disable checks for darwin ``                                                                                |
| [`159771c2`](https://github.com/NixOS/nixpkgs/commit/159771c2b4e959e06ad6e66e2464c1e5717f4372) | `` bind: 9.20.22 -> 9.20.23 ``                                                                                            |
| [`c4f0039a`](https://github.com/NixOS/nixpkgs/commit/c4f0039afccda3070e56d188af44315cd81bf46d) | `` bind: 9.20.21 -> 9.20.22 ``                                                                                            |
| [`bdffc485`](https://github.com/NixOS/nixpkgs/commit/bdffc485a3294564a95f0296b5e93f5fff3746ed) | `` linux_6_6: 6.6.140 -> 6.6.141 ``                                                                                       |
| [`d7c4d94a`](https://github.com/NixOS/nixpkgs/commit/d7c4d94a6018e76ee46d0b2a4b453172f04b82f6) | `` linux_6_12: 6.12.90 -> 6.12.91 ``                                                                                      |
| [`78a05466`](https://github.com/NixOS/nixpkgs/commit/78a05466c108dc236406c23a43f6713fb07e637e) | `` linux_6_18: 6.18.32 -> 6.18.33 ``                                                                                      |
| [`92cccc1a`](https://github.com/NixOS/nixpkgs/commit/92cccc1a3c21f51c26f8b6ba797f50a273fe0785) | `` linux_7_0: 7.0.9 -> 7.0.10 ``                                                                                          |
| [`1ec93e9a`](https://github.com/NixOS/nixpkgs/commit/1ec93e9a1c6897785d735e2f0758553454d6ae0f) | `` atril: 1.28.4 -> 1.28.5 ``                                                                                             |
| [`d5d06607`](https://github.com/NixOS/nixpkgs/commit/d5d06607512e93440f5c847cc36fb2ad9966b282) | `` atril: 1.28.3 -> 1.28.4 ``                                                                                             |
| [`7059f048`](https://github.com/NixOS/nixpkgs/commit/7059f048ad677462075e1791aa2c954021e8ac88) | `` mate.atril: 1.28.2 -> 1.28.3 ``                                                                                        |
| [`827aa1a9`](https://github.com/NixOS/nixpkgs/commit/827aa1a9a0066418ef10b43a070dd3b2a7ba0dcd) | `` mate.atril: prep for top-level ``                                                                                      |
| [`37fcce93`](https://github.com/NixOS/nixpkgs/commit/37fcce9389403d231cb26e2a3474c31698efeeae) | `` netron: 8.8.2 -> 9.0.8 ``                                                                                              |
| [`e378272d`](https://github.com/NixOS/nixpkgs/commit/e378272d2161ba67f61296e31c1afd944af79d1a) | `` xreader: 4.6.3 -> 4.6.4 ``                                                                                             |
| [`ac0919c2`](https://github.com/NixOS/nixpkgs/commit/ac0919c2d5000d3059b6ba2b4a5610c815d752a6) | `` xreader: switch to finalAttrs pattern ``                                                                               |
| [`5d542e0b`](https://github.com/NixOS/nixpkgs/commit/5d542e0be6b0e230669fe9cb75c4f3a81c14dd1a) | `` xreader: 4.6.2 -> 4.6.3 ``                                                                                             |
| [`21aa89ca`](https://github.com/NixOS/nixpkgs/commit/21aa89ca41e1f22a024da5052446dec84242a1a3) | `` xreader: 4.6.1 -> 4.6.2 ``                                                                                             |
| [`6ac4d7f8`](https://github.com/NixOS/nixpkgs/commit/6ac4d7f8407e18a4d8c6caa779b6dc08f36942b2) | `` xreader: 4.6.0 -> 4.6.1 ``                                                                                             |
| [`bad4852d`](https://github.com/NixOS/nixpkgs/commit/bad4852d1e2d8e9950e6b7bdcc573d95faed54bc) | `` matrix-synapse-unwrapped: 1.152.1 -> 1.153.0 ``                                                                        |
| [`bdb9ba47`](https://github.com/NixOS/nixpkgs/commit/bdb9ba47c689829ee909bad71d3d202f392afb0d) | `` gnome-desktop: mark darwin as badPlatform ``                                                                           |
| [`ddda3161`](https://github.com/NixOS/nixpkgs/commit/ddda31615e8d649d9f955b6e87feb11ffe6427d0) | `` nginxStable: add patch for CVE-2026-9256 ``                                                                            |
| [`d3a81ed6`](https://github.com/NixOS/nixpkgs/commit/d3a81ed68f20b669165bd16f31fe4a22311cd93e) | `` nginxMainline: add patch for CVE-2026-9256 ``                                                                          |
| [`7edb6a99`](https://github.com/NixOS/nixpkgs/commit/7edb6a99674d33ae060fe5b522ef2acc3b45e591) | `` mattermost, mattermostLatest: 10.11.17/11.7.0 -> 10.11.18/11.7.1 ``                                                    |
| [`8002f528`](https://github.com/NixOS/nixpkgs/commit/8002f528f3a005b7c3736cc1ee1833680f3136b4) | `` sharkey: 2025.4.6 -> 2025.4.7 ``                                                                                       |
| [`cb012a12`](https://github.com/NixOS/nixpkgs/commit/cb012a129d0afa9beb07380a61b18562b2208883) | `` brave: 1.90.122 -> 1.90.124 ``                                                                                         |
| [`820c9628`](https://github.com/NixOS/nixpkgs/commit/820c9628a118be77a567925573f0ac70ff64b688) | `` deezer-desktop: 7.1.190 -> 7.1.200 ``                                                                                  |
| [`f8a2c26f`](https://github.com/NixOS/nixpkgs/commit/f8a2c26f56af1d56122d00b78c1483e74410dddc) | `` vrcx: 2026.02.11 -> 2026.05.03 ``                                                                                      |
| [`2eaaf171`](https://github.com/NixOS/nixpkgs/commit/2eaaf1713c808b6a88c63559147b27983d766adb) | `` cudaPackages.tensorrt: mark insecure ``                                                                                |
| [`735ee55f`](https://github.com/NixOS/nixpkgs/commit/735ee55f1e62d9b1ccfe5d9214216ad0f812774c) | `` linuxKernel.kernels.linux_zen: 7.0.9-zen1 -> 7.0.9-zen2 ``                                                             |
| [`1f2eb14b`](https://github.com/NixOS/nixpkgs/commit/1f2eb14ba32b4b961f76274d5a04a0a631f0a752) | `` docker: 29.4.3 -> 29.5.1 ``                                                                                            |
| [`751b69dc`](https://github.com/NixOS/nixpkgs/commit/751b69dce5c829e3aa9ea90de988f2c03f709a82) | `` mautrix-signal: 26.04 -> 26.05 ``                                                                                      |
| [`3b781e5b`](https://github.com/NixOS/nixpkgs/commit/3b781e5bf0a896406410094d642ce23140d2beeb) | `` libsignal-ffi: 0.92.1 -> 0.93.2 ``                                                                                     |
| [`77800048`](https://github.com/NixOS/nixpkgs/commit/778000485dbda6dd97489a74dd5db713b0ca1911) | `` mautrix-whatsapp: 26.04 -> 26.05 ``                                                                                    |
| [`870a994b`](https://github.com/NixOS/nixpkgs/commit/870a994bed128796876888716efc6808c7bc87b2) | `` radicle-desktop: 0.10.0 -> 0.11.0 ``                                                                                   |
| [`cc666a67`](https://github.com/NixOS/nixpkgs/commit/cc666a67552a450c3d6895f1a9403ddb3e652cc4) | `` kanidm_1_10: 1.10.2 -> 1.10.3 ``                                                                                       |
| [`425cdd7c`](https://github.com/NixOS/nixpkgs/commit/425cdd7cc5a06cde10ac2744ab00d8e0c2f328be) | `` thunderbird-esr-bin-unwrapped: 140.10.2esr -> 140.11.0esr ``                                                           |
| [`410551eb`](https://github.com/NixOS/nixpkgs/commit/410551ebf2a0d960399ce4add1edb983dd91905a) | `` radicle-node-unstable: 1.9.0 -> 1.9.1 ``                                                                               |
| [`b1d6b0ae`](https://github.com/NixOS/nixpkgs/commit/b1d6b0aeb0c83fe46d309f613b63f28a93dbcd86) | `` radicle-node: 1.9.0 -> 1.9.1 ``                                                                                        |
| [`837e9d61`](https://github.com/NixOS/nixpkgs/commit/837e9d61303079f52c21e3da2ffebbc5cdf8c91e) | `` evince: 48.1 -> 48.4 ``                                                                                                |
| [`cfef500d`](https://github.com/NixOS/nixpkgs/commit/cfef500d2e7afce39b7a7636ed475aee407d9d2c) | `` firefox-bin-unwrapped: 151.0 -> 151.0.1 ``                                                                             |
| [`9b1cb5c2`](https://github.com/NixOS/nixpkgs/commit/9b1cb5c27f7f7ada603f174c36b78dfe0ccb19df) | `` firefox-unwrapped: 151.0 -> 151.0.1 ``                                                                                 |
| [`bf3111e3`](https://github.com/NixOS/nixpkgs/commit/bf3111e3bbcd1a6ed7453f1ab0bc1cb62ae2118a) | `` floorp-bin-unwrapped: 12.14.0 -> 12.14.2 ``                                                                            |
| [`cf4e4ffb`](https://github.com/NixOS/nixpkgs/commit/cf4e4ffb354288ac1f8143cf0b60af01bee0c2ca) | `` feishin: bump electron to 40 ``                                                                                        |
| [`bbaf15ff`](https://github.com/NixOS/nixpkgs/commit/bbaf15ffe5a8e2f9f3efd567ffb53419323e6525) | `` feishin: 1.10.0 -> 1.11.0 ``                                                                                           |
| [`65c3616b`](https://github.com/NixOS/nixpkgs/commit/65c3616ba9a2f05be60b59050dcde23949e5f97d) | `` feishin: 1.9.0 -> 1.10.0 ``                                                                                            |
| [`1894afe5`](https://github.com/NixOS/nixpkgs/commit/1894afe52ff4a8349b9d76031e44735447401e6b) | `` feishin: 1.8.0 -> 1.9.0 ``                                                                                             |
| [`45252c48`](https://github.com/NixOS/nixpkgs/commit/45252c489f996d4cac31201ac0d2e29c664c2b45) | `` feishin: Clean up darwin build ``                                                                                      |
| [`00c44fa5`](https://github.com/NixOS/nixpkgs/commit/00c44fa54b08f5108564eeb37c9a1b9a1c41ca15) | `` feishin: 1.7.0 -> 1.8.0 ``                                                                                             |
| [`c9ed29e9`](https://github.com/NixOS/nixpkgs/commit/c9ed29e938d3c03c09d56c31cc39e8512399f4ef) | `` nodejs_24: 24.15.0 -> 24.16.0 ``                                                                                       |
| [`72f674ae`](https://github.com/NixOS/nixpkgs/commit/72f674aedeedbcac27f72cdbbdf8dce3c1498a15) | `` olivetin-3k: 3000.11.3 -> 3000.12.0 ``                                                                                 |
| [`6b31e3b1`](https://github.com/NixOS/nixpkgs/commit/6b31e3b14f0e9ea0d0f0a10a52fcff963f78791a) | `` vivaldi: 7.9.3970.67 -> 8.0.4033.26 ``                                                                                 |
| [`99f1e5d3`](https://github.com/NixOS/nixpkgs/commit/99f1e5d31f8e5c43aeabafb84fd41b33f6f6b105) | `` pdns: 4.9.14 -> 4.9.15 ``                                                                                              |
| [`14325f3a`](https://github.com/NixOS/nixpkgs/commit/14325f3a0115f66b859121e5fc4fa0a526dffa58) | `` mastodon: 4.5.9 -> 4.5.10 ``                                                                                           |
| [`e3fb530e`](https://github.com/NixOS/nixpkgs/commit/e3fb530e1e6ec66c7e1d8de8e60262132a6660a1) | `` varnish: 8.0.1 -> 8.0.2 ``                                                                                             |
| [`87ecac4a`](https://github.com/NixOS/nixpkgs/commit/87ecac4aa32d525ce67a91a564dc8c71e98f545e) | `` varnish60: 6.0.17 -> 6.0.18 ``                                                                                         |
| [`9349d784`](https://github.com/NixOS/nixpkgs/commit/9349d7841ad4715e94ef41654e0647a849a4d912) | `` firefox-devedition-unwrapped: 150.0b7 -> 152.0b1 ``                                                                    |
| [`cec62527`](https://github.com/NixOS/nixpkgs/commit/cec62527f94f3aa1def8cfd1137f1278bf21d320) | `` ghgrab: 1.3.2 -> 2.0.1 ``                                                                                              |
| [`d8cd34ff`](https://github.com/NixOS/nixpkgs/commit/d8cd34ff6ad57105209994354e850630445a0bff) | `` ghgrab: 1.3.1 -> 1.3.2 ``                                                                                              |
| [`85c6cf10`](https://github.com/NixOS/nixpkgs/commit/85c6cf10a51106790c2b60bfa2bc1f10927f68b1) | `` openssh_hpn: 10.2p1 -> 10.3p1 ``                                                                                       |
| [`a42072f6`](https://github.com/NixOS/nixpkgs/commit/a42072f6b0dee8543bdf7f69ddc2e365d5085d3b) | `` edhm-ui: 3.0.64 -> 3.0.67 ``                                                                                           |
| [`88182f58`](https://github.com/NixOS/nixpkgs/commit/88182f5880101db9b1cd396a8472aad0ad990cf8) | `` drupal: 11.2.11 -> 11.2.12 ``                                                                                          |
| [`aa019a03`](https://github.com/NixOS/nixpkgs/commit/aa019a03dce6106616ad9be5f701d3497101bdea) | `` openbao: 2.5.3 -> 2.5.4 ``                                                                                             |
| [`c4351148`](https://github.com/NixOS/nixpkgs/commit/c43511484e072ffc6f171fc1e080fa5e3f0c2f36) | `` mongodb-7_0: 7.0.32 -> 7.0.34 ``                                                                                       |
| [`94b71330`](https://github.com/NixOS/nixpkgs/commit/94b713302207228970f10a71a01beb66d4581397) | `` dotnet/wrapper: remove nested list in test inputs ``                                                                   |
| [`2c02c099`](https://github.com/NixOS/nixpkgs/commit/2c02c099120eb2c6da881d4df1c2303e59188469) | `` tests.dotnet.cross-target: stop hiding dotnet output ``                                                                |
| [`12161708`](https://github.com/NixOS/nixpkgs/commit/12161708504b5dee6ef791edf29978f04a789a0c) | `` tests.dotnet.cross-target: use only target runtime ``                                                                  |
| [`c09e979f`](https://github.com/NixOS/nixpkgs/commit/c09e979fd2315e7718a2026d8e3663814eb50e0e) | `` tests.dotnet.cross-target: override runtime pack versions ``                                                           |
| [`075c27c9`](https://github.com/NixOS/nixpkgs/commit/075c27c9ec199e86cf114e5ea4022960ac640da2) | `` tests.dotnet.cross-target: include target sdk version in name ``                                                       |
| [`d020fe3e`](https://github.com/NixOS/nixpkgs/commit/d020fe3e792d796045b90f49438913d713824fe6) | `` dotnet: remove cross-target tests from broken SDKs ``                                                                  |
| [`4c52b6ce`](https://github.com/NixOS/nixpkgs/commit/4c52b6ce2d702effa0ca79ad11cc6ca73c7b13e4) | `` dotnetCorePackages.sdk_11_0: 11.0.100-preview.3.26207.106 -> 11.0.100-preview.4.26230.115 ``                           |
| [`58243bd8`](https://github.com/NixOS/nixpkgs/commit/58243bd898330a818d4715d3491725350e6f4a2e) | `` dotnet: may 2026 releases ``                                                                                           |
| [`bfbdb8ae`](https://github.com/NixOS/nixpkgs/commit/bfbdb8ae3f85ffdd6cb439e984001c3f63aaa2bc) | `` radicle-ci-broker: 0.27.0 -> 0.28.0 ``                                                                                 |
| [`3cdb49ec`](https://github.com/NixOS/nixpkgs/commit/3cdb49ece6829e3f0f797d7e6833c1da1f28c8a9) | `` ungoogled-chromium: 148.0.7778.167-1 -> 148.0.7778.178-1 ``                                                            |
| [`01d5e27a`](https://github.com/NixOS/nixpkgs/commit/01d5e27ac666fd05bdb3ae65a106badac7a359b6) | `` mullvad-browser: 15.0.12 -> 15.0.14 ``                                                                                 |
| [`248cc2cf`](https://github.com/NixOS/nixpkgs/commit/248cc2cff74b637cda7a1ea2f08bdb61d5adb169) | `` tor-browser: 15.0.13 -> 15.0.14 ``                                                                                     |
| [`38eae8c1`](https://github.com/NixOS/nixpkgs/commit/38eae8c1d66e9ead6c87330635d622b990511dcf) | `` osu-lazer: 2026.429.0 -> 2026.518.0 ``                                                                                 |
| [`2fed6ad7`](https://github.com/NixOS/nixpkgs/commit/2fed6ad71a19d3cbfeec2d2d8a0dde2a89d0f832) | `` osu-lazer-bin: 2026.429.0 -> 2026.518.0 ``                                                                             |
| [`367d5a57`](https://github.com/NixOS/nixpkgs/commit/367d5a57128fdb3291a13d4bcee373c6d83f7184) | `` [Backport release-25.11] sssd: 2.12.0 -> 2.13.0 ``                                                                     |
| [`eb0e96b8`](https://github.com/NixOS/nixpkgs/commit/eb0e96b84bbf7a2d9b869cbf34742314c6f7aec6) | `` chromium,chromedriver: 148.0.7778.167 -> 148.0.7778.178 ``                                                             |
| [`0340bf5d`](https://github.com/NixOS/nixpkgs/commit/0340bf5d18b38ee956514c3584783c66eef806f6) | `` radicle-node-unstable: 1.9.0-rc.3 -> 1.9.0 ``                                                                          |
| [`07589d59`](https://github.com/NixOS/nixpkgs/commit/07589d59ec4d97f0d00af8d246479bdb987b324a) | `` radicle-node: 1.8.0 -> 1.9.0 ``                                                                                        |
| [`6b160bbc`](https://github.com/NixOS/nixpkgs/commit/6b160bbcd0a3888d866a6f55238b972fe32011fc) | `` radicle-node-unstable: 1.9.0-rc.1 -> 1.9.0-rc.3 ``                                                                     |
| [`77a0f5f5`](https://github.com/NixOS/nixpkgs/commit/77a0f5f5a205fd8137fa77fb4573f23af485fe32) | `` radicle-node-unstable: 1.8.0 -> 1.9.0-rc.1 ``                                                                          |
| [`128c7c1f`](https://github.com/NixOS/nixpkgs/commit/128c7c1f4616b4e7c688270ccced58b5f72e18f3) | `` mprisence: 1.5.2 -> 1.6.0 ``                                                                                           |
| [`56bd39e1`](https://github.com/NixOS/nixpkgs/commit/56bd39e11bf87c59379e4153f9007329fa8097f1) | `` google-chrome: 148.0.7778.167 -> 148.0.7778.178 ``                                                                     |
| [`d03df731`](https://github.com/NixOS/nixpkgs/commit/d03df73102bb506531a5e9fd54779c0b75889bdd) | `` rapid-photo-downloader: change homepage to correct URL ``                                                              |
| [`45ae0cc8`](https://github.com/NixOS/nixpkgs/commit/45ae0cc8b220cf55eb855e895cd061218aa9081e) | `` microsoft-edge: 147.0.3912.98 -> 148.0.3967.54 ``                                                                      |
| [`a3a14edd`](https://github.com/NixOS/nixpkgs/commit/a3a14edd3046c33f43da8c0de77cff6e97331509) | `` traefik: 3.6.10 -> 3.6.17 ``                                                                                           |
| [`7b4f16fd`](https://github.com/NixOS/nixpkgs/commit/7b4f16fd37cde29fdad564b8025e6d3ad0434933) | `` linux-firmware: 20260410 -> 20260519 ``                                                                                |
| [`b880c419`](https://github.com/NixOS/nixpkgs/commit/b880c4194d845e15da3ed832915b27f8e5600357) | `` gajim: 2.4.5 -> 2.4.6 ``                                                                                               |
| [`01b13b9a`](https://github.com/NixOS/nixpkgs/commit/01b13b9a9902e95b6d7cc694349c347f9a05a563) | `` jackett: 0.24.1831 -> 0.24.1879 ``                                                                                     |
| [`2c22d802`](https://github.com/NixOS/nixpkgs/commit/2c22d8026dd70eafaf7975e9c075d0f724d0732b) | `` electron-chromedriver: enable strictDeps, __structuredAttrs ``                                                         |
| [`0e8973d8`](https://github.com/NixOS/nixpkgs/commit/0e8973d893c20479f1d10a52a48484f3553376de) | `` electron_bin: enable strictDeps, __structuredAttrs ``                                                                  |
| [`054c8418`](https://github.com/NixOS/nixpkgs/commit/054c841809328fb90eee4b4c3d9b0abccdf04bab) | `` electron: set strictDeps to true, enable __structuredAttrs ``                                                          |
| [`d5bffdc6`](https://github.com/NixOS/nixpkgs/commit/d5bffdc6e009802ecb71c8f9a512cfcec2303cd8) | `` electron-chromedriver_42: 42.0.1 -> 42.1.0 ``                                                                          |
| [`177cdee5`](https://github.com/NixOS/nixpkgs/commit/177cdee5c5a3967802aefe2bfd7d8a6cc808fbb2) | `` electron_42-bin: 42.0.1 -> 42.1.0 ``                                                                                   |
| [`a5cb7eb2`](https://github.com/NixOS/nixpkgs/commit/a5cb7eb274b989bd3e64820bb261e8bb761ed77d) | `` electron-chromedriver_41: 41.5.2 -> 41.6.1 ``                                                                          |
| [`cedd9302`](https://github.com/NixOS/nixpkgs/commit/cedd93026e3042f5c8d6d5a8ac84162faf13e73f) | `` electron_41-bin: 41.5.2 -> 41.6.1 ``                                                                                   |
| [`3dd6c112`](https://github.com/NixOS/nixpkgs/commit/3dd6c112743f60b76251d5bb36435c7f1b4d6c01) | `` electron-source.electron_42: 42.0.1 -> 42.1.0 ``                                                                       |
| [`10ee3c7e`](https://github.com/NixOS/nixpkgs/commit/10ee3c7efadbb5f38d4207128a46ff708e661fb1) | `` electron-source.electron_41: 41.5.2 -> 41.6.1 ``                                                                       |
| [`8d726124`](https://github.com/NixOS/nixpkgs/commit/8d726124f667fbdcf9c2dbcde9c955035eebf3c2) | `` electron-chromedriver_42: 42.0.0 -> 42.0.1 ``                                                                          |
| [`99875e57`](https://github.com/NixOS/nixpkgs/commit/99875e57c71d88b92c92045e7c52d7053a5667cd) | `` electron_42-bin: 42.0.0 -> 42.0.1 ``                                                                                   |
| [`0832f570`](https://github.com/NixOS/nixpkgs/commit/0832f57082b76beb21911d8d40eb2a4aa93677a1) | `` electron-chromedriver_41: 41.5.0 -> 41.5.2 ``                                                                          |
| [`06148ec8`](https://github.com/NixOS/nixpkgs/commit/06148ec8e2b9e957dd7187b1e02a52708c3513f0) | `` electron_41-bin: 41.5.0 -> 41.5.2 ``                                                                                   |
| [`3b25793a`](https://github.com/NixOS/nixpkgs/commit/3b25793a4a27d2d7d7644ee7de185370621f6581) | `` electron-chromedriver_40: 40.9.3 -> 40.10.0 ``                                                                         |
| [`8b2370f3`](https://github.com/NixOS/nixpkgs/commit/8b2370f39ba797d2a4c6fe987835c9efd13159ee) | `` electron_40-bin: 40.9.3 -> 40.10.0 ``                                                                                  |
| [`0cabbb0f`](https://github.com/NixOS/nixpkgs/commit/0cabbb0ff98d28c76d003c51ac159fdd2e1e36e8) | `` electron-source.electron_42: 42.0.0 -> 42.0.1 ``                                                                       |
| [`b418ea84`](https://github.com/NixOS/nixpkgs/commit/b418ea8434fb3d3ab021599f23ab6955908b76a1) | `` electron-source.electron_41: 41.5.0 -> 41.5.2 ``                                                                       |
| [`af12f3cc`](https://github.com/NixOS/nixpkgs/commit/af12f3ccecda2be2b8a0b4363698246b4e2156ad) | `` electron-source.electron_40: 40.9.3 -> 40.10.0 ``                                                                      |
| [`9b76d7f0`](https://github.com/NixOS/nixpkgs/commit/9b76d7f0c88b7081684c6fa634b8f28a7a77e13d) | `` electron: update.py: fetch missing-hashes ``                                                                           |
| [`e07ecc21`](https://github.com/NixOS/nixpkgs/commit/e07ecc21deb54501aa4d4d54d13737a4299b901d) | `` electron-chromedriver_41: 41.3.0 -> 41.5.0 ``                                                                          |
| [`522eb5b3`](https://github.com/NixOS/nixpkgs/commit/522eb5b39ff4c1489ae3b553e1f7bc671fb70eba) | `` electron_41-bin: 41.3.0 -> 41.5.0 ``                                                                                   |
| [`4e4668c3`](https://github.com/NixOS/nixpkgs/commit/4e4668c33d211961708ca1f32d181a24a10ca5fc) | `` electron-chromedriver_40: 40.9.2 -> 40.9.3 ``                                                                          |
| [`a46e5dbc`](https://github.com/NixOS/nixpkgs/commit/a46e5dbc6f5a115a61a85e59b4c396f96efb1d12) | `` electron_40-bin: 40.9.2 -> 40.9.3 ``                                                                                   |
| [`a7b73356`](https://github.com/NixOS/nixpkgs/commit/a7b7335670e5a2ad7e04987142993a0a3e0cd1b3) | `` electron-chromedriver_39: 39.8.9 -> 39.8.10 ``                                                                         |
| [`b4fe821d`](https://github.com/NixOS/nixpkgs/commit/b4fe821d1d715df3a79fcaf0341488e291921300) | `` electron_39-bin: 39.8.9 -> 39.8.10 ``                                                                                  |
| [`8edcfb17`](https://github.com/NixOS/nixpkgs/commit/8edcfb17f68d77514b42e3f6f7275c8ae193497f) | `` electron-source.electron_39: 39.8.9 -> 39.8.10 ``                                                                      |
| [`db4905c2`](https://github.com/NixOS/nixpkgs/commit/db4905c24699b3a9f21fd8bf25f49eea13afeee8) | `` electron-source.electron_41: 41.3.0 -> 41.5.0 ``                                                                       |
| [`1860becc`](https://github.com/NixOS/nixpkgs/commit/1860becc29a7944ea6a62bf354f05d45483e931b) | `` electron-source.electron_40: 40.9.2 -> 40.9.3 ``                                                                       |
| [`cc89cb2b`](https://github.com/NixOS/nixpkgs/commit/cc89cb2bf6fd06cc37593207f41eeaf25f1fd9c7) | `` electron-chromedriver_42: init at 42.0.0 ``                                                                            |
| [`5724ee21`](https://github.com/NixOS/nixpkgs/commit/5724ee21c99be87f3c213609f9d4e5c38b763cfa) | `` electron_42-bin: init at 42.0.0 ``                                                                                     |
| [`d07aa655`](https://github.com/NixOS/nixpkgs/commit/d07aa65536545f133750908629ca02829d46e496) | `` electron-source.electron_42: init at 42.0.0 ``                                                                         |
| [`4e52ef64`](https://github.com/NixOS/nixpkgs/commit/4e52ef6480b09cd0711a53ec9d1ba3ff9219ecf9) | `` openimageio: 3.1.12.0 -> 3.1.13.1 ``                                                                                   |
| [`667fce87`](https://github.com/NixOS/nixpkgs/commit/667fce878161f79f6a6badc304d6389aed79f264) | `` openimageio: 3.1.11.0 -> 3.1.12.0 ``                                                                                   |
| [`27e6b85f`](https://github.com/NixOS/nixpkgs/commit/27e6b85f940e3016290a63f8def201fb2eed4e64) | `` nixosTests.discourse: make imap polling quieter ``                                                                     |
| [`5fbf78d4`](https://github.com/NixOS/nixpkgs/commit/5fbf78d491a7d11ecbbd6a87d3afb1e859fb8518) | `` discourse-mail-receiver: replace `replace` with `sd` ``                                                                |
| [`64b70c3a`](https://github.com/NixOS/nixpkgs/commit/64b70c3a1de59cfdd9fde9ed65764fbf2d3576ee) | `` discourse: 2026.1.3 -> 2026.1.4 ``                                                                                     |
| [`0a1aa563`](https://github.com/NixOS/nixpkgs/commit/0a1aa56374887f53302772e23f908ce1d9c2041d) | `` nixos/prefect: respect services.prefect.package ``                                                                     |
| [`9a5fe597`](https://github.com/NixOS/nixpkgs/commit/9a5fe597b0ba2ead78159497333841767ea0b6c7) | `` Revert "ci/github-script/reviewers: revoke stale review requests" ``                                                   |
| [`004d5487`](https://github.com/NixOS/nixpkgs/commit/004d548768be8ee5e3873a888cf1f12e549a05af) | `` Revert "ci/github-script/reviewers: keep team members when revoking stale requests" ``                                 |
| [`4aaba361`](https://github.com/NixOS/nixpkgs/commit/4aaba36168f8aa81086a3c95e04392a13dfb9a50) | `` nextcloud33Packages: update ``                                                                                         |
| [`aad764ac`](https://github.com/NixOS/nixpkgs/commit/aad764ac7b958adc7fd802237f06692cd6e83a17) | `` nextcloud32Packages: update ``                                                                                         |
| [`a6dfbdff`](https://github.com/NixOS/nixpkgs/commit/a6dfbdff6bb224e8924c71dc02f2c18234230b5e) | `` qbz: 1.2.12 -> 1.2.13 ``                                                                                               |
| [`4456d8d3`](https://github.com/NixOS/nixpkgs/commit/4456d8d3bdcc82643c5e03811dd50c37cc312302) | `` ci/github-script/reviewers: keep team members when revoking stale requests ``                                          |
| [`69e4c3df`](https://github.com/NixOS/nixpkgs/commit/69e4c3dfd4ce046b754f36e0e98be129c4552817) | `` nextcloud33: 33.0.2 -> 33.0.3 ``                                                                                       |
| [`f61ebb10`](https://github.com/NixOS/nixpkgs/commit/f61ebb1008a4318c7482d4a7d2f515605c9f658c) | `` nextcloud32: 32.0.8 -> 32.0.9 ``                                                                                       |
| [`7851eccc`](https://github.com/NixOS/nixpkgs/commit/7851eccc52fc432f9ad8cebb55fbf358f8ce324d) | `` firefox-esr-140-unwrapped: 140.10.2esr -> 140.11.0esr ``                                                               |
| [`1b45af79`](https://github.com/NixOS/nixpkgs/commit/1b45af790882147d8c9b078b19771c3326632a18) | `` firefox-bin-unwrapped: 150.0.3 -> 151.0 ``                                                                             |
| [`5c57973e`](https://github.com/NixOS/nixpkgs/commit/5c57973ea869ccbf7f665f69f20495da6fdb6eb5) | `` firefox-unwrapped: 150.0.3 -> 151.0 ``                                                                                 |
| [`17fdbb17`](https://github.com/NixOS/nixpkgs/commit/17fdbb1759182b24d77d90fa769b754c996454e4) | `` github-runner: 2.333.1 -> 2.334.0 ``                                                                                   |
| [`7df0ddc3`](https://github.com/NixOS/nixpkgs/commit/7df0ddc300d3d87c59b87c26a084ce03a852f210) | `` wayle: 0.2.3 -> 0.3.0 ``                                                                                               |
| [`0bfcc128`](https://github.com/NixOS/nixpkgs/commit/0bfcc128ebed68129d1b8ea4342c78ea48591b1c) | `` obsidian: pin electron to 40 ``                                                                                        |
| [`798f9480`](https://github.com/NixOS/nixpkgs/commit/798f9480906378ab009c7741e514d14e20f8a389) | `` imagemagick6: 6.9.13-38 -> 6.9.13-48 ``                                                                                |
| [`dc7706d5`](https://github.com/NixOS/nixpkgs/commit/dc7706d5b3a95e7031daee26398df0535a151843) | `` vivaldi: 7.9.3970.64 -> 7.9.3970.67 ``                                                                                 |
| [`e4704809`](https://github.com/NixOS/nixpkgs/commit/e470480942475f234784228bf833c30652c651db) | `` asciinema-agg: 1.7.0 -> 1.8.1 ``                                                                                       |
| [`211bf102`](https://github.com/NixOS/nixpkgs/commit/211bf102c758d78e8040c083192ddf9f020eb37a) | `` linux_xanmod_latest: 7.0.8 -> 7.0.9 ``                                                                                 |
| [`b054dd77`](https://github.com/NixOS/nixpkgs/commit/b054dd7700261b1af6e1c0fa2051f93603fcd0ca) | `` linux_xanmod: 6.18.31 -> 6.18.32 ``                                                                                    |
| [`86e668d9`](https://github.com/NixOS/nixpkgs/commit/86e668d9b98cd07f68e29908cdc1c0af53b5a04d) | `` mailpit: disallow building nixos tests on darwin ``                                                                    |
| [`6c893f96`](https://github.com/NixOS/nixpkgs/commit/6c893f96ed9b07a75272a86cf72df04355334eca) | `` mailpit: 1.29.7 -> 1.30.0 ``                                                                                           |
| [`7ad7af81`](https://github.com/NixOS/nixpkgs/commit/7ad7af81946d55bfd3db14826c6521bf45924802) | `` spamassassin: skip the problematic test ``                                                                             |
| [`04e69f48`](https://github.com/NixOS/nixpkgs/commit/04e69f48e197846c2f7d78b14a517269935cfeb3) | `` linuxKernel.kernels.linux_zen: 7.0.8-zen1 -> 7.0.9-zen1 ``                                                             |
| [`37bf1b9b`](https://github.com/NixOS/nixpkgs/commit/37bf1b9b9c08d1181367f24393573bed1fd1f627) | `` llvmPackages_git: 23.0.0-unstable-2026-05-10 -> 23.0.0-unstable-2026-05-17 ``                                          |
| [`6c32334f`](https://github.com/NixOS/nixpkgs/commit/6c32334f99eea3be0fc484013dfd02be35631426) | `` mailpit: 1.29.6 -> 1.29.7 ``                                                                                           |
| [`df70c858`](https://github.com/NixOS/nixpkgs/commit/df70c8585c14a2990c1162d52e4faf8fa582311f) | `` sogo: 5.12.7 -> 5.12.8 ``                                                                                              |
| [`1d2c9a5a`](https://github.com/NixOS/nixpkgs/commit/1d2c9a5af222ed82bf3c5bfe90d0086e004473a8) | `` sope: 5.12.7 -> 5.12.8 ``                                                                                              |
| [`801622e3`](https://github.com/NixOS/nixpkgs/commit/801622e34c5b0377cbb11b563adb80ba3d199b42) | `` python3Packages.nbxmpp: 7.1.0 -> 7.2.0 ``                                                                              |
| [`0481c95d`](https://github.com/NixOS/nixpkgs/commit/0481c95d86bfb0b31ddd7edf85af75a221654032) | `` dprint-plugins.dprint-plugin-biome: 0.12.10 -> 0.12.11 ``                                                              |
| [`c9a679eb`](https://github.com/NixOS/nixpkgs/commit/c9a679eb7750f3164b4f91741bee8cb07d4342a0) | `` linux_6_6: 6.6.139 -> 6.6.140 ``                                                                                       |
| [`188c517f`](https://github.com/NixOS/nixpkgs/commit/188c517ff30716d0825f5ff0e6592c0a254c06f8) | `` linux_6_12: 6.12.89 -> 6.12.90 ``                                                                                      |
| [`ddb3a486`](https://github.com/NixOS/nixpkgs/commit/ddb3a486dda98196608ec20dc84e862387cb7b49) | `` linux_6_18: 6.18.31 -> 6.18.32 ``                                                                                      |
| [`b9fb458d`](https://github.com/NixOS/nixpkgs/commit/b9fb458dce9a839ff129a71c2209f54bbd4ca9fa) | `` linux_7_0: 7.0.8 -> 7.0.9 ``                                                                                           |
| [`35a9fe8b`](https://github.com/NixOS/nixpkgs/commit/35a9fe8bf381b043482a456a824f5965e191fa1e) | `` linux_testing: 7.1-rc3 -> 7.1-rc4 ``                                                                                   |
| [`bbcf1b76`](https://github.com/NixOS/nixpkgs/commit/bbcf1b76c7673e320f3ce4635acb67570b66def1) | `` github/workflows: build nixos manual on PRs targeting staging-nixos ``                                                 |
| [`d1638882`](https://github.com/NixOS/nixpkgs/commit/d16388826dd3a685c0c8d107412960d9f993ec86) | `` element-{web,desktop}: 1.12.14 -> 1.12.18 ``                                                                           |
| [`f06eefe5`](https://github.com/NixOS/nixpkgs/commit/f06eefe594f750a3acf576132708ac7f8c45fe9e) | `` ci/github-script/reviewers: revoke stale review requests ``                                                            |
| [`85846548`](https://github.com/NixOS/nixpkgs/commit/858465487d05bd53b39765fb8d92ba7b7b57dd0d) | `` cinny-unwrapped: add ryand56 as maintainer ``                                                                          |
| [`562b6bb4`](https://github.com/NixOS/nixpkgs/commit/562b6bb45bb159861105b4f1adee08391ec90bc8) | `` cinny{-unwrapped,-desktop}: 4.11.1 -> 4.12.1 ``                                                                        |
| [`52fa912f`](https://github.com/NixOS/nixpkgs/commit/52fa912f18111f0dcb21f05bab73e2b73b9e8af6) | `` ci/github-script: update npm versions ``                                                                               |
| [`92b8eb82`](https://github.com/NixOS/nixpkgs/commit/92b8eb829c5d3ce62f11a9bb0d9b0b6eafe00d2c) | `` ci/github-script/check-target-branch: disable review for xanmod kernels ``                                             |
| [`b604ce27`](https://github.com/NixOS/nixpkgs/commit/b604ce274da295dd36a5b37ada6d7cf2137e30d9) | `` buildbox: 1.4.5 -> 1.4.6 ``                                                                                            |
| [`c3eca25a`](https://github.com/NixOS/nixpkgs/commit/c3eca25ab66a09c17aac0b72b45723d90abad992) | `` hath-rust: 1.16.1 -> 1.17.0 ``                                                                                         |
| [`a4b6a06f`](https://github.com/NixOS/nixpkgs/commit/a4b6a06f612d8779fd52245237761d672c969c30) | `` thunderbird-latest-bin-unwrapped: 150.0.1 -> 150.0.2 ``                                                                |
| [`8374816e`](https://github.com/NixOS/nixpkgs/commit/8374816e457a9853d4248aa6c7b47dee477e8046) | `` boringssl: 0.20260413.0 -> 0.20260508.0 ``                                                                             |
| [`1f66e225`](https://github.com/NixOS/nixpkgs/commit/1f66e2259f5cc0f349ccc49fc97d6552108426dc) | `` sope: 5.12.3 -> 5.12.7 ``                                                                                              |
| [`5e5775c4`](https://github.com/NixOS/nixpkgs/commit/5e5775c412b68418ef07c0b729a176db5ac731c5) | `` sogo: 5.12.4 -> 5.12.7 ``                                                                                              |
| [`2e815c21`](https://github.com/NixOS/nixpkgs/commit/2e815c214a996c58a55858111a64fc06e23526b1) | `` mattermost, mattermostLatest: 10.11.15/11.5.3 -> 10.11.17/11.7.0 ``                                                    |
| [`158d6fd4`](https://github.com/NixOS/nixpkgs/commit/158d6fd4198eede22dba0a9c8800aba0fe880af4) | `` linuxKernel.kernels.linux_zen: 7.0.7-zen2 -> 7.0.8-zen1 ``                                                             |
| [`1ed0c1de`](https://github.com/NixOS/nixpkgs/commit/1ed0c1def4f803bac2ec7bdfa00362cdec8ab220) | `` shellhub-agent: 0.21.7 -> 0.24.2 ``                                                                                    |
| [`9f31f35d`](https://github.com/NixOS/nixpkgs/commit/9f31f35dcb77e771620b3fad334070d893bce6bd) | `` shellhub-agent: 0.24.1 -> 0.21.7 ``                                                                                    |
| [`ec876583`](https://github.com/NixOS/nixpkgs/commit/ec8765834df90b3614c2377b3729fa7a62d6bf7f) | `` shellhub-agent: 0.24.0 -> 0.24.1 ``                                                                                    |
| [`4f0d3ec3`](https://github.com/NixOS/nixpkgs/commit/4f0d3ec30dfd2ea12fefca8831a405ddc443822b) | `` shellhub-agent: 0.22.0 -> 0.24.0 ``                                                                                    |
| [`cf93330f`](https://github.com/NixOS/nixpkgs/commit/cf93330f228faf339d5386c3a0e43b922af33525) | `` shellhub-agent: 0.21.5 -> 0.22.0 ``                                                                                    |
| [`6278bd4b`](https://github.com/NixOS/nixpkgs/commit/6278bd4bffa0f529f9944ffeb7cef483167d6b0a) | `` miniflux: 2.2.19 -> 2.3.0 ``                                                                                           |
| [`b79d4ea7`](https://github.com/NixOS/nixpkgs/commit/b79d4ea7be0ab18cbab7338b9faa6ecb12019d94) | `` turbo-unwrapped: 2.9.6 -> 2.9.14 ``                                                                                    |
| [`122bd60c`](https://github.com/NixOS/nixpkgs/commit/122bd60cf5c4e6c0f75df4b5ac22a935f7d10d8a) | `` libmodsecurity: 3.0.14 -> 3.0.15 ``                                                                                    |
| [`358bd2f7`](https://github.com/NixOS/nixpkgs/commit/358bd2f7e18e23fae8e3630afec67baa255a7507) | `` logseq: pin electron to electron_39 to fix plugin loading ``                                                           |
| [`71c635e7`](https://github.com/NixOS/nixpkgs/commit/71c635e7347fac07f46d48b149d17974dd7c6e80) | `` gitlab: 18.11.2 -> 18.11.3 ``                                                                                          |
| [`087f7cb9`](https://github.com/NixOS/nixpkgs/commit/087f7cb920051007d0e4bfbe112d7851cffb6438) | `` openimageio: 3.1.10.0 -> 3.1.11.0 ``                                                                                   |
| [`647a83f3`](https://github.com/NixOS/nixpkgs/commit/647a83f389392dd053b105ee851647685079f549) | `` linux_xanmod_latest: 7.0.7 -> 7.0.8 ``                                                                                 |
| [`500ab82c`](https://github.com/NixOS/nixpkgs/commit/500ab82caf01a1e6f44b11a7d9c645e306e176ef) | `` linux_xanmod: 6.18.30 -> 6.18.31 ``                                                                                    |
| [`806dc1de`](https://github.com/NixOS/nixpkgs/commit/806dc1de0d2587e0f7c71c2a8a628f20b2968817) | `` openimageio: 3.1.9.0 -> 3.1.10.0 ``                                                                                    |
| [`19c1da01`](https://github.com/NixOS/nixpkgs/commit/19c1da012be7801ebb4d5ad84c051b0903dc2be3) | `` openimageio: 3.1.7.0 -> 3.1.9.0 ``                                                                                     |
| [`69ba92a2`](https://github.com/NixOS/nixpkgs/commit/69ba92a2ed4f48a92ec569a4d9060cea46097de4) | `` workflows/pull-request-target: don't try to use secrets in pull_request context on Dependabot PRs ``                   |
| [`6a2b7142`](https://github.com/NixOS/nixpkgs/commit/6a2b7142f06ed8439c0c92428d1d36c36ceb56b7) | `` ci/github-script: npm audit fix ``                                                                                     |
| [`104b8731`](https://github.com/NixOS/nixpkgs/commit/104b87317bdc94ede0089a24e7a06e5ea37d0a78) | `` ci/github-script/prepare: fix review dismissals ``                                                                     |
| [`44614377`](https://github.com/NixOS/nixpkgs/commit/4461437716f7419781b8ab4075885d99dd9334aa) | `` .github: Bump cachix/cachix-action ``                                                                                  |
| [`851f500f`](https://github.com/NixOS/nixpkgs/commit/851f500f163044651b89c11f0e548e320ece1fb1) | `` podofo_1_0: 1.0.3 -> 1.0.4, fix CVE-2026-44348 ``                                                                      |
| [`b5ae75e5`](https://github.com/NixOS/nixpkgs/commit/b5ae75e5eddc0eceadf360206d96d471439c682a) | `` signal-desktop: 8.8.0 -> 8.9.1 ``                                                                                      |
| [`61757373`](https://github.com/NixOS/nixpkgs/commit/61757373023c0c5c05dfec93c6032c5ec9dfb1f2) | `` .github: Bump actions/create-github-app-token from 3.1.1 to 3.2.0 ``                                                   |
| [`39dc21ae`](https://github.com/NixOS/nixpkgs/commit/39dc21ae3102abb380062dbba33ef88b76d02ae1) | `` .github: Bump korthout/backport-action from 4.5.1 to 4.5.2 ``                                                          |
| [`4174b434`](https://github.com/NixOS/nixpkgs/commit/4174b4344f6892c19d66e8cc68561c2a69b1604a) | `` octodns-providers.ddns: 0.3.0 -> 0.4.0 ``                                                                              |
| [`fba23c6e`](https://github.com/NixOS/nixpkgs/commit/fba23c6e0a764837a3203756fa86a5f0924e528f) | `` nss_latest: 3.123.1 -> 3.124 ``                                                                                        |
| [`4cf8a906`](https://github.com/NixOS/nixpkgs/commit/4cf8a9063cbcd677a7791bfdeda7fd04f23bc1e3) | `` radicle-explorer: refactor ``                                                                                          |
| [`9ac7d574`](https://github.com/NixOS/nixpkgs/commit/9ac7d5748a58153df284f989a8979fc8c1472c19) | `` cloud-hypervisor: 51.1 -> 52.0 ``                                                                                      |
| [`4e903a1d`](https://github.com/NixOS/nixpkgs/commit/4e903a1db0df0825e14ea672cd46f77bda1dcb6f) | `` cloud-hypervisor: 51.0 → 51.1 ``                                                                                       |
| [`a2169fce`](https://github.com/NixOS/nixpkgs/commit/a2169fcedb767ae71a70e58d2845a8326a3da502) | `` cloud-hypervisor: 50.2 -> 51.0 ``                                                                                      |
| [`3ac6f7f1`](https://github.com/NixOS/nixpkgs/commit/3ac6f7f1fdaea9e97700885413ed20512d583bf7) | `` radicle-job: 0.5.2 -> 0.6.0 ``                                                                                         |
| [`e4afe891`](https://github.com/NixOS/nixpkgs/commit/e4afe891b85509676c1bf7fdd3fb88157fd305e1) | `` macaulay2: modified tests for aarch64 compatibility ``                                                                 |
| [`4238c8ce`](https://github.com/NixOS/nixpkgs/commit/4238c8ce3ad344990db3ffe0ea2ef6393e6b45c3) | `` zabbix72: Mark as EOL ``                                                                                               |
| [`2adf4fc9`](https://github.com/NixOS/nixpkgs/commit/2adf4fc9aa5dbc4cd7cd4af131973ed3378d4d1e) | `` brave: 1.90.121 -> 1.90.122 ``                                                                                         |
| [`013b524b`](https://github.com/NixOS/nixpkgs/commit/013b524bd6c622854a043852dd460215d465994a) | `` zabbix74: 7.4.7 -> 7.4.8 ``                                                                                            |
| [`0055368c`](https://github.com/NixOS/nixpkgs/commit/0055368c43ae594329b54e22524d3f12f64f9726) | `` zabbix: 6.0.44 -> 6.0.45 ``                                                                                            |
| [`171dba4b`](https://github.com/NixOS/nixpkgs/commit/171dba4b97e6742b9578e1b599893b7a4d53cf0c) | `` zabbix70: 7.0.23 -> 7.0.24 ``                                                                                          |
| [`9bb1c2d8`](https://github.com/NixOS/nixpkgs/commit/9bb1c2d89d586c938e3d189ff138058329bc74c3) | `` zabbix74: 7.4.6 -> 7.4.7 ``                                                                                            |
| [`f098f563`](https://github.com/NixOS/nixpkgs/commit/f098f563086126c8c4b1385d287b90aa3cdb924f) | `` zabbix: 6.0.43 -> 6.0.44 ``                                                                                            |
| [`d1169faa`](https://github.com/NixOS/nixpkgs/commit/d1169faae4e67037f4e98799b8ffdec7ebe89f45) | `` zabbix70: 7.0.22 -> 7.0.23 ``                                                                                          |
| [`7987fc2c`](https://github.com/NixOS/nixpkgs/commit/7987fc2ce730329218dd80c981c3d2f1a3aaa3bd) | `` jenkins: 2.555.1 -> 2.555.2 ``                                                                                         |
| [`9ae2bc82`](https://github.com/NixOS/nixpkgs/commit/9ae2bc82b9dbe3df73c6e3c2dd0a8c8189b138e3) | `` wasm-pack: 0.14.0 -> 0.15.0 ``                                                                                         |
| [`fd3a429a`](https://github.com/NixOS/nixpkgs/commit/fd3a429a5397a9359e310b4801d337f89f2737cc) | `` linux_5_10: 5.10.255 -> 5.10.256 ``                                                                                    |
| [`54064d4c`](https://github.com/NixOS/nixpkgs/commit/54064d4c27384d8b4ddcf523da7dfe33a066b456) | `` linux_5_15: 5.15.206 -> 5.15.207 ``                                                                                    |
| [`fe6b92ee`](https://github.com/NixOS/nixpkgs/commit/fe6b92ee67f5ff9c53cb6b5c6ca8b005b727e85d) | `` linux_6_1: 6.1.172 -> 6.1.173 ``                                                                                       |
| [`85fba605`](https://github.com/NixOS/nixpkgs/commit/85fba605db90633099dea495f2b2a2afd6abc240) | `` linux_6_6: 6.6.138 -> 6.6.139 ``                                                                                       |
| [`cd4bba43`](https://github.com/NixOS/nixpkgs/commit/cd4bba436ef50bb65d359fb60055d1c5f8068517) | `` linux_6_12: 6.12.88 -> 6.12.89 ``                                                                                      |
| [`fde7d267`](https://github.com/NixOS/nixpkgs/commit/fde7d26762e8412f0a0add0694b887ba39973e64) | `` linux_6_18: 6.18.30 -> 6.18.31 ``                                                                                      |
| [`fb6033b1`](https://github.com/NixOS/nixpkgs/commit/fb6033b118ba24be64110ca140a03cf75c87ce56) | `` linux_7_0: 7.0.7 -> 7.0.8 ``                                                                                           |
| [`5c68f5c0`](https://github.com/NixOS/nixpkgs/commit/5c68f5c07eabac8802428ae59544d7e5f5356544) | `` linuxKernel.kernels.linux_zen: 7.0.6 -> 7.0.7 ``                                                                       |
| [`9783061b`](https://github.com/NixOS/nixpkgs/commit/9783061bf1276da0d42c1deab03ef0154f8bb4ae) | `` lldpd: fix oob heap read ``                                                                                            |
| [`b02b773c`](https://github.com/NixOS/nixpkgs/commit/b02b773c3f8f995e6128e28cfa03cd42adfda35f) | `` linux_xanmod_latest: 7.0.6 -> 7.0.7 ``                                                                                 |
| [`ff5b6efd`](https://github.com/NixOS/nixpkgs/commit/ff5b6efd92153e6f0b3d81b619e5b78cfc14407d) | `` linux_xanmod: 6.18.29 -> 6.18.30 ``                                                                                    |
| [`261b1a9d`](https://github.com/NixOS/nixpkgs/commit/261b1a9db049e69ace24429c27ad6080159f5302) | `` postgresql_18: 18.3 -> 18.4 ``                                                                                         |
| [`29ad1ea1`](https://github.com/NixOS/nixpkgs/commit/29ad1ea1ef30fbd6a53de0a759b406074c353147) | `` postgresql_17: 17.9 -> 17.10 ``                                                                                        |
| [`6e1467d0`](https://github.com/NixOS/nixpkgs/commit/6e1467d03b12059a82da5f2f8f012b111dccdaa1) | `` postgresql_16: 16.13 -> 16.14 ``                                                                                       |
| [`26d2cc8f`](https://github.com/NixOS/nixpkgs/commit/26d2cc8f642cc3f9a4bc1f5ed98fc8edc546f312) | `` postgresql_15: 15.17 -> 15.18 ``                                                                                       |
| [`35f2249b`](https://github.com/NixOS/nixpkgs/commit/35f2249bc92a6777ab0f8da82195af7af493659e) | `` postgresql_14: 14.22 -> 14.23 ``                                                                                       |
| [`6df107b9`](https://github.com/NixOS/nixpkgs/commit/6df107b9a39bd8765a247fedefe72f2f17501ef8) | `` buildMozillaMach: revert macOS sdk 26.4 update and minimize patches ``                                                 |
| [`02e12dbf`](https://github.com/NixOS/nixpkgs/commit/02e12dbf32b12ff07613c0c10d2fa58e1bd26112) | `` anki: 25.09.3 -> 25.09.4 ``                                                                                            |
| [`8f7e8171`](https://github.com/NixOS/nixpkgs/commit/8f7e8171915b60fc55531651d271c29d477708ed) | `` phpPackages.composer: 2.9.7 -> 2.9.8, fix CVE-2026-45793 ``                                                            |
| [`10808cda`](https://github.com/NixOS/nixpkgs/commit/10808cdafe24e641835a74af07c31729c8510f27) | `` linux_6_12: 6.12.87 -> 6.12.88 ``                                                                                      |
| [`10e05bcf`](https://github.com/NixOS/nixpkgs/commit/10e05bcf8d6b51f53106b613e2de047c23fffb3c) | `` linux_6_18: 6.18.29 -> 6.18.30 ``                                                                                      |
| [`8d349883`](https://github.com/NixOS/nixpkgs/commit/8d3498835f44e3d0e472ef8be133c22570c54773) | `` linux_7_0: 7.0.6 -> 7.0.7 ``                                                                                           |
| [`7c4f3d90`](https://github.com/NixOS/nixpkgs/commit/7c4f3d907c0747c61d07c5fdde915ad8c22c314c) | `` grafana: 12.3.6 -> 12.3.6+security-01 ``                                                                               |
| [`ffe0f095`](https://github.com/NixOS/nixpkgs/commit/ffe0f095c053e66b9b16e8f8961d2bcf4328d5f0) | `` perlPackages.YAMLSyck: 1.36 -> 1.45 ``                                                                                 |
| [`f01a94c4`](https://github.com/NixOS/nixpkgs/commit/f01a94c44b5fb216ddc2bd9de19806d25f76663d) | `` nginxMainline: patch CVE-2026-42926, CVE-2026-40460, CVE-2026-40701, CVE-2026-42934, CVE-2026-42945, CVE-2026-42946 `` |
| [`4a904ff4`](https://github.com/NixOS/nixpkgs/commit/4a904ff44a190a211342d16408ea9702c56106b0) | `` nginxStable: patch CVE-2026-40460, CVE-2026-40701, CVE-2026-42934, CVE-2026-42945, CVE-2026-42946 ``                   |
| [`a8cfe4df`](https://github.com/NixOS/nixpkgs/commit/a8cfe4dff9097a472d3383cc004170654ecbae9c) | `` kanidm_1_10: 1.10.1 -> 1.10.2 ``                                                                                       |
| [`e6b033a4`](https://github.com/NixOS/nixpkgs/commit/e6b033a421389ad98400b8035ad1478d27fca775) | `` kanidm_1_9: 1.9.3 -> 1.9.4 ``                                                                                          |
| [`66993381`](https://github.com/NixOS/nixpkgs/commit/6699338179db98d5ddbacd42919726835c24dade) | `` zfs_2_3: 2.3.6 -> 2.3.7 ``                                                                                             |
| [`423cbdea`](https://github.com/NixOS/nixpkgs/commit/423cbdea48d1f0141d2cb8f7208dd931247cc313) | `` zfs_2_4: 2.4.1 -> 2.4.2 ``                                                                                             |
| [`451405fd`](https://github.com/NixOS/nixpkgs/commit/451405fdcf20310079bfb33d0339478c9e765551) | `` nixosTests.zfs: Test installer with systemd stage 1 ``                                                                 |
| [`f68846ad`](https://github.com/NixOS/nixpkgs/commit/f68846ad48f5884318ccd42be1edd5d727b9a686) | `` nixosTests.zfs: Fix broken tests ``                                                                                    |
| [`f09bb011`](https://github.com/NixOS/nixpkgs/commit/f09bb0119c924c15a20cc569a233f7423285f123) | `` zfs_unstable: 2.4.0 -> 2.4.1 ``                                                                                        |
| [`b5601e9b`](https://github.com/NixOS/nixpkgs/commit/b5601e9be7644d6f24ad5673c41f7467030e7a5a) | `` claude-code: fix voice mode native module load on Linux ``                                                             |
| [`5dcf984e`](https://github.com/NixOS/nixpkgs/commit/5dcf984ea13ac4a01d8ab2ebbe5d51175f9c923a) | `` vscode-extensions.anthropic.claude-code: 2.1.138 -> 2.1.140 ``                                                         |
| [`ed9dd65e`](https://github.com/NixOS/nixpkgs/commit/ed9dd65e4d7283f362b9fc911e6ecf4a4ef93e23) | `` claude-code: 2.1.138 -> 2.1.140 ``                                                                                     |
| [`0aace1a4`](https://github.com/NixOS/nixpkgs/commit/0aace1a40cc99f3fef52214ed03e09e1a7cd7030) | `` vscode-extensions.anthropic.claude-code: 2.1.133 -> 2.1.138 ``                                                         |
| [`9f10359d`](https://github.com/NixOS/nixpkgs/commit/9f10359d0fcaa4d67b2a5e59c3de0933cb7d899b) | `` claude-code: 2.1.137 -> 2.1.138 ``                                                                                     |
| [`fc200aea`](https://github.com/NixOS/nixpkgs/commit/fc200aeae2efb79966b80551e2daf025840b6644) | `` claude-code: 2.1.133 -> 2.1.137 ``                                                                                     |
| [`f97e6ff8`](https://github.com/NixOS/nixpkgs/commit/f97e6ff8666feec51531f4a59e242ee8510ac23f) | `` vscode-extensions.anthropic.claude-code: 2.1.131 -> 2.1.133 ``                                                         |
| [`a098d45f`](https://github.com/NixOS/nixpkgs/commit/a098d45fb81906cd4e282f46f8c87606f0049eee) | `` claude-code: 2.1.131 -> 2.1.133 ``                                                                                     |
| [`d801def1`](https://github.com/NixOS/nixpkgs/commit/d801def14795347c6bed16b3dc4aa461da84d975) | `` vscode-extensions.anthropic.claude-code: 2.1.128 -> 2.1.131 ``                                                         |
| [`a384fee1`](https://github.com/NixOS/nixpkgs/commit/a384fee102492d904968e87a01a156133364d7cb) | `` claude-code: 2.1.128 -> 2.1.131 ``                                                                                     |

*... and 511 more commits (truncated)*