### PR TITLE
chore(flake/precommit-base): `cb27f0e8` -> `25fb3bf8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -722,11 +722,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -1540,11 +1540,11 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1777597424,
-        "narHash": "sha256-2szcq71hbF+FK4XrJa+sERYVo5rQVjPmxWjTMedLIXM=",
+        "lastModified": 1780274652,
+        "narHash": "sha256-CUWjnz7aASjtQqBJvRAHg9UhTxjAiBlGmoG5CRzMJ6A=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "cb27f0e8312a14e144978fac6963d55897aa6dea",
+        "rev": "25fb3bf809f873993ec3816091d86112b27cf6ba",
         "type": "github"
       },
       "original": {
@@ -1705,11 +1705,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1777519017,
-        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
+        "lastModified": 1780197589,
+        "narHash": "sha256-FVCr2Ij/jKf59a4LW481eeOF6rJRreOBrVgW/aUBTrw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
+        "rev": "21632e942d89bf1cce4e5a63d7e58a215a0cbfcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                                                     |
| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`25fb3bf8`](https://github.com/fredsystems/pre-commit-checks/commit/25fb3bf809f873993ec3816091d86112b27cf6ba) | `` chore(deps): lock file maintenance (#27) ``                              |
| [`09383f5f`](https://github.com/fredsystems/pre-commit-checks/commit/09383f5f0dfd038af0614bede6ca3288c36b61c9) | `` chore(deps): update cachix/install-nix-action digest to 8aa0397 (#26) `` |