### PR TITLE
feat(opencode): skills system + home-manager derivation distribution

### DIFF
--- a/.opencode/skills/languages/nix-best-practices/SKILL.md
+++ b/.opencode/skills/languages/nix-best-practices/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: nix-best-practices
+description: Use when editing `.nix` files in any of fred's flake-managed repos (nixos, freminal, docker-acarshub, and downstream). Codifies the active, strict Nix lint stack — `nixfmt` (auto-format), `statix check` (anti-patterns), `deadnix --fail` (unused bindings) — that runs on every `.nix` commit via the `fredsystems/precommit-base` pre-commit ruleset. Lists the common rejections (empty `{ ... }:` patterns, unused `let` / function args, `with` abuse, anti-patterns flagged by statix) and how to write Nix that passes on the first commit. No bypasses, no per-file disables without a real reason.
+---
+
+# Nix Best Practices — Lints Are Strict and Active
+
+## The non-negotiable
+
+Every `.nix` file in fred's flake repos is run through three lints on
+every commit. They are **enabled, strict, and not optional**:
+
+| Tool    | Command          | What it does on failure                  |
+| ------- | ---------------- | ---------------------------------------- |
+| nixfmt  | `nixfmt <file>`  | Auto-formats and re-stages.              |
+| statix  | `statix check`   | Reports anti-patterns; rejects commit.   |
+| deadnix | `deadnix --fail` | Reports unused bindings; rejects commit. |
+
+All three are configured in `fredsystems/precommit-base`
+(`checks/base.nix`) and inherited by every flake-managed repo. None
+of them accepts a `# noqa` / `# nolint` style escape hatch in source;
+disabling a rule means editing the shared `precommit-base`
+configuration, which is a deliberate, surface-it-first decision.
+
+There is no `--no-verify`. There is no "just this once". If a hook
+fires, fix the underlying Nix.
+
+## nixfmt (auto-format, re-stages)
+
+nixfmt 1.2.x runs with default settings. It is unopinionated about
+your logic but very opinionated about whitespace and bracket layout.
+It does not reject the commit on the first failure — it rewrites the
+file, re-stages it, and then later hooks run against the reformatted
+content. That means a "clean" commit attempt can still trigger
+follow-up hook failures on the reformatted text, so it pays to write
+in nixfmt's preferred style from the start.
+
+Rules of thumb:
+
+- Two-space indentation, no tabs.
+- Attribute sets and lists break onto multiple lines when they get
+  long — let nixfmt decide where; don't fight it.
+- Trailing semicolons on attribute-set bindings.
+- One space around `=`, `:`, and `?`.
+- Function arguments aligned by nixfmt — don't hand-align.
+
+If you find yourself reformatting after nixfmt, you're losing the
+fight. Re-stage and move on.
+
+## statix check (anti-patterns, hard reject)
+
+statix flags Nix anti-patterns. It does not auto-fix in our setup —
+it fails the commit and prints the offending location with a rule
+ID. Fix the source, don't suppress.
+
+The rejections that bite fred's repos most often:
+
+### Empty function pattern: `{ ... }:` → `_:`
+
+```nix
+# Rejected (statix: empty_pattern)
+{ ... }: {
+  services.foo.enable = true;
+}
+
+# Accepted
+_: {
+  services.foo.enable = true;
+}
+```
+
+The `{ ... }:` form is only meaningful when you actually destructure
+something out of it. If the body uses none of the module arguments,
+use `_:`. This bit the `features/ai/opencode/default.nix` rewrite
+during the skills work.
+
+### Unquoted URLs
+
+```nix
+# Rejected (statix: legacy_let_syntax / unquoted_uri depending on context)
+src = https://example.com/file.tar.gz;
+
+# Accepted
+src = "https://example.com/file.tar.gz";
+```
+
+### `let in` without bindings, or single-use `let` you could inline
+
+statix doesn't reject every single-use `let`, but it will flag
+patently dead ones. If statix complains about a `let`, the binding is
+either unused (and deadnix will also yell) or pointlessly indirect.
+
+### Manual `if ... then true else false`
+
+```nix
+# Rejected (statix: bool_simplification)
+enable = if cfg.useFoo then true else false;
+
+# Accepted
+enable = cfg.useFoo;
+```
+
+### `with` in module scopes
+
+`with pkgs;` and `with lib;` at the top of a module are flagged
+(`with` makes name resolution opaque and hides shadowing). Prefer
+explicit references or a tight `let` binding:
+
+```nix
+# Rejected (statix: with_attr_set in many contexts)
+{ pkgs, ... }: with pkgs; {
+  environment.systemPackages = [ vim git curl ];
+}
+
+# Accepted
+{ pkgs, ... }: {
+  environment.systemPackages = with pkgs; [ vim git curl ];
+}
+```
+
+The narrow `with pkgs;` directly in front of a list is typically
+fine; the module-wide `with` at the top is not.
+
+### Useless parens, useless `inherit`, find-and-replace style
+
+statix will flag `inherit foo;` when `foo` is not in scope, redundant
+parens around already-atomic expressions, and similar housekeeping
+issues. Just fix them — they're always real.
+
+## deadnix --fail (unused bindings, hard reject)
+
+deadnix is run with `--fail`, so any unused `let` binding, unused
+function argument, or unused `inherit` will reject the commit. It
+does not auto-fix in this setup.
+
+### Unused function arguments
+
+```nix
+# Rejected
+{ pkgs, lib, config, ... }: {
+  # only uses pkgs
+  environment.systemPackages = [ pkgs.vim ];
+}
+
+# Accepted
+{ pkgs, ... }: {
+  environment.systemPackages = [ pkgs.vim ];
+}
+```
+
+If you genuinely need a future-proof signature (e.g. you're
+prototyping and will use `lib` shortly), don't add it speculatively
+— add it when you use it.
+
+### Unused `let` bindings
+
+```nix
+# Rejected
+let
+  unused = "value";
+  pkg = pkgs.vim;
+in
+[ pkg ]
+
+# Accepted
+let
+  pkg = pkgs.vim;
+in
+[ pkg ]
+```
+
+### Underscore-prefix to silence: only when intentional
+
+deadnix respects `_name` (leading underscore) as an explicit
+"intentionally unused" marker. Use it sparingly — for arguments
+required by an interface but not consumed in this implementation:
+
+```nix
+# Acceptable when the signature is dictated by an upstream module
+mkConfig = _config: {
+  defaults = { /* ... */ };
+};
+```
+
+Don't use `_` to dodge a real deadnix finding. If the binding is
+actually unused, delete it.
+
+## Other Nix hygiene (not lint-enforced, but expected)
+
+- **Pin imports through the flake**, not by URL. New external code
+  enters via `flake.nix` inputs, runs through the `# CI:` /
+  `nixos-input-category-sync` workflow, and gets cached.
+- **No `import <nixpkgs> {}`** — channels are not in scope; everything
+  flows from flake inputs.
+- **No `builtins.fetchurl` or `builtins.fetchTarball`** in committed
+  code — they bypass the lock file and break reproducibility.
+- **Module options get types and descriptions.** `mkOption { type =
+types.bool; default = false; description = "..."; }` not
+  `mkOption { default = false; }`.
+- **Use `lib.mkIf` over inline `if ... then ... else { }`** for
+  conditional config — it composes properly with the module merge
+  algorithm.
+- **Use `lib.mkDefault` / `lib.mkForce` deliberately**, not
+  reflexively. Default priority is almost always what you want.
+
+## Workflow when a Nix hook fires
+
+1. Read the rule ID and the file:line from the hook output. statix
+   and deadnix both give precise locations.
+2. Fix the source, never the symptom. Don't add `_` prefixes to make
+   deadnix shut up if the binding is genuinely unused; don't add a
+   per-file statix disable comment without surfacing why.
+3. Re-stage and re-commit. nixfmt may have rewritten the file in the
+   meantime — that's expected; `git add` the result.
+4. If you're stuck in a loop (statix and nixfmt seem to disagree, or
+   deadnix keeps flagging something you swear is used), stop and
+   load `precommit-fix-loop`. It is almost always a real bug in the
+   source, not a tooling bug.
+
+## When to stop and ask
+
+- A statix rejection seems wrong for the specific case (e.g. a
+  `with` is genuinely the cleanest form for a generated module).
+  Surface it before adding a per-file disable.
+- deadnix flags something you believe is used through a dynamic
+  attrset access (`config.${name}` style). Surface — there may be a
+  better refactor.
+- You want to disable a rule globally. That's a `precommit-base`
+  change, not a per-repo change. Surface and discuss before editing
+  the upstream config.
+- A new Nix lint (`nixpkgs-fmt`, `alejandra`, `nix-linter`) is being
+  proposed. fred's stack is nixfmt + statix + deadnix; adding a
+  fourth tool needs a deliberate decision, not a drive-by addition.

--- a/.opencode/skills/languages/rust-best-practices/SKILL.md
+++ b/.opencode/skills/languages/rust-best-practices/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: rust-best-practices
+description: Use when editing `.rs` files, running `cargo`, `cargo clippy`, `cargo test`, `cargo xtask`, or before declaring any Rust change complete. Codifies the "lints maxed, no bypasses, no panics in production" Rust policy that applies across every Rust crate in fred's repos.
+---
+
+# Rust: lints maxed, no bypasses
+
+The standing policy for **every** Rust crate in fred's projects:
+
+- Clippy is run with `--all-targets --all-features -- -D warnings`. Any
+  warning is a failure.
+- `unwrap()` and `expect()` are **forbidden in production code** and
+  enforced via `#![deny(clippy::unwrap_used, clippy::expect_used)]`.
+  Test code (`#[cfg(test)]` modules, files under `tests/`, benches) is
+  the only place they are allowed.
+- `#[allow(dead_code)]` is forbidden in production modules. Test-only
+  helpers and code gated behind an explicit `TODO` comment for a known
+  transient refactor are the only acceptable uses.
+- Raw `as` casts for **numeric** conversions are forbidden in production.
+  Prefer fallible conversions (`TryFrom`/`TryInto`) and crate-specific
+  numeric-conversion helpers when the project provides them. `as` is OK
+  only for casts the type system guarantees lossless (e.g. `u8 -> u32`),
+  and in test/bench code. Project-specific skills may name the exact
+  conversion crate or helper to use.
+- `anyhow` is OK in binary / orchestration code (e.g. `xtask`) and never
+  in library crates. Libraries return domain-specific typed error enums.
+
+If a lint is firing in new code, **fix the code**. Adding `#[allow(...)]`,
+`// clippy::allow`, or sprinkling `#[allow(clippy::unwrap_used)]` to
+silence the panic-free policy is the wrong move and will be reverted at
+review. The only acceptable suppression is a `#[allow(...)]` with a
+comment on the next line explaining _why_ the rule is genuinely wrong
+for this specific call site.
+
+## Verification ritual (run before reporting done)
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+cargo machete                # detect unused dependencies
+```
+
+If the crate has an `xtask` target, prefer `cargo xtask ci` which wraps
+the above plus benchmarks-compile and `cargo deny`.
+
+If any step fails, fix it before reporting. "Existing failures unrelated
+to my change" is not a valid reason to ship — either fix them, or stop
+and surface the situation with the user before continuing.
+
+## When `unwrap` / `expect` "must" happen in production
+
+It does not. Convert the panic into a typed error:
+
+```rust
+// Wrong (production):
+let value = map.get(&key).unwrap();
+
+// Right (production):
+let value = map.get(&key).ok_or(MyError::MissingKey(key))?;
+```
+
+If the invariant _is_ unreachable by construction, encode that in the
+type system (e.g. `NonZeroUsize`, a newtype that can only be constructed
+through a validating constructor) so the unwrap is structurally
+unnecessary, rather than papering over it.
+
+## When to stop and ask
+
+- A clippy lint fires that the codebase clearly cannot satisfy without
+  changing behavior (e.g. a new `clippy::pedantic` rule from a toolchain
+  bump that disagrees with an existing pattern across hundreds of
+  sites). Stop and surface it; do not bulk-suppress.
+- The MSRV in `rust-toolchain.toml` / `Cargo.toml`'s `rust-version`
+  conflicts with a fix that needs a newer language feature. Stop —
+  bumping the MSRV is a user decision.

--- a/.opencode/skills/languages/typescript-best-practices/SKILL.md
+++ b/.opencode/skills/languages/typescript-best-practices/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: typescript-best-practices
+description: Use when editing `.ts` or `.tsx` files, when running `tsc`, `biome`, `eslint`, `vitest`, `playwright`, or `npm`/`pnpm`/`yarn` test/lint commands in any of fred's TypeScript projects. Codifies the strict-mode, no-`any`, no-`@ts-ignore`, explicit-return-types, structured-logger policy.
+---
+
+# TypeScript: strict mode, no escape hatches
+
+The standing policy for every TS/TSX file in fred's projects:
+
+## Type discipline
+
+- **`strict: true` in `tsconfig.json`** is required. If the project's
+  tsconfig has it off, that's a bug to fix, not a license to skip
+  types.
+- **No `any`.** Use `unknown` plus a type guard, or define an
+  interface. `any` in new code is a review-rejecting finding.
+- **No `// @ts-ignore`, no `// @ts-expect-error` without a comment
+  explaining exactly why and a linked issue.** If a type error is
+  genuinely correct ("the library types are wrong"), the right fix is
+  a typed wrapper or a `.d.ts` augmentation, not an ignore.
+- **Explicit function return types** on every exported function and
+  every non-trivial internal function. Inference is OK only when the
+  type is obvious at the call site.
+- **Explicit parameter types.** Always.
+- **Interfaces for complex objects.** A function that takes 4+
+  properties on a parameter object should take a named interface, not
+  an inline structural type.
+- **Generics where they earn their keep.** Don't make everything
+  generic; do reach for generics when a function genuinely operates
+  uniformly over multiple types.
+
+Example:
+
+```typescript
+// Wrong
+function processData(data: any): any {
+  return data.value;
+}
+
+// Right
+interface MessageData {
+  uid: string;
+  text: string;
+  timestamp: number;
+}
+
+function processData(data: MessageData): string {
+  return data.text;
+}
+```
+
+## Logging
+
+**Use the project's structured logger, never `console.*`** in
+application code. Most of fred's TS projects expose a `createLogger`
+or equivalent factory; consult the project's own skills/AGENTS.md for
+the exact namespace convention.
+
+General rules:
+
+- `error` — critical failures preventing functionality
+- `warn` — potential issues, degraded functionality
+- `info` — important state changes, major events
+- `debug` — detailed debugging, state transitions
+- `trace` — very verbose, high-frequency events
+
+`console.log` / `console.error` are not allowed in shipping code; the
+biome / eslint config will flag them.
+
+## Verification ritual
+
+```sh
+# Whatever the project's aggregated lint+typecheck+test target is
+# (e.g. `just ci`, `npm run check`, `pnpm verify`, ...).
+```
+
+Or, when iterating:
+
+```sh
+npx biome check .
+npx tsc --noEmit
+npx vitest run
+```
+
+If any step fails, fix it before reporting done. New code that
+triggers a biome / eslint rule is a bug in the code — do not add
+`// biome-ignore` or `// eslint-disable` to silence it. The only
+acceptable suppression is for a genuine false positive, with a
+comment on the next line explaining why.
+
+## When to stop and ask
+
+- A library you must use ships untyped or with `any`-laden types.
+  Stop — propose either a wrapper module with proper types, or a
+  `.d.ts` augmentation. Don't infect the codebase with `any` just to
+  use it.
+- The type the codebase has for X is genuinely wrong and fixing it
+  cascades into many call sites. Surface the cascade size to the
+  user before doing a large rewrite.
+- A biome / eslint rule is firing on a pattern that looks correct
+  for this codebase. The rule might genuinely not fit; that's a
+  precommit-base or `biome.json` change, not a per-call-site
+  suppression. See `precommit-fix-loop`.

