### PR TITLE
chore(flake/nixvim): `b7521616` -> `816a1528`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1480,11 +1480,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1780421606,
-        "narHash": "sha256-ZRAMRXQE1UKBtpnPwwOqV8teaPDD/fdABvUXMjcyhow=",
+        "lastModified": 1780646548,
+        "narHash": "sha256-Ckyl/l1XBmEwnaHcHD8PvBZk1uph0NqwbJ//CAvB7iE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b7521616f15ad73c6bec458d64ed7f06f4095edb",
+        "rev": "816a15282e58678dde831477964987d0262d4293",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`816a1528`](https://github.com/nix-community/nixvim/commit/816a15282e58678dde831477964987d0262d4293) | `` tests/all-package-defaults: combine darwin + aarch64-darwin `` |
| [`0292e9a8`](https://github.com/nix-community/nixvim/commit/0292e9a8c8857b99d0ac89cb1221828592110aa2) | `` tests: stop handling x86_64-darwin ``                          |
| [`99ae1779`](https://github.com/nix-community/nixvim/commit/99ae17797ffc1ed28fb2c5b13f2eaeb300940832) | `` readme: drop x86_64-darwin ``                                  |
| [`cf8a487c`](https://github.com/nix-community/nixvim/commit/cf8a487ce058e1d8aba192ed10791cf0781a178f) | `` templates: drop x86_64-darwin ``                               |