### PR TITLE
fix(flake): disambiguate nixpkgs-kernel URL from nixpkgs-stable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,14 +24,19 @@
 
     # CI: server
     #
-    # Pinned-kernel input.  Tracks the same nixos-25.11 channel as
+    # Pinned-kernel input.  Tracks the same stable channel as
     # nixpkgs-stable but lives as its own flake input so the kernel can be
     # bumped on its own cadence (monthly, manual-merge PR via the
     # update-flakes workflow) instead of riding the weekly auto-merged
     # nixpkgs-stable bump.  Servers consume linuxPackages_6_12 from this
     # input via modules/system/kernel-pin.nix.
+    #
+    # NOTE: the ?ref= URL form is intentional — it resolves to the same
+    # channel as nixpkgs-stable above, but the differing string lets
+    # Renovate's nix manager update each input independently without the
+    # two identical URLs colliding during in-place replacement.
     nixpkgs-kernel = {
-      url = "github:nixos/nixpkgs/nixos-25.11";
+      url = "github:nixos/nixpkgs?ref=nixos-25.11";
     };
 
     # CI: server


### PR DESCRIPTION
## Problem

Renovate's nix manager has been failing to open the stable-channel bump PRs (e.g. `nixos-25.11` → `nixos-26.05`) for both `nixpkgs-stable` and `nixpkgs-kernel`. Log excerpt from a recent run:

```
branch: renovate/nixpkgs-kernel-26.x
  depName: nixpkgs-kernel
  Found match at index 950   → expectedValue: nixos-26.05  foundValue: nixos-25.11  "Value is not updated"
  Found match at index 1039  → expectedValue: nixos-26.05  foundValue: nixos-25.11  "Value is not updated"
  Found match at index 1451  → expectedValue: nixos-26.05  foundValue: nixos-25.11  "Value is not updated"
Error updating branch: update failure
```

## Root cause

Renovate's nix manager scans `flake.nix` as a flat string when applying an update. Both `nixpkgs-stable` (line 22) and `nixpkgs-kernel` (line 34) had byte-identical URLs:

```nix
url = "github:nixos/nixpkgs/nixos-25.11";
```

When updating either input, the manager found multiple indistinguishable matches, couldn't decide which to rewrite, and bailed without writing. (A literal `nixos-25.11` in the surrounding comment was a third spurious match but not the primary cause.)

## Fix

Switch `nixpkgs-kernel`'s URL to the `?ref=` form. It resolves to the same channel commit (verified via `nix flake lock --update-input nixpkgs-kernel` — `flake.lock` unchanged) but the differing string lets Renovate update each input independently. The two-input design is preserved so CI can continue bumping the kernel on its own cadence.

Also reworded the surrounding comment so the literal version string `nixos-25.11` no longer appears in prose, and added a NOTE explaining why the two URL forms differ.

## Verification

- `nix flake lock --update-input nixpkgs-kernel` produces no rev change.
- No scripts/CI grep the URL string shape — all consumers reference the input by Nix attribute name (`nixpkgs-kernel`).