--- a/.opencode/skills/projects/nixos-add-flake-input/SKILL.md
+++ b/.opencode/skills/projects/nixos-add-flake-input/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: nixos-add-flake-input
+description: Use ONLY when working in the fred/nixos flake repository AND the task is to add (or remove) a flake input in flake.nix. Walks the four-location sync requirement, the `# CI:` comment convention, and the post-add verification that confirms CI will rebuild the right host set when the new input changes.
+---
+
+# NixOS: adding a new flake input
+
+Adding an input to `flake.nix` is a small mechanical change that has
+to land in four files at once to keep CI honest. The mapping rule and
+the why are in the `nixos-input-category-sync` skill; this one is the
+step-by-step.
+
+## Procedure
+
+1. **Pick the category** the input belongs to. See the table in
+   `nixos-input-category-sync`. If genuinely unclear, default to
+   `global` -- safe over-build.
+
+2. **Add the input to `flake.nix`** with a `# CI:` comment on the
+   line immediately above it:
+
+   ```nix
+   # CI: desktop
+   my-new-input = {
+     url = "github:someone/something";
+     inputs.nixpkgs.follows = "nixpkgs";
+   };
+   ```
+
+   The `# CI:` comment is mandatory. It documents the choice for
+   future readers and is the human source of truth that the other
+   three places mirror.
+
+3. **Wire the input through** wherever it's consumed -- typically
+   the `flake/lib/mkSystem.nix` or `flake/lib/mkDarwinSystem.nix`
+   helpers, or directly in a feature module. This is the part that
+   actually does anything useful.
+
+4. **Update `agents.md`** -- add a row to the input-to-category
+   mapping table with the same category you put in the `# CI:`
+   comment, plus a short "Affects" description.
+
+5. **Update `.github/workflows/ci-linux.yaml`** -- add the input to
+   the `input_category` associative array in the `Detect changed
+paths` step:
+
+   ```bash
+   input_category[my-new-input]="desktop"
+   ```
+
+6. **Update the impacted-hosts script** at
+   `.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh`
+   -- add the same entry to its `INPUT_CATEGORY` array.
+
+7. **Lock the new input**:
+
+   ```sh
+   nix flake lock --update-input my-new-input
+   ```
+
+   (Or it'll be locked automatically the first time `nix eval` runs
+   against the flake.)
+
+8. **Verify**:
+   - The eval still works:
+
+     ```sh
+     nix eval .#nixosConfigurations --apply 'cfgs: builtins.attrNames cfgs' --json
+     ```
+
+   - The impacted-hosts script reports the right host set for a
+     synthetic update of the new input. Bump it, commit, then:
+
+     ```sh
+     ./.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh HEAD~1
+     ```
+
+     For a `desktop`-category input, this should print the two
+     desktop hostnames. For `global`, it prints `GLOBAL`. For
+     `skip`, it prints nothing. For `desktop+fredhub`, it prints
+     both desktops plus `fredhub`.
+
+9. **Commit**. Convention: `chore(flake): add <input-name> input`.
+
+## Removing an input
+
+Same procedure in reverse. Remove from all four places. CI will not
+silently break -- the input simply won't appear in `flake.lock`, so
+the parser won't try to categorize it. But leaving stale entries in
+the bash array and the markdown table is sloppy and will mislead
+future readers.
+
+## Recategorizing an input
+
+Update the category in all four places in the same commit. Mention
+the rationale in the commit message -- why did it change?
+
+## When to stop and ask
+
+- The input has a non-obvious classification (used by both classes
+  but only sometimes). Default to `global`, surface the ambiguity.
+- The input is large / slow to fetch (e.g. a big `flake=false`
+  source tree). Mention impact on CI time before adding it.
+- The input replaces an existing one. That's two coupled changes;
+  do them in separate commits if possible, and update all four
+  locations for both.

--- a/.opencode/skills/projects/nixos-add-host/SKILL.md
+++ b/.opencode/skills/projects/nixos-add-host/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: nixos-add-host
+description: Use ONLY when working in the fred/nixos flake repository AND the task is to add a new NixOS host (server or desktop) to the configuration. Covers the directory layout under hosts/linux/, the servers.nix node-table entry, the desktop_names array in CI, the colmena topology entry for deployment, and the verification dance.
+---
+
+# NixOS: adding a new host
+
+This repo manages 9 Linux hosts + macOS. Adding a new one touches
+several files in a specific order. CI will auto-discover the host
+once its `nixosConfigurations` attribute exists, but several pieces
+must be wired by hand before that discovery does what you want.
+
+## Procedure
+
+1. **Pick a name** (lowercase, kebab-case if multi-word). The
+   directory name and the `nixosConfigurations` attribute name must
+   match. Convention in this repo: directory is lowercase
+   (`daytona`), the attribute the host is registered under matches
+   the directory name. Note: the _CI desktop_names_ historically used
+   title-cased names (`Daytona`); this is an artifact and new
+   desktops should match exactly whatever case the
+   `nixosConfigurations` attribute uses.
+
+2. **Create the host directory and configuration**:
+
+   ```sh
+   mkdir -p hosts/linux/<name>
+   $EDITOR hosts/linux/<name>/configuration.nix
+   ```
+
+   Use an adjacent host of the same class (server vs desktop) as a
+   structural template -- import the appropriate profiles, set
+   `networking.hostName`, set up disk / boot config, etc.
+
+3. **If it's a server**, add it to the node table at
+   `flake/hosts/servers.nix`. This is the single source of truth for
+   server hosts -- the `mkSystem` helper there is what wires it into
+   `nixosConfigurations`. The entry needs at minimum the host name
+   and any per-host overrides (channel choice, etc.).
+
+4. **If it's a desktop**:
+   - Add the `nixosConfigurations` attribute name to the
+     `desktop_names=(...)` array in `.github/workflows/ci-linux.yaml`.
+     This is what tells CI to classify the host as a desktop (the
+     default classification is server).
+   - Desktops default to the unstable channel and the desktop feature
+     set. If the new desktop should diverge from that, the divergence
+     goes in `hosts/linux/<name>/configuration.nix`.
+
+5. **If it should be deployable via colmena**, add it to
+   `flake/deployment/colmena.nix`. Specify target hostname/IP, SSH
+   user, and any tags.
+
+6. **If it has secrets**, wire up sops-nix in `configuration.nix` and
+   add the host's age key to `.sops.yaml`.
+
+7. **Verify before pushing**:
+
+   ```sh
+   # Confirm the host appears in the flake outputs
+   nix eval .#nixosConfigurations --apply 'cfgs: builtins.attrNames cfgs' --json
+
+   # Eval the new host's toplevel and home-manager activation
+   nix eval ".#nixosConfigurations.<name>.config.system.build.toplevel.drvPath"
+   nix eval ".#nixosConfigurations.<name>.config.home-manager.users.fred.home.activationPackage.drvPath"
+
+   # Run the impacted-hosts script to confirm CI will include the new host
+   ./.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh HEAD~1
+   ```
+
+   Any `evaluation warning:` in stderr is treated as fatal by CI (see
+   step 9 of the build job in `ci-linux.yaml`); fix it before push.
+
+8. **Commit and PR**. The commit message convention here is
+   `feat(<name>): add <name> host` (server) or
+   `feat(<name>): add <name> desktop`.
+
+## Common mistakes
+
+- **Desktop added but not in `desktop_names`** -> CI treats it as a
+  server, builds it with the stable channel, eval fails because the
+  config imports desktop-only features.
+- **Server added but not in `flake/hosts/servers.nix`** -> the
+  `nixosConfigurations` attribute won't exist; CI's
+  `find-systems` job won't see it.
+- **Host name case mismatch** between the directory, the
+  `nixosConfigurations` attribute, and `desktop_names` -> the
+  per-machine filter in CI silently fails to match the changed-paths
+  output.
+- **Missing `.sops.yaml` entry for secrets** -> first build will fail
+  with a decrypt error.
+
+## When to stop and ask
+
+- The new host is conceptually neither a normal server nor a normal
+  desktop (e.g. an embedded SBC, a router, a Raspberry Pi running
+  ADS-B). Stop and discuss classification -- it may need a new CI
+  category, which would also be a `nixos-input-category-sync`
+  change.
+- Adding the host would push the CI matrix size past anything that's
+  been tested in parallel before. Mention it.
+- The host needs hardware-specific firmware changes
+  (`firmware.nix`). That file is classified `global` for CI, so a
+  firmware change triggers a full rebuild -- worth flagging.

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/SKILL.md
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/SKILL.md
@@ -54,7 +54,7 @@ truth. Cases where drift happens:
   `agents.md` -> "Adding a new flake input", all three locations
   (`flake.nix` comments, `agents.md` table, `ci-linux.yaml` array)
   must be updated, and now this script's `INPUT_CATEGORY` array as
-  well. Default to `global` for any unknown input \u2014 safe over-build.
+  well. Default to `global` for any unknown input — safe over-build.
 - A new desktop host was added but `desktop_names=(...)` in CI was not
   updated. This script reads `desktop_names` from CI at runtime so it
   auto-recovers, but CI itself will be broken until the array is fixed.

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/SKILL.md
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: nixos-eval-impacted-hosts
+description: Use ONLY when working in the fred/nixos flake repository (the NixOS configuration at ~/GitHub/nixos with hosts/linux/, modules/, profiles/, features/, home-profiles/, flake.nix, flake.lock) and a change has been made that needs verification before push. This NixOS repo has no `cargo test` equivalent -- verification is `nix eval` on the impacted hosts' system.build.toplevel.drvPath. This skill computes which hosts are impacted from the git diff (mirroring the CI's path-based filter and flake.lock input-aware parser) and runs the evals locally so push-time CI failures are caught beforehand.
+---
+
+# NixOS: eval impacted hosts before push
+
+This repo has 9 Linux hosts + macOS. Running a full eval on every host
+before every push is wasteful and slow. CI already filters down to just
+the impacted hosts using a `case` statement in
+`.github/workflows/ci-linux.yaml` plus an input-aware parser for
+`flake.lock` diffs. **This skill bundles a script that mirrors that
+exact logic locally**, so an agent or human can run the same filter
+before pushing and catch eval errors that would otherwise blow up CI.
+
+## Procedure
+
+1. Make your changes and stage them (or commit them).
+2. From the repo root, run:
+
+   ```sh
+   ./.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+   ```
+
+   Output is one host attribute name per line (e.g. `Daytona`,
+   `fredhub`), or the single token `GLOBAL` if every host needs a
+   rebuild. Empty output means no Linux host is impacted (e.g. only
+   `darwin` input changed, or only `renovate.json5`).
+
+3. To not just _list_ the impacted hosts but actually eval them as a
+   pre-push correctness gate, add `--eval`:
+
+   ```sh
+   ./.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh origin/main --eval
+   ```
+
+   That runs `nix eval .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath`
+   for each impacted host. Any eval error fails the script with a
+   non-zero exit code, exactly like CI would.
+
+4. If the eval pass succeeds, you're safe to push. CI will perform the
+   same filtering and likely rebuild the same set; you'll just save a
+   round-trip.
+
+## When the script disagrees with CI
+
+If you observe the script saying "X hosts" but CI rebuilding a different
+set, **the script is wrong, not CI**. The CI workflow is the source of
+truth. Cases where drift happens:
+
+- A new flake input was added to `flake.nix` but the
+  `INPUT_CATEGORY` array in this script (and in
+  `.github/workflows/ci-linux.yaml`) was not updated. Per
+  `agents.md` -> "Adding a new flake input", all three locations
+  (`flake.nix` comments, `agents.md` table, `ci-linux.yaml` array)
+  must be updated, and now this script's `INPUT_CATEGORY` array as
+  well. Default to `global` for any unknown input \u2014 safe over-build.
+- A new desktop host was added but `desktop_names=(...)` in CI was not
+  updated. This script reads `desktop_names` from CI at runtime so it
+  auto-recovers, but CI itself will be broken until the array is fixed.
+- The `case` patterns in `ci-linux.yaml` were edited. Sync the changes
+  into the script's `case` block.
+
+If you find yourself updating this script to track a CI change, also
+update the related skill: `nixos-input-category-sync` (which tracks the
+flake input -> CI category mapping in its three sync points).
+
+## What the script does NOT do
+
+- It does not run `home-manager.users.fred.home.activationPackage`
+  builds. CI does this as step 7-8 of each matrix job. For a really
+  thorough pre-push check, add a follow-up eval:
+
+  ```sh
+  for h in $(./.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh); do
+    [[ "$h" == "GLOBAL" ]] && break
+    nix eval ".#nixosConfigurations.${h}.config.home-manager.users.fred.home.activationPackage.drvPath" >/dev/null
+  done
+  ```
+
+- It does not check Darwin hosts. The `darwin` flake input is
+  classified `skip` for Linux CI, and Darwin builds happen in a
+  separate workflow.
+
+- It does not push to Attic. CI does that on success.
+
+## When to stop and ask
+
+- The script reports `GLOBAL` for a change that intuitively should only
+  hit one or two hosts. Either the `case` logic genuinely flagged a
+  broad path (e.g. you edited `modules/`), or there's a script bug. Run
+  with `bash -x` to see which branch fired.
+- A host eval fails with a warning rather than an error. CI fails on
+  any `evaluation warning:` in stderr (see ci-linux.yaml step 9), so
+  treat warnings as fatal too.

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -151,17 +151,23 @@ if [[ $LOCK_CHANGED -eq 1 && $GLOBAL -eq 0 ]]; then
         [[ $GLOBAL -eq 1 ]] && break
       done
     else
