### PR TITLE
fix(features/common): grant fwupd-refresh user polkit access to refresh metadata

### DIFF
--- a/features/common/system/default.nix
+++ b/features/common/system/default.nix
@@ -80,6 +80,24 @@
           return polkit.Result.YES;
         }
       })
+
+      // Workaround for upstream NixOS bug: fwupd-refresh.service runs
+      // fwupdmgr as the `fwupd-refresh` user, which has no seat and
+      // therefore falls under <allow_any>auth_admin</allow_any> for the
+      // refresh polkit actions, so the unit fails with
+      // "Failed to obtain auth" on every timer fire. Upstream expects
+      // the uid to be listed under TrustedUids in fwupd.conf, but on
+      // NixOS the uid is allocated at activation time and not known
+      // during evaluation, so we grant the actions via a polkit rule
+      // keyed on the user name instead. Mirrors NixOS/nixpkgs#526476;
+      // remove this block once that lands in the channels we track.
+      polkit.addRule(function(action, subject) {
+        if ((action.id == "org.freedesktop.fwupd.get-remotes" ||
+             action.id == "org.freedesktop.fwupd.refresh-remote") &&
+            subject.user == "fwupd-refresh") {
+          return polkit.Result.YES;
+        }
+      });
     '';
   };
 }


### PR DESCRIPTION
The fwupd-refresh.service unit runs fwupdmgr as the `fwupd-refresh`
user, which has no seat. With fwupd 2.x, the metadata refresh
action falls under polkit's <allow_any>auth_admin</allow_any> rule
and fails immediately with "Failed to obtain auth" on every timer
fire:

    fwupdmgr[...]: Downloading...: 100.0%
    fwupdmgr[...]: Authenticating...: 100.0%
    fwupdmgr[...]: Failed to obtain auth
    systemd[1]: fwupd-refresh.service: Main process exited, code=exited, status=1/FAILURE

Upstream fwupd expects the uid to be listed under TrustedUids in
fwupd.conf, but on NixOS the uid is allocated at activation time
and not known during evaluation. The NixOS fix (PR NixOS/nixpkgs#526476,
opened 2026-05-31, not yet merged) is a polkit rule keyed on the
user name rather than the uid. Mirror that rule here as a local
workaround so all our hosts stop logging the recurring failure;
remove the block once the upstream PR lands in the channels we
track.
