### PR TITLE
chore(flake/nixpkgs-stable): `9b696460` -> `bd0ff2d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -696,11 +696,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1780734595,
-        "narHash": "sha256-DmTfP92QFYRLOGXlMIE54MAgxSJjDWocl3gRNOu72Os=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9b696460ac78b5ccfc17c854d8c976f20456e943",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`da29d4f5`](https://github.com/NixOS/nixpkgs/commit/da29d4f53ef736d4d680d540504fa0a5562935c3) | `` nixos/plasma6: install plasma-keyboard by default ``                          |
| [`a240e1e3`](https://github.com/NixOS/nixpkgs/commit/a240e1e3719302f75c13092054a48f5c40923855) | `` haveged: 1.9.20 -> 1.9.21 ``                                                  |
| [`078137aa`](https://github.com/NixOS/nixpkgs/commit/078137aa207804fdeaf0f5794442d5a7f4e53438) | `` ollama: fix darwin build by disabling MLX backends ``                         |
| [`662ac762`](https://github.com/NixOS/nixpkgs/commit/662ac762a4f8dbf71759e1b9d195cc237c8e2367) | `` ollama: use `tag` field for llama.cpp pin + drop redundant version comment `` |
| [`dec60791`](https://github.com/NixOS/nixpkgs/commit/dec607914a6087e869bba86ca85db55b4107f4e8) | `` calibre: 9.8.0 -> 9.9.0 ``                                                    |
| [`aa1625de`](https://github.com/NixOS/nixpkgs/commit/aa1625de35e6d72cc1e6eae8545d474d7b8878d4) | `` librepods: 0.2.0 -> 0.2.5 ``                                                  |
| [`e4a88414`](https://github.com/NixOS/nixpkgs/commit/e4a88414a5a709d9c62f273ffe39a99dc85547f4) | `` openspec: 1.3.1 -> 1.4.1 ``                                                   |
| [`2007c375`](https://github.com/NixOS/nixpkgs/commit/2007c375d18c763d71da9a3847a1ac807bb1b336) | `` pgdog: 0.1.42 -> 0.1.43 ``                                                    |
| [`a1fada17`](https://github.com/NixOS/nixpkgs/commit/a1fada17230b88b45a4e822e291d1b90a2c11458) | `` sub-store-frontend: 2.17.19 -> 2.17.31 ``                                     |
| [`eb8720b0`](https://github.com/NixOS/nixpkgs/commit/eb8720b009cd6394cf64edf97bf9e15eb81dc7b7) | `` arti: add patch for TROVE-2026-024 ``                                         |
| [`ac5764a5`](https://github.com/NixOS/nixpkgs/commit/ac5764a5e9cbf36f8fe7491258f5ebb2be9ecef6) | `` arti: 2.3.0 -> 2.4.0 ``                                                       |
| [`cb755e62`](https://github.com/NixOS/nixpkgs/commit/cb755e62246aea5d83102c8bbb49e990a06eecc8) | `` cargo-mutants: 27.0.0 -> 27.1.0 ``                                            |
| [`cfc2d4c2`](https://github.com/NixOS/nixpkgs/commit/cfc2d4c22e583a245d6cfe09ce40e9ea5998fa33) | `` delineate: 0.1.1 -> 0.1.2 ``                                                  |
| [`e6306473`](https://github.com/NixOS/nixpkgs/commit/e630647319b86cafb364388e970badd7f6f1f00d) | `` weblate: relax hiredis dependency ``                                          |
| [`0b04114a`](https://github.com/NixOS/nixpkgs/commit/0b04114a84479b437829ba19048c900bf4a6c3a8) | `` python3Packages.hiredis: add hythera as maintainer ``                         |
| [`d63076bf`](https://github.com/NixOS/nixpkgs/commit/d63076bfdcaa1cb9d44584b412e6293f3a8f7e9a) | `` python3Packages.hiredis: modernize ``                                         |
| [`f50a2054`](https://github.com/NixOS/nixpkgs/commit/f50a2054800e381c3bd2d8335d7fcbe7bb91feba) | `` python3Packages.hiredis: 3.3.1 -> 3.4.0 ``                                    |
| [`7d09fe5f`](https://github.com/NixOS/nixpkgs/commit/7d09fe5ff0512c1a4198dd03941ff0994aba377a) | `` mumble, murmur: add hax404 as maintainer ``                                   |
| [`c40c3065`](https://github.com/NixOS/nixpkgs/commit/c40c306541b3cd9690513089f049927be9844e0e) | `` ci/eval/compare: show performance comparison even when package sets differ `` |
| [`80ddccfc`](https://github.com/NixOS/nixpkgs/commit/80ddccfcb7b2ad11775215ee79353cde93e99b25) | `` vacuum-tube: 1.7.1 -> 1.7.2 ``                                                |
| [`6e384312`](https://github.com/NixOS/nixpkgs/commit/6e384312d3c082b6690cd0a72efd6e0f42cbe15c) | `` microsoft-edge: 148.0.3967.83 -> 149.0.4022.52 ``                             |
| [`7b3f6107`](https://github.com/NixOS/nixpkgs/commit/7b3f6107fb2cec637efc13df4b52d4d71b466da4) | `` bookstack: 26.03.3 -> 26.05 ``                                                |
| [`bd6c03e3`](https://github.com/NixOS/nixpkgs/commit/bd6c03e3e2acd0d6190c419d41609d9196bb4b08) | `` mycelium: 0.7.9 -> 0.7.10 ``                                                  |
| [`f9d3e462`](https://github.com/NixOS/nixpkgs/commit/f9d3e462c7c558aa46e67f063c8993e0a10676f4) | `` fluentd: move to by-name ``                                                   |
| [`3be819cb`](https://github.com/NixOS/nixpkgs/commit/3be819cb2244ed39b4db446b386ea79a3c29a07c) | `` repath-studio: 0.4.14 -> 0.4.15 ``                                            |
| [`3d14db37`](https://github.com/NixOS/nixpkgs/commit/3d14db37d5cfc5a5f1bd6d2521beee1417bd1a07) | `` pony-corral: fix compile with 0.63+ ``                                        |
| [`2beaf021`](https://github.com/NixOS/nixpkgs/commit/2beaf021fad4d10c73928de227e457dada107924) | `` ponyc: 0.60.6 -> 0.64.0 ``                                                    |
| [`d7fa3449`](https://github.com/NixOS/nixpkgs/commit/d7fa34496e8a26d72b183d07e44ffe42bedd70d8) | `` qbz: 1.2.14 -> 1.2.15 ``                                                      |
| [`04ec7f25`](https://github.com/NixOS/nixpkgs/commit/04ec7f254bf0da00f498c47f6e593bf888f7705a) | `` qbz: Add missing wrap enabling TLS support in the built-in browser ``         |
| [`56ab3ef2`](https://github.com/NixOS/nixpkgs/commit/56ab3ef259cdf48a04a8354a00dba720bc199b0c) | `` victoriatraces: 0.9.0 -> 0.9.2 ``                                             |
| [`b680f107`](https://github.com/NixOS/nixpkgs/commit/b680f10725374930db5413f5c737ab92f6555d0a) | `` kavita: 0.8.8.3 -> 0.9.0.2 ``                                                 |
| [`ffff8775`](https://github.com/NixOS/nixpkgs/commit/ffff8775afff987b3a05938089967ee44d9dbc65) | `` kavita: fix update-script for by-name ``                                      |
| [`90c14af0`](https://github.com/NixOS/nixpkgs/commit/90c14af08abaf613569b767a6c7d8835e878d357) | `` rgx: 0.12.4 -> 0.12.6 ``                                                      |
| [`845d8b53`](https://github.com/NixOS/nixpkgs/commit/845d8b530f9d2149abdfea8174d45f42fafe0737) | `` brave: 1.90.128 -> 1.91.168 ``                                                |
| [`ce0b8cc5`](https://github.com/NixOS/nixpkgs/commit/ce0b8cc5ddebd680874a1df33ada910b3d2a8da3) | `` ci/github-script/merge: ignore case when checking for merge bot comment ``    |
| [`4947e460`](https://github.com/NixOS/nixpkgs/commit/4947e460ac574565eab53c8554e257b698372641) | `` rustdesk: 1.4.6 -> 1.4.7 ``                                                   |
| [`242b2928`](https://github.com/NixOS/nixpkgs/commit/242b2928b91264376383edfae1119213448a7d0e) | `` {dropbox,dropbox-cli}: move to by-name ``                                     |
| [`5ca9ff26`](https://github.com/NixOS/nixpkgs/commit/5ca9ff267f515db8dc57ea1756841b08f82c13b6) | `` {ibus,ibus-with-plugins}: move to by-name ``                                  |
| [`3e6ab71f`](https://github.com/NixOS/nixpkgs/commit/3e6ab71fb1a0c095e06304c29dd7249c94d076b1) | `` {cni-plugin-,}flannel: move to by-name ``                                     |
| [`11194bf0`](https://github.com/NixOS/nixpkgs/commit/11194bf096a016444abae01676e7ac24aebb7a66) | `` gup: move to by-name ``                                                       |
| [`3c16850a`](https://github.com/NixOS/nixpkgs/commit/3c16850ad85d52007d888cc698462546ac07818a) | `` git-credential-manager: move to by-name ``                                    |
| [`2211d6e2`](https://github.com/NixOS/nixpkgs/commit/2211d6e2760d90a306a72800aa4ce49cc97027aa) | `` compass: move to by-name ``                                                   |
| [`752bd501`](https://github.com/NixOS/nixpkgs/commit/752bd5015a8afa3c47a881abe0ad263eb52a7381) | `` {geany,geany-with-vte}: move to by-name ``                                    |
| [`72903286`](https://github.com/NixOS/nixpkgs/commit/729032866133cbac277ff12ef63ad576691e628e) | `` {m17n_lib,libotf}: move to by-name ``                                         |
| [`2f7fed6b`](https://github.com/NixOS/nixpkgs/commit/2f7fed6ba9c0b899c3d058667c7cb4eca86aaf4f) | `` {mypaint-brushes,mypaint-brushes1}: move to by-name ``                        |
| [`0b1d7a06`](https://github.com/NixOS/nixpkgs/commit/0b1d7a0662075bbbf16d6cc1f0cc4bc8cafc8250) | `` github-changelog-generator: move to by-name ``                                |
| [`11091207`](https://github.com/NixOS/nixpkgs/commit/110912079417c3c66772da80590e2076aa7edc5d) | `` nixos/fwupd: allow fwupd-refresh user to refresh metadata via polkit ``       |
| [`3d54c5f2`](https://github.com/NixOS/nixpkgs/commit/3d54c5f242561d47705f8339d4af02e48f2c5e9c) | `` librewolf: only do LTO on linux ``                                            |
| [`882750e2`](https://github.com/NixOS/nixpkgs/commit/882750e2fe75fa3833de85f7365cf4011d3e672e) | `` pizauth: use upstream's install targets ``                                    |
| [`601e88b5`](https://github.com/NixOS/nixpkgs/commit/601e88b58ddec6419a40a35f0915f886806d84ef) | `` pizauth: add doronbehar to maintainers ``                                     |
| [`e62811ae`](https://github.com/NixOS/nixpkgs/commit/e62811ae083b7efc59ef2db5a2eafd6b7f43de57) | `` inspircd: 4.10.1 -> 4.11.0 ``                                                 |
| [`609fe56b`](https://github.com/NixOS/nixpkgs/commit/609fe56b54fb5f06b0b6bdb1c83d8e19103f7777) | `` {palemoon-bin,palemoon-gtk2-bin}: 34.2.2 -> 34.3.0 ``                         |
| [`eabd9a38`](https://github.com/NixOS/nixpkgs/commit/eabd9a385394422438e777ee748e0eafea04d511) | `` php85: 8.5.6 -> 8.5.7 ``                                                      |
| [`f07570ce`](https://github.com/NixOS/nixpkgs/commit/f07570ce762c6a9314ee6af0c43a06ab7f86ce93) | `` php84: 8.4.21 -> 8.4.22 ``                                                    |
| [`21f3c364`](https://github.com/NixOS/nixpkgs/commit/21f3c364997bb6498d7da8fec07e0611a0eacba9) | `` python3: include ABI debug suffix `d` in `executable` (fixes FT+debug) ``     |
| [`2fef7264`](https://github.com/NixOS/nixpkgs/commit/2fef72642d7eb105061c65d971f4c4f48bd49699) | `` threadcat: init at 0.1.2 ``                                                   |
| [`43458aa7`](https://github.com/NixOS/nixpkgs/commit/43458aa7e5bab52c0b783c074f0265b00a49fd70) | `` frankenphp: 1.12.3 -> 1.12.4 ``                                               |
| [`f4a29156`](https://github.com/NixOS/nixpkgs/commit/f4a29156bec3a3761a8e49cc581806fce4489476) | `` maintainers: add bubylou ``                                                   |
| [`a2b347fb`](https://github.com/NixOS/nixpkgs/commit/a2b347fbc1c9df36dfc9d62e09b1092a5e21d391) | `` vintagestory: 1.22.2 → 1.22.3 ``                                              |
| [`56d438c8`](https://github.com/NixOS/nixpkgs/commit/56d438c83f9f4b440c6dd8d864dba05db2fba608) | `` lima-full: 2.1.1 -> 2.1.2 ``                                                  |
| [`7ebaa9d5`](https://github.com/NixOS/nixpkgs/commit/7ebaa9d54e83fd582f3b9409c8aed02403685eb1) | `` firefoxpwa: fix build failure with wrapper ``                                 |
| [`e39795df`](https://github.com/NixOS/nixpkgs/commit/e39795df10c018240b00a5efb76a013139242a3b) | `` nixosTests.pdfding: fix tests on aarch64-linux gha ``                         |
| [`a766d6ef`](https://github.com/NixOS/nixpkgs/commit/a766d6efbe2897c8c113923ed1f4c8d955eeb36d) | `` pdfding: 1.7.2 -> 1.8.0 ``                                                    |
| [`0937042f`](https://github.com/NixOS/nixpkgs/commit/0937042f5745a2bc759fe1880195484c4899860f) | `` pantheon.xdg-desktop-portal-pantheon: 8.2.0 -> 8.2.0-unstable-2026-06-04 ``   |
| [`574b4010`](https://github.com/NixOS/nixpkgs/commit/574b4010164bba6149435cbb31e5d51442413d95) | `` webkitgtk_6_0: fix build with system malloc ``                                |
| [`79ac2b3e`](https://github.com/NixOS/nixpkgs/commit/79ac2b3e244b7ceb5bb9f31366a2f91158361b3a) | `` webkitgtk_6_0: 2.52.3 → 2.52.4 ``                                             |
| [`83d091e8`](https://github.com/NixOS/nixpkgs/commit/83d091e84662d172911d46c1c55ab20057588003) | `` opensc: fix CVE-2026-10275 ``                                                 |
| [`a25cdbf0`](https://github.com/NixOS/nixpkgs/commit/a25cdbf0f93347f3a268f6cf62d028fde8ae82e0) | `` exiftool: 13.58 -> 13.59 ``                                                   |
| [`7cb1a09c`](https://github.com/NixOS/nixpkgs/commit/7cb1a09cab72549a38f40f14081227406353ec8f) | `` libgphoto2: add meta.changelog ``                                             |
| [`fc80050a`](https://github.com/NixOS/nixpkgs/commit/fc80050a596013f1a9b981ba305e09d64448aa1b) | `` libgphoto2: fetch tag instead of branch ``                                    |
| [`bb44cc5e`](https://github.com/NixOS/nixpkgs/commit/bb44cc5e39c3b9d34947e4f7253f9c5c4ba4d9d0) | `` libgphoto2: 2.5.33 -> 2.5.34 ``                                               |
| [`5c4d9e19`](https://github.com/NixOS/nixpkgs/commit/5c4d9e195d3910d0065eb1db177d8fd987e3ebe8) | `` zabbix.server: add timescaledb support ``                                     |
| [`b7258cac`](https://github.com/NixOS/nixpkgs/commit/b7258caca2823906e2d73fd64046182254b23b34) | `` exim: 4.99.3 -> 4.99.4 ``                                                     |
| [`9e5ab294`](https://github.com/NixOS/nixpkgs/commit/9e5ab294504f229977f046fead74b6e601382832) | `` firefly-iii: 6.6.2 -> 6.6.3 ``                                                |