-      # jq missing \u2014 safe over-build.
+      # jq missing — safe over-build.
       GLOBAL=1
     fi
   else
-    # No old lock retrievable \u2014 safe over-build.
+    # No old lock retrievable — safe over-build.
     GLOBAL=1
   fi
 fi
 
 # Build the final host list.
-ALL_HOSTS_JSON="$(nix eval .#nixosConfigurations --apply 'cfgs: builtins.attrNames cfgs' --json 2>/dev/null || echo '[]')"
+# Fail loud if nix eval can't enumerate nixosConfigurations -- a broken
+# flake silently producing an empty host list would defeat the whole
+# point of this verification gate.
+if ! ALL_HOSTS_JSON="$(nix eval .#nixosConfigurations --apply 'cfgs: builtins.attrNames cfgs' --json 2>&1)"; then
+  printf 'ERROR: failed to enumerate nixosConfigurations:\n%s\n' "$ALL_HOSTS_JSON" >&2
+  exit 1
+fi
 mapfile -t ALL_HOSTS < <(echo "$ALL_HOSTS_JSON" | tr -d '[]" ' | tr ',' '\n' | grep -v '^$')
 
 if [[ $GLOBAL -eq 1 ]]; then

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# scripts/impacted-hosts.sh
+#
+# Given a base ref (defaults to origin/main), print the NixOS host
+# attribute names that need to be re-evaluated for the working tree's
+# changes. Mirrors the `case` logic and flake.lock input-aware parsing
+# in .github/workflows/ci-linux.yaml so an agent (or human) can run the
+# same filter locally before pushing.
+#
+# Usage:
+#   ./impacted-hosts.sh                 # diff against origin/main
+#   ./impacted-hosts.sh HEAD~1          # diff against the previous commit
+#   ./impacted-hosts.sh main --eval     # also run `nix eval` on each host's
+#                                       # config.system.build.toplevel.drvPath
+#
+# Output: one host attribute name per line, or `GLOBAL` if every host is
+# impacted. Empty output means no rebuild needed.
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+shift || true
+DO_EVAL=0
+for arg in "$@"; do
+  case "$arg" in
+    --eval) DO_EVAL=1 ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Determine desktop hosts dynamically from ci-linux.yaml so this script
+# never drifts from CI. (Falls back to the well-known list if parsing
+# fails so the script is resilient to formatting changes.)
+DESKTOP_NAMES=()
+if [[ -f .github/workflows/ci-linux.yaml ]]; then
+  while IFS= read -r line; do
+    DESKTOP_NAMES+=("$line")
+  done < <(
+    grep -oE 'desktop_names=\("[^)]*"\)' .github/workflows/ci-linux.yaml \
+      | tr ' ' '\n' \
+      | grep -oE '"[A-Za-z0-9_-]+"' \
+      | tr -d '"' || true
+  )
+fi
+if [[ ${#DESKTOP_NAMES[@]} -eq 0 ]]; then
+  DESKTOP_NAMES=("Daytona" "maranello")
+fi
+
+is_desktop() {
+  local name="$1"
+  for d in "${DESKTOP_NAMES[@]}"; do
+    [[ "$name" == "$d" ]] && return 0
+  done
+  return 1
+}
+
+# Get the list of changed paths against the base ref.
+CHANGED="$(git diff --name-only "$BASE_REF"...HEAD 2>/dev/null || git diff --name-only "$BASE_REF")"
+
+# Walk the changed paths through the same `case` logic CI uses.
+declare GLOBAL=0
+declare DESKTOP_GLOBAL=0
+declare SERVER_GLOBAL=0
+declare -A PER_MACHINE=()
+declare LOCK_CHANGED=0
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  case "$path" in
+    flake.nix|firmware.nix)
+      GLOBAL=1
+      ;;
+    flake.lock)
+      LOCK_CHANGED=1
+      ;;
+    modules/*|profiles/*|home-profiles/*|dotfiles/*)
+      GLOBAL=1
+      ;;
+    features/desktop/*)
+      DESKTOP_GLOBAL=1
+      ;;
+    features/*)
+      GLOBAL=1
+      ;;
+    .github/renovate.json5)
+      : # excluded
+      ;;
+    .github/*)
+      GLOBAL=1
+      ;;
+    hosts/linux/*/*)
+      # Extract the host directory name.
+      host="${path#hosts/linux/}"
+      host="${host%%/*}"
+      PER_MACHINE[$host]=1
+      ;;
+    *) : ;;
+  esac
+done <<<"$CHANGED"
+
+# Input-aware flake.lock parsing.
+# Mirrors the input_category associative array in ci-linux.yaml.
+declare -A INPUT_CATEGORY=(
+  [nixpkgs]="desktop+fredhub"
+  [home-manager]="desktop"
+  [catppuccin]="desktop"
+  [niri]="desktop"
+  [fredbar]="desktop"
+  [freminal]="desktop"
+  [solaar]="desktop"
+  [apple-fonts]="desktop"
+  [walls-catppuccin]="desktop"
+  [walls-zhichaoh]="desktop"
+  [walls-cozypixels]="desktop"
+  [nixvim]="global"
+  [nixpkgs-stable]="server"
+  [home-manager-stable]="server"
+  [catppuccin-stable]="server"
+  [sops-nix-stable]="server"
+  [sops-nix]="desktop"
+  [nixos-needsreboot]="global"
+  [darwin]="skip"
+  [colmena]="skip"
+  [flake-utils]="skip"
+  [precommit-base]="skip"
+)
+
+if [[ $LOCK_CHANGED -eq 1 && $GLOBAL -eq 0 ]]; then
+  # Compare each root input's locked.rev (or narHash) between base and HEAD.
+  OLD_LOCK="$(git show "$BASE_REF":flake.lock 2>/dev/null || true)"
+  NEW_LOCK="$(cat flake.lock)"
+  if [[ -n "$OLD_LOCK" ]]; then
+    # Use jq if available; otherwise fall back to "everything that's in the diff".
+    if command -v jq >/dev/null 2>&1; then
+      ROOT_INPUTS="$(echo "$NEW_LOCK" | jq -r '.nodes.root.inputs | keys[]')"
+      for input in $ROOT_INPUTS; do
+        OLD_REV="$(echo "$OLD_LOCK" | jq -r --arg i "$input" '.nodes[$i].locked.rev // .nodes[$i].locked.narHash // ""' 2>/dev/null)"
+        NEW_REV="$(echo "$NEW_LOCK" | jq -r --arg i "$input" '.nodes[$i].locked.rev // .nodes[$i].locked.narHash // ""' 2>/dev/null)"
+        [[ "$OLD_REV" == "$NEW_REV" ]] && continue
+
+        category="${INPUT_CATEGORY[$input]:-global}"
+        case "$category" in
+          global) GLOBAL=1 ;;
+          desktop) DESKTOP_GLOBAL=1 ;;
+          server) SERVER_GLOBAL=1 ;;
+          desktop+fredhub) DESKTOP_GLOBAL=1; PER_MACHINE[fredhub]=1 ;;
+          skip) : ;;
+        esac
+        [[ $GLOBAL -eq 1 ]] && break
+      done
+    else
+      # jq missing \u2014 safe over-build.
+      GLOBAL=1
+    fi
+  else
+    # No old lock retrievable \u2014 safe over-build.
+    GLOBAL=1
+  fi
+fi
+
+# Build the final host list.
+ALL_HOSTS_JSON="$(nix eval .#nixosConfigurations --apply 'cfgs: builtins.attrNames cfgs' --json 2>/dev/null || echo '[]')"
+mapfile -t ALL_HOSTS < <(echo "$ALL_HOSTS_JSON" | tr -d '[]" ' | tr ',' '\n' | grep -v '^$')
+
+if [[ $GLOBAL -eq 1 ]]; then
+  printf '%s\n' "GLOBAL"
+  HOSTS=("${ALL_HOSTS[@]}")
+elif [[ $SERVER_GLOBAL -eq 1 && $DESKTOP_GLOBAL -eq 1 ]]; then
+  printf '%s\n' "GLOBAL"
+  HOSTS=("${ALL_HOSTS[@]}")
+else
+  HOSTS=()
+  for h in "${ALL_HOSTS[@]}"; do
+    if [[ $SERVER_GLOBAL -eq 1 ]] && ! is_desktop "$h"; then
+      HOSTS+=("$h"); continue
+    fi
+    if [[ $DESKTOP_GLOBAL -eq 1 ]] && is_desktop "$h"; then
+      HOSTS+=("$h"); continue
+    fi
+    if [[ -n "${PER_MACHINE[$h]+x}" ]]; then
+      HOSTS+=("$h"); continue
+    fi
+    # Case-insensitive fallback for desktop_names mismatch (Daytona vs daytona).
+    h_lower="$(echo "$h" | tr '[:upper:]' '[:lower:]')"
+    if [[ -n "${PER_MACHINE[$h_lower]+x}" ]]; then
+      HOSTS+=("$h")
+    fi
+  done
+  printf '%s\n' "${HOSTS[@]}"
+fi
+
+# Optional: actually evaluate each host so we catch eval errors before push.
+if [[ $DO_EVAL -eq 1 ]]; then
+  echo "--- eval pass ---" >&2
+  for h in "${HOSTS[@]}"; do
+    echo "[eval] $h" >&2
+    nix eval ".#nixosConfigurations.${h}.config.system.build.toplevel.drvPath" >/dev/null
+  done
+  echo "[eval] OK" >&2
+fi

