### PR TITLE
chore(flake/catppuccin): `9f015db9` -> `fd265813`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780394337,
-        "narHash": "sha256-qsiTng/LjFuxN5SNKIKhUWqFFbpvdpnYqRj2F7inK3k=",
+        "lastModified": 1780650205,
+        "narHash": "sha256-FYgqDufUWHbY+ne5z/OTBUCCeLGPJ5sA6d+Fa5aKKxo=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "9f015db982efc83ae1eb0074960e812ee386f3bb",
+        "rev": "fd265813d18cc39bc0d27750c47a09766a535162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`fd265813`](https://github.com/catppuccin/nix/commit/fd265813d18cc39bc0d27750c47a09766a535162) | `` chore: update port sources (#973) `` |
| [`26499acc`](https://github.com/catppuccin/nix/commit/26499acc530aa989e5d174b4343e08e7254326a9) | `` chore: update flakes (#972) ``       |