### PR TITLE
chore(flake/darwin): `56c666e1` -> `6a771120`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                       |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`f8531f95`](https://github.com/nix-darwin/nix-darwin/commit/f8531f95fe4abebe17b794f3f6c01a8f886b97bd) | `` tests/github-runners: limit to supported node runtimes ``  |
| [`7c3d11b1`](https://github.com/nix-darwin/nix-darwin/commit/7c3d11b160b601ced23ff93177a18aaa446b3d6e) | `` modules/terminfo: update list of packages with terminfo `` |
| [`8073b91a`](https://github.com/nix-darwin/nix-darwin/commit/8073b91aa3bcd8041a70501c4ffcd59002e4a30a) | `` scripts/release: init ``                                   |
| [`ae3e2b18`](https://github.com/nix-darwin/nix-darwin/commit/ae3e2b18d37b3cce4b75abea3281bc2e9520aada) | `` flake.lock: update ``                                      |
| [`82325d90`](https://github.com/nix-darwin/nix-darwin/commit/82325d90a1692b6f74862f9f557f468b6c01febb) | `` version: bump to 26.11 ``                                  |