--- a/.opencode/skills/projects/nixos-input-category-sync/SKILL.md
+++ b/.opencode/skills/projects/nixos-input-category-sync/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: nixos-input-category-sync
+description: Use ONLY when working in the fred/nixos flake repository AND editing flake.nix inputs, flake.lock entries, .github/workflows/ci-linux.yaml, or the `nixos-eval-impacted-hosts` skill's script. Codifies the four-place sync invariant: every flake input must be classified consistently in (1) the `# CI:` comment in flake.nix, (2) the input-to-category table in agents.md, (3) the `input_category` bash associative array in ci-linux.yaml, and (4) the `INPUT_CATEGORY` array in scripts/impacted-hosts.sh of the nixos-eval-impacted-hosts skill.
+---
+
+# NixOS: keep flake-input CI category in sync across four locations
+
+The CI in this repo decides which hosts to rebuild based on which
+flake input changed in `flake.lock`. That decision is driven by a
+hand-maintained input-to-category mapping that lives in **four**
+places. They must agree, or CI will either over-build (wasting
+machine time) or under-build (missing required rebuilds, which is
+worse).
+
+## The four sync points
+
+| #   | Location                                                                        | Form                                                                           |
+| --- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| 1   | `flake.nix`                                                                     | `# CI: <category>` comment immediately above each input declaration            |
+| 2   | `agents.md` (this repo)                                                         | The "Input-to-category mapping" markdown table                                 |
+| 3   | `.github/workflows/ci-linux.yaml`                                               | The `input_category` bash associative array in the `Detect changed paths` step |
+| 4   | `.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh` | The `INPUT_CATEGORY` bash associative array                                    |
+
+## Valid categories
+
+| Category          | Meaning                                                                                  |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| `global`          | All Linux hosts rebuild                                                                  |
+| `desktop`         | Only desktop hosts rebuild                                                               |
+| `server`          | Only server hosts rebuild                                                                |
+| `desktop+fredhub` | All desktops rebuild, plus `fredhub` (the one server that pulls a package from unstable) |
+| `skip`            | No Linux rebuild (e.g. macOS-only inputs, dev tooling)                                   |
+
+**Unknown / new inputs default to `global`** in all four places. That
+is the safe fallback -- it may over-build but never under-builds.
+
+## When you must update all four
+
+- Adding a new flake input (see also: `nixos-add-flake-input` skill).
+- Removing a flake input.
+- Recategorizing an existing input (e.g. a server suddenly starts
+  pulling a package from a previously desktop-only input).
+- Renaming an input.
+
+## Verification
+
+1. After editing, the four locations must agree on every input. A
+   one-shot check:
+
+   ```sh
+   # Inputs declared in flake.nix (root-level inputs only)
+   grep -E '^\s+\w[\w-]*\.url' flake.nix | awk -F. '{print $1}' | tr -d ' '
+   ```
+
+   Cross-reference against the keys in the `input_category` arrays in
+   the two scripts and the table in `agents.md`. A missing entry in
+   any of those falls back to `global` -- usually safe, occasionally
+   wasteful.
+
+2. Run the impacted-hosts script against a synthetic `flake.lock`
+   change for the new input to confirm the category is honored. The
+   easiest way: bump the input via `nix flake update <input>`, commit,
+   then run:
+
+   ```sh
+   ./.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh HEAD~1
+   ```
+
+   The output should match the category you intended.
+
+## When to stop and ask
+
+- The category is genuinely ambiguous (e.g. an input is used by both
+  desktops and one server in a way that doesn't cleanly map). Default
+  to `global` and surface the situation to the user; do not invent a
+  new category without discussion.
+- An input's classification needs to change because of an unrelated
+  refactor (e.g. a server stops pulling unstable). That's a separate
+  PR with its own justification, not a drive-by during another change.

--- a/.opencode/skills/shared/commit-discipline/SKILL.md
+++ b/.opencode/skills/shared/commit-discipline/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: commit-discipline
+description: Use whenever about to run `git commit`, `git push`, `git rebase`, `git amend`, or open a pull request in any of fred's repos. Codifies atomic-commit policy, conventional-commits format, the "never amend onto a rejected commit" rule, the "each commit must leave tests green" invariant, and the interaction with pre-commit hooks.
+---
+
+# Commit & PR discipline
+
+The standing rules across every one of fred's repos:
+
+## Commit shape
+
+- **Atomic.** One logical change per commit. If you find yourself
+  writing "and also..." in a commit message, split the commit.
+- **Conventional Commits format**: `<type>: <subject>` (and optionally
+  a scope: `<type>(<scope>): <subject>`). Common types: `feat`, `fix`,
+  `refactor`, `test`, `docs`, `chore`, `ci`, `perf`, `build`.
+  - In freminal, plan-subtask commits reference the subtask number:
+    `refactor: 30.3 -- replace casting suppressions in freminal-common`.
+- **Each commit must leave the project's primary verification green.**
+  In freminal that's `cargo test --all`. In docker-acarshub it's
+  `just ci`. In nixos it's `nix eval` of any impacted hosts (see the
+  `nixos-eval-impacted-hosts` skill). A broken intermediate commit
+  destroys `git bisect` and is not acceptable just because "the next
+  commit fixes it".
+- **No `--no-verify`.** Pre-commit hooks are mandatory. See the
+  `precommit-fix-loop` skill for the full failure-resolution procedure.
+  The only exception is when the user explicitly requests a bypass for
+  one specific commit.
+
+## When a commit gets rejected
+
+A rejected commit is **not** a commit. There is nothing in `git log` to
+fix up. So:
+
+- **Never `git commit --amend` onto a commit that was rejected.** That
+  amend is creating a _new_ commit, not fixing the rejected one. Just
+  run `git commit` again (no flags) after fixing the issue. If the
+  initial work was already partially staged when the hook ran, re-stage
+  what you fixed and commit.
+- If the rejection happened on `--amend` of a _previously accepted_
+  commit and you've now lost the original message, you can recover it
+  from the reflog: `git reflog show HEAD | head` shows the prior tip,
+  then `git commit --amend -C <sha>` reuses that commit's message.
+
+## Combining multiple subtasks into one commit (freminal-style)
+
+In freminal, plan execution defaults to one commit per subtask. Merging
+multiple subtasks into a single commit is **acceptable** when:
+
+- The subtasks are individually small enough that splitting them adds
+  noise.
+- Multiple sub-agents worked on the same files and splitting would
+  cause merge conflicts or broken intermediate states.
+- The subtasks are tightly intertwined (a type change in one requires
+  signature changes tracked by another).
+
+When merging, the commit message must list every subtask number:
+`refactor: 25.4 + 25.5 -- inline data.rs and remove dead Theme enum`.
+
+This convention is freminal-specific. The other repos do not have
+plan-numbered subtasks; commit-per-logical-change is the rule there.
+
+## Branches and PRs
+
+- **Implementation work happens on feature branches, never directly on
+  `main`.**
+- Branch naming follows the convention each repo establishes. In
+  freminal: `task-NN/short-description` (e.g. `task-06/test-gaps`). In
+  the others: any clear short kebab-case slug.
+- PRs reference the underlying task / plan / issue if one exists.
+- PRs are merged via the GitHub merge queue where one exists (the
+  nixos repo). Do not bypass branch protection.
+
+## Hard prohibitions
+
+- **No force-push to `main` or any long-lived branch.** Force-push to
+  your own feature branch is fine if needed to clean up history before
+  review.
+- **No `git rebase -i` on commits that have already been pushed and are
+  visible to others.** Local cleanup only.
+- **No empty commits** (`git commit --allow-empty`) unless the user
+  explicitly asks for one to trigger CI.
+- **No commits that contain secrets, tokens, or `.env` files.** If you
+  staged one by accident, do not just remove it from the index and
+  commit again -- the value is in the reflog. Rotate the secret.
+
+## When to stop and ask
+
+- The change you're about to commit doesn't fit cleanly into a single
+  `<type>:`. Stop and propose a split.
+- A pre-commit hook is rejecting in a way that would require disabling
+  it. Don't disable -- surface to the user (see `precommit-fix-loop`).
+- The user asked for "a commit" but you have multiple logical changes
+  staged. Stop and confirm whether to split or squash.
+- You're about to amend a pushed commit. Stop and confirm.

--- a/.opencode/skills/shared/flake-dev-shell-discipline/SKILL.md
+++ b/.opencode/skills/shared/flake-dev-shell-discipline/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: flake-dev-shell-discipline
+description: Use whenever a task in a Nix-flake-managed repository (freminal, docker-acarshub, nixos, or any future flake-managed project) requires a system-level tool — compiler, linker, system library, test runner, CLI utility — that may not already be in the dev shell. Mandates the "add to flake.nix, then STOP and tell the user to run `nix develop` / `direnv allow`, then wait for confirmation" protocol. Forbids working around missing tools by modifying application logic or installing out-of-band.
+---
+
+# Nix flake dev shells: add the tool, stop, wait
+
+In any of fred's flake-managed repositories, the dev environment is
+fully described by `flake.nix` (and any module it imports). Adding a
+required tool is a config change, not a side-channel install.
+
+## The rule
+
+**Adding language-level dependencies** (npm packages, cargo crates,
+PyPI packages where the project uses them):
+
+1. Add to the appropriate manifest (`package.json`, `Cargo.toml`, ...).
+2. Run the install / lock command (`npm install`, `cargo build`, ...).
+3. Continue working.
+
+**Adding system tools** (compilers, system libraries, test runners,
+CLI utilities — anything that ends up on `PATH` rather than in a
+language-level lockfile):
+
+1. Add to `flake.nix` in the appropriate package list (usually a
+   `devShells.default` `packages = [...]`, or an equivalent
+   project-local helper module).
+2. **STOP.** Tell the user:
+   > "Please run `nix develop` or `direnv allow` to pick up the new
+   > tool, then let me know when ready."
+3. **Wait for the user to confirm** the new shell is active.
+4. Continue.
+
+## Why the stop-and-wait
+
+The shell the agent is running in **does not auto-reload** when
+`flake.nix` changes. If the agent adds a tool and then immediately
+tries to use it, the tool isn't on `PATH` and the agent gets
+confused ("but I just added it!"). The right answer is the same as
+for any nix-managed dev shell: re-enter it.
+
+The user is the one who controls when their shell re-enters. The
+agent does not get to assume.
+
+## What NOT to do
+
+- **Do NOT work around a missing tool by modifying application
+  logic.** If the tests need `sqlite3` on `PATH` and it's missing,
+  the fix is "add sqlite to `flake.nix`", not "rewrite the tests to
+  avoid needing sqlite".
+- **Do NOT silently install via `apt` / `brew` / `pip install
+--user` / `cargo install --global`**, etc. The dev shell is the
+  only sanctioned source of system tools; out-of-band installs
+  break reproducibility for everyone else and for CI.
+- **Do NOT proceed past step 2 without confirmation.** Even if the
+  tool _seems_ available in your shell (because of a stale env),
+  CI / other contributors won't have it until the flake commit
+  lands.
+
+## When the addition itself needs review
+
+- Large packages (multi-gigabyte downloads, kernel modules,
+  cross-arch toolchains) deserve a one-line "I'm about to add X
+  which pulls Y MB" before adding.
+- Adding a new package set that overlaps with existing ones (e.g.
+  another node version, another python interpreter) is usually
+  wrong. Stop and confirm the existing one isn't sufficient.
+- Adding a tool that already exists under a different name is a
+  rename, not an addition. Surface that.
+
+## When to stop and ask
+
+- The tool requirement comes from a transitive dep (e.g. an npm
+  package's build script needs `cmake`). That's still a `flake.nix`
+  addition, but worth a quick note explaining the chain.
+- The tool exists in nixpkgs only in an old version. Check whether
+  the project genuinely needs newer; if so, surface and discuss
+  (overlay vs unstable-pin vs upstreaming a bump).
+- The project also has a project-specific skill (e.g. an
+  `acarshub-tool-additions` catalog naming exactly which list to
+  append to). Defer to it for the exact mechanical step.

--- a/.opencode/skills/shared/flaky-tests-are-bugs/SKILL.md
+++ b/.opencode/skills/shared/flaky-tests-are-bugs/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: flaky-tests-are-bugs
+description: Use whenever a test fails sporadically, when CI fails for "the flaky one", when a test depends on parallel scheduling or timing, when a retry is being considered, or when `it.skip` / longer timeouts / fake-async patches are being proposed. Codifies the no-punting policy: a flaky test is a broken test, root-cause it before continuing other work. Applies to every one of fred's repos regardless of language.
+---
+
+# Flaky tests are broken tests — no punting
+
+A flaky test is a broken test. Period. CI failures caused by flakes
+we already knew about are unacceptable — every red CI run that turns
+out to be "oh, that one's just flaky" erodes trust in the suite and
+trains everyone to ignore real failures.
+
+This policy applies across every one of fred's repos (freminal,
+docker-acarshub, nixos, anything new). If a flake surfaces during
+any work (a CI retry, a `cargo test` / `npm test` loop, parallel-suite
+stress, manual repro — anything), it becomes a **hard blocker** under
+the following rules.
+
+## The rules
+
+1. **Finish the current sub-task.** Do not abandon a half-done
+   refactor or partially-staged change. Finish what's in flight and
+   leave it in a clean committable state.
+2. **The very next unit of work is the flake fix.** No new
+   features, no new refactors, no jumping to the next plan item
+   until the flake is either:
+   - fixed, or
+   - proven to be environmental noise outside the test code (and
+     even then: documented and tracked).
+3. **Root-cause it.** Symptomatic patches are NOT acceptable:
+   - Test retries (`it.retry(N)`, `--retries`, `extend({ retries })`,
+     `#[retry]` macros, etc.)
+   - Longer timeouts to mask a race
+   - `it.skip` / `#[ignore]` with a TODO
+   - `flaky: true` tags that disable the test in CI
+   - "Run it three times and take majority"
+
+   Identify the actual race / shared-state / boundary issue and fix
+   the _cause_.
+
+4. **Add a deterministic regression test** that reproduces the race
+   reliably without depending on parallel scheduling. The flaky
+   test itself does NOT count as the regression test — flakes by
+   definition pass sometimes, so they can't gate the fix. The
+   regression test must fail with 100% reliability without the fix.
+5. **Stress-test the fix.** Minimum **10 consecutive full-suite
+   runs clean** before declaring victory. More if the original
+   repro rate was lower than 1-in-5 (e.g. a 1-in-50 flake needs at
+   least 50 clean runs to be statistically meaningful).
+6. **Never push a known flake to `main` or any long-lived branch.**
+   If a flake surfaces mid-way through long-lived work, it gets
+   its own commit ahead of further feature/refactor work on the
+   same branch.
+
+## Multiple flakes during one sub-task
+
+If you find more than one flake during a single sub-task:
+
+1. Finish the current sub-task.
+2. Queue all the flakes.
+3. Drain the queue in order of **reproduction frequency** (most
+   frequent first) before resuming planned work.
+
+## What "environmental noise" actually means
+
+Acceptable as "not a code bug":
+
+- A CI runner with intermittent disk pressure that no test code can
+  defend against (rare; usually solvable in CI config).
+- A network call to a third-party that's genuinely outside the
+  project's control. The fix is to mock it, not to retry.
+- A timezone / locale assumption in the CI runner that's reasonable
+  to fix in CI config.
+
+Not acceptable as "environmental":
+
+- "It depends on which test ran before it." → shared state in the
+  suite. Code bug.
+- "It depends on which order the runner schedules workers." → order
+  dependence. Code bug.
+- "It depends on whether the dev machine is fast." → race
+  condition. Code bug.
+- "It depends on the moon phase." → you didn't root-cause it.
+
+## When to stop and ask
+
+- The flake is real, root-caused, and the fix is _architectural_
+  (e.g. the whole test infrastructure assumes shared state).
+  Surface the scope before doing a multi-day refactor.
+- The flake is in a third-party tool (e.g. a Playwright bug, a
+  tokio scheduler quirk). The workaround might be a version pin or
+  a transient retry _with a comment linking to the upstream issue_
+  and a follow-up plan to remove it once upstream ships a fix.
+  Confirm that case with the user; don't decide unilaterally that
+  "this one's the upstream's fault".

