### PR TITLE
feat(user): add primary and extra users to the input group

### DIFF
--- a/modules/base/user.nix
+++ b/modules/base/user.nix
@@ -29,6 +29,7 @@ in
           "wheel"
           "docker"
           "wireshark"
+          "input"
         ];
 
         packages = with pkgs; [
@@ -50,6 +51,7 @@ in
           "wheel"
           "docker"
           "wireshark"
+          "input"
         ];
         packages = with pkgs; [
           gh


### PR DESCRIPTION
## Summary

Grants both the primary user and any extra users membership in the `input`
group for access to `/dev/input` devices (evdev-based input tooling,
controllers, and similar). Added to both user blocks in
`modules/base/user.nix` for consistency.

## Verification

- `nix eval` clean on a representative spread: Daytona (desktop), fredvps
  (the only host with an extra user), and acarshub (server).