### PR TITLE
chore(flake/nixpkgs-stable): `b51242d7` -> `6b316287`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1283,11 +1283,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1780203844,
-        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`ece683ec`](https://github.com/NixOS/nixpkgs/commit/ece683ec07214fb323ef2c9a4eb99816f321a2b0) | `` vicinae: 0.21.0 -> 0.21.3 ``                                                            |
| [`05fecb97`](https://github.com/NixOS/nixpkgs/commit/05fecb979e269f185a5de2f9380668f26c91ae54) | `` hash_extender: add Darwin to badPlatforms ``                                            |
| [`e39c90c0`](https://github.com/NixOS/nixpkgs/commit/e39c90c011832c3c30897ea200172859b9425703) | `` linux_xanmod_latest: 7.0.10 -> 7.0.11 ``                                                |
| [`b45852b8`](https://github.com/NixOS/nixpkgs/commit/b45852b8b16eda6f6bf027afdc3846817dbe8a44) | `` linux_xanmod: 6.18.33 -> 6.18.34 ``                                                     |
| [`52c23579`](https://github.com/NixOS/nixpkgs/commit/52c2357987b58ef39b5176f688fba2d146f8b6cc) | `` google-chrome: 148.0.7778.215 -> 149.0.7827.53 ``                                       |
| [`0a993720`](https://github.com/NixOS/nixpkgs/commit/0a9937204aa7e7b4faa3b2066e9eb97f96db9088) | `` fastcdr: 2.3.5 -> 2.3.6 ``                                                              |
| [`efbecb04`](https://github.com/NixOS/nixpkgs/commit/efbecb049efee52f0b276729d22033a6e2c7265b) | `` python315: 3.15.0b1 -> 3.15.0b2 ``                                                      |
| [`29981659`](https://github.com/NixOS/nixpkgs/commit/29981659bf7fbd0fdb996c87e48fa359a3f296cb) | `` nixos/tests/incus: pass package to releases config ``                                   |
| [`9393bd44`](https://github.com/NixOS/nixpkgs/commit/9393bd4441dac933de9b8ad5aa49261ac692d271) | `` ns-3: 44 -> 47 ``                                                                       |
| [`b5c2ef75`](https://github.com/NixOS/nixpkgs/commit/b5c2ef75eaa9e711e7d814c304eec381c74a737c) | `` kubelogin-oidc: 1.36.1 -> 1.36.2 ``                                                     |
| [`d0c19cb7`](https://github.com/NixOS/nixpkgs/commit/d0c19cb7b74f99815d0903b1528b143c709110ac) | `` firefox-bin-unwrapped: 151.0.2 -> 151.0.3 ``                                            |
| [`edfc89ad`](https://github.com/NixOS/nixpkgs/commit/edfc89ad0aa120d9f80a22d6fb7e94ca568ab210) | `` firefox-unwrapped: 151.0.2 -> 151.0.3 ``                                                |
| [`9e10ad7a`](https://github.com/NixOS/nixpkgs/commit/9e10ad7a0872cf438cf77ae7e6df35e6c59d6016) | `` mpvScripts.videoclip: 0.2-unstable-2026-01-22 -> 0.2-unstable-2026-05-31 ``             |
| [`d7a741fb`](https://github.com/NixOS/nixpkgs/commit/d7a741fbf709b5e156ec5754b93ef89ff24d4d48) | `` ryzenadj: 0.17.0 -> 0.19.0 ``                                                           |
| [`0589efee`](https://github.com/NixOS/nixpkgs/commit/0589efee207b1ece33a342b43e8e24abadd0d83a) | `` maintainers: add peterwaller-arm ``                                                     |
| [`fa0382ec`](https://github.com/NixOS/nixpkgs/commit/fa0382eccd2a9b4c1fea5c1c8338d458540affb5) | `` ios-deploy: fix build ``                                                                |
| [`8a7ee952`](https://github.com/NixOS/nixpkgs/commit/8a7ee9521f197df18ba1ab3445546f6d0b33aea0) | `` tail-tray: 0.2.32 -> 0.2.33 ``                                                          |
| [`1c4ea412`](https://github.com/NixOS/nixpkgs/commit/1c4ea4129ceba59b2076bd9e080f2212a485a792) | `` nixos/tests/flap-alerted: init ``                                                       |
| [`5f80d2e1`](https://github.com/NixOS/nixpkgs/commit/5f80d2e172f5b90c71dcf013d1eebcffda055e64) | `` nixos/flap-alerted: init module ``                                                      |
| [`d91c0ffa`](https://github.com/NixOS/nixpkgs/commit/d91c0ffa10a1a87cd2a018999b01e28326caa633) | `` flap-alerted: init at 4.5.0 ``                                                          |
| [`eb412eeb`](https://github.com/NixOS/nixpkgs/commit/eb412eeb5c7cd1561ee943c9ab2c6e23066f925d) | `` radicle-ci-broker: 0.28.0 -> 0.28.1 ``                                                  |
| [`ece683ec`](https://github.com/NixOS/nixpkgs/commit/ece683ec07214fb323ef2c9a4eb99816f321a2b0) | `` vicinae: 0.21.0 -> 0.21.3 ``                                                            |
| [`05fecb97`](https://github.com/NixOS/nixpkgs/commit/05fecb979e269f185a5de2f9380668f26c91ae54) | `` hash_extender: add Darwin to badPlatforms ``                                            |
| [`e39c90c0`](https://github.com/NixOS/nixpkgs/commit/e39c90c011832c3c30897ea200172859b9425703) | `` linux_xanmod_latest: 7.0.10 -> 7.0.11 ``                                                |
| [`b45852b8`](https://github.com/NixOS/nixpkgs/commit/b45852b8b16eda6f6bf027afdc3846817dbe8a44) | `` linux_xanmod: 6.18.33 -> 6.18.34 ``                                                     |
| [`52c23579`](https://github.com/NixOS/nixpkgs/commit/52c2357987b58ef39b5176f688fba2d146f8b6cc) | `` google-chrome: 148.0.7778.215 -> 149.0.7827.53 ``                                       |
| [`0a993720`](https://github.com/NixOS/nixpkgs/commit/0a9937204aa7e7b4faa3b2066e9eb97f96db9088) | `` fastcdr: 2.3.5 -> 2.3.6 ``                                                              |
| [`efbecb04`](https://github.com/NixOS/nixpkgs/commit/efbecb049efee52f0b276729d22033a6e2c7265b) | `` python315: 3.15.0b1 -> 3.15.0b2 ``                                                      |
| [`29981659`](https://github.com/NixOS/nixpkgs/commit/29981659bf7fbd0fdb996c87e48fa359a3f296cb) | `` nixos/tests/incus: pass package to releases config ``                                   |
| [`9393bd44`](https://github.com/NixOS/nixpkgs/commit/9393bd4441dac933de9b8ad5aa49261ac692d271) | `` ns-3: 44 -> 47 ``                                                                       |
| [`b5c2ef75`](https://github.com/NixOS/nixpkgs/commit/b5c2ef75eaa9e711e7d814c304eec381c74a737c) | `` kubelogin-oidc: 1.36.1 -> 1.36.2 ``                                                     |
| [`d0c19cb7`](https://github.com/NixOS/nixpkgs/commit/d0c19cb7b74f99815d0903b1528b143c709110ac) | `` firefox-bin-unwrapped: 151.0.2 -> 151.0.3 ``                                            |
| [`edfc89ad`](https://github.com/NixOS/nixpkgs/commit/edfc89ad0aa120d9f80a22d6fb7e94ca568ab210) | `` firefox-unwrapped: 151.0.2 -> 151.0.3 ``                                                |
| [`9e10ad7a`](https://github.com/NixOS/nixpkgs/commit/9e10ad7a0872cf438cf77ae7e6df35e6c59d6016) | `` mpvScripts.videoclip: 0.2-unstable-2026-01-22 -> 0.2-unstable-2026-05-31 ``             |
| [`d7a741fb`](https://github.com/NixOS/nixpkgs/commit/d7a741fbf709b5e156ec5754b93ef89ff24d4d48) | `` ryzenadj: 0.17.0 -> 0.19.0 ``                                                           |
| [`0589efee`](https://github.com/NixOS/nixpkgs/commit/0589efee207b1ece33a342b43e8e24abadd0d83a) | `` maintainers: add peterwaller-arm ``                                                     |
| [`fa0382ec`](https://github.com/NixOS/nixpkgs/commit/fa0382eccd2a9b4c1fea5c1c8338d458540affb5) | `` ios-deploy: fix build ``                                                                |
| [`8a7ee952`](https://github.com/NixOS/nixpkgs/commit/8a7ee9521f197df18ba1ab3445546f6d0b33aea0) | `` tail-tray: 0.2.32 -> 0.2.33 ``                                                          |
| [`1c4ea412`](https://github.com/NixOS/nixpkgs/commit/1c4ea4129ceba59b2076bd9e080f2212a485a792) | `` nixos/tests/flap-alerted: init ``                                                       |
| [`5f80d2e1`](https://github.com/NixOS/nixpkgs/commit/5f80d2e172f5b90c71dcf013d1eebcffda055e64) | `` nixos/flap-alerted: init module ``                                                      |
| [`d91c0ffa`](https://github.com/NixOS/nixpkgs/commit/d91c0ffa10a1a87cd2a018999b01e28326caa633) | `` flap-alerted: init at 4.5.0 ``                                                          |
| [`eb412eeb`](https://github.com/NixOS/nixpkgs/commit/eb412eeb5c7cd1561ee943c9ab2c6e23066f925d) | `` radicle-ci-broker: 0.28.0 -> 0.28.1 ``                                                  |
| [`ba247e29`](https://github.com/NixOS/nixpkgs/commit/ba247e293c60314221b534a360ca0e7003686850) | `` nixos/gdm: ensure environment from display-manager.service is propagated ``             |
| [`b48bc864`](https://github.com/NixOS/nixpkgs/commit/b48bc864539bfac9d8ef775d38373a4f2ba6c371) | `` cudaPackages_13_3: init at 13.3.0 ``                                                    |
| [`7a650673`](https://github.com/NixOS/nixpkgs/commit/7a6506737109a1d14516a5ebbb36d12146113e61) | `` ocamlPackages: remove legacy uses of dune_3 ``                                          |
| [`30430930`](https://github.com/NixOS/nixpkgs/commit/30430930265645babac6340d1c4143405cedcbb0) | `` recordbox: 0.10.4 -> 0.11.0 ``                                                          |
| [`3b18e631`](https://github.com/NixOS/nixpkgs/commit/3b18e631220768e8d6d50a80a26ed7a84183f247) | `` python3Packages.biopandas: fix numpy 2.4 compatibility ``                               |
| [`18c47325`](https://github.com/NixOS/nixpkgs/commit/18c47325a5cb341b44d9dd488d3b7455b0c8e67b) | `` rhvoice: 1.16.5 -> 1.18.4 ``                                                            |
| [`55da7a16`](https://github.com/NixOS/nixpkgs/commit/55da7a162f568a89e5f99c4d6ef4fd0aa00af6b0) | `` journalist: fix malformed vendorHash (stray trailing "s") ``                            |
| [`ed34b89f`](https://github.com/NixOS/nixpkgs/commit/ed34b89feed1e1acf824a40b245c8d49c668990a) | `` xwayland: 24.1.11 -> 24.1.12 ``                                                         |
| [`5dcb31c1`](https://github.com/NixOS/nixpkgs/commit/5dcb31c19ac763901c0689db9254e3045030ff57) | `` stellar-core: fix PostgreSQL check on Hydra ``                                          |
| [`4716df91`](https://github.com/NixOS/nixpkgs/commit/4716df9133f411a149d6f5beb31087c6deafcfc4) | `` _1password-gui: Upstream repackaged without changing versions, again ``                 |
| [`efd96768`](https://github.com/NixOS/nixpkgs/commit/efd96768420de69560a84881a4c382c308a5c4d8) | `` linuxPackages.vhba: 20250329 -> 20260313 ``                                             |
| [`f0917694`](https://github.com/NixOS/nixpkgs/commit/f091769423ff8fc8ce8297921a8f4d1bca7076fa) | `` Revert "microsoft-edge: fix CJK fonts by default" ``                                    |
| [`d7894cd9`](https://github.com/NixOS/nixpkgs/commit/d7894cd92ed96ec1dae2210c2a6c3d04f66bc74a) | `` Revert "google-chrome: fix CJK fonts by default" ``                                     |
| [`d8805b05`](https://github.com/NixOS/nixpkgs/commit/d8805b05b63392afe9d97030e7bf9a17f71475ec) | `` nixos/fonts: add Noto CJK to default fonts ``                                           |
| [`787fbc7d`](https://github.com/NixOS/nixpkgs/commit/787fbc7da1f55f92ffaec5cd0d49a1adadeb5bfd) | `` nixos/lxcfs: fuse -> fuse3 ``                                                           |
| [`5128aded`](https://github.com/NixOS/nixpkgs/commit/5128aded5eb22a75003000ceaa13476e628a13bd) | `` linux_5_10: 5.10.257 -> 5.10.258 ``                                                     |
| [`b05b39ea`](https://github.com/NixOS/nixpkgs/commit/b05b39eac970d828c0471792938c34569a76fe42) | `` linux_5_15: 5.15.208 -> 5.15.209 ``                                                     |
| [`bf1b218f`](https://github.com/NixOS/nixpkgs/commit/bf1b218f268654e0d99d7790f967233a13d72774) | `` linux_6_1: 6.1.174 -> 6.1.175 ``                                                        |
| [`ea955419`](https://github.com/NixOS/nixpkgs/commit/ea9554192b1ad067d3681164081a2d7d61b85f13) | `` linux_6_6: 6.6.141 -> 6.6.142 ``                                                        |
| [`0b3de77c`](https://github.com/NixOS/nixpkgs/commit/0b3de77cbe824bb5d2ec3509d24ace640bbf6325) | `` linux_6_12: 6.12.91 -> 6.12.92 ``                                                       |
| [`37dbe866`](https://github.com/NixOS/nixpkgs/commit/37dbe8663f6051367aabb43e2d0349692b6eb238) | `` linux_6_18: 6.18.33 -> 6.18.34 ``                                                       |
| [`7a72d385`](https://github.com/NixOS/nixpkgs/commit/7a72d38546c4842b650fbdf14c05191e5f904786) | `` linux_7_0: 7.0.10 -> 7.0.11 ``                                                          |
| [`e3c5cb38`](https://github.com/NixOS/nixpkgs/commit/e3c5cb38e38017e3951e061ed7b1c577ec1393e0) | `` linux_testing: 7.1-rc4 -> 7.1-rc6 ``                                                    |
| [`4149ca64`](https://github.com/NixOS/nixpkgs/commit/4149ca644fe54e61da54c7567b1964e497cab683) | `` gearboy: 3.8.4 -> 3.8.6 ``                                                              |
| [`57026768`](https://github.com/NixOS/nixpkgs/commit/57026768d3015eed54dba0181953e76308101027) | `` kstars: 3.8.2 -> 3.8.3 ``                                                               |
| [`27c8b5b1`](https://github.com/NixOS/nixpkgs/commit/27c8b5b13e997b0b13121f0574ae9d820f52de5b) | `` {cri-o,cri-o-unwrapped}: move to by-name ``                                             |
| [`fb4f51c5`](https://github.com/NixOS/nixpkgs/commit/fb4f51c5dc757457d5542218909dd41e29ecb83b) | `` onioncircuits: add missing dependency ``                                                |
| [`0d26947f`](https://github.com/NixOS/nixpkgs/commit/0d26947f311018e79d8178239d63227776714352) | `` maintainers/github-teams.json: Automated sync ``                                        |
| [`499525fa`](https://github.com/NixOS/nixpkgs/commit/499525fa30674a6d10aca636cb03870895526117) | `` firefox-gnome-theme: 149.1 -> 150 ``                                                    |
| [`bb963a16`](https://github.com/NixOS/nixpkgs/commit/bb963a164760daf65ea852870bba3cf9feafc075) | `` open-vm-tools: fix strictDeps inputs ``                                                 |
| [`61aa0b00`](https://github.com/NixOS/nixpkgs/commit/61aa0b00f7caf0918a3bae93251f356e0a066e47) | `` heroic: add `extraEnv` input ``                                                         |
| [`ba488fa7`](https://github.com/NixOS/nixpkgs/commit/ba488fa7957e6815be9197d260655ec19ed9cfe6) | `` hol_light: unstable-2024-07-07 -> 0-unstable-2026-05-19 ``                              |
| [`ada314f0`](https://github.com/NixOS/nixpkgs/commit/ada314f04a1a002646a2d2ece67076299bdc3605) | `` camlp5: propagate findlib deps pcre2 and fmt ``                                         |
| [`49b60a6c`](https://github.com/NixOS/nixpkgs/commit/49b60a6c47f4f68dff96b5d5d88e805e8906180c) | `` glaze: 7.7.0 -> 7.7.1 ``                                                                |
| [`8f5a4edd`](https://github.com/NixOS/nixpkgs/commit/8f5a4edd5fca37fea04d7bfbb6a4baf543ff95a6) | `` jitterentropy-rngd: add configurable memlock limit ``                                   |
| [`b2dc7abf`](https://github.com/NixOS/nixpkgs/commit/b2dc7abf5940fd340fbb8d11e28709e369c8951d) | `` jitterentropy-rngd: fix systemd service to allow mlock and restict mlockall ``          |
| [`8b751704`](https://github.com/NixOS/nixpkgs/commit/8b751704ea80266192e33470b886187c0517bd6e) | `` tor: 0.4.9.8 -> 0.4.9.9 ``                                                              |
| [`b57605d1`](https://github.com/NixOS/nixpkgs/commit/b57605d1f88349c1cd4825d7c3d83bc930af80e2) | `` kdePackages.kdenlive: add missing qtimageformats dependency ``                          |
| [`03f5ddcf`](https://github.com/NixOS/nixpkgs/commit/03f5ddcf71124440b4fb85e86b7207c5420104f0) | `` phpantom-lsp: 0.7.0 -> 0.8.0 ``                                                         |
| [`b35b60c9`](https://github.com/NixOS/nixpkgs/commit/b35b60c93762f5db82638e20ff11ef5d090aca3c) | `` nixos/iso-image: update comment to reflect systemd and scripted initrd paths ``         |
| [`1b5c71ff`](https://github.com/NixOS/nixpkgs/commit/1b5c71fffe8550c10a52df922a98c8b449968377) | `` doc/rl-2605: document `/dev/root` unavailability with systemd stage 1 ``                |
| [`d6c86d32`](https://github.com/NixOS/nixpkgs/commit/d6c86d3286553d513a4cafd85cf12e5a4a095e07) | `` docs/readme: link to release 26.05 on hydra ``                                          |
| [`5f5f7412`](https://github.com/NixOS/nixpkgs/commit/5f5f7412da6646fbc3505cfc457965b6c78195f6) | `` opencv: fix on cuda 13.2 ``                                                             |
| [`7b8ab5a9`](https://github.com/NixOS/nixpkgs/commit/7b8ab5a90c4b426f8f3cfcf1a493cb66ed20b9c4) | `` plover.dev: aliase to plover_4 ``                                                       |
| [`b19d3d49`](https://github.com/NixOS/nixpkgs/commit/b19d3d49d5b7fd3a052043eb0246407770b9b20d) | `` python3Packages.plover: change reference plover_4 -> plover_5 ``                        |
| [`e8e49a39`](https://github.com/NixOS/nixpkgs/commit/e8e49a39637a5850f85775217a4c42fccb18f1c9) | `` [chore] python3Packages.plover: fix comment typo ``                                     |
| [`2756f6a6`](https://github.com/NixOS/nixpkgs/commit/2756f6a678c3b66b71f1e2bac8976324e717766c) | `` badkeys: 0.0.17 -> 0.0.18 ``                                                            |
| [`1f3725c8`](https://github.com/NixOS/nixpkgs/commit/1f3725c857aa7d24c4c9855185002d398ae70384) | `` gmobile: fix `LIBEXECDIR` being exported in public header ``                            |
| [`b66d89d4`](https://github.com/NixOS/nixpkgs/commit/b66d89d4dee5860ddadcf672cd6e004ccfcf6cc0) | `` gmobile: 0.7.0 -> 0.7.1 ``                                                              |
| [`eb615601`](https://github.com/NixOS/nixpkgs/commit/eb615601bbe83c843cad9aab240163dbde0ded10) | `` aspellWithDicts: fix data-dir path ``                                                   |
| [`62a1572e`](https://github.com/NixOS/nixpkgs/commit/62a1572e0668eade18fc17dafe4366940aa4217b) | `` hyprlandPlugins.hypr-dynamic-cursors: 0-unstable-2026-03-09 -> 0-unstable-2026-05-29 `` |
| [`ca8c65b7`](https://github.com/NixOS/nixpkgs/commit/ca8c65b7d44c2eb02d66ef6d7c028c35db1428d2) | `` incus: fix lxc environment quoting ``                                                   |
| [`e8ceffd4`](https://github.com/NixOS/nixpkgs/commit/e8ceffd43b0b1ca86da770c09b79cc1ad0deba0e) | `` sshfs-fuse: 3.7.5 -> 3.7.6 ``                                                           |
| [`658a60a9`](https://github.com/NixOS/nixpkgs/commit/658a60a9c20eb596146e00f317ff6bccfb1ff77f) | `` sshfs-fuse: remove common.nix ``                                                        |
| [`b2b6cea4`](https://github.com/NixOS/nixpkgs/commit/b2b6cea4667a58468a0e78dedf8583e058874a4f) | `` collabora-desktop: fix spreadsheet crash ``                                             |
| [`5b307cfc`](https://github.com/NixOS/nixpkgs/commit/5b307cfcf2fde84ed380fe835a9aeed9316f0a78) | `` vscodium: quote curl command to isolate version string ``                               |
| [`831105a4`](https://github.com/NixOS/nixpkgs/commit/831105a4b63d6d9ff860662f1c4bb2ef87c56950) | `` vscodium: vscodium.vscodeVersion should be set to latestUpstream ``                     |
| [`87eff8d4`](https://github.com/NixOS/nixpkgs/commit/87eff8d41b70d6930e2b315e1d864390139c8fd5) | `` rauthy: 0.35.1 -> 0.35.2 ``                                                             |
| [`94769b0f`](https://github.com/NixOS/nixpkgs/commit/94769b0fa2996936166a6c7084aa3c570bfca6ec) | `` qmediathekview: 0.2.1 -> 0.2.3 ``                                                       |
| [`a11faae8`](https://github.com/NixOS/nixpkgs/commit/a11faae8bfe9c5cdf845f58c42d2d4fc402c5f20) | `` teams-for-linux: 2.10.0 -> 2.11.1 ``                                                    |
| [`5dd42aa5`](https://github.com/NixOS/nixpkgs/commit/5dd42aa55e30aa30d13dc557c86d49166e9bc8ad) | `` livebook: add ngi team ``                                                               |
| [`2258deb1`](https://github.com/NixOS/nixpkgs/commit/2258deb1b4250beee1c153686f3627e2825a0e55) | `` livebook: 0.18.6 -> 0.19.8; fix build ``                                                |
| [`9cee5daf`](https://github.com/NixOS/nixpkgs/commit/9cee5dafcaf8054b70ec8231e6383ff2c7d51c96) | `` anytype-cli: 0.3.2 -> 0.3.3 ``                                                          |
| [`2b0034c6`](https://github.com/NixOS/nixpkgs/commit/2b0034c68ec5b973b9989f383e7f6ac5382c1194) | `` nodejs_26: 26.2.0 -> 26.3.0 ``                                                          |
| [`d3f0698a`](https://github.com/NixOS/nixpkgs/commit/d3f0698a781560c2e57f9606b1550667ce046af9) | `` planify: 4.19.3 -> 4.19.4 ``                                                            |
| [`4b439ab2`](https://github.com/NixOS/nixpkgs/commit/4b439ab2b439c2b50538e8671f563c7b66aee70c) | `` bodyclose: drop ``                                                                      |
| [`28c686b0`](https://github.com/NixOS/nixpkgs/commit/28c686b02758c9b497dd028c03008ec96acf1f55) | `` n8n: 2.20.6 -> 2.22.5 ``                                                                |
| [`87c68b6d`](https://github.com/NixOS/nixpkgs/commit/87c68b6d786997530cc0405a6cac895dcdf61613) | `` n8n: fix update script ``                                                               |
| [`39469670`](https://github.com/NixOS/nixpkgs/commit/3946967040dfdd70dcfb5e1dd65bb1bd8e43d481) | `` mullvad-browser: remove unnecessary auto-update policies ``                             |
| [`b74040f6`](https://github.com/NixOS/nixpkgs/commit/b74040f67a3427240aa5101881bb9d89f1b18bbb) | `` tor-browser: remove unnecessary auto-update policies ``                                 |
| [`0b785fd8`](https://github.com/NixOS/nixpkgs/commit/0b785fd83f8ceccb61615639875e76f0bbdea0eb) | `` tabbyapi: 0-unstable-2026-01-20 -> 0-unstable-2026-05-29 ``                             |
| [`dbbb29de`](https://github.com/NixOS/nixpkgs/commit/dbbb29dee44b8a8924983d3184c8e925cf654bf5) | `` python3Packages.exllamav2: fix build after g++ bump ``                                  |
| [`bf4e849c`](https://github.com/NixOS/nixpkgs/commit/bf4e849c842e5511e561a88000d48c21d6b384c3) | `` python3Packages.exllamav3: 0.0.26 -> 0.0.38 ``                                          |
| [`09006bf3`](https://github.com/NixOS/nixpkgs/commit/09006bf31b1b84f71798fe260057ee561315b430) | `` nixfmt: add `meta.changelog` ``                                                         |
| [`281ffa98`](https://github.com/NixOS/nixpkgs/commit/281ffa987c258b62de853178b382da1eaa9abd61) | `` nixfmt: add versionCheckHook ``                                                         |
| [`0078ded3`](https://github.com/NixOS/nixpkgs/commit/0078ded3e90f7eb548f9f4ee52d73057daec5a21) | `` nixfmt: 1.2.0 → 1.3.1 ``                                                                |
| [`86040258`](https://github.com/NixOS/nixpkgs/commit/86040258e561f4b3bbcab89548fe51f2091e30cc) | `` nixos/kernel_config: remove redundant mergeEqualOption ``                               |
| [`aeda169c`](https://github.com/NixOS/nixpkgs/commit/aeda169c6c43613835002e6f04fe4eae07d098b6) | `` mattermost: 11.7.1 -> 11.7.2 ``                                                         |
| [`effc9ab9`](https://github.com/NixOS/nixpkgs/commit/effc9ab958a91ba16365bd49108ab59cf1bc9dbd) | `` filebeat8: 8.19.15 -> 8.19.16 ``                                                        |
| [`43e5e04d`](https://github.com/NixOS/nixpkgs/commit/43e5e04d37befecb30bd8ed5af5be7736b2a25eb) | `` rsonpath: 0.10.0 -> 0.10.1 ``                                                           |
| [`446e01f6`](https://github.com/NixOS/nixpkgs/commit/446e01f62eb4b898564e7eb77a8219e580071329) | `` openvpn3: 25 -> 27 ``                                                                   |
| [`a38fd422`](https://github.com/NixOS/nixpkgs/commit/a38fd422e0d12f3b9a1982515a8cad777515307b) | `` rgx: 0.12.3 -> 0.12.4 ``                                                                |
| [`3495957b`](https://github.com/NixOS/nixpkgs/commit/3495957bf54e479ff752f50bc8ceec628371e5ea) | `` lmstudio: 0.4.14.4 -> 0.4.15.2 ``                                                       |
| [`bc175e6f`](https://github.com/NixOS/nixpkgs/commit/bc175e6f94143f47207fe02ee582bead3f4977c4) | `` jextract: unstable-2025-05-08 -> 0-unstable-2025-11-12 ``                               |
| [`c6e716ff`](https://github.com/NixOS/nixpkgs/commit/c6e716ffd723208805ab1a912ebef69324b10b34) | `` jextract: fix build on Darwin ``                                                        |
| [`12c78331`](https://github.com/NixOS/nixpkgs/commit/12c7833132d3859ecea9ac301a8c70fd826c5532) | `` nix-update: 1.15.0 -> 1.15.1 ``                                                         |
| [`b781eeee`](https://github.com/NixOS/nixpkgs/commit/b781eeee11ecf55665fe8a623efe3592f5f6d2db) | `` wayle: 0.4.1 -> 0.6.0 ``                                                                |
| [`406fc80e`](https://github.com/NixOS/nixpkgs/commit/406fc80e79d8eb605c30f47a2c4177c814ac4863) | `` uriparser: move gtest from nativeCheckInputs to checkInputs ``                          |
| [`440f4f4a`](https://github.com/NixOS/nixpkgs/commit/440f4f4a11d14ba9ce1b3043f41a6df5cc3dbb00) | `` uptime-kuma: 2.3.2 -> 2.4.0 ``                                                          |
| [`fab1a418`](https://github.com/NixOS/nixpkgs/commit/fab1a418b174f9b978556e0ef92d25b43da53630) | `` luaPackages.lrexlib-pcre2: init at 2.9.2-1 ``                                           |
| [`4fccc551`](https://github.com/NixOS/nixpkgs/commit/4fccc551cb06a091c061fe03a81c4d80db7a7c28) | `` makehuman: mark broken ``                                                               |
| [`8ac2eaa1`](https://github.com/NixOS/nixpkgs/commit/8ac2eaa11d74c42d39054c4fe4f916167bdc6af6) | `` various: use finalAttrs ``                                                              |
| [`80a36c0c`](https://github.com/NixOS/nixpkgs/commit/80a36c0cd555f50ec48f08289fd9bf6729307909) | `` sail-riscv: migrate to by-name ``                                                       |
| [`9c964793`](https://github.com/NixOS/nixpkgs/commit/9c964793b04756f504effd936abbbb778dff12ac) | `` ladspaPlugins: migrate to by-name ``                                                    |
| [`500de9e8`](https://github.com/NixOS/nixpkgs/commit/500de9e89c4fa9ed2bbebef76afc0635cd90d553) | `` snapcast: migrate to by-name ``                                                         |
| [`1211e26c`](https://github.com/NixOS/nixpkgs/commit/1211e26c99f08bb24eb58119b4a3578e193cd43d) | `` syncthing: migrate to by-name ``                                                        |
| [`d63f6146`](https://github.com/NixOS/nixpkgs/commit/d63f61466011c26bf206a77035ff2b4bf6148d0b) | `` lysncd: migrate to by-name ``                                                           |
| [`94aa1c85`](https://github.com/NixOS/nixpkgs/commit/94aa1c85e90bc1fe0f70ff8be3e7f678d3526902) | `` rsync: migrate to by-name ``                                                            |
| [`c3df325a`](https://github.com/NixOS/nixpkgs/commit/c3df325a3c63d286629d3a30ed8ad13801073487) | `` rrsync: migrate to by-name ``                                                           |
| [`161b8446`](https://github.com/NixOS/nixpkgs/commit/161b844662461bec2a8348dc4750f45e7e1a79e3) | `` kbdVlock: remove redundant pkgs in path ``                                              |
| [`de6cf11b`](https://github.com/NixOS/nixpkgs/commit/de6cf11b1d4e4987f1a15950fc924e65cba59fbc) | `` fwupd: 2.1.3 -> 2.1.4 ``                                                                |
| [`d96ea094`](https://github.com/NixOS/nixpkgs/commit/d96ea094b59483b25cd9effdbb1d90fafc234ffa) | `` fwupd: 2.1.2 -> 2.1.3 ``                                                                |
| [`8a890bf9`](https://github.com/NixOS/nixpkgs/commit/8a890bf9b16cfa444b54367e04719ec7c2d2fff5) | `` fwupd: rm superfluous meson feature enable flags ``                                     |
| [`55a6100f`](https://github.com/NixOS/nixpkgs/commit/55a6100f0359a307f28711b8cb74da17559e4a54) | `` fwupd: put jcat-tool on path for tests ``                                               |
| [`3c3517b4`](https://github.com/NixOS/nixpkgs/commit/3c3517b4004ea250050a7704c764fa50796c55fe) | `` fwupd: 2.1.1 -> 2.1.2 ``                                                                |
| [`6822d175`](https://github.com/NixOS/nixpkgs/commit/6822d17508a40f06df32ce66898709e5ec537be9) | `` woodpecker-pipeline-transform: 0.3.0 -> 1.0.0 ``                                        |
| [`f23cc3b3`](https://github.com/NixOS/nixpkgs/commit/f23cc3b3be7c884e5114fc1b0d5fa4019bd1e51d) | `` maintainers/github-teams.json: Automated sync ``                                        |
| [`7aae69f4`](https://github.com/NixOS/nixpkgs/commit/7aae69f48e976584e935aae798a017cb453a57c3) | `` ladybird: fix wrong icu error ``                                                        |
| [`c4d38474`](https://github.com/NixOS/nixpkgs/commit/c4d38474d3dee9cd04007a0b1c53758bca71acc7) | `` ladybird: add maintainer schembriaiden ``                                               |
| [`bd3275bd`](https://github.com/NixOS/nixpkgs/commit/bd3275bd9b517b2190d3e0594b645997d831a7e0) | `` sdl_gamecontrollerdb: 0-unstable-2026-05-12 -> 0-unstable-2026-05-28 ``                 |
| [`b6ee01aa`](https://github.com/NixOS/nixpkgs/commit/b6ee01aa6344b881bbec9b6f26699519e64d39ea) | `` {lemonbar,lemonbar-xft}: move to by-name ``                                             |
| [`736747c3`](https://github.com/NixOS/nixpkgs/commit/736747c37b30031efaf0d356df6c42b3f44dc581) | `` python3Packages.aioesphomeapi: 44.23.0 -> 44.24.1 ``                                    |
| [`02957dd2`](https://github.com/NixOS/nixpkgs/commit/02957dd24ab4313c3d514bf47bdf1b2d9078a459) | `` python3Packages.aioesphomeapi: add version compat note ``                               |
| [`a014656f`](https://github.com/NixOS/nixpkgs/commit/a014656fd804d4844f33f66df65b9c5b6353f348) | `` Revert "python3Packages.aioesphomeapi: 44.23.0 -> 45.0.2" ``                            |
| [`f4915750`](https://github.com/NixOS/nixpkgs/commit/f49157501d6ad729f985b93d6df3b73b36669300) | `` home-assistant: construct package set with overrideScope ``                             |
| [`146deea1`](https://github.com/NixOS/nixpkgs/commit/146deea18ea41f08e6bad56364d63e61695fd2aa) | `` gnuradioPackages.fosphor: fix build with boost 1.89 ``                                  |
| [`be6da99b`](https://github.com/NixOS/nixpkgs/commit/be6da99b16b9575cf39c1e861828c5ab89752686) | `` grantlee: migrate to pkgs/by-name ``                                                    |
| [`52258f22`](https://github.com/NixOS/nixpkgs/commit/52258f2251b7e6c793b4690bbc03167f034d13e0) | `` obsidian: fix internal PDF viewer on Electron 40 ``                                     |
| [`cd2c3717`](https://github.com/NixOS/nixpkgs/commit/cd2c37178f72290de9b2c4305f96291c98f83da5) | `` servo: 0.1.0 -> 0.2.0 ``                                                                |
| [`d133ade2`](https://github.com/NixOS/nixpkgs/commit/d133ade2fad4e72b9108798e6171e4a15acd00d1) | `` satisfactorymodmanager: 3.0.6 -> 3.0.7 ``                                               |
| [`70cf55ef`](https://github.com/NixOS/nixpkgs/commit/70cf55ef6178aebe1ea9b2a67c40dff0124d8388) | `` perlPackages.ArchiveTar: 3.02 -> 3.10 ``                                                |