### PR TITLE
feat(monitoring): desktops on prometheus + fwupd firmware tracking

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,21 @@
         }) agentNodes
       );
 
+      desktopNodes = builtins.filter (
+        name: self.nixosConfigurations.${name}.config.deployment.role == "desktop"
+      ) (builtins.attrNames self.nixosConfigurations);
+
+      desktopScrapeMap = builtins.listToAttrs (
+        map (name: {
+          inherit name;
+          value =
+            let
+              addr = self.nixosConfigurations.${name}.config.deployment.scrapeAddress;
+            in
+            if addr != null then addr else "${name}.local";
+        }) desktopNodes
+      );
+
       ##########################################################################
       ## Shared arguments                                                     ##
       ##                                                                      ##
@@ -279,6 +294,8 @@
           agentNodes
           agentTargets
           agentScrapeMap
+          desktopNodes
+          desktopScrapeMap
           forAllSystems
           # Channel inputs used as defaults for server nodes
           nixpkgs-stable

--- a/flake/deployment/colmena.nix
+++ b/flake/deployment/colmena.nix
@@ -19,6 +19,9 @@
 #   github_email, github_signing_key — git identity strings
 #   hmlib        — home-manager lib
 #   agentNodes, agentTargets, agentScrapeMap — monitoring topology
+#   desktopNodes, desktopScrapeMap — desktop monitoring topology (consumed by
+#     prometheus.nix on the master; harmless on agent nodes that import the
+#     same module set)
 {
   inputs,
   self,
@@ -31,6 +34,8 @@
   agentNodes,
   agentTargets,
   agentScrapeMap,
+  desktopNodes,
+  desktopScrapeMap,
   ...
 }:
 let
@@ -108,6 +113,8 @@ let
           agentNodes
           agentTargets
           agentScrapeMap
+          desktopNodes
+          desktopScrapeMap
           ;
         system = "x86_64-linux";
         isDarwin = false;

--- a/flake/lib/mk-system.nix
+++ b/flake/lib/mk-system.nix
@@ -17,6 +17,8 @@
 #   agentNodes       – list of monitoring-agent hostnames
 #   agentTargets     – list of scrape target strings
 #   agentScrapeMap   – attrset of hostname → scrape address
+#   desktopNodes     – list of desktop hostnames
+#   desktopScrapeMap – attrset of desktop hostname → scrape address
 #
 # Per-host arguments (all optional — defaults shown):
 #
@@ -44,6 +46,8 @@
   agentNodes,
   agentTargets,
   agentScrapeMap,
+  desktopNodes,
+  desktopScrapeMap,
   ...
 }:
 {
@@ -77,6 +81,8 @@ let
       agentNodes
       agentTargets
       agentScrapeMap
+      desktopNodes
+      desktopScrapeMap
       isDesktop
       catppuccinInput
       sopsNixInput

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -164,7 +164,10 @@
     // lib.optionalAttrs config.services.fwupd.enable {
       fwupd-updates-metric = {
         description = "Emit fwupd available-firmware-updates metrics";
-        # fwupd-refresh updates metadata; querying right after means fresh data.
+        # Ordering only — `after=` does NOT trigger fwupd-refresh. We rely on
+        # the upstream fwupd-refresh.timer (daily, persistent) to keep LVFS
+        # metadata current; this service simply consumes whatever metadata
+        # exists on disk when it fires (every 30 minutes).
         after = [ "fwupd-refresh.service" ];
         serviceConfig = {
           Type = "oneshot";
@@ -197,12 +200,21 @@
               echo "fwupd_updates_available{host=\"$HOST\"} $COUNT"
               echo "# HELP fwupd_device_update_info Per-device firmware update info (value is always 1; metadata in labels)."
               echo "# TYPE fwupd_device_update_info gauge"
+              # Prometheus exposition format requires label values to escape
+              # backslash, double-quote, and newline. Order matters: escape
+              # backslashes first or you'll double-escape the ones added by
+              # the quote/newline steps.
               echo "$JSON" | "$JQ" -r --arg host "$HOST" '
+                def promesc:
+                  tostring
+                  | gsub("\\\\"; "\\\\")
+                  | gsub("\""; "\\\"")
+                  | gsub("\n"; "\\n");
                 .Devices[]?
                 | select(.Releases[0]? != null)
                 | . as $d
                 | .Releases[0] as $r
-                | "fwupd_device_update_info{host=\"\($host)\",device=\"\(($d.Name // "unknown") | gsub("\""; "\\\""))\",vendor=\"\(($d.Vendor // "unknown") | gsub("\""; "\\\""))\",version_current=\"\(($d.Version // "") | gsub("\""; "\\\""))\",version_available=\"\(($r.Version // "") | gsub("\""; "\\\""))\",urgency=\"\(($r.Urgency // "unknown") | ascii_downcase)\"} 1"
+                | "fwupd_device_update_info{host=\"\($host | promesc)\",device=\"\(($d.Name // "unknown") | promesc)\",vendor=\"\(($d.Vendor // "unknown") | promesc)\",version_current=\"\(($d.Version // "") | promesc)\",version_available=\"\(($r.Version // "") | promesc)\",urgency=\"\(($r.Urgency // "unknown") | ascii_downcase | promesc)\"} 1"
               '
             } > "$TMP"
             mv "$TMP" "$OUT"

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -1,6 +1,7 @@
 {
   config,
   pkgs,
+  lib,
   inputs,
   ...
 }:
@@ -159,6 +160,55 @@
           '';
         };
       };
+    }
+    // lib.optionalAttrs config.services.fwupd.enable {
+      fwupd-updates-metric = {
+        description = "Emit fwupd available-firmware-updates metrics";
+        # fwupd-refresh updates metadata; querying right after means fresh data.
+        after = [ "fwupd-refresh.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = pkgs.writeShellScript "fwupd-updates-metric.sh" ''
+            set -u
+            FWUPDMGR=${config.services.fwupd.package}/bin/fwupdmgr
+            JQ=${pkgs.jq}/bin/jq
+            HOST="${config.networking.hostName}"
+            OUT=/var/lib/node_exporter/textfiles/fwupd_updates.prom
+            TMP="$OUT.tmp"
+
+            mkdir -p /var/lib/node_exporter/textfiles
+
+            # fwupdmgr exits non-zero when there are no updates AND when
+            # something goes wrong. Capture stdout regardless and fall back
+            # to an empty device list so the script always emits valid
+            # metrics for prometheus textfile collector consumption.
+            JSON=$("$FWUPDMGR" get-updates --json 2>/dev/null || echo '{"Devices":[]}')
+
+            # Validate JSON; treat malformed output as "no updates".
+            if ! echo "$JSON" | "$JQ" -e . >/dev/null 2>&1; then
+              JSON='{"Devices":[]}'
+            fi
+
+            COUNT=$(echo "$JSON" | "$JQ" '[.Devices[]?.Releases[0]?] | map(select(. != null)) | length')
+
+            {
+              echo "# HELP fwupd_updates_available Total firmware updates available on this host."
+              echo "# TYPE fwupd_updates_available gauge"
+              echo "fwupd_updates_available{host=\"$HOST\"} $COUNT"
+              echo "# HELP fwupd_device_update_info Per-device firmware update info (value is always 1; metadata in labels)."
+              echo "# TYPE fwupd_device_update_info gauge"
+              echo "$JSON" | "$JQ" -r --arg host "$HOST" '
+                .Devices[]?
+                | select(.Releases[0]? != null)
+                | . as $d
+                | .Releases[0] as $r
+                | "fwupd_device_update_info{host=\"\($host)\",device=\"\(($d.Name // "unknown") | gsub("\""; "\\\""))\",vendor=\"\(($d.Vendor // "unknown") | gsub("\""; "\\\""))\",version_current=\"\(($d.Version // "") | gsub("\""; "\\\""))\",version_available=\"\(($r.Version // "") | gsub("\""; "\\\""))\",urgency=\"\(($r.Urgency // "unknown") | ascii_downcase)\"} 1"
+              '
+            } > "$TMP"
+            mv "$TMP" "$OUT"
+          '';
+        };
+      };
     };
 
     timers = {
@@ -188,6 +238,15 @@
         wantedBy = [ "timers.target" ];
         timerConfig = {
           OnCalendar = "*:0/15"; # every 15 minutes
+          Persistent = true;
+        };
+      };
+    }
+    // lib.optionalAttrs config.services.fwupd.enable {
+      fwupd-updates-metric = {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          OnCalendar = "*:0/30"; # every 30 minutes — firmware changes infrequently
           Persistent = true;
         };
       };

--- a/modules/monitoring/master/alert-rules/alert-rules.yaml
+++ b/modules/monitoring/master/alert-rules/alert-rules.yaml
@@ -2,7 +2,8 @@ groups:
   - name: node-alerts
     rules:
       - alert: NodeDown
-        expr: up{job="node"} == 0
+        # Desktops sleep/shut down regularly; scope to non-desktop roles.
+        expr: up{job="node", role!="desktop"} == 0
         for: 2m
         labels:
           severity: critical
