### PR TITLE
chore(flake/home-manager): `b2b7db48` -> `e9cbe698`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1780938273,
+        "narHash": "sha256-jWV4rIH90Sy/Q8eakQwCuboTztx7D8HnoGpRUfij1gM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "e9cbe69850d67c2b472db8416faca7292960f99f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`e9cbe698`](https://github.com/nix-community/home-manager/commit/e9cbe69850d67c2b472db8416faca7292960f99f) | `` sshAuthSock: avoid cycles for socket providers ``  |
| [`301871cd`](https://github.com/nix-community/home-manager/commit/301871cd96c005a410e8317e90b80d59ac312c4a) | `` zellij: add support for plugins ``                 |
| [`ec56189b`](https://github.com/nix-community/home-manager/commit/ec56189b4f94a81e1aef3b1b42ee5d880fd7261b) | `` zellij: add myself to maintainers ``               |
| [`78da10c4`](https://github.com/nix-community/home-manager/commit/78da10c4af3c897cce979efb8f0d3da014c4e4e9) | `` zed-editor: wrap meta.mainProgram ``               |
| [`5c34a3c7`](https://github.com/nix-community/home-manager/commit/5c34a3c7590cfadd0784ee879998509daf3e665b) | `` maintainers: update all-maintainers.nix ``         |
| [`4fe95527`](https://github.com/nix-community/home-manager/commit/4fe95527cbe952713318ada8a4d122e1a6ab120f) | `` pi-coding-agent: scrub package in Darwin tests ``  |
| [`0c42c7a6`](https://github.com/nix-community/home-manager/commit/0c42c7a66f0af09b0dfc3bce4846c784de96a2da) | `` darkman: replace removed python2 in test ``        |
| [`aa14fc7b`](https://github.com/nix-community/home-manager/commit/aa14fc7b467fffc4dae4bcabbb1c04facdcb83b8) | `` tests: update generated TOML expectations ``       |
| [`e4b8f8c8`](https://github.com/nix-community/home-manager/commit/e4b8f8c8bfd44024ec407a43269c8989100f5aef) | `` flake: bump nixpkgs from `4100e83` to `ffa10e2` `` |
| [`d4d5d9bb`](https://github.com/nix-community/home-manager/commit/d4d5d9bb4ae5d97b2af13ad26b0c5704cd485714) | `` nushell: add abbreviations option ``               |
| [`ddb70826`](https://github.com/nix-community/home-manager/commit/ddb7082625bd0c0c568e6ffaff00e72b7a724b27) | `` lib: separate eval config file ``                  |