### PR TITLE
chore(flake/catppuccin): `3c724845` -> `9f015db9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780346501,
-        "narHash": "sha256-nRuvgxeweMfpsyErSrumeVHKPy4RboTyIzGHLMdZkI8=",
+        "lastModified": 1780394337,
+        "narHash": "sha256-qsiTng/LjFuxN5SNKIKhUWqFFbpvdpnYqRj2F7inK3k=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "3c72484582bbeb239eeb10412f8eaa6eaead63a6",
+        "rev": "9f015db982efc83ae1eb0074960e812ee386f3bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`9f015db9`](https://github.com/catppuccin/nix/commit/9f015db982efc83ae1eb0074960e812ee386f3bb) | `` chore(home-manager/fzf): update (#971) `` |