@@ -11,7 +12,7 @@ groups:
           description: "Prometheus has not scraped {{ $labels.hostname }} for 2 minutes."
 
       - alert: HighNodeCPU
-        expr: 100 - (avg by (hostname) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 70
+        expr: 100 - (avg by (hostname) (irate(node_cpu_seconds_total{mode="idle", role!="desktop"}[5m])) * 100) > 70
         for: 5m
         labels:
           severity: warning
@@ -20,7 +21,7 @@ groups:
           description: "CPU usage exceeded 70% for 5 minutes."
 
       - alert: HighNodeMemory
-        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 0.80
+        expr: (1 - (node_memory_MemAvailable_bytes{role!="desktop"} / node_memory_MemTotal_bytes{role!="desktop"})) > 0.80
         for: 5m
         labels:
           severity: warning
@@ -53,7 +54,7 @@ groups:
   - name: systemd-alerts
     rules:
       - alert: SystemdUnitFailed
-        expr: node_systemd_unit_state{state="failed", name!~"docker-.*"} == 1
+        expr: node_systemd_unit_state{state="failed", name!~"docker-.*", role!="desktop"} == 1
         for: 2m
         labels:
           severity: critical
@@ -62,7 +63,7 @@ groups:
           description: "The unit {{ $labels.name }} has been in a failed state for >2 minutes."
 
       - alert: SystemdUnitFlapping
-        expr: changes(node_systemd_unit_state{state="active", name!~"docker-.*|github-runner-runner-.*"}[10m]) > 3
+        expr: changes(node_systemd_unit_state{state="active", name!~"docker-.*|github-runner-runner-.*", role!="desktop"}[10m]) > 3
         for: 5m
         labels:
           severity: warning
@@ -111,7 +112,8 @@ groups:
   - name: system-alerts
     rules:
       - alert: PrometheusTargetDown
-        expr: sum by (job, instance) (up == 0) > 0
+        # Desktops sleep regularly; exclude their scrape targets from this alert.
+        expr: sum by (job, instance) (up{role!="desktop"} == 0) > 0
         for: 2m
         labels:
           severity: critical

--- a/modules/monitoring/master/alert-rules/firmware-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/firmware-alerts.yaml
@@ -1,0 +1,24 @@
+groups:
+  - name: firmware-alerts
+    rules:
+      - alert: FwupdUpdatesAvailable
+        # Long for: window — firmware updates appear continuously and we
+        # only want a nudge, not an immediate page.
+        expr: fwupd_updates_available > 0
+        for: 24h
+        labels:
+          severity: info
+        annotations:
+          summary: "Firmware updates available on {{ $labels.host }}"
+          description: "{{ $value }} firmware update(s) available via fwupd on {{ $labels.host }}. Run `fwupdmgr update` to apply."
+
+      - alert: FwupdCriticalUpdate
+        # Critical / high urgency firmware (per LVFS metadata) should not
+        # sit for a full day before notification.
+        expr: max by (host) (fwupd_device_update_info{urgency=~"critical|high"}) > 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Critical firmware update available on {{ $labels.host }}"
+          description: "fwupd reports at least one critical- or high-urgency firmware update on {{ $labels.host }}. Run `fwupdmgr get-updates` for details and `fwupdmgr update` to apply."

--- a/modules/monitoring/master/alert-rules/system-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/system-alerts.yaml
@@ -20,7 +20,8 @@ groups:
           description: "Host {{ $labels.host }} has pending upgrades and needs a reboot."
 
       - alert: NixOSRevisionBehind
-        expr: nixos_revision_behind == 1
+        # Desktops are updated manually on a different cadence than servers.
+        expr: nixos_revision_behind{role!="desktop"} == 1
         for: 6h
         labels:
           severity: warning

--- a/modules/monitoring/master/dashboards/fleet-overview.json
+++ b/modules/monitoring/master/dashboards/fleet-overview.json
@@ -31,7 +31,7 @@
       "type": "stat",
       "title": "Nodes Up",
       "description": "Number of nodes currently reachable by Prometheus",
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -74,7 +74,7 @@
       "type": "stat",
       "title": "Nodes Down",
       "description": "Number of nodes not reachable by Prometheus",
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -111,7 +111,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "count(up{job=\"node\"} == 0) or vector(0)",
+          "expr": "count(up{job=\"node\", role!=\"desktop\"} == 0) or vector(0)",
           "legendFormat": "Down",
           "instant": true
         }
