### PR TITLE
chore(flake/catppuccin): `fd265813` -> `71770b00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780650205,
-        "narHash": "sha256-FYgqDufUWHbY+ne5z/OTBUCCeLGPJ5sA6d+Fa5aKKxo=",
+        "lastModified": 1780755633,
+        "narHash": "sha256-2NZLaQTroHWrXHOeBJhHD7cb8nM4BnlAMNoxIUqs/Os=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "fd265813d18cc39bc0d27750c47a09766a535162",
+        "rev": "71770b00f2b97631339026e78b4a045cd9aee6f3",
         "type": "github"
       },
       "original": {

--- a/modules/base/home.nix
+++ b/modules/base/home.nix
@@ -48,8 +48,6 @@ in
   }
   // lib.optionalAttrs (options.catppuccin ? autoEnable) {
     autoEnable = true;
-    # Prevent warning from home-manager option rename until catppuccin catches up
-    gemini-cli.enable = false;
   };
 
   ##########################################################################


### PR DESCRIPTION
| Commit                                                                                          | Message                                             |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`71770b00`](https://github.com/catppuccin/nix/commit/71770b00f2b97631339026e78b4a045cd9aee6f3) | `` feat!(home-manager/gemini-cli): remove (#975) `` |