### PR TITLE
chore(flake/freminal): `99d2984f` -> `cd6c72b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -583,11 +583,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1780501476,
-        "narHash": "sha256-JOKvD6B/hgMzVfd4tjiDwgdn2yqLfpGbT73T+XlzuYE=",
+        "lastModified": 1780685417,
+        "narHash": "sha256-V2MTxWN+9nJSFze452M1Gm1hNr3l6IjoJpBq/nvkajU=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "99d2984f588a9e9b0cfc853867cd5904fc812e2d",
+        "rev": "cd6c72b74cc567d336815d19c86be7b116b0fefd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`b7f7d878`](https://github.com/fredsystems/freminal/commit/b7f7d878780d6052ae2e6426a80d8b81e24e5aec) | `` docs: 72.8b -- fix stale doc/comment drift flagged by PR-333 review ``                  |
| [`4d29c467`](https://github.com/fredsystems/freminal/commit/4d29c4670918e2e2bd8ea83b6816acd976d838a0) | `` fix: 72.8b -- never write to packaging shell-integration dirs ``                        |
| [`363648ca`](https://github.com/fredsystems/freminal/commit/363648ca70854f5b17a8b92308bf0ff1352fea9d) | `` fix: 72.12 -- hover-tint band spans full terminal width ``                              |
| [`e1683a71`](https://github.com/fredsystems/freminal/commit/e1683a71e5872b66f0c15cc3ff65dd809dee6ad5) | `` fix: 72.15 -- fish vendor_conf.d uses if-guard instead of exit 0 ``                     |
| [`ed460a33`](https://github.com/fredsystems/freminal/commit/ed460a331b6ea624e57657d9e4a51bb50c03334c) | `` docs: 72.15 -- mark Task 72 complete in plan documents ``                               |
| [`4adff19c`](https://github.com/fredsystems/freminal/commit/4adff19cd9c384460dd0cdfe68a7292a7fdff3f4) | `` feat: 72.15 -- wire OSC 1338 HISTFILE auto-reload into command-history palette ``       |
| [`e41e9efa`](https://github.com/fredsystems/freminal/commit/e41e9efab29eae635c5332df2d13f8d4f78946bd) | `` feat: 72.15 -- emit OSC 1338 from shell-integration scripts ``                          |
| [`19f2eb8e`](https://github.com/fredsystems/freminal/commit/19f2eb8e4ee8f9de1c963ea92de1c61d4dbb3da6) | `` feat: 72.15 -- OSC 1338 ShellInfoHistFile parser + snapshot field ``                    |
| [`9619c412`](https://github.com/fredsystems/freminal/commit/9619c412e92fdbc6d6e31340003a7f2c01168b6b) | `` fix: 72.15 -- truncate command-history palette entries to popup width ``                |
| [`16d7a286`](https://github.com/fredsystems/freminal/commit/16d7a28648a47b76c15e68d38abb1c2994d15b7e) | `` chore: 72.15 -- enrich shell-history loader diagnostic logging ``                       |
| [`1741b3be`](https://github.com/fredsystems/freminal/commit/1741b3be2a68e58e6371b311e90f1e976242f1e9) | `` fix: 72.15 -- reassemble zsh multi-line history entries ``                              |
| [`00cced35`](https://github.com/fredsystems/freminal/commit/00cced3545b652a2a3a08c73f223dd5b39f34531) | `` fix: 72.15 -- release terminal focus while command-history palette is open ``           |
| [`8447400d`](https://github.com/fredsystems/freminal/commit/8447400dd77f723f4f5c6fa3c0c870aeb1720392) | `` fix: 72.15 -- shell history loader handles non-UTF-8 bytes ``                           |
| [`ca2efcb2`](https://github.com/fredsystems/freminal/commit/ca2efcb2aee2ea9300b55a676204f8b84a9724bb) | `` feat: 72.15 -- palette UI and key binding ``                                            |
| [`00396311`](https://github.com/fredsystems/freminal/commit/00396311e92b0a771f189279be39fbf17b21e47f) | `` docs: 72.15 -- record shell-history data layer completion ``                            |
| [`8bdeb85d`](https://github.com/fredsystems/freminal/commit/8bdeb85d847103c32dde054bc9b609f81be29100) | `` feat: 72.15 -- shell-history data layer ``                                              |
| [`fab1fbad`](https://github.com/fredsystems/freminal/commit/fab1fbadadea682aa111d9e3e325cf44e937124d) | `` docs: 72.14 -- completion notes for 31c1b1a ``                                          |
| [`31c1b1a6`](https://github.com/fredsystems/freminal/commit/31c1b1a625bb23100d2c5c14aa2b71ad832357fc) | `` feat: 72.14 -- Copy URL right-click menu item ``                                        |
| [`66706757`](https://github.com/fredsystems/freminal/commit/66706757a67baabd5e625f4e756434679ea11f2c) | `` docs: 72.10 -- completion notes for 5b029a4 and 8d1056e ``                              |
| [`8d1056e0`](https://github.com/fredsystems/freminal/commit/8d1056e0f502964080802def3001d5d63e5250d0) | `` refactor: 72.10b -- rename ToggleFoldAtCursor to FoldPreviousCommand ``                 |
| [`5b029a4d`](https://github.com/fredsystems/freminal/commit/5b029a4db8a563f63da9f86bfb0c6bcfb8d9191a) | `` fix: 72.10b -- correct OSC 133 fold renderer ``                                         |
| [`8d08e384`](https://github.com/fredsystems/freminal/commit/8d08e384f68f1874b42d0e2c3d2e578678343319) | `` docs(plan-090): post-rebase SHA refresh + uniform completion markers ``                 |
| [`603001b8`](https://github.com/fredsystems/freminal/commit/603001b8c03788538345f771843e2256d14a687c) | `` docs: 72.13 — refresh OSC 133 status in escape-sequence docs ``                         |
| [`b27539d9`](https://github.com/fredsystems/freminal/commit/b27539d9135ab3fbdfbbd7f1803960f2983f8afe) | `` fix: 72.16.e — demote XTGETTCAP unknown-capability log to debug level ``                |
| [`93feefcf`](https://github.com/fredsystems/freminal/commit/93feefcf1d1b334fda8da107116c66aafcaa3cb6) | `` docs: add Task 98 — block close on running commands ``                                  |
| [`dc8b3fb1`](https://github.com/fredsystems/freminal/commit/dc8b3fb1205e72501d06194b97efaf36279324fd) | `` fix: DECBKM default sends DEL (0x7F) instead of BS (0x08) ``                            |
| [`780dc365`](https://github.com/fredsystems/freminal/commit/780dc365ad44714bc32e0ef1a6f172e6d8d616fc) | `` docs: add Task 73 subtasks 73.5–73.7 for hover/duration relocation and timing bug ``    |
| [`9d5e8330`](https://github.com/fredsystems/freminal/commit/9d5e8330980d5569687afad9b4090c095b1c7829) | `` docs: note 72.12a fix hash in plan completion notes ``                                  |
| [`8d95ad39`](https://github.com/fredsystems/freminal/commit/8d95ad398b9ecece9105a0b4285f466ea4087caf) | `` fix: 72.12a — drop command blocks erased by CSI 2J (clear) ``                           |
| [`209ed8fa`](https://github.com/fredsystems/freminal/commit/209ed8fafb6324423cca7687ebf06f4e0552bd6c) | `` docs: 72.12 — mark complete in PLAN_VERSION_090 ``                                      |
| [`238e9035`](https://github.com/fredsystems/freminal/commit/238e9035199048ddaca7b17fbe26d4a416356226) | `` feat: 72.12 — hover highlight and command-duration overlay ``                           |
| [`6c44f603`](https://github.com/fredsystems/freminal/commit/6c44f6037717ef7c51236cdecfde69bd8d8e0778) | `` docs: 72.11 — mark complete in PLAN_VERSION_090 ``                                      |
| [`8c3cd779`](https://github.com/fredsystems/freminal/commit/8c3cd779c225942eb875df16a9db74c9ec52da46) | `` feat: 72.11 — copy command output actions ``                                            |
| [`bf5a4002`](https://github.com/fredsystems/freminal/commit/bf5a4002a4310ea1bc439a069f1583c041c0a335) | `` docs: 72.10c — backfill commit hash in PLAN_VERSION_090 completion notes ``             |
| [`bf6a2b4f`](https://github.com/fredsystems/freminal/commit/bf6a2b4fda25bebfa222d51986bedcdbd4faf060) | `` fix: 72.10a — fall back to most-recent completed block when cursor outside any block `` |
| [`5a44c684`](https://github.com/fredsystems/freminal/commit/5a44c6844544018b1f9f3470082915dd4998d6cc) | `` docs: 72.10b-3 — fix commit hash reference in plan doc ``                               |
| [`d0c7098a`](https://github.com/fredsystems/freminal/commit/d0c7098a4e0d1157f945398f30c8e33313d3520b) | `` feat: 72.10b-3 — fold placeholder row, click-to-unfold, hover cursor ``                 |
| [`31e15add`](https://github.com/fredsystems/freminal/commit/31e15addaff78a046f3525ed0ae82d0999685844) | `` chore(version + flake) ``                                                               |
| [`a9f368fe`](https://github.com/fredsystems/freminal/commit/a9f368fed53e72069a8a0f0ea59d43461737567d) | `` feat: 72.10b-2 — wire RowMap into widget render path ``                                 |
| [`f5798bb9`](https://github.com/fredsystems/freminal/commit/f5798bb9beb1eac35837290b3e1d0e13e0dad1ba) | `` feat: 72.10b-1 — folding helper and row-index mapping ``                                |
| [`e3c3996f`](https://github.com/fredsystems/freminal/commit/e3c3996f7d3a4f0f142c3857e1d1da62e4b6b038) | `` feat: 72.10a — add command-block fold/unfold view state and keybindings ``              |
| [`52d94c80`](https://github.com/fredsystems/freminal/commit/52d94c80c1d64d0051b06bb5e67dc2060b1579f8) | `` docs(update) with 72.9 completion status ``                                             |
| [`d11ccf9a`](https://github.com/fredsystems/freminal/commit/d11ccf9ace6ae0fe6730ee58dbfb85d35d98d967) | `` feat(gui): wire CommandFinishedEvent to GUI panes (Task 72.9) ``                        |
| [`85d8a6d3`](https://github.com/fredsystems/freminal/commit/85d8a6d3388de0fde858404d8cee706d79d8a51a) | `` docs: 72.8b — mark shell-integration env injection complete; file 72.16.e ``            |
| [`3e80e6d1`](https://github.com/fredsystems/freminal/commit/3e80e6d190ba79e127fd2df6820d431820c5e491) | `` feat: 72.8b — spawn-time shell-integration env injection ``                             |
| [`579f10ab`](https://github.com/fredsystems/freminal/commit/579f10ab65c30484d7104fc12ea8509463b517ad) | `` docs(plan-090): mark 72.8c complete ``                                                  |
| [`94db3c27`](https://github.com/fredsystems/freminal/commit/94db3c2714a9e95dc1958167620b8a7d483cc63c) | `` feat: 72.8c — parser support for freminal=1; fid=<id> OSC 133 markers ``                |
| [`82a948e2`](https://github.com/fredsystems/freminal/commit/82a948e21ad476c5d45a92010390018d62cd42ee) | `` docs(plan-090): restructure Task 72 for spawn-time shell integration ``                 |
| [`1560df1c`](https://github.com/fredsystems/freminal/commit/1560df1c0a40bab3f8d3231f6adf371af990da4e) | `` docs(decisions): record shell-integration architecture ``                               |
| [`cb74e361`](https://github.com/fredsystems/freminal/commit/cb74e361872533fe652b3fa1a58f075d493ef98f) | `` docs: mark 72.8 complete; add 72.16.d; document OSC 7 double-emit ``                    |
| [`168c364f`](https://github.com/fredsystems/freminal/commit/168c364f07cfa6e76c796ae4bf7bb8612f62e16d) | `` feat: 72.8 — auto-install shell integration scripts on first launch ``                  |
| [`bcfd1e79`](https://github.com/fredsystems/freminal/commit/bcfd1e791a2996ba4a6964d29f247a0c44c2384d) | `` docs: mark 72.7 complete; file 72.16.b and 72.16.c follow-ups ``                        |
| [`f6c62371`](https://github.com/fredsystems/freminal/commit/f6c62371b2c0d3691702c260ac65256857e048e9) | `` feat: 72.7 — ship shell integration scripts for bash, zsh, fish ``                      |
| [`31dec8c5`](https://github.com/fredsystems/freminal/commit/31dec8c53b687d02704624a6426913130e105cb7) | `` docs: mark 72.16.a complete ``                                                          |
| [`703e9985`](https://github.com/fredsystems/freminal/commit/703e9985dfb6447abfb8570b5781667ac89ab7c0) | `` fix: 72.16.a — OSC 133 dispatcher preserves numeric tokens ``                           |
| [`bed41a95`](https://github.com/fredsystems/freminal/commit/bed41a954daf2cf52d5c3c64b5c1c71bc37126a3) | `` docs: mark 72.6 complete in v0.9.0 plan ``                                              |
| [`14d1cadc`](https://github.com/fredsystems/freminal/commit/14d1cadc89717bb0526c18d2503c5dd2110c4c95) | `` feat: 72.6 — gate TERM_PROGRAM/VERSION env on shell_integration config ``               |
| [`bbc37c98`](https://github.com/fredsystems/freminal/commit/bbc37c987039ca2298f7fed072c93630467ad006) | `` docs: mark 72.5 complete in v0.9.0 plan ``                                              |
| [`0434bfb3`](https://github.com/fredsystems/freminal/commit/0434bfb30e77b6aa7a558380a87abd4e142bb633) | `` feat: 72.5 — add [shell_integration] and [command_blocks] config sections ``            |
| [`236dcfb0`](https://github.com/fredsystems/freminal/commit/236dcfb03ebab097293a79a2e5eb8535da2cf1ac) | `` docs: mark 72.4 complete; add 72.16 cleanup section + 72.16.a ``                        |
| [`d6900642`](https://github.com/fredsystems/freminal/commit/d69006421b5dd6b3312fb0a09828ecae5e21c963) | `` feat: 72.4 — expose command_blocks through TerminalSnapshot ``                          |
| [`40cd9648`](https://github.com/fredsystems/freminal/commit/40cd9648b042d763f942185baa5b9dda3d477199) | `` docs: mark 72.3 complete in v0.9.0 plan; record Path C decision ``                      |
| [`4950f3f5`](https://github.com/fredsystems/freminal/commit/4950f3f5c7c981e2b48c470dbb6e836f2ddacb4f) | `` feat: 72.3 — wire FTCS markers into Buffer command-block API ``                         |
| [`401137ee`](https://github.com/fredsystems/freminal/commit/401137ee177497a1a882e4d53642f1d89775cc41) | `` docs: mark 72.2 complete in v0.9.0 plan ``                                              |
| [`cbda480c`](https://github.com/fredsystems/freminal/commit/cbda480cc783fb758b904004b7b43cf74bdb0b1b) | `` feat: 72.2 — add command_blocks VecDeque to Buffer ``                                   |
| [`14fe9d02`](https://github.com/fredsystems/freminal/commit/14fe9d02b46c13bd75440ba69f976acd21ad42fd) | `` docs: mark 72.1 complete in v0.9.0 plan ``                                              |
| [`965aacfe`](https://github.com/fredsystems/freminal/commit/965aacfec17bf3e14288917324af68465a4ad1fd) | `` feat: 72.1 — define CommandBlock types in freminal-common ``                            |
| [`f16c35cc`](https://github.com/fredsystems/freminal/commit/f16c35cc6815aba6f61ea8ca3eb3f47751084534) | `` chore: switch sub-agent provider to opencode/claude-sonnet-4-6 ``                       |