@@ -122,7 +122,7 @@
       "type": "stat",
       "title": "Nodes Needing Reboot",
       "description": "Nodes with /run/reboot-required present",
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -170,7 +170,7 @@
       "type": "stat",
       "title": "Nodes Behind Main",
       "description": "Nodes whose deployed commit is behind GitHub main",
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -207,7 +207,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "count(nixos_revision_behind == 1) or vector(0)",
+          "expr": "count(nixos_revision_behind{role!=\"desktop\"} == 1) or vector(0)",
           "legendFormat": "Behind",
           "instant": true
         }
@@ -218,7 +218,7 @@
       "type": "stat",
       "title": "Failed Systemd Units",
       "description": "Total count of failed systemd units across all nodes",
-      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -255,7 +255,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "count(node_systemd_unit_state{state=\"failed\"} == 1) or vector(0)",
+          "expr": "count(node_systemd_unit_state{state=\"failed\", role!=\"desktop\"} == 1) or vector(0)",
           "legendFormat": "Failed Units",
           "instant": true
         }
@@ -266,7 +266,7 @@
       "type": "stat",
       "title": "Active Alerts",
       "description": "Number of currently firing Alertmanager alerts",
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -305,6 +305,102 @@
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
           "expr": "count(ALERTS{alertstate=\"firing\"}) or vector(0)",
           "legendFormat": "Firing",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Firmware Updates",
+      "description": "Total firmware updates available across the fleet (fwupd)",
+      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "0": { "text": "None", "color": "green" } }
+            }
+          ],
+          "unit": "none",
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "sum(fwupd_updates_available) or vector(0)",
+          "legendFormat": "Updates",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Critical Firmware",
+      "description": "Devices with critical- or high-urgency firmware updates pending",
+      "gridPos": { "h": 4, "w": 3, "x": 21, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "0": { "text": "None", "color": "green" } }
+            }
+          ],
+          "unit": "none",
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "count(fwupd_device_update_info{urgency=~\"critical|high\"}) or vector(0)",
+          "legendFormat": "Critical",
           "instant": true
         }
       ]
@@ -857,17 +953,163 @@
       ]
     },
     {
+      "id": 35,
+      "type": "row",
+      "title": "Pending Firmware Updates",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 }
+    },
+    {
+      "id": 36,
+      "type": "table",
+      "title": "Firmware Updates by Device",
+      "description": "Devices across the fleet with firmware updates available (fwupd). Run `fwupdmgr update` on the affected host to apply.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": { "show": false, "reducer": ["sum"], "fields": "" },
+        "frameIndex": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "transparent", "value": null }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "host" },
+            "properties": [{ "id": "custom.width", "value": 140 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "device" },
+            "properties": [{ "id": "custom.width", "value": 280 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "vendor" },
+            "properties": [{ "id": "custom.width", "value": 140 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "version_current" },
+            "properties": [
+              { "id": "displayName", "value": "Current" },
+              { "id": "custom.width", "value": 140 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "version_available" },
+            "properties": [
+              { "id": "displayName", "value": "Available" },
+              { "id": "custom.width", "value": 140 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "urgency" },
+            "properties": [
+              { "id": "custom.width", "value": 100 },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": { "critical": { "color": "red" } }
+                  },
+                  {
+                    "type": "value",
+                    "options": { "high": { "color": "orange" } }
+                  },
+                  {
+                    "type": "value",
+                    "options": { "medium": { "color": "yellow" } }
+                  },
+                  {
+                    "type": "value",
+                    "options": { "low": { "color": "green" } }
+                  }
+                ]
+              },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Time" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "__name__" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "job" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "instance" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "hostname" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "role" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "exporter" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "host": 0,
+              "device": 1,
+              "vendor": 2,
+              "version_current": 3,
+              "version_available": 4,
+              "urgency": 5
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "fwupd_device_update_info",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
       "id": 40,
       "type": "row",
       "title": "Resource Trends",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 }
     },
     {
       "id": 41,
       "type": "timeseries",
       "title": "CPU Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -913,7 +1155,7 @@
       "id": 42,
       "type": "timeseries",
       "title": "Memory Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -959,7 +1201,7 @@
       "id": 43,
       "type": "timeseries",
       "title": "Network Receive — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 39 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -996,7 +1238,7 @@
       "id": 44,
       "type": "timeseries",
       "title": "Network Transmit — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 39 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1033,7 +1275,7 @@
       "id": 45,
       "type": "timeseries",
       "title": "System Load (1m) — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 47 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1070,7 +1312,7 @@
       "id": 46,
       "type": "timeseries",
       "title": "Root Disk Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 47 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 56 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -3,11 +3,14 @@
   pkgs,
   agentNodes,
   agentScrapeMap,
+  desktopNodes,
+  desktopScrapeMap,
   user,
   ...
 }:
 let
   agentHosts = agentNodes;
+  desktopHosts = desktopNodes;
 
 in
 {
@@ -198,6 +201,14 @@ in
                 exporter = "node";
               };
             }) agentHosts)
