### PR TITLE
chore(flake/freminal): `cd6c72b7` -> `21259ced`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1780685417,
-        "narHash": "sha256-V2MTxWN+9nJSFze452M1Gm1hNr3l6IjoJpBq/nvkajU=",
+        "lastModified": 1780940979,
+        "narHash": "sha256-4txVd3ZVSYTMsjlyLQd7/qVp5cbG9TWY4pN1gLeXT/w=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "cd6c72b74cc567d336815d19c86be7b116b0fefd",
+        "rev": "21259ced9c5a2cb9e71321c2174df4324b0a3e3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`4d332d04`](https://github.com/fredsystems/freminal/commit/4d332d04714d4a645126945579e1f421ef07fb99) | `` fix: keep the screen full and the live bottom pinned when folding command blocks `` |
| [`08ebe4a4`](https://github.com/fredsystems/freminal/commit/08ebe4a40e4b13e23408b4484500d478e08ab024) | `` chore: update cargo deps ``                                                         |
| [`b2487af0`](https://github.com/fredsystems/freminal/commit/b2487af0e557ff65078f67cb3d9e623b2c1fc209) | `` feat: 73.6 -- move command-duration label into the gutter ``                        |
| [`4bdc6c7e`](https://github.com/fredsystems/freminal/commit/4bdc6c7e9075c5384f5e39bdf251f1421f68abd3) | `` fix: bash shell integration emits OSC 133 C under bash --posix ``                   |
| [`2a14818d`](https://github.com/fredsystems/freminal/commit/2a14818dfe3bcea10c7808f6a43992555431ee72) | `` feat: 73.5 -- gutter is the sole command-block hover trigger ``                     |
| [`c53ead85`](https://github.com/fredsystems/freminal/commit/c53ead85550736eebf19f1e95812ea9e9b82a8d5) | `` fix: 73.7 -- measure command duration from execution start, not prompt start ``     |
| [`dbce587b`](https://github.com/fredsystems/freminal/commit/dbce587befaa6a3eff6f4061eb8de27d7f80ad9c) | `` feat: 73.4 -- settings dropdown for command-block gutter position ``                |
| [`9abdbf81`](https://github.com/fredsystems/freminal/commit/9abdbf81bb8b7d3b11aa5b62bd2bc2f7db936804) | `` feat: 73.3 -- command-block gutter click and hover ``                               |
| [`c82ec9a2`](https://github.com/fredsystems/freminal/commit/c82ec9a2be4c3eba4ca4510cd25040eb89d22e13) | `` feat: 73.2 -- render command-block status gutter column ``                          |
| [`f100bc20`](https://github.com/fredsystems/freminal/commit/f100bc20f879bca27b9db33a7a563cb53ad04522) | `` feat: 73.1 -- add command-block gutter colors to ThemePalette ``                    |
| [`f929a669`](https://github.com/fredsystems/freminal/commit/f929a6693ea044785d269e1095e0510ed00ba200) | `` fix: suppress command-block overlays on the alternate screen ``                     |