### PR TITLE
chore(flake/nixpkgs-stable): `6b316287` -> `9b696460`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -696,11 +696,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1780453794,
-        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
+        "lastModified": 1780734595,
+        "narHash": "sha256-DmTfP92QFYRLOGXlMIE54MAgxSJjDWocl3gRNOu72Os=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
+        "rev": "9b696460ac78b5ccfc17c854d8c976f20456e943",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`806105cc`](https://github.com/NixOS/nixpkgs/commit/806105cc98c9e69aa4e498d0ef0b94103d02b1a1) | `` splayer: 3.0.0 -> 3.1.1 ``                                                                                      |
| [`d83bfb5b`](https://github.com/NixOS/nixpkgs/commit/d83bfb5b70582312a4e98eda21505fcf2b8deef4) | `` gogup: 1.1.4 -> 1.2.0 ``                                                                                        |
| [`cdb16195`](https://github.com/NixOS/nixpkgs/commit/cdb16195ed783fcd8681120639d305b789169b97) | `` hyfetch: 2.0.5 -> 2.1.0 ``                                                                                      |
| [`90ddf633`](https://github.com/NixOS/nixpkgs/commit/90ddf633c650a7d39e837bc57ec035a81f7d0842) | `` hyfetch: add Misaka13514 to maintainers ``                                                                      |
| [`146dac3b`](https://github.com/NixOS/nixpkgs/commit/146dac3bc8401c6f59976073105df8ab880d774d) | `` chhoto-url: 7.1.5 -> 7.2.1 ``                                                                                   |
| [`0e7caa74`](https://github.com/NixOS/nixpkgs/commit/0e7caa74dbedba6fa6d0baaffa06a976f37239a0) | `` upterm: 0.20.0 -> 0.24.0 ``                                                                                     |
| [`9d33e8a5`](https://github.com/NixOS/nixpkgs/commit/9d33e8a548fce62e801e284b9ac174f77f2fabcb) | `` nixosTests/zfs: replace direct bootctl call with switch-to-configuration invocation ``                          |
| [`c52f73ff`](https://github.com/NixOS/nixpkgs/commit/c52f73ffa7edc82e1e510e08bfe42d56847ac1b7) | `` nixosTests/systemd-initrd-swraid: replace direct bootctl call with switch-to-configuration invocation ``        |
| [`6d483d3d`](https://github.com/NixOS/nixpkgs/commit/6d483d3d0b30886945d0836c3c194cd81aba990a) | `` nixosTests/systemd-initrd-luks-unl0kr: replace direct bootctl call with switch-to-configuration invocation ``   |
| [`55821a2c`](https://github.com/NixOS/nixpkgs/commit/55821a2c87102689d108e2798b7dd1b34489ad3f) | `` nixosTests/systemd-initrd-luks-tpm2: replace direct bootctl call with switch-to-configuration invocation ``     |
| [`2ee654b9`](https://github.com/NixOS/nixpkgs/commit/2ee654b9896fdf38a18d92746d2e07a4210e77c3) | `` nixosTests/systemd-initrd-luks-password: replace direct bootctl call with switch-to-configuration invocation `` |
| [`fa5560aa`](https://github.com/NixOS/nixpkgs/commit/fa5560aa0d23182a9ae74f36fe579afdceb5da57) | `` nixosTests/systemd-initrd-luks-keyfile: replace direct bootctl call with switch-to-configuration invocation ``  |
| [`8057a2a5`](https://github.com/NixOS/nixpkgs/commit/8057a2a5150fa95151ed562ec3340afe7b164633) | `` nixosTests/systemd-initrd-luks-fido2: replace direct bootctl call with switch-to-configuration invocation ``    |
| [`eafa0659`](https://github.com/NixOS/nixpkgs/commit/eafa065980e67c4489fee64d245a0669a900ba1e) | `` nixosTests/systemd-initrd-btrfs-raid: replace direct bootctl call with switch-to-configuration invocation ``    |
| [`ad1aef53`](https://github.com/NixOS/nixpkgs/commit/ad1aef5382f4558a50fbba38701f280cc54c8107) | `` nixosTests/lvm2: replace direct bootctl call with switch-to-configuration invocation ``                         |
| [`82f64ad3`](https://github.com/NixOS/nixpkgs/commit/82f64ad378257f177b80de5b972c71c6dd0c9107) | `` nixosTests/luks: replace direct bootctl call with switch-to-configuration invocation ``                         |
| [`c4d6d13b`](https://github.com/NixOS/nixpkgs/commit/c4d6d13b69d21ba4274434116102232676f4f02d) | `` nixosTests/initrd-luks-empty-passphrase: replace direct bootctl call with switch-to-configuration invocation `` |
| [`4222368a`](https://github.com/NixOS/nixpkgs/commit/4222368a3d00768b00255f4d7bfa15335f26813d) | `` nixos/tests/lvm2: switch to runTest ``                                                                          |
| [`897b813d`](https://github.com/NixOS/nixpkgs/commit/897b813dbb1f114a6be633e8d119d401f88f1da7) | `` nixos/tests/zfs: switch to runTest ``                                                                           |
| [`c0987120`](https://github.com/NixOS/nixpkgs/commit/c0987120f88de396c2fcbd32837d4108428997bb) | `` proton-authenticator: add maintainer ``                                                                         |
| [`707e30d9`](https://github.com/NixOS/nixpkgs/commit/707e30d931baef3268e24aadbb66424cd7e76b81) | `` proton-authenticator: 1.1.4 -> 1.1.5 ``                                                                         |
| [`08030556`](https://github.com/NixOS/nixpkgs/commit/0803055632629204441ec527358d5f7424d7c427) | `` git: Fix cross compilation ``                                                                                   |
| [`5991f55f`](https://github.com/NixOS/nixpkgs/commit/5991f55ffd8119bd5b68e8158545b32084036565) | `` prl-tools: 26.3.2-57398 -> 26.3.3-57507 ``                                                                      |
| [`77886e09`](https://github.com/NixOS/nixpkgs/commit/77886e09a6534474b13222d7927f0d9002b969dd) | `` lockbook: 26.5.22 -> 26.6.1 ``                                                                                  |
| [`d7b97cf5`](https://github.com/NixOS/nixpkgs/commit/d7b97cf51788c795cd9c45c35da18878bfb0e5fa) | `` lockbook-desktop: 26.5.22 -> 26.6.1 ``                                                                          |
| [`a6de9441`](https://github.com/NixOS/nixpkgs/commit/a6de94419ae97d9f5e0344b66a1d78a923df8d45) | `` hol_light: move to by-name/ ``                                                                                  |
| [`4c9777c4`](https://github.com/NixOS/nixpkgs/commit/4c9777c4608ee14a87b090b5768e49339178bb40) | `` tor-browser: 15.0.14 -> 15.0.15 ``                                                                              |
| [`48a56739`](https://github.com/NixOS/nixpkgs/commit/48a567395463d63e69b4e4c160b308e49d8353a6) | `` grafana: 13.0.1+security-01 -> 13.0.2 ``                                                                        |
| [`43f6da80`](https://github.com/NixOS/nixpkgs/commit/43f6da8026ddf76f405dcafce1a4cec4845908a1) | `` signal-desktop: 8.9.1 -> 8.13.0 ``                                                                              |
| [`e42f4530`](https://github.com/NixOS/nixpkgs/commit/e42f4530e886a19da3a9c015408c8e9b5f30f783) | `` prometheus-redis-exporter: 1.84.0 -> 1.85.0 ``                                                                  |
| [`c3bf2a7b`](https://github.com/NixOS/nixpkgs/commit/c3bf2a7b24b878c34f40d132dbc16a5b44d81de2) | `` nextcloud33Packages: update ``                                                                                  |
| [`d0813d3c`](https://github.com/NixOS/nixpkgs/commit/d0813d3cdb141d2ff5911b7a809e232eb5868214) | `` nextcloud32: 33.0.4 -> 33.0.5 ``                                                                                |
| [`8228fab8`](https://github.com/NixOS/nixpkgs/commit/8228fab8862670c39c268559e866cd4f6ce5c928) | `` nextcloud32Packages: update ``                                                                                  |
| [`442545e5`](https://github.com/NixOS/nixpkgs/commit/442545e58e01a4ad75e1d1fd373c9ac369a85f0a) | `` nextcloud32: 32.0.10 -> 32.0.11 ``                                                                              |
| [`d2808f8c`](https://github.com/NixOS/nixpkgs/commit/d2808f8c0e4c9a84f167f5121739af516cfdc729) | `` .github: Bump actions/checkout from 6.0.2 to 6.0.3 ``                                                           |
| [`1fbda0dd`](https://github.com/NixOS/nixpkgs/commit/1fbda0dd891d0d06ae2a7cf80df164d0f7a3f713) | `` nom: 3.3.0 -> 3.3.1 ``                                                                                          |
| [`8aa67cf4`](https://github.com/NixOS/nixpkgs/commit/8aa67cf4d237016509a24cf4bad2f34567a5a3eb) | `` jackett: 0.24.1954 -> 0.24.2021 ``                                                                              |
| [`251e82b8`](https://github.com/NixOS/nixpkgs/commit/251e82b864dac9367110f4a9f336758cab90a5ee) | `` nixosTests.pixelfed.standard: allow running on aarch64-linux ``                                                 |
| [`58993bc3`](https://github.com/NixOS/nixpkgs/commit/58993bc3e582ef4089d31b223a7833e3ca2614e0) | `` pixelfed: 0.12.6 -> 0.12.7; fix build ``                                                                        |
| [`0125dd85`](https://github.com/NixOS/nixpkgs/commit/0125dd85ba9b19a414356c7ebe79a9ea01a270c2) | `` checkstyle: 13.4.2 -> 13.5.0 ``                                                                                 |
| [`5e026fcb`](https://github.com/NixOS/nixpkgs/commit/5e026fcb572e87f2d941ec322f539ebb00cae5b6) | `` ollama: fix darwin build for 0.30.5 ``                                                                          |
| [`1d53a5d3`](https://github.com/NixOS/nixpkgs/commit/1d53a5d32dde22087a5c06941dc737de89a4b01a) | `` ollama: 0.30.4 -> 0.30.5 ``                                                                                     |
| [`48c8ccf0`](https://github.com/NixOS/nixpkgs/commit/48c8ccf0f0711a1cbd46ff0dbfb4511aa48560d3) | `` ollama: fix vulkan variant — wire SPIRV-Headers across the ExternalProject boundary ``                          |
| [`e2dd21ba`](https://github.com/NixOS/nixpkgs/commit/e2dd21ba2b2075f547aa1edbcdb568793e5f6f39) | `` ollama: 0.24.0 -> 0.30.4 ``                                                                                     |
| [`788da811`](https://github.com/NixOS/nixpkgs/commit/788da811d5ed2b7bb815ccf38e92975a62aa41a6) | `` scaleway-cli: disable time-dependent test ``                                                                    |
| [`813a2797`](https://github.com/NixOS/nixpkgs/commit/813a27972299b704abd7ba4bea3a85f9c0a9d0ee) | `` uutils-coreutils-noprefix: 0.8.0 -> 0.9.0 ``                                                                    |
| [`ab33851b`](https://github.com/NixOS/nixpkgs/commit/ab33851ba8777205f51549a0380853e53c5abf96) | `` mailpit: 1.30.0 -> 1.30.1 ``                                                                                    |
| [`ec3a9fca`](https://github.com/NixOS/nixpkgs/commit/ec3a9fca7c99d751b54823384b7ae1ebb06939bd) | `` pretix: relax diango-formtools constraint ``                                                                    |
| [`bfff353b`](https://github.com/NixOS/nixpkgs/commit/bfff353b19bdc15cadb541ef47b9926bb2321a3a) | `` dexter: 0.6.0 -> 0.7.0 ``                                                                                       |
| [`ee250790`](https://github.com/NixOS/nixpkgs/commit/ee250790b63f13d22fd913db0cd623eacf6cd10b) | `` ungoogled-chromium: 148.0.7778.215-1 -> 149.0.7827.53-1 ``                                                      |
| [`0c6e2129`](https://github.com/NixOS/nixpkgs/commit/0c6e21290a305c06737f2104c34f731b2983c366) | `` fluent-bit: 5.0.5 -> 5.0.6 ``                                                                                   |
| [`bd0cdc7b`](https://github.com/NixOS/nixpkgs/commit/bd0cdc7b3373c9b9df2834ec8eb6dcefda0cc0b2) | `` glance: 0.8.4 -> 0.8.5 ``                                                                                       |
| [`1459fad5`](https://github.com/NixOS/nixpkgs/commit/1459fad584aedce4cc948b97c98613f01d43fef7) | `` nixos/wireless: restrict chown /etc/wpa_supplicant scope ``                                                     |
| [`a010a9b7`](https://github.com/NixOS/nixpkgs/commit/a010a9b728b17c1f84d66fc27a18266290b8ff03) | `` keycloak: 26.6.2 -> 26.6.3 ``                                                                                   |
| [`284fa832`](https://github.com/NixOS/nixpkgs/commit/284fa832b19634702b4dff9b167defdd9c830a0f) | `` kimai: 2.57.0 -> 2.58.0 ``                                                                                      |
| [`518ddb99`](https://github.com/NixOS/nixpkgs/commit/518ddb999cf0f32b27af1eaa2e14fc4d6ee31ed4) | `` dprint-plugins.dprint-plugin-biome: 0.12.11 -> 0.12.12 ``                                                       |
| [`7a7d7e91`](https://github.com/NixOS/nixpkgs/commit/7a7d7e916bffa5a694a724e20f08f0ef9e2da6cf) | `` pretalx: relax django-formtools ``                                                                              |
| [`c61baa7a`](https://github.com/NixOS/nixpkgs/commit/c61baa7a41c43a51d24f1d53d0ea0c1b2b1f320f) | `` zipline: 4.6.1 -> 4.6.2 ``                                                                                      |
| [`61f430b1`](https://github.com/NixOS/nixpkgs/commit/61f430b1013a1de7f553ca0fb2e71a3d474ccd56) | `` vivaldi: 8.0.4033.34 -> 8.0.4033.42 ``                                                                          |
| [`35e13738`](https://github.com/NixOS/nixpkgs/commit/35e137381f4453691733f226037e37013ddea4f0) | `` go-httpbin: 2.22.1 -> 2.23.0 ``                                                                                 |
| [`2e9f2f88`](https://github.com/NixOS/nixpkgs/commit/2e9f2f88d712e3f089b8c506eb3497fee381a77e) | `` kdePackages: Gear 26.04.1 -> 26.04.2 ``                                                                         |
| [`59e00733`](https://github.com/NixOS/nixpkgs/commit/59e00733121904b989ad90713ee3e3e30bf5a6bf) | `` music-assistant-desktop: 0.3.6 -> 0.3.7 ``                                                                      |
| [`23f75822`](https://github.com/NixOS/nixpkgs/commit/23f75822bd61ba518421641c92d8112f3fa2b599) | `` polyml: Fix polyc linking script ``                                                                             |
| [`19e44e26`](https://github.com/NixOS/nixpkgs/commit/19e44e2608e842745dde447a432609c8b3d30147) | `` polyml: replace kovirobi with sempiternal-aurora as maintainer ``                                               |
| [`d9611a2c`](https://github.com/NixOS/nixpkgs/commit/d9611a2cd77723d76aa54f029679ac9e8bd51cfd) | `` polyml: cleanup and mark cross broken ``                                                                        |
| [`e5eb5cbe`](https://github.com/NixOS/nixpkgs/commit/e5eb5cbed4960db2efc04988bb1d5eceb578464a) | `` polyml: migrate to by-name ``                                                                                   |
| [`4a5860b8`](https://github.com/NixOS/nixpkgs/commit/4a5860b8f891b6d2fe6d19e9ecb5f3c0caf87ea1) | `` python3Packages.django_6: fix flaky test on aarch64-linux ``                                                    |
| [`a37b229b`](https://github.com/NixOS/nixpkgs/commit/a37b229b120ec965c464786c496f2a8ae94844ff) | `` python3Packages.django-formtools: disable failing test ``                                                       |
| [`ac986b65`](https://github.com/NixOS/nixpkgs/commit/ac986b65d9eff37f2168d2817564780263e27337) | `` python3Packages.django_6: 6.0.5 -> 6.0.6 ``                                                                     |
| [`575805ab`](https://github.com/NixOS/nixpkgs/commit/575805ab846fe68cf56c5966524416a71bb9b15e) | `` python3Packages.django-formtools: 2.5.1 -> 2.6.1 ``                                                             |
| [`878fbce6`](https://github.com/NixOS/nixpkgs/commit/878fbce64b2e29a489e3d04c5d7dd16af49b37cf) | `` gromacs: 2026.1 -> 2026.2 ``                                                                                    |
| [`620f6399`](https://github.com/NixOS/nixpkgs/commit/620f6399ab2de30f0563535281d0da0c497f06b3) | `` halloy: 2026.7 -> 2026.7.1 ``                                                                                   |
| [`ccb7c34d`](https://github.com/NixOS/nixpkgs/commit/ccb7c34d0dd770bab2235d1a1f66d9f8acccdd9c) | `` zsh: 5.9 -> 5.9.1 ``                                                                                            |
| [`a27ae705`](https://github.com/NixOS/nixpkgs/commit/a27ae7050d10885a7c0974c70891394c2770943d) | `` pnpm_11: 11.4.0 -> 11.5.1 ``                                                                                    |
| [`215542fe`](https://github.com/NixOS/nixpkgs/commit/215542fe4bea2a8b0e80eeec17d3743deb92530b) | `` noriskclient-launcher-unwrapped: 0.6.21 -> 0.6.22 ``                                                            |
| [`96d8886c`](https://github.com/NixOS/nixpkgs/commit/96d8886cd7065323c5c85179e1a0bf3226452f7f) | `` caddy: 2.11.3 -> 2.11.4 ``                                                                                      |
| [`69dfbb74`](https://github.com/NixOS/nixpkgs/commit/69dfbb74c9c6cb5caba1ac647c537470d899cabf) | `` nixos/preSwitchChecks: actually set errexit inside check bodies ``                                              |
| [`007d830d`](https://github.com/NixOS/nixpkgs/commit/007d830d1cab5a1bd2597d72c5544b78d7624ac2) | `` saunafs: 5.9.0 -> 5.10.0 ``                                                                                     |
| [`d357c1ac`](https://github.com/NixOS/nixpkgs/commit/d357c1ac4d886e6f24420b8b6204d888b8774066) | `` feishin: 1.11.0 -> 1.13.0 ``                                                                                    |
| [`6fc02d06`](https://github.com/NixOS/nixpkgs/commit/6fc02d06ed9cef3fc118e7c30b20e106dfaaf6ab) | `` libinput: 1.31.2 -> 1.31.3 ``                                                                                   |
| [`4a083bdf`](https://github.com/NixOS/nixpkgs/commit/4a083bdf0b6ca4a063c7b48712c2c12669a1cde4) | `` libinput: 1.31.1 -> 1.31.2 ``                                                                                   |
| [`a88dd025`](https://github.com/NixOS/nixpkgs/commit/a88dd0258933e80b4a44f68a86d20d9ab88ba1d5) | `` apache-airflow: fix building on darwin ``                                                                       |
| [`a06bebb6`](https://github.com/NixOS/nixpkgs/commit/a06bebb644ec3d823e7d17079401f6b3bfd9ddaa) | `` prooftree: refactor ``                                                                                          |
| [`43ca50fc`](https://github.com/NixOS/nixpkgs/commit/43ca50fc10ac481cbeaa59e1eda9afe71569eac1) | `` minizinc: 2.9.3 → 2.9.7 ``                                                                                      |
| [`a6e7e9fd`](https://github.com/NixOS/nixpkgs/commit/a6e7e9fdb679d2222dc5d3bc48dd68bf328c86b2) | `` beamMinimal27Packages.erlang: use upstream doc target patch ``                                                  |
| [`9a2ae538`](https://github.com/NixOS/nixpkgs/commit/9a2ae538fd4202f087a75ce0df0c04bd8ed42c51) | `` ddhx: add meta.mainProgram ``                                                                                   |
| [`5b74e0e8`](https://github.com/NixOS/nixpkgs/commit/5b74e0e8dff75696614a287ad58f21d0f4324bbe) | `` gleam: 1.16.0 -> 1.17.0 ``                                                                                      |
| [`30af2c2b`](https://github.com/NixOS/nixpkgs/commit/30af2c2b67ac2778fc61195aa735fc5cc2e15ce0) | `` mastodon: 4.5.10 -> 4.5.11 ``                                                                                   |
| [`f3a3507c`](https://github.com/NixOS/nixpkgs/commit/f3a3507cdf1c9919617b580c320eec4e99e7fc0b) | `` beamPackages.elixir_1_20: 1.20.0-rc.6 -> 1.20.0 ``                                                              |
| [`3d4f0209`](https://github.com/NixOS/nixpkgs/commit/3d4f0209d30e5ac53fa20491ce93914c0a50da1b) | `` andcli: 2.6.2 -> 2.7.0 ``                                                                                       |
| [`1ce3eb21`](https://github.com/NixOS/nixpkgs/commit/1ce3eb217363eed43e8e1a570614ed2125bfd4fa) | `` github-desktop: link libexec/git-core into git wrapper ``                                                       |
| [`4e1d9c42`](https://github.com/NixOS/nixpkgs/commit/4e1d9c4272c099b4abffb73925fb86ac6aa4876e) | `` hiredis: 1.3.0 -> 1.4.0 ``                                                                                      |
| [`0c27613c`](https://github.com/NixOS/nixpkgs/commit/0c27613c790faa45d90c85549a231cf6a50ef74b) | `` appflowy: update license ``                                                                                     |
| [`f8de93b6`](https://github.com/NixOS/nixpkgs/commit/f8de93b612f03011278cd2b4e62e7258fafc9190) | `` nixos/transmission: drop stale activationScripts reference from docs ``                                         |
| [`0bfa9a89`](https://github.com/NixOS/nixpkgs/commit/0bfa9a8993f728b25e794a44ccd9420008da917c) | `` turbo-unwrapped: 2.9.14 -> 2.9.16 ``                                                                            |
| [`2cbfd1ea`](https://github.com/NixOS/nixpkgs/commit/2cbfd1eab4f02d4ec5ceff671524d379e60e58d2) | `` sdl3-mixer: 3.2.2 -> 3.2.4 ``                                                                                   |
| [`2b8e5006`](https://github.com/NixOS/nixpkgs/commit/2b8e5006b03845a28e3d2ff8e783de245cd09f4c) | `` source2viewer-cli: 19.1 -> 19.2 ``                                                                              |
| [`680e469f`](https://github.com/NixOS/nixpkgs/commit/680e469f8a61dde02ffda249011e2d8d42a64ba9) | `` garnet: 1.1.9 -> 1.1.10 ``                                                                                      |
| [`1a324a30`](https://github.com/NixOS/nixpkgs/commit/1a324a307b712fc8787c13913f8b74dd1941873a) | `` ultrastardx: 2026.5.0 -> 2026.6.0 ``                                                                            |
| [`a6ee667a`](https://github.com/NixOS/nixpkgs/commit/a6ee667a2572a8139fa6fbf3548b952cfa7c3835) | `` actool: 2.1.2 -> 2.2.4 ``                                                                                       |
| [`2eeaba33`](https://github.com/NixOS/nixpkgs/commit/2eeaba33b4ef60d92c69746b5dc874c6a34aa2de) | `` actool: 2.0.0 -> 2.1.2 ``                                                                                       |
| [`be1ac3c6`](https://github.com/NixOS/nixpkgs/commit/be1ac3c60d481d283da6e428457056e5cdac7164) | `` modrinth-app-unwrapped: 0.13.17 -> 0.14.2 ``                                                                    |
| [`b931d45d`](https://github.com/NixOS/nixpkgs/commit/b931d45d5867e4d65253ae48dde7bc3566e8515d) | `` nixos/weblate: ensure ssh wrappers are up to date ``                                                            |
| [`f2edf48a`](https://github.com/NixOS/nixpkgs/commit/f2edf48a3c1971e1b272e67c2ad264e02922a6ce) | `` openlist: 4.2.1 -> 4.2.2 ``                                                                                     |
| [`7f2c7b32`](https://github.com/NixOS/nixpkgs/commit/7f2c7b323ed9de67d94864abed0cc1a3a19f3b9d) | `` openlist: remove fuse ``                                                                                        |
| [`23c8e0dd`](https://github.com/NixOS/nixpkgs/commit/23c8e0dd634f291ea0b7e6f16a698fd4d6c73ae7) | `` mesa: 26.1.1 -> 26.1.2 ``                                                                                       |
| [`9190bf77`](https://github.com/NixOS/nixpkgs/commit/9190bf77cb790b86b333704c1a174089b301c8e4) | `` mesa: drop a patch applied in 26.1.1 ``                                                                         |
| [`668a3af6`](https://github.com/NixOS/nixpkgs/commit/668a3af6913e3af5394d0c883043da28adae7602) | `` mesa: fix timeout on Darwin ``                                                                                  |
| [`deb4c366`](https://github.com/NixOS/nixpkgs/commit/deb4c366da30944d54b9b6a4f12b31c6be0314f6) | `` boringssl: 0.20260508.0 -> 0.20260526.0 ``                                                                      |
| [`62f3b525`](https://github.com/NixOS/nixpkgs/commit/62f3b525b24ba30949084f8e8d88965c4d0c58fb) | `` linux/common-config: drop X86_AMD_PSTATE_DYNAMIC_EPP ``                                                         |
| [`af0ca98c`](https://github.com/NixOS/nixpkgs/commit/af0ca98c62dc200ef884c645baa11dfdd4cdcf25) | `` apache-airflow: 3.2.1 -> 3.2.2 ``                                                                               |
| [`2c18330c`](https://github.com/NixOS/nixpkgs/commit/2c18330c02ee770f59389d2fb9d625c6256d1766) | `` python3Packages.stanza: 1.12.0 -> 1.12.1 ``                                                                     |
| [`411c5727`](https://github.com/NixOS/nixpkgs/commit/411c57276685190704c336913b049293d1c330d9) | `` chromium,chromedriver: 148.0.7778.215 -> 149.0.7827.53 ``                                                       |
| [`6adc107f`](https://github.com/NixOS/nixpkgs/commit/6adc107f4f86f5d5ba86447d9df62416ece1ab06) | `` mattermost: add patches for user limit and free banner removal ``                                               |
| [`7d286e09`](https://github.com/NixOS/nixpkgs/commit/7d286e09d707a7c7bcaac9e4906e010fcb699bc4) | `` go_1_25: 1.25.10 -> 1.25.11 ``                                                                                  |
| [`08ef7275`](https://github.com/NixOS/nixpkgs/commit/08ef7275ad8bc6882bf7da6ef949c52783685802) | `` mapserver: 8.6.3 -> 8.6.4 ``                                                                                    |
| [`a55c1ba6`](https://github.com/NixOS/nixpkgs/commit/a55c1ba67c70cec98cc4000ec276fabd1692cb53) | `` geoserver: 2.28.3 -> 2.28.4 ``                                                                                  |
| [`6c385e4b`](https://github.com/NixOS/nixpkgs/commit/6c385e4ba058a90334f257b469d898a6cd069510) | `` weechat-unwrapped: 4.9.0 -> 4.9.1 ``                                                                            |
| [`5d18c2f4`](https://github.com/NixOS/nixpkgs/commit/5d18c2f467b7724ba737a638976e1af8aecb573f) | `` irpf: 2026-1.3 -> 2026-1.4 ``                                                                                   |
| [`4a329e09`](https://github.com/NixOS/nixpkgs/commit/4a329e09f5d922a76bc7ce22a581fa27b2482ca3) | `` irpf: 2026-1.2 -> 2026-1.3 ``                                                                                   |
| [`dca03c1e`](https://github.com/NixOS/nixpkgs/commit/dca03c1e851d013b1ce041fc62e578736cba01d2) | `` brlcad: reduce bext source size ``                                                                              |
| [`7d40ef12`](https://github.com/NixOS/nixpkgs/commit/7d40ef12861aac83de274a6aef13c6f20e8812f5) | `` brave: 1.90.124 -> 1.90.128 ``                                                                                  |
| [`c6295c84`](https://github.com/NixOS/nixpkgs/commit/c6295c84151262e805a545697cd157138fcfc92d) | `` root: fix Darwin build ``                                                                                       |
| [`7d688f23`](https://github.com/NixOS/nixpkgs/commit/7d688f236e81baeb551a2fd784fe70082fdb4665) | `` nixos/displayManager: replace ad-hoc type // { check } overrides ``                                             |
| [`739fb94c`](https://github.com/NixOS/nixpkgs/commit/739fb94ce2073821b128968aa3252fd44d26750b) | `` thunderbird-latest-bin-unwrapped: 150.0.2 -> 151.0.1 ``                                                         |
| [`5544a150`](https://github.com/NixOS/nixpkgs/commit/5544a1507d3597fa43bdd3c61a7ac4ef43cd33be) | `` reaction: 2.4.0 -> 2.4.1 ``                                                                                     |
| [`b51fb2f9`](https://github.com/NixOS/nixpkgs/commit/b51fb2f952762920379b211d2ab9087884eea04b) | `` xorg-server: 21.1.22 -> 21.1.23 ``                                                                              |
| [`199600b1`](https://github.com/NixOS/nixpkgs/commit/199600b191097e243d4f81631c1326b1ad372f0f) | `` bitwarden-desktop: 2026.3.1 -> 2026.5.0 ``                                                                      |
| [`743df204`](https://github.com/NixOS/nixpkgs/commit/743df204ebd572fe176c5dc343df1a51fceeb04f) | `` k3s_1_36: 1.36.0+k3s1 -> 1.36.1+k3s1 ``                                                                         |
| [`743fc036`](https://github.com/NixOS/nixpkgs/commit/743fc0361ed82e5a3c61ac6d58523fa3765ea41d) | `` k3s_1_35: 1.35.4+k3s1 -> 1.35.5+k3s1 ``                                                                         |
| [`0a00d0df`](https://github.com/NixOS/nixpkgs/commit/0a00d0dfc7644a6dd3b128917871ffaa72c00090) | `` k3s_1_34: 1.34.7+k3s1 -> 1.34.8+k3s1 ``                                                                         |
| [`2bec9c33`](https://github.com/NixOS/nixpkgs/commit/2bec9c3358e415f78ed15559717a687edffb56a0) | `` k3s_1_33: 1.33.11+k3s1 -> 1.33.12+k3s1 ``                                                                       |
| [`da2bfff4`](https://github.com/NixOS/nixpkgs/commit/da2bfff4b1948ca63be89f8660422df73677f4fd) | `` redis: 8.6.3 -> 8.8.0 ``                                                                                        |