### PR TITLE
chore(flake/apple-fonts): `e593ac86` -> `a11f7174`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         "sf-pro": "sf-pro"
       },
       "locked": {
-        "lastModified": 1779851139,
-        "narHash": "sha256-MbveJ0ka8bAIAXHXPEoQ5xnDDejeu1ptuBpNwQSPER8=",
+        "lastModified": 1780240721,
+        "narHash": "sha256-O5dSz9h4zRnYyGYTS0hfMamYEDutsEC1PzxQELdsttU=",
         "owner": "Lyndeno",
         "repo": "apple-fonts.nix",
-        "rev": "e593ac862763f1863359d066f0b1032b180ec993",
+        "rev": "a11f7174137d4a0267bd8d7abd85da05bd9a41cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                             |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`dfe227af`](https://github.com/Lyndeno/apple-fonts.nix/commit/dfe227af4e7e8532e85089343b76c59c6a9377d3) | `` fix: Re-enable darwin targets `` |