### PR TITLE
chore(flake/home-manager-stable): `e28654b7` -> `4eb4fec4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -533,11 +533,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780361225,
-        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
+        "lastModified": 1780883961,
+        "narHash": "sha256-WU6SUrESuPiEXEUvX4D51AgWrXRJty+sLJBwBaDBGqE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
+        "rev": "4eb4fec41674d5b059aa2eedf0f98453890546fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`4eb4fec4`](https://github.com/nix-community/home-manager/commit/4eb4fec41674d5b059aa2eedf0f98453890546fa) | `` flake: bump nixpkgs from `ec942ba` to `6b31628` `` |