### PR TITLE
chore(flake/nixvim): `816a1528` -> `19fd9d7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780646548,
-        "narHash": "sha256-Ckyl/l1XBmEwnaHcHD8PvBZk1uph0NqwbJ//CAvB7iE=",
+        "lastModified": 1780865526,
+        "narHash": "sha256-znDAT8hY5w5rdgdcU7jMkNzW8hHMDc61QoCYmYd04XU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "816a15282e58678dde831477964987d0262d4293",
+        "rev": "19fd9d7d1ed85e32871987f5e0a57aa5fa9673b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`19fd9d7d`](https://github.com/nix-community/nixvim/commit/19fd9d7d1ed85e32871987f5e0a57aa5fa9673b7) | `` treewide: bump stable 25.11 → 26.05 ``                                    |
| [`70886b71`](https://github.com/nix-community/nixvim/commit/70886b715e044fbaa8acf54c2458881283703e14) | `` docs: take defaults from environment variables ``                         |
| [`98acb923`](https://github.com/nix-community/nixvim/commit/98acb923e5882a6a6a2b660d99e8c5124e08b838) | `` lsp/servers/packages: add package for prismals ``                         |
| [`201960ae`](https://github.com/nix-community/nixvim/commit/201960ae642c89d37b839f82544689b0d2865ffd) | `` ci: bump actions/upload-pages-artifact in /.github/actions/build-docs ``  |
| [`4b98b6ae`](https://github.com/nix-community/nixvim/commit/4b98b6ae9c88b105dacd9fbf8712275b28077ff8) | `` ci: run dependabot on GitHub Actions ``                                   |
| [`a509dd26`](https://github.com/nix-community/nixvim/commit/a509dd2645048641c255b34e3e95fe6c836ed097) | `` docs/platforms: add standalone-legacy page ``                             |
| [`5dff6a8c`](https://github.com/nix-community/nixvim/commit/5dff6a8cab2162c7eae87239286f64bb9df1b865) | `` docs/platforms/standalone: document convenience functions ``              |
| [`86bb52ee`](https://github.com/nix-community/nixvim/commit/86bb52ee5f32fb7915086952e38444e0e2c0b007) | `` docs/platforms/standalone: update to use `evalNixvim` ``                  |
| [`d12c8e43`](https://github.com/nix-community/nixvim/commit/d12c8e43d31f152a33656cb340560e637bd7e605) | `` docs/user-guide/install: update "standalone usage" to use `evalNixvim` `` |
| [`7f8cdfca`](https://github.com/nix-community/nixvim/commit/7f8cdfcac75274b83a5dae2eb2c64f03bc98e8b8) | `` readme: update "standalone usage" to use `evalNixvim` ``                  |
| [`a50452bd`](https://github.com/nix-community/nixvim/commit/a50452bdc1d779a94b2cb5734af277e173759132) | `` doc/lib: add `lib.nixvim.modules` page ``                                 |
| [`13e7d8a9`](https://github.com/nix-community/nixvim/commit/13e7d8a9b335799c6a74e4d1c939f6d68bd4a282) | `` lib/modules: add `evalNixvim` nixdoc ``                                   |
| [`b984bc81`](https://github.com/nix-community/nixvim/commit/b984bc81596550a48a73c48a3a12e9d12775be2f) | `` templates/simple: add README link to docs ``                              |
| [`62c949bb`](https://github.com/nix-community/nixvim/commit/62c949bbc7ba68ee2db81ffb89c63e1cf812606a) | `` templates/simple: update to use `evalNixvim` ``                           |