### PR TITLE
fix(zsh): use inetutils hostname for --fqdn

### DIFF
--- a/features/common/system/default.nix
+++ b/features/common/system/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   pkgs,
+  lib,
   inputs,
   ...
 }:
@@ -16,7 +17,8 @@
       unzip
       file
       zip
-      toybox
+      (lib.lowPrio toybox)
+      inetutils
       nix-index
       lm_sensors
       dig


### PR DESCRIPTION
toybox's `hostname` doesn't support `--fqdn`, causing an error when `/etc/zshrc` runs `hostname --fqdn` on shell startup.

- Lower toybox priority with `lib.lowPrio` so its binaries lose buildEnv collision resolution.
- Add `inetutils` explicitly so `hostname` resolves to the GNU version that supports `--fqdn`.