### PR TITLE
chore(flake/home-manager): `d0af9b8b` -> `f384af1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780347968,
-        "narHash": "sha256-I8ibSDQx+E8cgw6k3UxX6Bm7awmGoKSTXc8Gt1Zbpp4=",
+        "lastModified": 1780408569,
+        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0af9b8bf3b4a1d449be7034bebc9f8f9fd6ee99",
+        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`f384af1b`](https://github.com/nix-community/home-manager/commit/f384af1bec6423a0d4ba1855917ab948f64e5808) | `` macos-terminal: add module ``                                  |
| [`a7c15f4f`](https://github.com/nix-community/home-manager/commit/a7c15f4f6508eb15d7f10364d2f732429a6fdd4f) | `` maintainers: add kayskayskays ``                               |
| [`70fc4b4b`](https://github.com/nix-community/home-manager/commit/70fc4b4b5efce98ac2329bd6ebf9e6c2f656a19b) | `` aerospace: add regression test for reload guard ``             |
| [`58e05d16`](https://github.com/nix-community/home-manager/commit/58e05d16d771614f061e46a7afb77e98fcdc4c75) | `` aerospace: skip config reload when AeroSpace is not running `` |
| [`f15c764b`](https://github.com/nix-community/home-manager/commit/f15c764b1449f45c9034b2f67873f8c4164ea21c) | `` password-store: improve warning message ``                     |
| [`68227a93`](https://github.com/nix-community/home-manager/commit/68227a9363266a1d1b51469bfcd31679855d2e62) | `` fontconfig: add test for font discovery ``                     |
| [`af1588ad`](https://github.com/nix-community/home-manager/commit/af1588ad6fb3fc41fcaf9e2e41f1a389a483a41c) | `` fontconfig: add test for default fonts ``                      |
| [`c0436bc0`](https://github.com/nix-community/home-manager/commit/c0436bc028b1f4a8e346f32ae76a91b53a9eecc5) | `` fontconfig: enable config files by default ``                  |
| [`07c723c3`](https://github.com/nix-community/home-manager/commit/07c723c3fe06c8e24d76882184e8bdee0073ba34) | `` zsh: fix oh-my-zsh custom path expansion ``                    |
| [`a7a41588`](https://github.com/nix-community/home-manager/commit/a7a415883195ffbd4dabec8f098f201e6eaaadf8) | `` infat: use list for autoActivate extraArgs ``                  |
| [`27429964`](https://github.com/nix-community/home-manager/commit/274299642bb423b2832850b8fcece0df0d62a133) | `` vscode: make keybindings submodule freeform ``                 |
| [`26e34a99`](https://github.com/nix-community/home-manager/commit/26e34a99e464d2a660c2e6d132ac1ea5b5f0fe6c) | `` hyprland: reorganize config generation ``                      |
| [`a6a13bb0`](https://github.com/nix-community/home-manager/commit/a6a13bb0a0a33f67cdfc4b0879b0e333737ab276) | `` hyprland: add extraLuaFiles option ``                          |
| [`51480019`](https://github.com/nix-community/home-manager/commit/5148001968d1189a3715759998b6dcce5ba3ac5f) | `` nix-search-tv: add keybindings and actions ``                  |
| [`c7e4087b`](https://github.com/nix-community/home-manager/commit/c7e4087b4da746d61f654a6e7971d3e693e188fd) | `` zsh: rename plugin completions to functions ``                 |
| [`c7c139f7`](https://github.com/nix-community/home-manager/commit/c7c139f7427b9900876ebd8217ed32193e06b19d) | `` zsh: escape double-quoted values ``                            |
| [`3e17edd5`](https://github.com/nix-community/home-manager/commit/3e17edd5e6d75e3908338e28b7101e847182b581) | `` zsh: escape named directory hashes ``                          |
| [`d00b16c5`](https://github.com/nix-community/home-manager/commit/d00b16c51115e41b00e0bf4a1ec3b539b8a91c6a) | `` zsh: escape cdpath entries ``                                  |
| [`112a3a37`](https://github.com/nix-community/home-manager/commit/112a3a37835010924e9f3940d6a78863cbf0b6ef) | `` zsh: add common plugin function paths ``                       |
| [`04ec113f`](https://github.com/nix-community/home-manager/commit/04ec113f8bab80fe476b69310a5a1b0a0e1da4a8) | `` zsh: load session vars from zprofile for login shells ``       |