--- a/.opencode/skills/shared/markdown-lint-discipline/SKILL.md
+++ b/.opencode/skills/shared/markdown-lint-discipline/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: markdown-lint-discipline
+description: Use whenever writing or editing any `.md` / `.mdx` / `.markdown` file (AGENTS.md, agents.md, README.md, agent-docs/*.md, SKILL.md frontmatter bodies, RFCs, design docs, anything). Codifies the markdownlint rules that bite fred's repos most often (MD031, MD040, MD024, MD058, MD012, MD041), the table-column-width rule, the no-emoji-in-tables rule, and the pre-commit fix loop. Prevents the common "pre-commit rejected your commit because of trailing whitespace / missing language tag / unbalanced table" round trip.
+---
+
+# Markdown: lint-clean on the first try
+
+Every one of fred's repos runs a strict markdownlint pre-commit hook
+(usually via `fredsystems/precommit-base` + prettier). Most lint
+failures are mechanical and predictable. This skill lists the rules
+that bite most often and the small habits that avoid them.
+
+If a commit gets rejected by the markdown lint anyway, jump to
+`precommit-fix-loop`. This skill is about not getting rejected in
+the first place.
+
+## The rules that bite
+
+### MD040 — fenced code blocks must declare a language
+
+Every fenced code block needs a language identifier. Use `text` (or
+`plain`) for output that has no language.
+
+````text
+Wrong:
+
+​```
+some output
+​```
+
+Right:
+
+​```text
+some output
+​```
+````
+
+Common languages used in these repos: `bash`, `sh`, `zsh`, `nix`,
+`rust`, `toml`, `typescript`, `tsx`, `json`, `jsonc`, `yaml`,
+`scss`, `markdown`, `text`, `diff`.
+
+### MD031 — blank lines around fenced code blocks
+
+A fenced block needs a blank line above AND below it. Same for
+lists (MD032) and headings (MD022).
+
+````text
+Wrong:
+
+Here's the command:
+​```sh
+do-the-thing
+​```
+And then ...
+
+Right:
+
+Here's the command:
+
+​```sh
+do-the-thing
+​```
+
+And then ...
+````
+
+### MD058 — blank lines around tables
+
+A table needs a blank line above and below. Same shape as MD031.
+
+### MD024 — no duplicate heading content
+
+Two headings with identical text break anchor links and trip the
+linter. Most repos configure this as `siblings_only: true` (only
+siblings under the same parent collide), but it's safer to just
+make every heading unique.
+
+If you genuinely need two "## Examples" sections (e.g. one per
+section), prefix them: "## Examples (TypeScript)" / "## Examples
+(Rust)".
+
+### MD012 — no consecutive blank lines
+
+One blank line between blocks. Never two. Editors that auto-format
+on save will collapse them; if you're hand-editing, watch for them.
+
+### MD041 — first line should be a top-level heading
+
+The first non-frontmatter line of every `.md` file is a single `#
+Heading`. After that, only one H1 per file (MD025). All subsequent
+sections use `##`, `###`, etc.
+
+Frontmatter (the `---` block at the top of SKILL.md files) does
+NOT count as content for MD041 purposes — the H1 comes after the
+closing `---`.
+
+### MD034 — no bare URLs
+
+Wrap bare URLs in angle brackets or markdown links:
+
+```text
+Wrong: see https://example.com for more
+
+Right: see <https://example.com> for more
+Right: see [more docs](https://example.com)
+```
+
+### MD033 — inline HTML
+
+Most configs allow a small allowlist (`<br>`, `<sub>`, `<sup>`,
+sometimes `<details>` / `<summary>`). Don't sprinkle other HTML;
+use markdown equivalents.
+
+## Tables: the rule prettier won't always fix for you
+
+### Column widths must be uniform across every row
+
+Each column in a markdown table must be padded to the same width
+on every row, including the header separator. Prettier and most
+formatters do this on save, but if you're hand-writing a table or
+adding one row to an existing table, mirror the existing column
+widths exactly.
+
+```text
+Wrong (column 2 widths differ row to row):
+
+| Skill            | When it fires           |
+| ---------------- | -------------------- |
+| short-name       | always                                    |
+| longer-name-here | sometimes |
+
+Right:
+
+| Skill            | When it fires |
+| ---------------- | ------------- |
+| short-name       | always        |
+| longer-name-here | sometimes     |
+```
+
+Pick the longest cell in each column, add one space of padding on
+each side, pad every other cell in that column with trailing
+spaces to match.
+
+### Separator row dashes must match column width
+
+The `| --- |` row should use dashes wide enough to match the
+column. Prettier normalises this; don't fight it.
+
+### Do NOT put emojis in table cells
+
+Emojis (✅, ❌, 🚀, 🔥, etc.) have ambiguous display widths.
+Markdown linters compute table column widths using character
+counts; the rendered width in a browser or terminal is different,
+which causes:
+
+- linter rejecting a table the human eye sees as aligned, or
+- prettier "fixing" widths in a way that breaks linter alignment,
+  causing a fix-loop ping-pong.
+
+Use plain text markers instead:
+
+```text
+Wrong:                            Right:
+
+| Feature  | Status |             | Feature  | Status      |
+| -------- | ------ |             | -------- | ----------- |
+| Login    | ✅     |             | Login    | done        |
+| Signup   | ❌     |             | Signup   | not started |
+```
+
+This skill does not ban emojis in prose — only in tables and in
+heading text (which is also flaky in some TOC generators).
+
+## Lists
+
+- One blank line between the prose above and the list (MD032).
+- One blank line after the last bullet before the next prose
+  block.
+- Indent continuation lines with **2 spaces** (or whatever the
+  repo's prettier config uses — check `.prettierrc` /
+  `prettier.config.*` if unsure).
+- Use `-` for unordered (consistent within a file) and `1.`,
+  `2.`, ... for ordered. Don't mix `*` and `-`.
+
+## Headings
+
+- Use ATX-style headings (`#`, `##`, `###`), not setext (underline
+  style).
+- Blank line above and below every heading (MD022).
+- Don't skip levels (`#` → `###` without `##`) — MD001.
+- No trailing punctuation in heading text (MD026). "## Conclusion"
+  not "## Conclusion:".
+
+## SKILL.md frontmatter (specifically)
+
+The frontmatter block:
+
+```markdown
+---
+name: my-skill
+description: ...
+---
+```
+
+- The opening `---` must be the very first line of the file. No
+  blank line, no BOM, no comment above it.
+- The closing `---` must be on its own line.
+- Inside the block: `key: value` only. No nested objects, no
+  multi-line strings unless you use proper YAML block scalars (`>`
+  or `|`).
+- `description:` on a single line — if it gets long, wrap inside
+  one quoted YAML string rather than spilling onto multiple lines.
+
+After the closing `---`, leave one blank line, then the H1, then
+the body.
+
+## When to stop and ask
+
+- The repo's `.markdownlint.json` (or `.markdownlint.jsonc`, or
+  `markdownlint.yaml`) disables one of the rules above. Defer to
+  the repo config — don't fight it. Surface only if the repo
+  config seems wrong.
+- Prettier and markdownlint disagree (e.g. prettier wants 2-space
+  list indent, markdownlint wants 4). That's a config bug;
+  surface it to fred rather than picking a side per-file. See
+  `precommit-fix-loop`.
+- A table genuinely needs an emoji for content reasons (a doc
+  about emoji support, an aviation status board where the emoji
+  IS the data). Surface — there are escape valves
+  (`<!-- markdownlint-disable MD013 -->`-style) but they should
+  be an exception, not a habit.

--- a/.opencode/skills/shared/markdown-lint-discipline/SKILL.md
+++ b/.opencode/skills/shared/markdown-lint-discipline/SKILL.md
@@ -214,6 +214,69 @@ description: ...
 After the closing `---`, leave one blank line, then the H1, then
 the body.
 
+## Prettier auto-normalizations (write it this way the first time)
+
+Prettier runs alongside markdownlint in fred's pre-commit setup and
+will silently rewrite your file on commit, then re-stage. The fixes
+don't reject the commit on the first round, but the file ends up
+modified again and the next round of hooks runs against the new
+content. Writing markdown the way prettier wants it from the start
+avoids that ping-pong.
+
+The normalizations to anticipate:
+
+- **Emphasis with underscores, not asterisks.** Write `_italic_`,
+  not `*italic*`. Strong (`**bold**`) keeps the asterisks.
+- **Unordered lists use `-`.** Not `*`, not `+`. Stay consistent
+  within a file.
+- **Numbered lists keep literal `1.`, `2.`, ...** Prettier does not
+  renumber, and it expects a single space after the dot before the
+  item text.
+- **Blank line between numbered-list items that contain fenced code
+  blocks.** Prettier and MD031 disagree about list-with-fence
+  formatting otherwise — prettier will add the blank line, so just
+  write it that way:
+
+  ````markdown
+  1. Step one.
+
+     ```sh
+     do-thing
+     ```
+
+  2. Step two.
+  ````
+
+- **Tables get re-padded.** Don't waste time hand-aligning a table
+  to pixel-perfect widths; prettier will redo it on commit. Just
+  make sure every row has the same number of `|` separators and
+  prettier handles the rest.
+- **Trailing whitespace stripped.** Don't leave it.
+- **Final newline at EOF.** Always end the file with one newline.
+
+## codespell (sibling hook, runs alongside markdownlint)
+
+`codespell` is a separate pre-commit hook that scans for common
+typos. It is **not** markdownlint and will reject the commit
+independently. Frequent offender patterns (written with a space
+to dodge codespell flagging this file itself — in real prose the
+hyphenated or misspelled form is what trips the hook):
+
+- The `re- use` / `re- uses` / `re- used` family → collapse to
+  `reuse` / `reuses` / `reused` (no hyphen).
+- `sep arately` (with the missing `a` in the wrong place) →
+  `separately`.
+- `occ ured` (single `r`) → `occurred`.
+- `rec ieve` (i-before-e violation) → `receive`.
+- `acc omodate` (single `m`) → `accommodate`.
+- `pre- existing` is often allowed; check the repo's wordlist.
+
+If a flagged word is a genuine proper noun, a domain term, or a
+deliberate spelling, add it to the repo's `.codespellrc`
+`ignore-words-list` or `typos.toml` rather than working around it
+case by case. New additions should be real exceptions — don't
+pollute the wordlist to dodge typos.
+
 ## When to stop and ask
 
 - The repo's `.markdownlint.json` (or `.markdownlint.jsonc`, or

--- a/.opencode/skills/shared/no-summary-documents/SKILL.md
+++ b/.opencode/skills/shared/no-summary-documents/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: no-summary-documents
+description: Use whenever about to create a new markdown file, write documentation, or finalize a multi-step task in any of fred's repos (nixos, freminal, docker-acarshub, and downstream). Codifies the strict no-summary-documents policy -- no PHASE_X_SUMMARY.md, no IMPLEMENTATION_PROGRESS.md, no REFACTOR_NOTES.md, no "what I did" markdown. Documentation only exists if it is durable reference material.
+---
+
+# No summary documents — ever
+
+Across every one of fred's repos, the rule is the same: **do not create
+markdown files that summarize work that was done.** This includes (but
+is not limited to):
+
+- `PHASE_X_SUMMARY.md`, `PHASE_1_COMPLETE.md`, `MILESTONE_*.md`
+- `IMPLEMENTATION_PROGRESS.md`, `PROGRESS.md`, `STATUS.md`
+- `REFACTOR_NOTES.md`, `MIGRATION_NOTES.md`, `CHANGES.md`
+  (when it duplicates `CHANGELOG.md` or git history)
+- `SESSION_NOTES.md`, `WORKLOG.md`
+- "Recap" / "wrap-up" / "what was done in task N" documents
+- Per-PR or per-commit `*_SUMMARY.md` files
+
+These files are summaries of _the work_, not of _the system_. They go
+stale immediately, they duplicate `git log`, and they pollute repo
+search results forever.
+
+## What documentation IS allowed
+
+Documentation must serve a **durable** purpose. Acceptable:
+
+| Type                  | Examples                                                           | Why durable                                    |
+| --------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
+| Reference             | `ARCHITECTURE.md`, `agent-docs/DECODER_CONNECTIONS.md`             | Describes how the system works today           |
+| Standards / patterns  | `DESIGN_LANGUAGE.md`, `TESTING.md`, `AGENTS.md`                    | Defines rules the codebase must follow         |
+| Coverage / inventory  | `Documents/ESCAPE_SEQUENCE_COVERAGE.md`                            | Authoritative table updated with each change   |
+| Active plan documents | `Documents/PLAN_XX_*.md`, `Documents/MASTER_PLAN.md` (in freminal) | Living working documents for in-progress tasks |
+| Onboarding            | `README.md`, `DEV-QUICK-START.md`, `CONTRIBUTING.md`               | First-read material for newcomers              |
+| Changelogs            | `CHANGELOG.md` (one per repo)                                      | Single canonical history file, not per-task    |
+
+If the document you're tempted to write doesn't fit one of these, the
+answer is no.
+
+## What goes where instead of a summary doc
+
+| Instinct                                                     | Right destination                                                                                            |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| "I want to capture what I did in task 12"                    | Commit message (one per logical change). That IS the durable record.                                         |
+| "I want to track what subtasks are complete"                 | Tick boxes in the existing `Documents/PLAN_XX_*.md`. Do NOT spawn a new file.                                |
+| "I want to summarize a refactor for posterity"               | Update the relevant reference doc (`ARCHITECTURE.md`, etc.) to reflect the new state. Discard the narrative. |
+| "I want to record decisions made during the task"            | If the decision is durable, ADR-style entry in an existing decisions doc. If situational, commit message.    |
+| "I want to leave handoff notes for the next session / agent" | They live in the existing plan doc, or in the chat with the user. NOT a new markdown file.                   |
+| "I discovered a bug while doing X"                           | File it as a numbered cleanup entry in the host task's plan section (freminal convention), or open an issue. |
+
+## Hard prohibitions
+
+- Do not create a markdown file just because you "completed" something.
+- Do not create a markdown file to "track progress" outside of an
+  already-existing plan document.
+- Do not create a markdown file because the user asked for "a summary"
+  -- they meant a chat response, not a file. If genuinely uncertain,
+  ask.
+- Do not create per-PR review notes as markdown files in the repo. PR
+  description and review comments are the venue.
+
+## When to stop and ask
+
+- The user explicitly asks for "documentation of X" and X is genuinely
+  new system-level knowledge (e.g. a newly added subsystem). Propose
+  the file name and location FIRST, get approval, then write -- do not
+  preemptively create.
+- A plan document is missing for an in-progress multi-step task and the
+  task is large enough to need one. Stop and confirm with the user
+  before spawning `Documents/PLAN_XX_*.md`.
+- You're tempted to write "notes for the next agent". Don't. The
+  durable replacements above cover every legitimate case; the others
+  belong in the conversation, not in the repo.

--- a/.opencode/skills/shared/performance-benchmarks/SKILL.md
+++ b/.opencode/skills/shared/performance-benchmarks/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: performance-benchmarks
+description: Use when changing code in a performance-sensitive area of any of fred's projects — rendering pipelines, parsers, I/O hot paths, data-flatten loops, or anything the project's own skills flag as benchmark-mandated. Codifies the before/after capture procedure, the 15% regression threshold, the recording format, and the "add a benchmark first if none exists" rule. Project-specific skills (e.g. `freminal-bench-table`) list which benchmark file covers which area; this skill is the generic policy that uses those tables.
+---
+
+# Performance benchmarks: before/after is mandatory
+
+If a change touches code in a benchmark-mandated area (consult the
+project's own catalog skill, e.g. `freminal-bench-table`), the agent
+MUST capture benchmark numbers **before and after** the change and
+include them in the completion report. No exceptions.
+
+If no appropriate benchmark exists for the code being changed, the
+agent MUST create a new benchmark as part of the task **before**
+proceeding with the change. Performance regressions must be
+justified and documented, or the change must be revised.
+
+## Procedure
+
+1. Identify the relevant benchmark file(s) and benchmark name(s)
+   from the project's catalog skill for the code area you're
+   changing. If the project has no catalog and the area looks
+   performance-sensitive, stop and ask — don't assume "there are
+   no benchmarks for this".
+2. **Before** making the change, capture baseline. For Criterion
+   (Rust):
+
+   ```sh
+   cargo bench --bench <bench-name> -- --save-baseline before
+   ```
+
+   For other runners, use the equivalent baseline-save flag.
+
+3. Make the change.
+4. **After** the change, capture and compare:
+
+   ```sh
+   cargo bench --bench <bench-name> -- --baseline before
+   ```
+
+   The runner will print delta percentages.
+
+5. Record results in the completion report (see format below).
+
+## Recording format
+
+The completion report MUST include a table like:
+
+```text
+| Benchmark | Before | After | Change |
+| --- | --- | --- | --- |
+| bench_handle_incoming_data | 1.23 ms | 1.19 ms | -3.3% |
+```
+
+One row per benchmark touched. Use the names the bench runner
+prints, not made-up shorthand.
+
+## Regression threshold
+
+- Any regression **> 15%** on a relevant benchmark **must be
+  justified** in the completion report (with the reason —
+  correctness, maintainability, etc.) **or the change must be
+  revised**.
+- Regressions **≤ 15%** are acceptable if the change provides
+  correctness or maintainability benefits that outweigh the
+  performance cost. Still call them out explicitly.
+- Wins of any size are reported as such — no need to justify a
+  speedup.
+
+## When no benchmark exists
+
+If you're changing code in a benchmark-mandated area but no
+benchmark covers the specific code path, **add a benchmark first**,
+in the same PR, **before** the change. The added benchmark itself
+should land in a separate commit ahead of the behavioral change so
+the baseline is a clean "before" measurement.
+
+Place new benchmarks in the crate/package that owns the code being
+measured, following the existing pattern in that project.
+
+## When to stop and ask
+
+- The change is in a benchmark-mandated area but no obvious
+  benchmark fits. Stop — describe what you'd need to benchmark and
+  ask if a new benchmark is in scope.
+- Numbers swing wildly between runs (>5% noise on a "no-op" rerun).
+  That's bench environment noise, not a real measurement. Stop and
+  rebench in a quieter shell, or surface the noise issue.
+- A regression > 15% looks justified but the user might disagree.
+  Surface the trade-off rather than ship it.

--- a/.opencode/skills/shared/precommit-fix-loop/SKILL.md
+++ b/.opencode/skills/shared/precommit-fix-loop/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: precommit-fix-loop
+description: Use when a git commit is rejected by pre-commit hooks, when the user mentions "pre-commit", "lint failed", "hook failed", or before running `git commit` in any of fred's repos that share the fredsystems/precommit-base ruleset (nixos, freminal, docker-acarshub, and downstream projects). Covers diagnosing which hook fired, fixing the underlying issue (never the symptom), and the strict no-bypass policy.
+---
+
+# Pre-commit fix loop
+
+All of fred's repos source their pre-commit configuration from
+`fredsystems/precommit-base` (pinned via `flake.nix` as the `precommit-base`
+input). The hooks are deliberately strict. They are the contract for "this
+code is allowed to enter main".
+
+## Non-negotiable rules
+
+- **`git commit --no-verify` is forbidden.** Do not pass `--no-verify`,
+  `-n`, or set `HUSKY_SKIP_HOOKS=1` / `PRE_COMMIT_ALLOW_NO_CONFIG=1` /
+  any equivalent escape hatch. The only exception is when the user
+  explicitly tells you to bypass on a specific commit.
+- **Fix the cause, not the symptom.** If a hook fails, the problem is in
+  the code (or in a missing dev-shell tool), never in the hook. Do not
+  add `# noqa`, `// eslint-disable`, `#[allow(...)]`, `// biome-ignore`,
+  `<!-- markdownlint-disable -->`, etc. to silence a rule that fired
+  on new code.
+- **If a hook genuinely needs to change**, the change goes in
+  `fredsystems/precommit-base` via a PR, not in the consuming repo's
+  config. Stop and tell the user.
+- **A failed commit is not a committed commit.** If a hook rejected the
+  commit, fix the issue and create a new commit. Do NOT `git commit
+--amend` onto a commit that the hooks already rejected (you'd be
+  hiding the failure from history).
+
+## Diagnostic loop
+
+1. Read the hook output top-to-bottom. Pre-commit prints one section per
+   hook. Find the first hook that says `Failed` and start there \u2014
+   downstream failures are often consequences of the first.
+2. Note the hook's `id:` line (e.g. `id: clippy`, `id: biome`,
+   `id: nixfmt-rfc-style`, `id: markdownlint`). That tells you which
+   tool, which file types, and which config.
+3. Reproduce the failure outside the commit context so you can iterate
+   fast:
+   - `nix develop` (or `direnv allow`) to enter the dev shell so the
+     exact tool versions the hook uses are on PATH.
+   - Run the hook in isolation: `pre-commit run <hook-id> --files
+<paths>` for just the files you changed, or `pre-commit run -a
+<hook-id>` if the failure looks repo-wide.
+4. Fix the underlying issue.
+5. Re-stage (`git add`) and re-run `pre-commit run <hook-id> --files
+<paths>` to confirm green before re-attempting the commit.
+6. `git commit` again (no flags).
+
+## Common hook failure classes
+
+| Symptom in output                           | Likely hook              | Real cause                                                                                                                                                                  |
+| ------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `error: ...clippy::...`                     | clippy                   | Lint violation in `.rs` change. Fix the code; do NOT add `#[allow]`.                                                                                                        |
+| `Formatted N files`                         | rustfmt / nixfmt / biome | A formatter rewrote files. Re-stage them and commit again \u2014 this is not a "failure" so much as a "you forgot to format".                                               |
+| `error: typos found`                        | typos                    | A real typo, or a project-specific word missing from `typos.toml` / `.dictionary.txt`. Adding to the dictionary is acceptable only for genuine proper nouns / domain terms. |
+| `MD0xx ... markdownlint`                    | markdownlint             | A real markdown rule violation. See the rule reference: <https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md>.                                                |
+| `evaluation warning:` from a nix build      | flake check              | A nixpkgs deprecation surfaced during eval. Update the call site.                                                                                                           |
+| `tool not found` / `command not found: <x>` | (any)                    | Dev shell not entered. `nix develop` and retry. Do NOT work around by skipping the hook.                                                                                    |
+
+## When to stop and ask
+
+- The failing rule looks wrong for this codebase (e.g. a new rule from a
+  precommit-base bump that doesn't fit the repo). Stop \u2014 the right
+  fix is upstream.
+- A hook is asking for a tool that isn't in the dev shell. Stop \u2014
+  the right fix is either adding the tool to `flake.nix` (then re-enter
+  the shell) or removing the hook's requirement.
+- Fixing the lint requires meaningfully changing behavior. Stop, surface
+  the situation, do not silently rewrite behavior to satisfy a lint.

--- a/.opencode/skills/shared/precommit-fix-loop/SKILL.md
+++ b/.opencode/skills/shared/precommit-fix-loop/SKILL.md
@@ -32,7 +32,7 @@ code is allowed to enter main".
 ## Diagnostic loop
 
 1. Read the hook output top-to-bottom. Pre-commit prints one section per
-   hook. Find the first hook that says `Failed` and start there \u2014
+   hook. Find the first hook that says `Failed` and start there —
    downstream failures are often consequences of the first.
 2. Note the hook's `id:` line (e.g. `id: clippy`, `id: biome`,
    `id: nixfmt-rfc-style`, `id: markdownlint`). That tells you which
@@ -54,7 +54,7 @@ code is allowed to enter main".
 | Symptom in output                           | Likely hook              | Real cause                                                                                                                                                                  |
 | ------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `error: ...clippy::...`                     | clippy                   | Lint violation in `.rs` change. Fix the code; do NOT add `#[allow]`.                                                                                                        |
-| `Formatted N files`                         | rustfmt / nixfmt / biome | A formatter rewrote files. Re-stage them and commit again \u2014 this is not a "failure" so much as a "you forgot to format".                                               |
+| `Formatted N files`                         | rustfmt / nixfmt / biome | A formatter rewrote files. Re-stage them and commit again — this is not a "failure" so much as a "you forgot to format".                                                    |
 | `error: typos found`                        | typos                    | A real typo, or a project-specific word missing from `typos.toml` / `.dictionary.txt`. Adding to the dictionary is acceptable only for genuine proper nouns / domain terms. |
 | `MD0xx ... markdownlint`                    | markdownlint             | A real markdown rule violation. See the rule reference: <https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md>.                                                |
 | `evaluation warning:` from a nix build      | flake check              | A nixpkgs deprecation surfaced during eval. Update the call site.                                                                                                           |
@@ -63,9 +63,9 @@ code is allowed to enter main".
 ## When to stop and ask
 
 - The failing rule looks wrong for this codebase (e.g. a new rule from a
-  precommit-base bump that doesn't fit the repo). Stop \u2014 the right
+  precommit-base bump that doesn't fit the repo). Stop — the right
   fix is upstream.
-- A hook is asking for a tool that isn't in the dev shell. Stop \u2014
+- A hook is asking for a tool that isn't in the dev shell. Stop —
   the right fix is either adding the tool to `flake.nix` (then re-enter
   the shell) or removing the hook's requirement.
 - Fixing the lint requires meaningfully changing behavior. Stop, surface

--- a/.opencode/skills/shared/testing-mandate/SKILL.md
+++ b/.opencode/skills/shared/testing-mandate/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: testing-mandate
+description: Use before declaring any task complete in fred's repos, before opening a PR, when adding a new function/module/service, or when fixing a bug. Codifies the mandatory-testing policy that applies across freminal (cargo test + benches), docker-acarshub (vitest + playwright), and the NixOS repo (nix eval of impacted hosts). "It compiles and old tests pass" is never sufficient -- new code requires new tests, bug fixes require regression tests, and a task is not done until verification is green.
+---
+
+# Testing is mandatory
+
+## The rule
+
+Every new feature, bug fix, or refactor MUST include tests that cover
+the new or changed behavior. "It compiles and existing tests pass" is
+explicitly **insufficient**. New code requires new tests; bug fixes
+require regression tests; and a task is not "done" until the project's
+verification suite is fully green.
+
+This applies in all of fred's repos. The shape differs per project:
+
+| Repo              | New code requires                                                                                                                                                                                                                  | Bug fix requires                                                                                                      | Final verification before "done"                                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `freminal`        | Unit tests in the same crate (in `tests/` or `#[cfg(test)]` module). Performance-sensitive code in render/PTY/buffer also requires before/after benchmark numbers.                                                                 | A regression test that FAILS without the fix and PASSES with it.                                                      | `cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo machete`. Or `cargo xtask ci`. |
+| `docker-acarshub` | Vitest tests under the appropriate `__tests__/` directory. New components also need accessibility coverage.                                                                                                                        | Regression test in vitest (or Playwright if the bug is UX-level).                                                     | `just ci`.                                                                                                            |
+| `nixos`           | Not unit-testable in the programmatic sense. The equivalent: a successful `nix eval` of `system.build.toplevel` (and `home.activationPackage` when home-manager changes) for every impacted host. See `nixos-eval-impacted-hosts`. | A reproducer in the form of the bad eval before, the green eval after. Capture the exact error in the commit message. | `nix eval` of impacted hosts (the `nixos-eval-impacted-hosts` skill bundles a script).                                |
+
+## Coverage expectations
+
+These are floors, not ceilings. Pushing above them is encouraged.
+
+- **freminal**: target 100% across crates. Public APIs without tests are
+  treated as incomplete.
+- **docker-acarshub**:
+  - Utilities: 90%+
+  - Stores: 80%+
+  - Components: 70%+
+  - Backend services: 80%+
+  - Backend formatters/enrichment: 90%+
+- **nixos**: not a coverage metric; the "eval of every impacted host
+  succeeds" gate is the equivalent.
+
+## Test quality
+
+Tests are first-class code. They must be:
+
+- **Hermetic.** No external network, no shared filesystem state across
+  tests, no global mutable state.
+- **Order-independent.** A test must pass whether it runs alone, first,
+  last, or in parallel with the rest of the suite.
+- **Focused on observable behavior**, not implementation details. A
+  test that breaks on a pure refactor is testing the wrong thing.
+- **Written for humans first.** A failing test should explain what
+  invariant it was checking, not just "expected X got Y".
+
+Duplication in tests is acceptable if it improves clarity. Do not
+extract test helpers so aggressively that a reader can't see what's
+being asserted without three jumps.
+
+## Flake handling (docker-acarshub specifically, generalizes)
+
+A flaky test is a broken test. The full no-punting rules live in the
+`flaky-tests-are-bugs` skill, but the headline applies to every
+repo: do not paper over a sporadic failure with a retry, longer
+timeout, or `it.skip`. Root-cause it.
+
+## What "the task is done" means
+
+A task is done ONLY when ALL of the following are true:
+
+1. Every new public surface area has tests (or, in nixos, has been
+   evaluated successfully on every impacted host).
+2. If this was a bug fix, a regression test exists that demonstrably
+   fails without the fix.
+3. The project's full verification suite (per the table above) passes
+   cleanly with zero warnings.
+4. The relevant plan document (if any) has been updated to reflect
+   completion -- without spawning a new summary doc (see
+   `no-summary-documents`).
+5. The commit history is clean (atomic, conventional commits, each
+   commit green -- see `commit-discipline`).
+
+If any of these is false, the task is in progress, not done. Report it
+that way.
+
+## When to stop and ask
+
+- The new code is genuinely untestable as designed (e.g. a hardware
+  side-effect with no abstraction boundary). Stop -- the fix is to add
+  the abstraction, not to skip the test. Surface this to the user.
+- The existing test infrastructure is missing for the area you're
+  working in. The implementing agent must create the infrastructure
+  (test module, helpers, fixtures) as part of the task, but stop and
+  confirm scope with the user before doing a large infrastructure
+  bring-up.
+- A test is failing for reasons unrelated to your change. Do NOT skip
+  it. Do NOT push around it. Stop, surface it, and fix it (it counts
+  as a flake -- see the flake policy).

--- a/agents.md
+++ b/agents.md
@@ -1,16 +1,19 @@
-# Agent Guide — NixOS Flake Repository
+# Agent Guide -- NixOS Flake Repository
 
-This document explains the repository architecture, CI design, and maintenance
-rules. It is written for AI coding agents and human contributors alike.
+This document is the always-on orientation for AI coding agents and human
+contributors working in this NixOS flake. **Operational procedures are no
+longer inlined here** -- they live as opencode skills under
+`.opencode/skills/` and are loaded on demand. This document gives you the
+map; the skills give you the moves.
 
 ---
 
 ## Repository overview
 
-This is a NixOS flake that manages **9 Linux hosts** (7 servers + 2 desktops)
+This is a NixOS flake managing **9 Linux hosts** (7 servers + 2 desktops)
 and at least one macOS (nix-darwin) host. The infrastructure is heavily
-aviation / SDR-focused — most servers run containerised ADS-B, VDL-M, and
-HFDL decoders.
+aviation / SDR-focused -- most servers run containerised ADS-B, VDL-M,
+and HFDL decoders.
 
 ### Directory layout
 
@@ -50,12 +53,29 @@ HFDL decoders.
 ├── dotfiles/              # Dotfile configurations managed by home-manager
 ├── overlays/              # Nixpkgs overlays
 ├── scripts/               # Helper scripts
+├── opencode.jsonc         # opencode project config for this repo
+├── .opencode/             # Skills directory: this repo holds the
+│   │                      # cross-repo shared + generic-language skills
+│   │                      # used by every one of fred's projects. The
+│   │                      # `ai.opencode` home-manager module bakes this
+│   │                      # tree into the derivation and installs it at
+│   │                      # `~/.config/opencode/skills/`, so Colmena
+│   │                      # targets do NOT need this checkout at runtime.
+│   │                      # Project-specific skills live in each
+│   │                      # respective project repo's `.opencode/skills/`.
+│   └── skills/
+│       ├── shared/        # Cross-repo policies (precommit, commits,
+│       │                  # testing, no-summary-documents, flaky tests,
+│       │                  # performance benchmarks, flake dev-shell,
+│       │                  # markdown-lint-discipline)
+│       ├── languages/     # Per-language rules (rust, typescript)
+│       └── projects/      # nixos-specific procedures only
 └── .github/
     ├── workflows/
-    │   ├── ci-linux.yaml        # Linux CI (this doc's main focus)
+    │   ├── ci-linux.yaml        # Linux CI
     │   ├── ci-darwin.yaml       # macOS CI
     │   ├── ci-lint.yaml         # Pre-commit / linting
-    │   └── update-flakes.yaml   # Per-input flake update (opens 1 PR per input)
+    │   └── update-flakes.yaml   # Per-input flake update (1 PR per input)
     ├── merge-queue-ci-skipper/  # Composite action: skip redundant merge-queue builds
     └── renovate.json5           # Renovate Bot config
 ```
@@ -74,261 +94,99 @@ HFDL decoders.
 | hfdlhub1  | Server  | HFDL decoder                              |
 | hfdlhub2  | Server  | HFDL decoder                              |
 
-Desktops are hardcoded in `ci-linux.yaml` as `desktop_names=("Daytona" "maranello")`.
-Everything else from `nixosConfigurations` is treated as a server.
+Desktops are hardcoded in `ci-linux.yaml` as
+`desktop_names=("Daytona" "maranello")`. Everything else from
+`nixosConfigurations` is treated as a server.
 
-Servers default to the **stable** channel (`nixpkgs-stable`, `home-manager-stable`,
-`catppuccin-stable`, `sops-nix-stable`). Per-server overrides are possible via
-the node table in `flake/hosts/servers.nix`.
+Servers default to the **stable** channel (`nixpkgs-stable`,
+`home-manager-stable`, `catppuccin-stable`, `sops-nix-stable`).
+Per-server overrides are possible via the node table in
+`flake/hosts/servers.nix`.
 
----
-
-## Flake inputs and CI categories
-
-Each flake input affects a specific subset of hosts. When a flake input is
-updated (via `flake.lock` changes), CI should ideally only rebuild the hosts
-that depend on that input. The current CI uses path-based filtering (not yet
-input-aware — see "Future work" below), but this mapping is the authoritative
-reference for that future implementation.
-
-### Input-to-category mapping
-
-| Input                 | CI Category             | Affects                                                    |
-| --------------------- | ----------------------- | ---------------------------------------------------------- |
-| `nixpkgs`             | desktop + fredhub       | Desktops + fredhub (unstable channel)                      |
-| `home-manager`        | desktop                 | Desktop home-manager configs                               |
-| `catppuccin`          | desktop                 | Desktop theming                                            |
-| `niri`                | desktop                 | Niri Wayland compositor (desktop only)                     |
-| `fredbar`             | desktop                 | Status bar (desktop only)                                  |
-| `freminal`            | desktop                 | Terminal emulator (desktop only)                           |
-| `solaar`              | desktop                 | Logitech device manager (desktop only)                     |
-| `apple-fonts`         | desktop                 | Apple fonts (desktop only)                                 |
-| `walls-catppuccin`    | desktop                 | Wallpapers — orangci (desktop only, `flake=false`)         |
-| `walls-zhichaoh`      | desktop                 | Wallpapers — zhichaoh mirror (desktop only, `flake=false`) |
-| `walls-cozypixels`    | desktop                 | Wallpapers — CozyPixels (desktop only, `flake=false`)      |
-| `nixvim`              | global (all linux)      | Neovim config (all systems)                                |
-| `nixpkgs-stable`      | server                  | All servers (stable channel)                               |
-| `home-manager-stable` | server                  | Server home-manager configs                                |
-| `catppuccin-stable`   | server                  | Server theming                                             |
-| `sops-nix-stable`     | server                  | Server secrets management                                  |
-| `sops-nix`            | desktop                 | Secrets management (unstable, desktops only)               |
-| `nixos-needsreboot`   | global (all linux)      | Reboot detection module (all hosts)                        |
-| `darwin`              | skip (no linux rebuild) | macOS only — does not affect Linux CI                      |
-| `colmena`             | skip (no linux rebuild) | Deployment tool — no effect on builds                      |
-| `flake-utils`         | skip (no linux rebuild) | Utility lib — no effect on system builds                   |
-| `precommit-base`      | skip (no linux rebuild) | Dev tooling only — no system builds                        |
-
-**Unknown / new inputs should default to `global`** (rebuilds all Linux hosts).
-This is the safe fallback — it may over-build but will never miss a required
-rebuild.
-
-### Special case: `fredhub`
-
-`fredhub` is classified as a server and uses the stable channel by default, but
-it imports one package from `nixpkgs` (unstable). Therefore, changes to
-`nixpkgs` should trigger a rebuild of **desktops + fredhub** (not just
-desktops).
+`fredhub` is a stable-channel server that imports one package from
+unstable `nixpkgs`. CI treats changes to the `nixpkgs` input as
+"desktops + fredhub".
 
 ---
 
-## CI architecture (`ci-linux.yaml`)
+## Skills you will need in this repo
 
-### Event triggers
+These are loaded on demand by opencode when their description matches
+the task. The full bodies live under `.opencode/skills/`.
 
-- `pull_request` (opened, synchronize, reopened)
-- `merge_group` (merge queue)
-- `workflow_dispatch` (manual — always builds everything)
+| Skill                       | When it fires                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| `nixos-eval-impacted-hosts` | Before pushing any change. Computes impacted hosts from the diff and runs evals.           |
+| `nixos-input-category-sync` | When editing flake inputs / `flake.lock` / `ci-linux.yaml` / the impacted-hosts script.    |
+| `nixos-add-host`            | When adding a new host (server or desktop).                                                |
+| `nixos-add-flake-input`     | When adding (or removing) a flake input.                                                   |
+| `precommit-fix-loop`        | When a commit is rejected by pre-commit hooks.                                             |
+| `commit-discipline`         | Before any commit / PR.                                                                    |
+| `testing-mandate`           | Before declaring any task done.                                                            |
+| `no-summary-documents`      | Before creating any new markdown file.                                                     |
+| `markdown-lint-discipline`  | Before writing or editing any `.md` file. MD031, MD040, table widths, no emojis in tables. |
 
-### Job graph
-
-```text
-skip-if-clean
-     │
-     ├──▶ find-systems
-     │        │
-     │        ├──▶ build-servers   (matrix)
-     │        └──▶ build-desktops  (matrix)
-     │
-     └──▶ build-linux-summary  (required status check)
-```
-
-### Merge-queue skip logic (`skip-if-clean`)
-
-Uses `.github/merge-queue-ci-skipper/` — a composite action that detects
-whether the merge-queue synthetic commit is identical to the already-tested PR
-tip. If so, it outputs `skip=true` and all downstream jobs are skipped
-(the summary job still runs and passes, satisfying the required check).
-
-### Path-based and input-aware change detection (`find-systems`)
-
-Instead of `dorny/paths-filter` (which mishandles negation patterns — see
-below), we use a bash step with `git diff --name-only` and a `case` statement.
-When `flake.lock` changes, we additionally parse the lock file diff to
-determine which flake inputs changed and map them to CI categories.
-
-**Why not `dorny/paths-filter`?** That action uses picomatch internally.
-A negation pattern like `!features/desktop/**` becomes an independent matcher
-that matches everything _except_ `features/desktop/**` — i.e., nearly every
-file. Combined with other patterns via OR, the "global" filter matched on
-virtually every PR, defeating the entire filtering system.
-
-**Current `case` logic:**
-
-```text
-flake.nix | firmware.nix  → global
-flake.lock  → input-aware parsing (see below)
-modules/* | profiles/* | home-profiles/* | dotfiles/*  → global
-features/desktop/*  → desktop_global  (checked BEFORE features/*)
-features/*  → global
-.github/renovate.json5  → excluded  (checked BEFORE .github/*)
-.github/*  → global
-hosts/linux/*  → per-machine filtering
-(anything else)  → ignored
-```
-
-The `case` statement order matters: more-specific patterns (e.g.
-`features/desktop/*`) are checked before their broader parents
-(`features/*`). `.github/renovate.json5` is excluded before the catch-all
-`.github/*` pattern.
-
-**Input-aware `flake.lock` parsing:**
-
-When `flake.lock` is in the changed files and `global` is not already set by
-other changed paths, the workflow:
-
-1. Retrieves the old `flake.lock` from the base commit via `git show`
-2. Iterates over all root inputs in the new lock file
-3. Compares `locked.rev` (or `locked.narHash` for non-git sources) between
-   old and new for each input
-4. Looks up each changed input in a bash associative array that maps input
-   names to CI categories (`desktop`, `server`, `desktop+fredhub`, `global`,
-   `skip`)
-5. Sets the appropriate flags: `global`, `desktop_global`, `server_global`,
-   or injects a synthetic machine path for the `fredhub` special case
-6. Unknown inputs default to `global` (safe over-build)
-7. Short-circuits if `global` becomes true (no point checking further)
-
-The `desktop+fredhub` category (used only by `nixpkgs` unstable) sets
-`desktop_global=true` and injects `hosts/linux/fredhub/_input_change` into
-the machine files list. The downstream filtering extracts the third path
-segment (`fredhub`) and includes it in the per-machine server build, while
-all desktops are rebuilt.
-
-**Filtering outcomes:**
-
-| Scenario                                       | Servers built | Desktops built |
-| ---------------------------------------------- | ------------- | -------------- |
-| `global=true`                                  | All           | All            |
-| `server_global=true`                           | All           | (per-machine)  |
-| `desktop_global=true`                          | (per-machine) | All            |
-| Only `hosts/linux/<name>/*` changed            | Only affected | Only affected  |
-| Only `features/desktop/*` changed              | None          | All            |
-| `flake.lock`: only `nixpkgs` changed           | Only fredhub  | All            |
-| `flake.lock`: only `nixpkgs-stable` changed    | All           | None           |
-| `flake.lock`: only `darwin` changed            | None          | None           |
-| `flake.lock`: only `nixos-needsreboot` changed | All           | All            |
-| `flake.lock`: unknown new input changed        | All           | All            |
-| Only `.github/renovate.json5` changed          | None          | None           |
-| `workflow_dispatch`                            | All           | All            |
-
-### Build steps (servers and desktops)
-
-Each matrix entry:
-
-1. Checks out the repo
-2. Installs Nix (with `access-tokens` for GitHub API auth — avoids rate limits)
-3. Enables the Magic Nix Cache
-4. Logs in to the **Attic binary cache** at `192.168.31.14`
-5. Builds `nixosConfigurations.<host>.config.system.build.toplevel`
-6. Pushes the result to Attic
-7. Builds `nixosConfigurations.<host>.config.home-manager.users.fred.home.activationPackage`
-8. Pushes the result to Attic
-9. Fails if any `evaluation warning:` is detected in stderr
-
-### Summary job (`build-linux-summary`)
-
-Required status check for merge-queue / branch protection. It:
-
-- Passes immediately if `skip-if-clean` said `skip=true`
-- Passes if both build jobs succeeded or were skipped (empty matrix = no hosts in scope)
-- Fails if either build job failed or was cancelled
+If the skill doesn't fire automatically and you think it should, that
+means the skill description needs a stronger trigger -- fix the skill,
+don't paste its contents into this file.
 
 ---
+
+## CI in one paragraph
+
+`ci-linux.yaml` has a `find-systems` job that classifies changed paths
+(via a bash `case` statement) and parses `flake.lock` diffs (input-aware)
+to decide which hosts to rebuild. `dorny/paths-filter` was rejected
+because negation patterns under picomatch match nearly every file. The
+matrix builds toplevel + home-manager activation for each impacted host
+and pushes to the Attic binary cache at `192.168.31.14`. Any
+`evaluation warning:` in stderr fails the build. `build-linux-summary`
+is the required status check.
+
+The full input-to-category mapping (the source of truth shared between
+`flake.nix` comments, this file, `ci-linux.yaml`, and the impacted-hosts
+script) is in the `nixos-input-category-sync` skill. When changing it,
+load that skill.
 
 ## Update workflows
 
-### `update-flakes.yaml` (custom)
-
-- Runs weekly (Sundays at 05:00 UTC) or on `workflow_dispatch`
-- Enumerates all flake inputs from `flake.lock`
-- Opens **one PR per input** (branch prefix: `update-`)
-- Uses `fredsystems/flake-update-action` with automerge enabled
-
-### Renovate Bot (`.github/renovate.json5`)
-
-- Runs weekly (Sundays at 12:00 UTC)
-- **Lock file maintenance** opens a **single PR** with all `flake.lock` changes
-  (this is the one that requires future input-diff parsing — see below)
-- Also manages:
-  - Docker container image tags (custom regex in `hosts/linux/*/configuration.nix`
-    and `modules/services/mk-dozzle-agent.nix`)
-  - GitHub Actions version pins
-- All update types automerge via `platformAutomerge`
-- Unlimited PR rate/concurrency limits
+- **`update-flakes.yaml`** runs weekly, opens one PR per input via
+  `fredsystems/flake-update-action` with automerge.
+- **Renovate Bot** runs weekly; lock file maintenance opens a single PR
+  with all `flake.lock` changes; also manages Docker image tags and
+  GitHub Actions pins; everything automerges via `platformAutomerge`.
 
 ---
 
-## Maintenance rules
+## Maintenance rules (one-liners; full procedures in skills)
 
-### Adding a new flake input
-
-1. Add the input to `flake.nix` under `inputs`
-2. Add a `# CI: <category>` comment above it (see existing pattern in `flake.nix`)
-3. **Update the input-to-category mapping table** in this file (`agents.md`)
-4. **Update the `input_category` associative array** in the `Detect changed paths`
-   step of `ci-linux.yaml`
-5. If the input is not added to the associative array, it will default to
-   `global` (safe but over-builds)
-
-### Adding a new host
-
-1. Create `hosts/linux/<name>/configuration.nix` (directory name lowercase)
-2. If it is a server, add an entry to `flake/hosts/servers.nix`
-3. If it is a desktop, add its `nixosConfigurations` attribute name to the
-   `desktop_names` array in `ci-linux.yaml`
-4. The CI will automatically discover it via `nix eval .#nixosConfigurations --apply builtins.attrNames`
-
-### Adding a new desktop
-
-Same as above, but also:
-
-- Add the configuration name to `desktop_names` in `ci-linux.yaml`
-- Changes under `features/desktop/` will automatically trigger a rebuild for
-  all desktops
-
-### Modifying CI filtering logic
-
-The filtering logic lives in the `Detect changed paths` step of the
-`find-systems` job in `ci-linux.yaml`. Key things to remember:
-
-- `case` pattern order matters — put specific patterns before general ones
-- `flake.lock` triggers the input-aware parser (not `global` directly)
-- `flake.nix` and `firmware.nix` still trigger `global=true`
-- To exclude a path from triggering builds, add a no-op `;;` case before the
-  broader catch-all (like `.github/renovate.json5` is excluded before `.github/*`)
-- The `input_category` associative array in the flake.lock parsing block must
-  be kept in sync with the `# CI:` comments in `flake.nix` and the mapping
-  table in this file
+- **Adding a new host** -> `nixos-add-host` skill.
+- **Adding / removing / recategorizing a flake input** ->
+  `nixos-add-flake-input` skill, which references
+  `nixos-input-category-sync`.
+- **Verifying a change before push** -> `nixos-eval-impacted-hosts`
+  skill (includes a bundled script that mirrors the CI's filter
+  exactly).
+- **Modifying CI filtering logic in `ci-linux.yaml`** -> remember the
+  `case` order rule (specific patterns before broad ones) and the
+  four-place sync invariant; load `nixos-input-category-sync`.
 
 ---
 
-## Keeping things in sync
+## What this file deliberately does NOT contain
 
-There are **three places** that define the input-to-CI-category mapping:
+The following used to live here. They were moved to skills to keep this
+file as a stable orientation document and to avoid paying the token cost
+on every turn:
 
-1. **`flake.nix`** — `# CI: <category>` comments above each input
-2. **`agents.md`** — the input-to-category mapping table (this file)
-3. **`ci-linux.yaml`** — the `input_category` bash associative array in the
-   `Detect changed paths` step
+- The full input-to-category mapping table -> `nixos-input-category-sync`.
+- The step-by-step procedures for adding hosts and inputs -> their
+  respective skills above.
+- The detailed CI job graph and filtering outcome table -> implementation
+  detail; trust the workflow itself and the impacted-hosts script.
+- The "three places to keep in sync" warning -> elevated to four places
+  (the impacted-hosts script is a fourth) in
+  `nixos-input-category-sync`.
 
-When adding or recategorizing a flake input, update all three locations.
+If you're tempted to add a long procedure back to this file, write it as
+a skill instead.

--- a/agents.md
+++ b/agents.md
@@ -114,17 +114,18 @@ unstable `nixpkgs`. CI treats changes to the `nixpkgs` input as
 These are loaded on demand by opencode when their description matches
 the task. The full bodies live under `.opencode/skills/`.
 
-| Skill                       | When it fires                                                                              |
-| --------------------------- | ------------------------------------------------------------------------------------------ |
-| `nixos-eval-impacted-hosts` | Before pushing any change. Computes impacted hosts from the diff and runs evals.           |
-| `nixos-input-category-sync` | When editing flake inputs / `flake.lock` / `ci-linux.yaml` / the impacted-hosts script.    |
-| `nixos-add-host`            | When adding a new host (server or desktop).                                                |
-| `nixos-add-flake-input`     | When adding (or removing) a flake input.                                                   |
-| `precommit-fix-loop`        | When a commit is rejected by pre-commit hooks.                                             |
-| `commit-discipline`         | Before any commit / PR.                                                                    |
-| `testing-mandate`           | Before declaring any task done.                                                            |
-| `no-summary-documents`      | Before creating any new markdown file.                                                     |
-| `markdown-lint-discipline`  | Before writing or editing any `.md` file. MD031, MD040, table widths, no emojis in tables. |
+| Skill                       | When it fires                                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `nixos-eval-impacted-hosts` | Before pushing any change. Computes impacted hosts from the diff and runs evals.                 |
+| `nixos-input-category-sync` | When editing flake inputs / `flake.lock` / `ci-linux.yaml` / the impacted-hosts script.          |
+| `nixos-add-host`            | When adding a new host (server or desktop).                                                      |
+| `nixos-add-flake-input`     | When adding (or removing) a flake input.                                                         |
+| `precommit-fix-loop`        | When a commit is rejected by pre-commit hooks.                                                   |
+| `commit-discipline`         | Before any commit / PR.                                                                          |
+| `testing-mandate`           | Before declaring any task done.                                                                  |
+| `no-summary-documents`      | Before creating any new markdown file.                                                           |
+| `markdown-lint-discipline`  | Before writing or editing any `.md` file. MD031, MD040, table widths, no emojis in tables.       |
+| `nix-best-practices`        | When editing any `.nix` file. Codifies the active strict lint stack (nixfmt + statix + deadnix). |
 
 If the skill doesn't fire automatically and you think it should, that
 means the skill description needs a stronger trigger -- fix the skill,

--- a/features/ai/opencode/default.nix
+++ b/features/ai/opencode/default.nix
@@ -8,6 +8,14 @@
 let
   cfg = config.ai.opencode;
   allUsers = [ user ] ++ extraUsers;
+
+  # Skills directory is baked into the derivation at build time. The path is
+  # resolved relative to this file (`features/ai/opencode/default.nix`) and
+  # walks back up to the repo root, then into `.opencode/skills/`. Nix copies
+  # the contents into the store, so the resulting derivation is fully
+  # self-contained -- Colmena-deployed targets do not need the source
+  # checkout (or any `~/GitHub/nixos/`) to exist on the deployed host.
+  skillsSource = ../../../.opencode/skills;
 in
 {
   options.ai.opencode = {
@@ -15,12 +23,28 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home-manager.users = lib.genAttrs allUsers (_: {
-      programs.opencode = {
-        enable = true;
-      };
+    home-manager.users = lib.genAttrs allUsers (
+      _userName: _: {
+        programs.opencode = {
+          enable = true;
+          settings = {
+            "$schema" = "https://opencode.ai/config.json";
+          };
+        };
 
-      catppuccin.opencode.enable = true;
-    });
+        # opencode auto-scans `~/.config/opencode/skills/**/SKILL.md`, so
+        # placing the baked-in skills tree there is sufficient -- no
+        # `skills.paths` entry is required. `recursive = true` mirrors the
+        # directory contents (one symlink per file) rather than symlinking
+        # the top-level directory itself, which would break opencode's
+        # ability to scan sub-folders managed alongside non-managed ones.
+        home.file.".config/opencode/skills" = {
+          source = skillsSource;
+          recursive = true;
+        };
+
+        catppuccin.opencode.enable = true;
+      }
+    );
   };
 }

--- a/features/ai/opencode/default.nix
+++ b/features/ai/opencode/default.nix
@@ -23,28 +23,26 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home-manager.users = lib.genAttrs allUsers (
-      _userName: _: {
-        programs.opencode = {
-          enable = true;
-          settings = {
-            "$schema" = "https://opencode.ai/config.json";
-          };
+    home-manager.users = lib.genAttrs allUsers (_userName: {
+      programs.opencode = {
+        enable = true;
+        settings = {
+          "$schema" = "https://opencode.ai/config.json";
         };
+      };
 
-        # opencode auto-scans `~/.config/opencode/skills/**/SKILL.md`, so
-        # placing the baked-in skills tree there is sufficient -- no
-        # `skills.paths` entry is required. `recursive = true` mirrors the
-        # directory contents (one symlink per file) rather than symlinking
-        # the top-level directory itself, which would break opencode's
-        # ability to scan sub-folders managed alongside non-managed ones.
-        home.file.".config/opencode/skills" = {
-          source = skillsSource;
-          recursive = true;
-        };
+      # opencode auto-scans `~/.config/opencode/skills/**/SKILL.md`, so
+      # placing the baked-in skills tree there is sufficient -- no
+      # `skills.paths` entry is required. `recursive = true` mirrors the
+      # directory contents (one symlink per file) rather than symlinking
+      # the top-level directory itself, which would break opencode's
+      # ability to scan sub-folders managed alongside non-managed ones.
+      home.file.".config/opencode/skills" = {
+        source = skillsSource;
+        recursive = true;
+      };
 
-        catppuccin.opencode.enable = true;
-      }
-    );
+      catppuccin.opencode.enable = true;
+    });
   };
 }

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  // Skills layout: see .opencode/skills/{shared,languages,projects}/<name>/SKILL.md
+  // The default scan picks up .opencode/skills/**/SKILL.md, so listing the path
+  // explicitly here is belt-and-braces (and serves as documentation for humans).
+  "skills": {
+    "paths": [".opencode/skills"],
+  },
+  "instructions": ["agents.md"],
+}