+            ++ (map (h: {
+              targets = [ "${desktopScrapeMap.${h}}:9100" ];
+              labels = {
+                hostname = h;
+                role = "desktop";
+                exporter = "node";
+              };
+            }) desktopHosts)
             ++ [
               {
                 targets = [ "sdrhub.local:9100" ];

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -151,6 +151,7 @@ in
       ruleFiles = [
         ./alert-rules/alert-rules.yaml
         ./alert-rules/docker-rules.yaml
+        ./alert-rules/firmware-alerts.yaml
         ./alert-rules/system-alerts.yaml
         ./alert-rules/sdr-alerts.yaml
       ];

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -13,6 +13,11 @@
     ../modules/secrets/sops.nix
     ../modules/data/nas-mounts.nix
     ../modules/data/wifi-networks.nix
+    # Monitoring: node_exporter only. cadvisor (Docker container metrics)
+    # and alloy (log shipping) are deliberately not pulled in — desktops
+    # don't run the same container fleet and log shipping is out of scope
+    # for this profile.
+    ../modules/monitoring/agent/node_exporter.nix
   ];
 
   options.profile.desktop = {


### PR DESCRIPTION
Brings desktops (Daytona, maranello) into Prometheus monitoring without generating sleep/shutdown false positives, and adds end-to-end firmware-update tracking via fwupd for the whole fleet.

## Commits (in order)

1. **`refactor(monitoring/alerts): scope server-only alerts with role!="desktop"`** — pure refactor; adds `role!="desktop"` to NodeDown, PrometheusTargetDown, SystemdUnitFailed/Flapping, HighNodeCPU, HighNodeMemory, NixOSRevisionBehind. No metric currently carries `role="desktop"` so behavior is unchanged until commit 2 lands. Fleet-wide alerts kept: NodeDiskLow, NodeDiskWarning, NodeInodesLow, ClockSkewDetected, NixOSNeedsReboot.

2. **`feat(monitoring): extend prometheus scraping to desktops`** — adds `desktopNodes` / `desktopScrapeMap` derivations to `flake.nix` (filter on `deployment.role == "desktop"`), threads them through `flake/lib/mk-system.nix` and `flake/deployment/colmena.nix`, adds a desktop static_configs block to the `node` job in `prometheus.nix` carrying `role="desktop"`. `profiles/desktop.nix` imports `modules/monitoring/agent/node_exporter.nix` directly — NOT the full agent default (cadvisor and alloy are out of scope).

3. **`feat(monitoring): emit fwupd update metrics and alert on them`** — adds `fwupd-updates-metric` oneshot + 30min timer, both gated on `config.services.fwupd.enable`. Reads `fwupdmgr get-updates --json` and emits:
   - `fwupd_updates_available{host}` — gauge, total update count.
   - `fwupd_device_update_info{host,device,vendor,version_current,version_available,urgency}` — gauge=1 per updatable device.

   New `firmware-alerts.yaml`:
   - `FwupdUpdatesAvailable` (info, for=24h) on any pending update.
   - `FwupdCriticalUpdate` (warning, for=1h) on critical/high LVFS urgency.

4. **`feat(monitoring/dashboard): add firmware updates to fleet overview`** — top stats row reshaped from 6×w=4 to 8×w=3; adds `Firmware Updates` + `Critical Firmware` stat panels. Scopes `Nodes Down`, `Nodes Behind Main`, `Failed Systemd Units` to `role!="desktop"` (kept fleet-wide: `Nodes Up`, `Nodes Needing Reboot`, `Active Alerts`). New `Pending Firmware Updates` row + per-device table (host / device / vendor / current / available / urgency, color-coded). Resource Trends shifted +9 in y.

## Verification

- `promtool check rules` — both alert files pass.
- `nix eval` on all 9 hosts (`Daytona`, `acarshub`, `fredhub`, `fredvps`, `hfdlhub1`, `hfdlhub2`, `maranello`, `sdrhub`, `vdlmhub`) — green.
- Deployed to sdrhub locally; manually fired the timer; the device table populated with three Microsoft UEFI dbx/CA refreshes via LVFS. Pipeline works end-to-end.

## Deliberately out of scope

- Alloy (log shipping) on desktops.
- Cadvisor on desktops.
- "Type" (server/desktop) column on the Node Deployment Status table — needs a join transformation, trivial follow-up.
- Pushgateway-based scrape model for truly off-LAN hosts — only needed if `maranello.local` resolution turns out to be too unreliable in practice.