### PR TITLE
chore(flake/home-manager): `f384af1b` -> `e621f12c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780408569,
-        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
+        "lastModified": 1780677568,
+        "narHash": "sha256-67R59A2ul8FM9pfslpdQfxfnS2kWTrdgldxGiXSFNMg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
+        "rev": "e621f12c02b7193240540c9f760c75f4ac2dc199",
         "type": "github"
       },
       "original": {

--- a/modules/base/home.nix
+++ b/modules/base/home.nix
@@ -48,6 +48,8 @@ in
   }
   // lib.optionalAttrs (options.catppuccin ? autoEnable) {
     autoEnable = true;
+    # Prevent warning from home-manager option rename until catppuccin catches up
+    gemini-cli.enable = false;
   };
 
   ##########################################################################


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`e621f12c`](https://github.com/nix-community/home-manager/commit/e621f12c02b7193240540c9f760c75f4ac2dc199) | `` pi-coding-agent: use lib.hm.strings.isPathLike ``             |
| [`c321a1c8`](https://github.com/nix-community/home-manager/commit/c321a1c8a7ef15fce4314c247ba8ff9c5408d85d) | `` opencode: use lib.hm.strings.isPathLike ``                    |
| [`6d4fb02e`](https://github.com/nix-community/home-manager/commit/6d4fb02e3406c4076444586cb79159d10fc72e4a) | `` github-copilot-cli: use lib.hm.strings.isPathLike ``          |
| [`4b9a9955`](https://github.com/nix-community/home-manager/commit/4b9a9955195db1f7e0069e2f3baf359e35910d03) | `` codex: use lib.hm.strings.isPathLike ``                       |
| [`09ff165b`](https://github.com/nix-community/home-manager/commit/09ff165ba6ed95c85be9dba95c8d638289686fa2) | `` claude-code: use lib.hm.strings.isPathLike ``                 |
| [`3a647b15`](https://github.com/nix-community/home-manager/commit/3a647b158e69895f4f7f1194175db07bc2798bdf) | `` antigravity-cli: use lib.hm.strings.isPathLike ``             |
| [`d33c97ec`](https://github.com/nix-community/home-manager/commit/d33c97ec1b3f26d6a2d4d6ec0246af48a1a2259d) | `` lib/strings: add isPathLike helper ``                         |
| [`eaca478c`](https://github.com/nix-community/home-manager/commit/eaca478c9505aeafadccf5f4621f56f3a9dd7e56) | `` antigravity-cli: add migration news ``                        |
| [`ff77a72f`](https://github.com/nix-community/home-manager/commit/ff77a72fe5fbfd5767bef332b996aba8965db824) | `` antigravity-cli: rename gemini-cli module ``                  |
| [`04505748`](https://github.com/nix-community/home-manager/commit/0450574818af22e3090f52d10e9bd76440ac428f) | `` flake: gate development outputs to supported systems ``       |
| [`37e8eef9`](https://github.com/nix-community/home-manager/commit/37e8eef933c68a4ca58e351b2ae31fb9f6631535) | `` pi-coding-agent: add module ``                                |
| [`5fadbec0`](https://github.com/nix-community/home-manager/commit/5fadbec07a5cb4c4d58fa2ff0263f620151e8b84) | `` maintainers: add semi710 ``                                   |
| [`447fd9ff`](https://github.com/nix-community/home-manager/commit/447fd9ff62501dae7206dfe180ee89f8de27b7d5) | `` sshAuthSock: add news entry ``                                |
| [`f1d5aa6f`](https://github.com/nix-community/home-manager/commit/f1d5aa6f690b46440ce3b36b0d50ae984e82c82e) | `` sshAuthSock: set in systemd ``                                |
| [`f4534a4f`](https://github.com/nix-community/home-manager/commit/f4534a4f3cc20e663b2a8c5814044f12013f7c19) | `` sshAuthSock: add option for initialization in Zsh ``          |
| [`efe95f11`](https://github.com/nix-community/home-manager/commit/efe95f113aac9923bbc9f0f9cf1174399c17ab8b) | `` sshAuthSock: use enable flag instead of nullable submodule `` |
| [`dc641330`](https://github.com/nix-community/home-manager/commit/dc641330e236cd2f6f4a8b7634468045d35898c2) | `` infat: use deprecation warning helper ``                      |
| [`18b4e1ea`](https://github.com/nix-community/home-manager/commit/18b4e1ea6f1655b3b3fb7625893fa500b51e1d33) | `` xdg-user-dirs: assert extraConfig key warning ``              |
| [`6459fc4a`](https://github.com/nix-community/home-manager/commit/6459fc4aeec03f4cd1d89288dc4e14221a3674c6) | `` firefox: assert bookmarks migration warning ``                |
| [`6a6941ad`](https://github.com/nix-community/home-manager/commit/6a6941ad20b7d5836a7dc9418dd62b907f02a2ea) | `` hyprpanel: assert theme name warning ``                       |
| [`c81a3d23`](https://github.com/nix-community/home-manager/commit/c81a3d2383a9bfdc0cd07f3d973100012ebefad3) | `` helix: assert languages migration warning ``                  |
| [`9a638c14`](https://github.com/nix-community/home-manager/commit/9a638c1442a2e547887eba55522f24aa252942c2) | `` swayidle: assert events migration warning ``                  |
| [`ff53fe10`](https://github.com/nix-community/home-manager/commit/ff53fe10e02b2d48304a7cf42ae1b8fb6be67c71) | `` qt: assert kde6 migration warning ``                          |
| [`5ded124f`](https://github.com/nix-community/home-manager/commit/5ded124f913d27a605fc873551ab492c98e623d5) | `` lib: add deprecated option warning helpers ``                 |
| [`4c5c1e8b`](https://github.com/nix-community/home-manager/commit/4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974) | `` alacritty: fix toml escape generation ``                      |