### PR TITLE
chore(flake/sops-nix-stable): `c591bf66` -> `9ed65852`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1850,11 +1850,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                        |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`81440e37`](https://github.com/Mic92/sops-nix/commit/81440e3757629e381f8c13c231f2df9911e44e59) | `` sops-install-secrets: call systemctl directly when run as a systemd unit `` |