### PR DESCRIPTION
Introduces the opencode skills system used across fred's three repos (nixos, freminal, docker-acarshub) and wires it into per-user home-manager derivations so Colmena targets get it without needing a source checkout.

## What lands

### Commit 1 — `docs(opencode): add skills tree, project config, and agents.md index`

- `.opencode/skills/` tree organized into:
  - `shared/` — cross-repo policies (commit-discipline, precommit-fix-loop, testing-mandate, no-summary-documents, flaky-tests-are-bugs, performance-benchmarks, flake-dev-shell-discipline, markdown-lint-discipline)
  - `languages/` — per-language rules (rust-best-practices, typescript-best-practices)
  - `projects/` — nixos-specific procedures (nixos-add-host, nixos-add-flake-input, nixos-input-category-sync, nixos-eval-impacted-hosts including the bundled `scripts/impacted-hosts.sh` that mirrors CI's path filter + flake.lock input-aware parser)
- Top-level `opencode.jsonc` project config (`$schema` + `instructions: ["agents.md"]`).
- `agents.md` rewritten as a stable orientation document with a skill-index table; long procedures moved into the skills.

Only truly cross-repo and nixos-specific skills live here. Freminal- and acarshub-specific skills live in their respective project repos so external contributors cloning those repos also get them.

### Commit 2 — `feat(features/ai/opencode): bake skills into home-manager derivation`

- Replaces the previous `skillsRepoPath` option (which pointed `skills.paths` at a checkout under $HOME) with `home.file.".config/opencode/skills".source = ../../../.opencode/skills` + `recursive = true`.
- Path is resolved at evaluation time and captured as a derivation input. Colmena-deployed targets no longer require `~/GitHub/nixos/` or any source checkout for skills to load.
- `programs.opencode.settings.skills.paths` removed — opencode auto-scans `~/.config/opencode/skills/\*\*/SKILL.md` by default.

## Verification

`scripts/impacted-hosts.sh origin/main --eval` ran clean on all 9 Linux hosts (`GLOBAL` classification because `features/*` matches every host; servers don't enable the opencode module so the rebuild surface is trivial there, but the eval still passes).

Pre-commit hooks (codespell, markdownlint, prettier, nixfmt, statix, shellcheck) all green.