### PR TITLE
chore(flake/nixvim): `19fd9d7d` -> `82f2ec36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -829,11 +829,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780865526,
-        "narHash": "sha256-znDAT8hY5w5rdgdcU7jMkNzW8hHMDc61QoCYmYd04XU=",
+        "lastModified": 1780884186,
+        "narHash": "sha256-ueTLp7DofvIZ0BXEWwi8AjP1cCsuEfO445dk6DtmfKc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "19fd9d7d1ed85e32871987f5e0a57aa5fa9673b7",
+        "rev": "82f2ec369eb597554a71ec82f33922d01b7dba8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`82f2ec36`](https://github.com/nix-community/nixvim/commit/82f2ec369eb597554a71ec82f33922d01b7dba8f) | `` lib/modules: drop removal stubs ``                                                         |
| [`11a58641`](https://github.com/nix-community/nixvim/commit/11a586418cce22c69bd4ed9729e8c319cb76ade4) | `` lib/builders: drop removal stubs ``                                                        |
| [`6d522f78`](https://github.com/nix-community/nixvim/commit/6d522f780544859bfec5b52926c5a6239b06f76d) | `` lib/options: drop removal stubs ``                                                         |
| [`5ff549fd`](https://github.com/nix-community/nixvim/commit/5ff549fdafffd437f49293fe4feeff67311078e2) | `` modules/opts: drop rename aliases ``                                                       |
| [`6a2a8308`](https://github.com/nix-community/nixvim/commit/6a2a8308fb407a0328f6a9e1d5d105da5841b4c9) | `` modules/autocmd: remove `autoCmd.description` deprecation ``                               |
| [`64f08f9a`](https://github.com/nix-community/nixvim/commit/64f08f9a8514ee8a808334dc5274ecf952247c14) | `` tests/plugins/multicursors: fix + re-enable `hint.border` example ``                       |
| [`43aea9e3`](https://github.com/nix-community/nixvim/commit/43aea9e35893128f5a04eab3bbfcc3d0129812bb) | `` plugins/windsurf-nvim: drop some renames ``                                                |
| [`48882009`](https://github.com/nix-community/nixvim/commit/488820094e22de54816f036d0232115e8bb2d6cb) | `` plugins/typescript-tools: drop settings renames ``                                         |
| [`f782166c`](https://github.com/nix-community/nixvim/commit/f782166c3d631af6db6ecbbcbd83b0fe6ed60ff0) | `` plugins/lualine: drop section-type coercion ``                                             |
| [`2d883617`](https://github.com/nix-community/nixvim/commit/2d8836174438c65ce08a13de5f79e10f800ccbdb) | `` lib/deprecations: drop `mkDeprecatedSubOptionModule` and deprecate `getOptionRecursive` `` |
| [`a25f7cf0`](https://github.com/nix-community/nixvim/commit/a25f7cf0561521c2cde685a176bb6cff4fb7071f) | `` plugins/web-devicons: drop auto-enable and back-compat ``                                  |
| [`6b494042`](https://github.com/nix-community/nixvim/commit/6b494042f856a407ba7b691442c77a4093035682) | `` modules/readonly-renames: drop ``                                                          |
| [`64328420`](https://github.com/nix-community/nixvim/commit/643284206b9fe4761fd1417025aebf6903b31fa5) | `` ci/website: simplify docs build ``                                                         |
| [`a1ef7c93`](https://github.com/nix-community/nixvim/commit/a1ef7c93db5f0dbf1d09a3280f7f9ae894742e7e) | `` ci/website: use pre-installed `yq` ``                                                      |