### PR TITLE
fix(nas): make gtk bookmark reconcile idempotent and race-safe

### DIFF
--- a/modules/services/nas-home.nix
+++ b/modules/services/nas-home.nix
@@ -54,18 +54,34 @@ in
         wifiCondition = if m.wifi != null then ''[ "$SSID" = "${m.wifi}" ]'' else "true";
 
         scriptFile = pkgs.writeShellScript "nas-bookmark-${lib.replaceStrings [ "/" ] [ "-" ] m.path}" ''
+          set -u
           BOOKMARK="$HOME/.config/gtk-3.0/bookmarks"
           mkdir -p "$(dirname "$BOOKMARK")"
+          touch "$BOOKMARK"
 
           SSID="$(${cfg.wifiDetectionCmd})"
 
-          if ${wifiCondition}; then
-            if ! grep -Fxq "${bookmarkLine}" "$BOOKMARK" 2>/dev/null; then
-              echo "${bookmarkLine}" >> "$BOOKMARK"
+          # Idempotent reconcile: always strip every existing copy of this
+          # bookmark line first, then add back exactly one when the wifi
+          # condition holds. The previous "append unless grep finds it"
+          # approach could not self-heal duplicates that had already
+          # accumulated (a missing guard in an earlier revision left
+          # ~/.config/gtk-3.0/bookmarks with hundreds of repeated NAS
+          # entries, which crashed gThumb's bookmark loader in memmove).
+          #
+          # One oneshot runs per mount and they all rewrite this single file,
+          # so a lock serialises them (read-modify-write would otherwise race,
+          # with the last `mv` clobbering a sibling's just-added line). The
+          # rewrite via a temp file keeps each update atomic.
+          exec ${pkgs.util-linux}/bin/flock "$BOOKMARK.lock" ${pkgs.bash}/bin/bash -c '
+            BOOKMARK="$1"; line="$2"; want="$3"
+            tmp="$(mktemp "$BOOKMARK.XXXXXX")"
+            grep -Fxv "$line" "$BOOKMARK" > "$tmp" 2>/dev/null || true
+            if [ "$want" = "1" ]; then
+              echo "$line" >> "$tmp"
             fi
-          else
-            sed -i "\|${bookmarkLine}|d" "$BOOKMARK" 2>/dev/null || true
-          fi
+            mv "$tmp" "$BOOKMARK"
+          ' bash "$BOOKMARK" "${bookmarkLine}" "$(if ${wifiCondition}; then echo 1; else echo 0; fi)"
         '';
       in
       acc


### PR DESCRIPTION
## Summary

Fixes a gThumb startup segfault caused by our own NAS bookmark service.

The per-mount bookmark oneshot only appended (guarded by an exact-line
`grep`) or removed its own line. It could not self-heal duplicates that had
already accumulated, and concurrent oneshots racing on the shared
`~/.config/gtk-3.0/bookmarks` file could reintroduce them. The file had grown
to hundreds of repeated NAS entries (652 lines, 12 unique), which crashed
gThumb's bookmark loader (`update_system_bookmark_list_ready` → `memmove`
SIGSEGV — reproduced on a trivial 64×64 PNG, confirming it was the bookmark
file and not the image).

Now reconciles idempotently: strip every existing copy of the line, then add
back exactly one when the wifi condition holds, writing via a temp file for
atomicity and serialising the per-mount services with an `flock` so they
cannot clobber each other's updates. This collapses the already-duplicated
file back to one entry per mount on next activation.

## Verification

- `nix eval` of both impacted desktops (Daytona, maranello) is clean.
- Dedup logic dry-run on the real corrupted file: 652 → 12 lines, all
  bookmarks preserved.
- After cleaning the live file, gThumb launches and stays open with no
  segfault (previously SIGSEGV on every launch).