### PR TITLE
chore(flake/nixpkgs): `331800de` -> `a799d3e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`5760cf80`](https://github.com/NixOS/nixpkgs/commit/5760cf8087080677622a1083bc5181be227acb5c) | `` python3Packages.fastapi-pagination: 0.15.13 -> 0.15.14 ``                                                       |
| [`e8c92bad`](https://github.com/NixOS/nixpkgs/commit/e8c92bad8ad82c8b220be50a178a8599998c30cf) | `` nixos/tests/installer: embiggen /boot for systemd efi boot ``                                                   |
| [`fb026cbc`](https://github.com/NixOS/nixpkgs/commit/fb026cbce1b295d915ae752081f8a690c808112e) | `` lux-cli: 0.30.1 -> 0.31.1 ``                                                                                    |
| [`883c60c7`](https://github.com/NixOS/nixpkgs/commit/883c60c7c1eb808c2fe6fd81cb54db9aa320a774) | `` libretro.flycast: 0-unstable-2026-05-22 -> 0-unstable-2026-06-05 ``                                             |
| [`e75ba886`](https://github.com/NixOS/nixpkgs/commit/e75ba88607ee0181d20b2a15e72e5fec3c051abd) | `` murmure: init at 1.9.0 ``                                                                                       |
| [`9444ac41`](https://github.com/NixOS/nixpkgs/commit/9444ac4134bff6291d545b21db19287c0357e0da) | `` i18next-cli: 1.56.12 -> 1.61.0 ``                                                                               |
| [`36310c6d`](https://github.com/NixOS/nixpkgs/commit/36310c6d3609d79ddce0a13d67cd117da84f5336) | `` vimPlugins.fugit2-nvim: add gpgme as runtimeDeps ``                                                             |
| [`c32084fc`](https://github.com/NixOS/nixpkgs/commit/c32084fc1df29bd058f3383df94ab8cbc44377f9) | `` python3Packages.smg-grpc-servicer: init at 0.5.3 ``                                                             |
| [`e534847c`](https://github.com/NixOS/nixpkgs/commit/e534847c746e6bbc632d6d877518a90a13d84a2a) | `` python3Packages.smg-grpc-proto: init at 0.4.8 ``                                                                |
| [`15bce03b`](https://github.com/NixOS/nixpkgs/commit/15bce03badd8bcc4f454f0f5956471b819fd3dd8) | `` python3Packages.pycrdt-websocket: 0.16.1 -> 0.16.2 ``                                                           |
| [`a26c36c8`](https://github.com/NixOS/nixpkgs/commit/a26c36c801ddea5d7bff19ef76b82ecd7acfd3a9) | `` vimPlugins.codesnap-nvim: 2.0.3 -> 2.0.5 ``                                                                     |
| [`912dd7ed`](https://github.com/NixOS/nixpkgs/commit/912dd7ed0c6bea027eb109cf4cad7fc67000fe8d) | `` malwoverview: 8.0.1 -> 8.0.2 ``                                                                                 |
| [`ce95dc8f`](https://github.com/NixOS/nixpkgs/commit/ce95dc8ff4532a5310f672e1f4cd27a9b297c991) | `` python3Packages.llm-anthropic: 0.25 -> 0.25.1 ``                                                                |
| [`2382a370`](https://github.com/NixOS/nixpkgs/commit/2382a370694114b6f5557da386d54a1c4b6bd541) | `` libretro.atari800: 0-unstable-2026-05-11 -> 0-unstable-2026-05-28 ``                                            |
| [`1b9b8555`](https://github.com/NixOS/nixpkgs/commit/1b9b85556942e6cf3add12206d2acf7c313028ca) | `` nixos/iotop: optionally enable delayacct tracking in kernel ``                                                  |
| [`6139b0f7`](https://github.com/NixOS/nixpkgs/commit/6139b0f7a5d88980f875de28f2c159562f03208b) | `` terraform-providers.hashicorp_google: 7.33.0 -> 7.35.0 ``                                                       |
| [`1dee995d`](https://github.com/NixOS/nixpkgs/commit/1dee995d54ac52203fb09bedbe479a5f3cd274c4) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.336 -> 0.13.337 ``                   |
| [`fb544afe`](https://github.com/NixOS/nixpkgs/commit/fb544afe3fd981e944bcacd7fde9a156df132fe7) | `` python314Packages.homeassistant-stubs: 2026.6.0 -> 2026.6.1 ``                                                  |
| [`73f8162e`](https://github.com/NixOS/nixpkgs/commit/73f8162e0c58d3adc66e44b849113a5f00726d49) | `` shopware-cli: 0.15.2 -> 0.15.3 ``                                                                               |
| [`b5676ba4`](https://github.com/NixOS/nixpkgs/commit/b5676ba4384f1458eae52df8eb956b5137a55f3a) | `` drupal: 11.3.10 -> 11.3.11 ``                                                                                   |
| [`3bd622d8`](https://github.com/NixOS/nixpkgs/commit/3bd622d8e90b50eefc403c320b055a781bb7b269) | `` terraform-providers.keycloak_keycloak: 5.7.0 -> 5.8.0 ``                                                        |
| [`aac0f488`](https://github.com/NixOS/nixpkgs/commit/aac0f488ab449c62d1431cddc5bae85ba856c569) | `` qmmp: 2.3.2 -> 2.3.3 ``                                                                                         |
| [`3f41116f`](https://github.com/NixOS/nixpkgs/commit/3f41116f59d581fb0e785443811644b3832f76c6) | `` python3Packages.dio-chacon-wifi-api: 1.2.2 -> 1.3.0 ``                                                          |
| [`d1cdcee9`](https://github.com/NixOS/nixpkgs/commit/d1cdcee97493e5d36ba9f784b8a8ecc766ccbb38) | `` home-assistant-custom-components.solax_modbus: 2026.06.1 -> 2026.06.3 ``                                        |
| [`be1889aa`](https://github.com/NixOS/nixpkgs/commit/be1889aabccf860a4c6de8c56b8e32deb74db9ab) | `` home-assistant-custom-components.dreo: 1.9.8 -> 1.9.9 ``                                                        |
| [`605041f1`](https://github.com/NixOS/nixpkgs/commit/605041f1af94c1a97a21e2fa979a7e4680f89068) | `` home-assistant-custom-lovelace-modules.meshcore-card: 0.3.5 -> 1.0.0 ``                                         |
| [`a19e792b`](https://github.com/NixOS/nixpkgs/commit/a19e792b033696abefe5230ba1bff62091051259) | `` home-assistant-custom-lovelace-modules.custom-sidebar: 14.0.0 -> 15.0.0 ``                                      |
| [`a08af742`](https://github.com/NixOS/nixpkgs/commit/a08af742a5042a44c9b5f5b4e2ee68260fbe6b09) | `` home-assistant-custom-components.homematicip_local: disable failing test ``                                     |
| [`d81453d9`](https://github.com/NixOS/nixpkgs/commit/d81453d943f6740aaf093fbd87ec5d2796d881ae) | `` home-assistant: ignore install method deprecation ``                                                            |
| [`bb6f2111`](https://github.com/NixOS/nixpkgs/commit/bb6f21118493a16742a431c6079df840a1db79d3) | `` home-assistant: 2026.6.0 -> 2026.6.1 ``                                                                         |
| [`e35abfb4`](https://github.com/NixOS/nixpkgs/commit/e35abfb4f8704088ff55df8861513b30e2c3e787) | `` python3Packages.yoto-api: 3.1.5 -> 3.2.0 ``                                                                     |
| [`becfc8ed`](https://github.com/NixOS/nixpkgs/commit/becfc8ed5b78b06cf44e1b8975e67de322ac99a1) | `` python3Packages.pysmartthings: 4.0.0 -> 4.0.1 ``                                                                |
| [`7b224bbc`](https://github.com/NixOS/nixpkgs/commit/7b224bbcff6f563dddd9e5a3955296c2b72daa29) | `` python3Packages.imgw-pib: 2.2.0 -> 2.2.2 ``                                                                     |
| [`7ad8175a`](https://github.com/NixOS/nixpkgs/commit/7ad8175a9fb78ae36bb3202205ece0ee6cbfb955) | `` python3Packages.idasen-ha: 2.6.5 -> 2.7.0 ``                                                                    |
| [`bd19bae4`](https://github.com/NixOS/nixpkgs/commit/bd19bae499f4c0dfe7d009a06d441d442cbf638e) | `` python3Packages.idasen: 0.12.0 -> 0.13.1 ``                                                                     |
| [`210c23f0`](https://github.com/NixOS/nixpkgs/commit/210c23f00b93681c6cdba7c3d25d3ed9a7ae584d) | `` python3Packages.homelink-integration-api: 0.0.1 -> 0.0.5 ``                                                     |
| [`2cc051c8`](https://github.com/NixOS/nixpkgs/commit/2cc051c8214f11f274c795ab1e052e0eaf22f90f) | `` python3Packages.aiostreammagic: 2.13.1 -> 2.13.2 ``                                                             |
| [`41a08dae`](https://github.com/NixOS/nixpkgs/commit/41a08dae27ddc68191c07f757d3b90673dacf01d) | `` python3Packages.actron-neo-api: 0.5.11 -> 0.5.12 ``                                                             |
| [`0e0393ec`](https://github.com/NixOS/nixpkgs/commit/0e0393ecd22ee4088e9df6fe47053b315eb56aeb) | `` emacs: fix src hash for 30.2 ``                                                                                 |
| [`052f82e8`](https://github.com/NixOS/nixpkgs/commit/052f82e8116bdc7734060e6e1033e06806ee0422) | `` hyfetch: 2.0.5 -> 2.1.0 ``                                                                                      |
| [`6e660616`](https://github.com/NixOS/nixpkgs/commit/6e6606166d52be5925c2879772f9e07280ab09a3) | `` example-robot-data: 4.4.0 -> 5.0.0 ``                                                                           |
| [`e92eb24f`](https://github.com/NixOS/nixpkgs/commit/e92eb24f38a37c5003e83bc8d8632cd5a0243af9) | `` hyfetch: add Misaka13514 to maintainers ``                                                                      |
| [`1c791e2b`](https://github.com/NixOS/nixpkgs/commit/1c791e2b49cd108df11b2be4a3f9b09346cf448c) | `` chhoto-url: 7.1.5 -> 7.2.1 ``                                                                                   |
| [`4462ec24`](https://github.com/NixOS/nixpkgs/commit/4462ec240d317eb86ddf6b435c3036be4b4f5243) | `` python3Packages.torch-geometric: 2.7.0 -> 2.8.0 ``                                                              |
| [`36b6c90e`](https://github.com/NixOS/nixpkgs/commit/36b6c90e6b2a4189806cc4859ce9756a522cfbed) | `` pnpm: switch to nodejs-slim ``                                                                                  |
| [`3617c2f3`](https://github.com/NixOS/nixpkgs/commit/3617c2f3f9da0eeb08e54aec6295247aaa6226e8) | `` tt-flash: 3.6.0 -> 3.8.0 ``                                                                                     |
| [`25dfa100`](https://github.com/NixOS/nixpkgs/commit/25dfa100da30e692d3d0f8cb666336eb8fe26e06) | `` tt-smi: 3.0.30 -> 5.2.0 ``                                                                                      |
| [`77bdaafa`](https://github.com/NixOS/nixpkgs/commit/77bdaafa0db6075f4cb198d75fb826e7381cc1ef) | `` python3Packages.luwen: 0.7.11 -> 0.8.5 ``                                                                       |
| [`44d3eedb`](https://github.com/NixOS/nixpkgs/commit/44d3eedbfb1f081140957c5bad473aa18d6a6f52) | `` luwen: 0.7.14 -> 0.8.5 ``                                                                                       |
| [`0fc34fd6`](https://github.com/NixOS/nixpkgs/commit/0fc34fd699b9e5e3348213e2cb24928106657794) | `` python3Packages.spsdk: 3.6.0 -> 3.9.0 ``                                                                        |
| [`f5b342c3`](https://github.com/NixOS/nixpkgs/commit/f5b342c3f21c3d27f416282fcff24fa67200f8bf) | `` python3Packages.jupyter-collaboration-ui: 2.4.0 -> 2.4.1 ``                                                     |
| [`da351bc9`](https://github.com/NixOS/nixpkgs/commit/da351bc98d5994375e96b59533e21afac902c736) | `` sandbox-runtime: 0.0.52 -> 0.0.54 ``                                                                            |
| [`e00ab5e8`](https://github.com/NixOS/nixpkgs/commit/e00ab5e88fd702cf5335eae78bc67722700b792f) | `` md-tui: 0.10.0 -> 0.10.1 ``                                                                                     |
| [`048ed483`](https://github.com/NixOS/nixpkgs/commit/048ed4834b40e57dbab0cfb37b0c934b619a69bf) | `` home-assistant-custom-components.cable_modem_monitor: 3.14.0-beta.6 -> 3.14.0-beta.10 ``                        |
| [`57b71d27`](https://github.com/NixOS/nixpkgs/commit/57b71d2781b218ccd04680196b5878d4a0ce8780) | `` emacs: drop stale dependency jansson ``                                                                         |
| [`b95e7291`](https://github.com/NixOS/nixpkgs/commit/b95e7291f5f8d5c12479009fb271188000e7ac5c) | `` emacs31: init ``                                                                                                |
| [`04b2b505`](https://github.com/NixOS/nixpkgs/commit/04b2b5057bc33fa78cfc19a7fb414d84a622384d) | `` emacs: refactor: fetchzip→fetchgit ``                                                                           |
| [`ca9bb6c7`](https://github.com/NixOS/nixpkgs/commit/ca9bb6c7372fb14116f7097f148f2d5a339503ff) | `` xenia-canary: 0-unstable-2026-05-03 -> 0-unstable-2026-06-05 ``                                                 |
| [`37b661f8`](https://github.com/NixOS/nixpkgs/commit/37b661f8fb5ef656fc11dba78b157659c183345e) | `` evcc: 0.308.0 -> 0.308.1 ``                                                                                     |
| [`f796d89f`](https://github.com/NixOS/nixpkgs/commit/f796d89fa0a7850b98720bfa309df386f0a21e95) | `` emacs: fix changelog URL for mainline ``                                                                        |
| [`3f2f77e0`](https://github.com/NixOS/nixpkgs/commit/3f2f77e00f3f1bc7b3fa6e9d2d90cd72fd5cbd43) | `` jugglinglab: fix typo in description ``                                                                         |
| [`c4f8bf76`](https://github.com/NixOS/nixpkgs/commit/c4f8bf760851be0f8450a168363f3d938c087c2e) | `` moor: 2.13.2 -> 2.13.4 ``                                                                                       |
| [`e7c25c0b`](https://github.com/NixOS/nixpkgs/commit/e7c25c0b3a53e831f57f20086ba86d50e8c73bcd) | `` python3Packages.libusbsio: 2.1.13 -> 2.2.0 ``                                                                   |
| [`492b25bb`](https://github.com/NixOS/nixpkgs/commit/492b25bbaa0b1712261451969b2b6a58130b970b) | `` rtkit: replace systemd dependency with systemdLibs ``                                                           |
| [`37ea8881`](https://github.com/NixOS/nixpkgs/commit/37ea88817c43f16f36fbee3d8791cec0d118e7f6) | `` golden-cheetah: 3.8-DEV2603 -> 3.8-DEV2605 ``                                                                   |
| [`825b3e6b`](https://github.com/NixOS/nixpkgs/commit/825b3e6b2590fc8889709fdbed4e8c8750e94768) | `` python3Packages.tesla-powerwall: 0.5.2 -> 0.5.3 ``                                                              |
| [`d4e7b4fa`](https://github.com/NixOS/nixpkgs/commit/d4e7b4faabbd612b6a665bb3ce5bdbabbab87ea0) | `` tt-umd: init 0.9.6 ``                                                                                           |
| [`0788a6c2`](https://github.com/NixOS/nixpkgs/commit/0788a6c2b03efe3c3997a148e86d851ff2f596b6) | `` vscode-extensions.bierner.github-markdown-preview: 0.3.0 -> 0.4.0 ``                                            |
| [`757c48b2`](https://github.com/NixOS/nixpkgs/commit/757c48b211fa2a78cf9fe553552dea3e18896a91) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 2.1.0 -> 2.2.0 ``                                          |
| [`2aa83071`](https://github.com/NixOS/nixpkgs/commit/2aa8307146cbb736a4b6e673a94ed7408c8b8072) | `` tt-logger: init 1.1.9 ``                                                                                        |
| [`848616a0`](https://github.com/NixOS/nixpkgs/commit/848616a0d2f0bfd217875b7611531ac6be193cec) | `` nanobench: fix being added via find_package ``                                                                  |
| [`b8f7257d`](https://github.com/NixOS/nixpkgs/commit/b8f7257d1597b2f64d154b4eadcb4d8e7b0e5105) | `` lazyjj: fix build ``                                                                                            |
| [`fd39be7c`](https://github.com/NixOS/nixpkgs/commit/fd39be7c81850bb93f28fff49f4c3f2b7dd54c05) | `` python3Packages.pydocket: 0.21.0 -> 0.21.1 ``                                                                   |
| [`30fdc15f`](https://github.com/NixOS/nixpkgs/commit/30fdc15fb47143f5e4ee96691c7c9b3ca8a7a232) | `` libretro.beetle-psx: 0-unstable-2026-05-23 -> 0-unstable-2026-06-02 ``                                          |
| [`77d458f0`](https://github.com/NixOS/nixpkgs/commit/77d458f0ebc67d4d0242b587ac3f9500f90911a0) | `` apko: 1.2.14 -> 1.2.15 ``                                                                                       |
| [`ce9ca33c`](https://github.com/NixOS/nixpkgs/commit/ce9ca33cc9dcf45dc1aa8eaf8ad0e4a381b46355) | `` python3Packages.symbolic: 13.1.0 -> 13.1.1 ``                                                                   |
| [`ddcc3c80`](https://github.com/NixOS/nixpkgs/commit/ddcc3c803a0ea9f5f1466ce6514e130b4cc87fcc) | `` python3Packages.beautifultable: modernize ``                                                                    |
| [`1fbe39de`](https://github.com/NixOS/nixpkgs/commit/1fbe39ded46bb8450a447ac4187681518a01fb44) | `` python3Packages.beautifultable: migrate to pyproject ``                                                         |
| [`78288812`](https://github.com/NixOS/nixpkgs/commit/78288812638cca3e3e5c621e0ae1b6fba158ee9d) | `` python3Packages.beanstalkc: fix meta.homepage URL ``                                                            |
| [`042f9503`](https://github.com/NixOS/nixpkgs/commit/042f9503512b9c917183bd8e56095850e27084cb) | `` python3Packages.beanstalkc: modernize ``                                                                        |
| [`54509f27`](https://github.com/NixOS/nixpkgs/commit/54509f27c55c255f51f3c1e3b1d9d47212664a50) | `` python3Packages.bc-jsonpath-ng: modernize ``                                                                    |
| [`18655570`](https://github.com/NixOS/nixpkgs/commit/1865557060ebe3846073f74bf6fac795b71ce3ee) | `` python3Packages.bc-jsonpath-ng: migrate to pyproject ``                                                         |
| [`78d31b40`](https://github.com/NixOS/nixpkgs/commit/78d31b401a30872af466fca982d064223ddb2e5a) | `` python3Packages.beanstalkc: migrate to pyproject ``                                                             |
| [`d1995efb`](https://github.com/NixOS/nixpkgs/commit/d1995efb0417cce3bf2834236324242d4a8b059d) | `` filebrowser: add meta.changelog ``                                                                              |
| [`ada2213b`](https://github.com/NixOS/nixpkgs/commit/ada2213bd246061c2d843a7331d73809dfb6724d) | `` rerun: 0.32.2 -> 0.33.0 ``                                                                                      |
| [`e3459d0d`](https://github.com/NixOS/nixpkgs/commit/e3459d0dffb42420726e38e889722cb2811e21eb) | `` glooctl: 1.21.6 -> 1.21.7 ``                                                                                    |
| [`9d170ff9`](https://github.com/NixOS/nixpkgs/commit/9d170ff9047a68fcee65fa6b6873eeb458799977) | `` filebrowser: migrate to finalAttrs ``                                                                           |
| [`01e2b207`](https://github.com/NixOS/nixpkgs/commit/01e2b2072da2a92490d2d1cae8168ab6684df77b) | `` gogup: 1.1.4 -> 1.2.0 ``                                                                                        |
| [`061f52e7`](https://github.com/NixOS/nixpkgs/commit/061f52e7b342cbff501890f83cd018190d70b6ef) | `` filebrowser: unpin nodejs and switch to slim ``                                                                 |
| [`41320d7f`](https://github.com/NixOS/nixpkgs/commit/41320d7fa9cdc53a6c33269ee795d7ddf120b26d) | `` filebrowser: use generic builder instead buildNpmPackage for frontend ``                                        |
| [`7fd167f8`](https://github.com/NixOS/nixpkgs/commit/7fd167f85398e901376343bf5e26cce0421740ae) | `` widevine-cdm: 4.10.2934.0 -> 4.10.3050.0 ``                                                                     |
| [`77a78f73`](https://github.com/NixOS/nixpkgs/commit/77a78f73d1314fac6a4053d09f806eb67437d576) | `` python3Packages.base58check: modernize ``                                                                       |
| [`1ef9f74e`](https://github.com/NixOS/nixpkgs/commit/1ef9f74e2c38d53311d8a47abd520c53ac3e6161) | `` python3Packages.base58check: migrate to pyproject ``                                                            |
| [`71210dc1`](https://github.com/NixOS/nixpkgs/commit/71210dc11c60fe6f79fe4f83e3e0aec64c66f2c6) | `` python3Packages.google-cloud-storage-control: 1.11.0 -> 1.12.0 ``                                               |
| [`30ce89ef`](https://github.com/NixOS/nixpkgs/commit/30ce89ef3ea9b44237aba32a24f14479fc375086) | `` rdap: modernize ``                                                                                              |
| [`b7646dc3`](https://github.com/NixOS/nixpkgs/commit/b7646dc31dcc6d9f44f9b20e589802ae6733553a) | `` python3Packages.victron-mqtt: 2026.5.9 -> 2026.6.1 ``                                                           |
| [`af42a116`](https://github.com/NixOS/nixpkgs/commit/af42a116c7b44015de788891df088ed24423e123) | `` zashboard: 3.6.0 -> 3.7.1 ``                                                                                    |
| [`bbe694f8`](https://github.com/NixOS/nixpkgs/commit/bbe694f8ea6f47bdff43000d3aa7aa0a590892f2) | `` git: Fix cross compilation ``                                                                                   |
| [`db3db433`](https://github.com/NixOS/nixpkgs/commit/db3db433ce445ff648460f2a5c676eec37e531d1) | `` python3Packages.unidata-blocks: migrate to finalAttrs ``                                                        |
| [`6615c522`](https://github.com/NixOS/nixpkgs/commit/6615c522face2e2af68c663b760b97b765329b76) | `` terraform-providers.oracle_oci: 8.15.0 -> 8.17.0 ``                                                             |
| [`074f246c`](https://github.com/NixOS/nixpkgs/commit/074f246ca9f6476e63082b5de0b50d802ea30a9e) | `` nixosTests/zfs: replace direct bootctl call with switch-to-configuration invocation ``                          |
| [`395784d0`](https://github.com/NixOS/nixpkgs/commit/395784d0ef7d118340272c22b33c897e31559537) | `` nixosTests/systemd-initrd-swraid: replace direct bootctl call with switch-to-configuration invocation ``        |
| [`b7e08105`](https://github.com/NixOS/nixpkgs/commit/b7e08105608ebfff482d85c99226b0620429150c) | `` nixosTests/systemd-initrd-luks-unl0kr: replace direct bootctl call with switch-to-configuration invocation ``   |
| [`cf30cd9b`](https://github.com/NixOS/nixpkgs/commit/cf30cd9b67429dd73caa621670ae0882ada31518) | `` nixosTests/systemd-initrd-luks-tpm2: replace direct bootctl call with switch-to-configuration invocation ``     |
| [`52e9fde3`](https://github.com/NixOS/nixpkgs/commit/52e9fde3d49bd999b34a74765eaaa88b70c56745) | `` nixosTests/systemd-initrd-luks-password: replace direct bootctl call with switch-to-configuration invocation `` |
| [`1954609d`](https://github.com/NixOS/nixpkgs/commit/1954609d885f33526dbcaa214cb749eaa933d600) | `` nixosTests/systemd-initrd-luks-keyfile: replace direct bootctl call with switch-to-configuration invocation ``  |
| [`050b24a3`](https://github.com/NixOS/nixpkgs/commit/050b24a35b85e9070833dd778247ff97d4437fda) | `` nixosTests/systemd-initrd-luks-fido2: replace direct bootctl call with switch-to-configuration invocation ``    |
| [`fc890171`](https://github.com/NixOS/nixpkgs/commit/fc890171ad7539498984555c3a4981c793a548cb) | `` nixosTests/systemd-initrd-btrfs-raid: replace direct bootctl call with switch-to-configuration invocation ``    |
| [`709f14a9`](https://github.com/NixOS/nixpkgs/commit/709f14a90c243e36ee34b006b6cf11bf75b55447) | `` nixosTests/lvm2: replace direct bootctl call with switch-to-configuration invocation ``                         |
| [`ec10ce87`](https://github.com/NixOS/nixpkgs/commit/ec10ce872eb66b1392d74347270e3e857711edce) | `` nixosTests/luks: replace direct bootctl call with switch-to-configuration invocation ``                         |
| [`923a32a6`](https://github.com/NixOS/nixpkgs/commit/923a32a64f0b04b2d6fbcccc348ff6223f6195d5) | `` nixosTests/initrd-luks-empty-passphrase: replace direct bootctl call with switch-to-configuration invocation `` |
| [`0d431aa1`](https://github.com/NixOS/nixpkgs/commit/0d431aa197b031f57c578117f8390bf3fa27447d) | `` python3Packages.unstructured: 0.18.28 -> 0.18.31 ``                                                             |
| [`7e7ed65f`](https://github.com/NixOS/nixpkgs/commit/7e7ed65f2982e58fcbbd837ac4a165d7aa7e9b0b) | `` nixos/tests/lvm2: switch to runTest ``                                                                          |
| [`133e0e44`](https://github.com/NixOS/nixpkgs/commit/133e0e44385aa540d20f7d960d2c48d4e1591f94) | `` nixos/tests/zfs: switch to runTest ``                                                                           |
| [`cd10996f`](https://github.com/NixOS/nixpkgs/commit/cd10996ffb0a6b55f8f5b8deb6d7c3d3d20673e0) | `` niimblue: fix hash ``                                                                                           |
| [`94bf14f6`](https://github.com/NixOS/nixpkgs/commit/94bf14f66474dbb50ea4534e7a7a363f5495ed77) | `` nocturne: add a gdk-pixbuf module ``                                                                            |
| [`d77d9a11`](https://github.com/NixOS/nixpkgs/commit/d77d9a1100f97f785ddf5188fe2249499bfd9cae) | `` 9pfs: drop ``                                                                                                   |
| [`84ad4330`](https://github.com/NixOS/nixpkgs/commit/84ad433021a6e0fe20e2656cfd0a2f7454ae1206) | `` afuse: drop ``                                                                                                  |
| [`aa080ad7`](https://github.com/NixOS/nixpkgs/commit/aa080ad7ede1a7f5725f793fa6d7288525ebf000) | `` zuban: fix hash ``                                                                                              |
| [`895ed70a`](https://github.com/NixOS/nixpkgs/commit/895ed70a11c63884f75bde5abba47002eb0543e2) | `` libtrace: 4.0.31-1 -> 4.0.32-2 ``                                                                               |
| [`919b70b2`](https://github.com/NixOS/nixpkgs/commit/919b70b29fc607d1d76f1e3e621d969c7ab13b8e) | `` nixos/systemd-boot: refuse to wipe ESP when no generations found ``                                             |
| [`227de9e9`](https://github.com/NixOS/nixpkgs/commit/227de9e910b00fc0558d01fadf7a954065cfa95c) | `` firefoxpwa: fix build failure with wrapper ``                                                                   |
| [`399c7632`](https://github.com/NixOS/nixpkgs/commit/399c7632ec979029fb2c85e065235c74257c3eb0) | `` tofu-ls: 0.4.2 -> 0.5.0 ``                                                                                      |
| [`94371177`](https://github.com/NixOS/nixpkgs/commit/943711778eb0e487b252a7b31ee2c9adc0fd0c92) | `` python3Packages.django-health-check: 4.4.1 -> 4.4.2 ``                                                          |
| [`0141fba7`](https://github.com/NixOS/nixpkgs/commit/0141fba76d28249201d14742a7945c1e600ac94a) | `` python3Packages.unidata-blocks: 0.0.24 -> 0.0.25 ``                                                             |
| [`fc597795`](https://github.com/NixOS/nixpkgs/commit/fc5977952601397cfb8cd7e6ba013756908c7e69) | `` fuse-7z-ng: drop ``                                                                                             |
| [`5f94c478`](https://github.com/NixOS/nixpkgs/commit/5f94c4782258d84ed37ca141f86ee12319cdf95d) | `` Revert "firefoxpwa: fix build failure with wrapper" ``                                                          |
| [`9a8fd459`](https://github.com/NixOS/nixpkgs/commit/9a8fd459f3ce8c81e0068edd7e35115fb02f6e53) | `` fuseiso: drop ``                                                                                                |
| [`94842ec8`](https://github.com/NixOS/nixpkgs/commit/94842ec8c7cf9f22de6b8655555e5988273c8f04) | `` goverlay: 1.8.1 -> 1.8.2 ``                                                                                     |
| [`1c132d2b`](https://github.com/NixOS/nixpkgs/commit/1c132d2b52515dd5679edaaf38951279419cff02) | `` act: 0.2.88 -> 0.2.89 ``                                                                                        |
| [`3f809e62`](https://github.com/NixOS/nixpkgs/commit/3f809e62dd34874298b956d3bc8846256ba19dfa) | `` cromfs: drop ``                                                                                                 |
| [`f2815afb`](https://github.com/NixOS/nixpkgs/commit/f2815afb25e0327e7e091694f46288738fc24e6f) | `` python3Packages.langchain-deepseek: 1.0.1 -> 1.1.0 ``                                                           |
| [`4f81c7e1`](https://github.com/NixOS/nixpkgs/commit/4f81c7e1014555f93570b8a0c863f114e4401662) | `` littlefs-fuse: drop ``                                                                                          |
| [`1f080aee`](https://github.com/NixOS/nixpkgs/commit/1f080aeeb0ca43f92390f836c3c989727c724aeb) | `` velocity: 3.5.0-unstable-2026-05-24 -> 3.5.0-unstable-2026-06-02 ``                                             |
| [`16b04655`](https://github.com/NixOS/nixpkgs/commit/16b046557b235530ccbf8883342e0337a2931aa2) | `` romdirfs: drop ``                                                                                               |
| [`37477de9`](https://github.com/NixOS/nixpkgs/commit/37477de9496c441c203becdfc6523138aa2a3604) | `` curlftpfs: drop ``                                                                                              |
| [`1cc9c0cf`](https://github.com/NixOS/nixpkgs/commit/1cc9c0cf12ed7f12adadc8adce7b09c2304338d6) | `` pkgs-lib/formats: Use .attrs.json directly for TOML ``                                                          |
| [`309e0a70`](https://github.com/NixOS/nixpkgs/commit/309e0a7036816974330f92d328e68b53462521a7) | `` s3fs: {bump to fuse3, 1.95 -> 1.97} ``                                                                          |
| [`2900201f`](https://github.com/NixOS/nixpkgs/commit/2900201fc4bcd1e04931a49ef85a5f794f53789c) | `` ciopfs: drop ``                                                                                                 |
| [`cc13fe63`](https://github.com/NixOS/nixpkgs/commit/cc13fe63ecc89508649624f1111f688fc1066ed4) | `` antigravity-cli: 1.0.5 -> 1.0.6 ``                                                                              |
| [`1baaa533`](https://github.com/NixOS/nixpkgs/commit/1baaa533290af5531bd946ebc90ef4ea4bd69a57) | `` home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.13 -> 2.1.14 ``                              |
| [`ca316cd1`](https://github.com/NixOS/nixpkgs/commit/ca316cd1ed17e50770b0a0d11fee0e797f06b92d) | `` fulcio: 1.8.6 -> 1.8.7 ``                                                                                       |
| [`c0469ffb`](https://github.com/NixOS/nixpkgs/commit/c0469ffbba5b21dd299722108c8f3d873ccd85d9) | `` securefs: drop ``                                                                                               |
| [`8f1ed870`](https://github.com/NixOS/nixpkgs/commit/8f1ed870e1804df609778bf1befddc9d4a3442d9) | `` limine-full: 12.3.1 -> 12.3.2 ``                                                                                |
| [`7266a29d`](https://github.com/NixOS/nixpkgs/commit/7266a29dd5eda302b7190d779dffc43362c5087b) | `` aws-vault: 7.10.8 -> 7.11.1 ``                                                                                  |
| [`0d6435dc`](https://github.com/NixOS/nixpkgs/commit/0d6435dcf208204dd4606767b1813c1113791501) | `` stackit-cli: 0.63.0 -> 0.64.0 ``                                                                                |
| [`640c05e8`](https://github.com/NixOS/nixpkgs/commit/640c05e8f315ac9b59b06f92a68f45aa06a5801a) | `` systemd: add passthru.nixosTests ``                                                                             |
| [`bbff1ce0`](https://github.com/NixOS/nixpkgs/commit/bbff1ce06ba16cb6f314653b1fb7834ea49cfa3a) | `` amnezia-vpn-bin: 4.8.15.4 -> 4.8.16.0 ``                                                                        |
| [`0b101e99`](https://github.com/NixOS/nixpkgs/commit/0b101e99a1fd3a79a4709b9e812ff4683708031c) | `` wiremix: 0.10.0 -> 0.11.0 ``                                                                                    |
| [`0c70015b`](https://github.com/NixOS/nixpkgs/commit/0c70015b80bbfbe4653aabc45b051c7eb97a6af9) | `` postgres-language-server: 0.25.0 -> 0.25.2 ``                                                                   |
| [`ce05f1ea`](https://github.com/NixOS/nixpkgs/commit/ce05f1eaaffb6da15d788a6939b549cf1c420bab) | `` python3Packages.azure-mgmt-nspkg: modernize ``                                                                  |
| [`f32a905a`](https://github.com/NixOS/nixpkgs/commit/f32a905a25ecb25feec4a8ecd7c707009134d507) | `` multica-cli: 0.3.9 -> 0.3.16 ``                                                                                 |
| [`4e680350`](https://github.com/NixOS/nixpkgs/commit/4e6803508679973995755e7360dd0a3eb7f0d3b5) | `` go-csp-collector: 0.0.17 -> 0.0.22 ``                                                                           |
| [`bdc89b8a`](https://github.com/NixOS/nixpkgs/commit/bdc89b8ab96ebf901c49c8c377f03d6a66ba7185) | `` itgmaniaPackages.digital-dance: 1.1.3-unstable-2026-05-14 -> 1.1.3-unstable-2026-06-04 ``                       |
| [`cc8e22fe`](https://github.com/NixOS/nixpkgs/commit/cc8e22fedbba516042f333be10594b659ca6528f) | `` itgmaniaPackages.itg3encore: 0-unstable-2026-05-26 -> 0-unstable-2026-06-05 ``                                  |
| [`96c6e4c8`](https://github.com/NixOS/nixpkgs/commit/96c6e4c89e19ce7c082de57772d7d70ef6d55598) | `` home-assistant-custom-lovelace-modules.tankerkoenig-card: 1.7.3 -> 1.7.4 ``                                     |
| [`d0dcf543`](https://github.com/NixOS/nixpkgs/commit/d0dcf543f3fa8bc59527600d1bded88e81714f40) | `` transmission_4: migrate to by-name ``                                                                           |
| [`4e55b654`](https://github.com/NixOS/nixpkgs/commit/4e55b654dd6faa66044b05f474f209fc6ece1034) | `` vscode-extensions.jjk.jjk: 0.10.0 -> 0.11.0 ``                                                                  |
| [`c07d260d`](https://github.com/NixOS/nixpkgs/commit/c07d260dc34f6b55a4cc381069124237f873e25f) | `` vimPlugins.codediff-nvim: 2.45.0 -> 2.45.1 ``                                                                   |
| [`fcb1e7da`](https://github.com/NixOS/nixpkgs/commit/fcb1e7dafcc363069ced3d0c15571a9edcb6c507) | `` home-assistant-custom-components.plant: 2026.5.1 -> 2026.6.0 ``                                                 |
| [`d90a8da3`](https://github.com/NixOS/nixpkgs/commit/d90a8da39fec118e6342766f1359e1fa2bce86ba) | `` .github: Bump actions/checkout from 6.0.2 to 6.0.3 ``                                                           |
| [`6901b09d`](https://github.com/NixOS/nixpkgs/commit/6901b09db6079f1fb9744f9edd53d61a6911b37f) | `` esphome: 2026.5.2 -> 2026.5.3 ``                                                                                |
| [`f60161f6`](https://github.com/NixOS/nixpkgs/commit/f60161f629c3aa4d327daaec753b19fd660a7b2b) | `` sqlar: drop ``                                                                                                  |
| [`d55578dc`](https://github.com/NixOS/nixpkgs/commit/d55578dcc4dbfd987af17f299d27627b9cb70641) | `` vimPlugins.heirline-components-nvim: init at 2026-02-25 ``                                                      |
| [`9d9e03ef`](https://github.com/NixOS/nixpkgs/commit/9d9e03ef41963974fbefe54c2641bc9072764c89) | `` python3Packages.{scancode-toolkit,typecode,extractcode}: add ngi team ``                                        |
| [`56739a4f`](https://github.com/NixOS/nixpkgs/commit/56739a4fb70ad944b79f2dd7332692d9d56cf0d1) | `` python3Packages.extractcode: 31.0.0 -> 31.1.0 ``                                                                |
| [`be64c201`](https://github.com/NixOS/nixpkgs/commit/be64c201ecfdbde0f230c9da289493bccf384962) | `` python3Packages.typecode: fix tests ``                                                                          |
| [`5dd1cda5`](https://github.com/NixOS/nixpkgs/commit/5dd1cda59ea6a3f23c468e95d723f2e9fbc05add) | `` prl-tools: 26.3.2-57398 -> 26.3.3-57507 ``                                                                      |
| [`d2676fad`](https://github.com/NixOS/nixpkgs/commit/d2676fad3c9bbc169490c4033dc1746dd937d874) | `` terraform-providers.tailscale_tailscale: 0.29.1 -> 0.29.2 ``                                                    |
| [`750a03a8`](https://github.com/NixOS/nixpkgs/commit/750a03a82f3abeeac9b2d516ba3af70ea7302872) | `` harper: 2.3.1 -> 2.4.0 ``                                                                                       |
| [`44d376db`](https://github.com/NixOS/nixpkgs/commit/44d376db3a9bd5a16246263d688524d8c2f0b996) | `` open-webui: 0.9.5 -> 0.9.6 ``                                                                                   |
| [`12df3af7`](https://github.com/NixOS/nixpkgs/commit/12df3af7e696e671fe449be93e76779cbb84a385) | `` vertcoin: move env variable into env for structuredAttrs ``                                                     |
| [`dc6f2c13`](https://github.com/NixOS/nixpkgs/commit/dc6f2c134f1f023f9ebd266ea76f59284744dc66) | `` systemd: add README ``                                                                                          |
| [`60dd5f93`](https://github.com/NixOS/nixpkgs/commit/60dd5f93719b8222852011a3ed91e5a881472fca) | `` hoppscotch: 26.4.1-0 -> 26.5.0-0 ``                                                                             |
| [`fe49e6ed`](https://github.com/NixOS/nixpkgs/commit/fe49e6ed3333c53d7ec16cc8179bc43462ee6981) | `` coroot: 1.21.0 -> 1.22.0 ``                                                                                     |
| [`ca6bea3b`](https://github.com/NixOS/nixpkgs/commit/ca6bea3b2a70e86eae496199eceab85e9420496d) | `` maintainers: update HttpRafa ``                                                                                 |
| [`1974596e`](https://github.com/NixOS/nixpkgs/commit/1974596e5dce9e5016fae43be530e19861210c87) | `` ntfy-sh: 2.23.0 -> 2.24.0 ``                                                                                    |
| [`dc0b6d4e`](https://github.com/NixOS/nixpkgs/commit/dc0b6d4e05e389e1baf4b47f295a0f3351d12560) | `` splayer: 3.0.0 -> 3.1.1 ``                                                                                      |
| [`824e2a07`](https://github.com/NixOS/nixpkgs/commit/824e2a07df5461a962b99a102325b31d5bdde690) | `` sish: 2.22.1 -> 2.23.0 ``                                                                                       |
| [`7e321952`](https://github.com/NixOS/nixpkgs/commit/7e32195263f6df2f435034c0a19bc3191fbc1eed) | `` heimdall-proxy: 0.17.15 -> 0.17.16 ``                                                                           |
| [`f3ec7192`](https://github.com/NixOS/nixpkgs/commit/f3ec71920e6cf025573ff03c7b73f1858812cc4d) | `` inputplumber: 0.77.2 -> 0.77.3 ``                                                                               |
| [`cf9e7400`](https://github.com/NixOS/nixpkgs/commit/cf9e74000287703fc0908628a11d2e57d6168a25) | `` python3Packages.marko: migrate to finalAttrs ``                                                                 |
| [`563ff058`](https://github.com/NixOS/nixpkgs/commit/563ff058dc807e09242daf75f5a547995901a8b2) | `` lockbook-desktop: 26.5.22 -> 26.6.1 ``                                                                          |
| [`e06edf94`](https://github.com/NixOS/nixpkgs/commit/e06edf949fd53f19d9e20212fb72fc74fea59356) | `` azure-cli: add msrest to azure-mgmt-cdn 12.0.0 override ``                                                      |
| [`a4fe7a4f`](https://github.com/NixOS/nixpkgs/commit/a4fe7a4f84bde7a99479c3fa1acd43cf37aacd3f) | `` python3Packages.cvxpy: 1.9.0 -> 1.9.1 ``                                                                        |
| [`f30cb849`](https://github.com/NixOS/nixpkgs/commit/f30cb8490a45f8e37440f8d32f79200f657e4d99) | `` home-assistant-custom-lovelace-modules.flower-card: 2026.4.1 -> 2026.6.0 ``                                     |
| [`06f7346d`](https://github.com/NixOS/nixpkgs/commit/06f7346dbb18d1d92da52d4fc8e70d02ce429e4a) | `` lockbook: 26.5.22 -> 26.6.1 ``                                                                                  |
| [`60f648cb`](https://github.com/NixOS/nixpkgs/commit/60f648cbe41d671555851513336da8923c0b09fb) | `` httm: 0.49.9 -> 0.50.0 ``                                                                                       |
| [`837bc64f`](https://github.com/NixOS/nixpkgs/commit/837bc64fe690d04dda8c27583bd769125d34ab11) | `` python3Packages.cyclonedx-python-lib: 11.7.0 -> 11.8.0 ``                                                       |
| [`424b9b03`](https://github.com/NixOS/nixpkgs/commit/424b9b030237dbfc658518afc30d62ec0b255414) | `` python3Packages.cwl-utils: 0.41 -> 0.42 ``                                                                      |
| [`da82e316`](https://github.com/NixOS/nixpkgs/commit/da82e3164016906f1ca40bcd9248f15646665a40) | `` python3Packages.claude-agent-sdk: 0.2.87 -> 0.2.91 ``                                                           |
| [`34ac08e0`](https://github.com/NixOS/nixpkgs/commit/34ac08e0319b4c8e074e93472bbf8b7b0de18a69) | `` python3Packages.aiosmtplib: 5.1.0 -> 5.1.1 ``                                                                   |
| [`72bdabcf`](https://github.com/NixOS/nixpkgs/commit/72bdabcf0dad731479aff32391de73870e1de89f) | `` python3Packages.aiohomeconnect: 0.36.0 -> 0.36.1 ``                                                             |
| [`b0a5fd06`](https://github.com/NixOS/nixpkgs/commit/b0a5fd06e617acdb4f1198552cb9906efb9f1e43) | `` python3Packages.aioautomower: 2.7.5 -> 2.7.6 ``                                                                 |
| [`8b00c310`](https://github.com/NixOS/nixpkgs/commit/8b00c310145ec3a8698cfee4db2a84685ccae2ae) | `` python3Packages.pyworxcloud: 6.3.6 -> 6.4.0 ``                                                                  |
| [`b139b578`](https://github.com/NixOS/nixpkgs/commit/b139b578804c967cbb6cfd82aca802997756b71f) | `` python3Packages.pytrydan: migrate to finalAttrs ``                                                              |
| [`e0ab6a3f`](https://github.com/NixOS/nixpkgs/commit/e0ab6a3f1bdf54fbbabb51ffcc6867f25c11b16b) | `` python3Packages.pytrydan: 1.0.0 -> 1.0.1 ``                                                                     |
| [`e49b6d63`](https://github.com/NixOS/nixpkgs/commit/e49b6d63b747756e9bb6afd1d46c6ff53027fb5f) | `` python3Packages.pytransportnswv2: 2.2.6 -> 3.0.2 ``                                                             |
| [`86ad8441`](https://github.com/NixOS/nixpkgs/commit/86ad84415de195ecf607baa96f744224b43c4c5b) | `` julia-mono: use installFonts ``                                                                                 |
| [`4e2fff26`](https://github.com/NixOS/nixpkgs/commit/4e2fff26fff4bf93f9d9583fc0a8625ee256e5b0) | `` trufflehog: 3.95.4 -> 3.95.5 ``                                                                                 |
| [`77fea166`](https://github.com/NixOS/nixpkgs/commit/77fea16658789d87480bbe98ecfa8da71c7ab040) | `` python3Packages.boto3-stubs: 1.43.22 -> 1.43.23 ``                                                              |
| [`053387cc`](https://github.com/NixOS/nixpkgs/commit/053387cc2f38994c78148473c4a61311169f1333) | `` python3Packages.mypy-boto3-workspaces: 1.43.0 -> 1.43.23 ``                                                     |
| [`5326cf0d`](https://github.com/NixOS/nixpkgs/commit/5326cf0d373af2fb25761ed5d35ebb58bf4e2c50) | `` python3Packages.mypy-boto3-workdocs: 1.43.0 -> 1.43.23 ``                                                       |
| [`c010ee0c`](https://github.com/NixOS/nixpkgs/commit/c010ee0c21d667f82e5e2ea5fca58cbc0630ba95) | `` python3Packages.mypy-boto3-sns: 1.43.0 -> 1.43.23 ``                                                            |
| [`fb3392c5`](https://github.com/NixOS/nixpkgs/commit/fb3392c5c1d812727ed9c3e170a9f4027a8b9901) | `` python3Packages.mypy-boto3-sagemaker: 1.43.20 -> 1.43.23 ``                                                     |
| [`141365bd`](https://github.com/NixOS/nixpkgs/commit/141365bdf603153003c251c56353c3640ec22e01) | `` python3Packages.mypy-boto3-kendra: 1.43.0 -> 1.43.23 ``                                                         |
| [`588c61d1`](https://github.com/NixOS/nixpkgs/commit/588c61d12a7c22c4a55db1f192cfd433b3d84e77) | `` python3Packages.mypy-boto3-ivs: 1.43.10 -> 1.43.23 ``                                                           |
| [`6e71b205`](https://github.com/NixOS/nixpkgs/commit/6e71b205cdc7da401be3a89ab3197a493f0e1363) | `` python3Packages.mypy-boto3-guardduty: 1.43.20 -> 1.43.23 ``                                                     |
| [`feb412cf`](https://github.com/NixOS/nixpkgs/commit/feb412cfb128b95369181356cecdabc514ff3f17) | `` python3Packages.mypy-boto3-glue: 1.43.8 -> 1.43.23 ``                                                           |
| [`8ef842b1`](https://github.com/NixOS/nixpkgs/commit/8ef842b1a27b4fd576914683cc7a0fd04d2cabae) | `` python3Packages.mypy-boto3-emr: 1.43.0 -> 1.43.23 ``                                                            |
| [`d2352865`](https://github.com/NixOS/nixpkgs/commit/d23528657a57fae51c9ddbf9ee5e698e4117170d) | `` python3Packages.mypy-boto3-efs: 1.43.0 -> 1.43.23 ``                                                            |
| [`9438d86e`](https://github.com/NixOS/nixpkgs/commit/9438d86e0868dc2bca0dd99f71e98e7a7d549193) | `` python3Packages.mypy-boto3-connectparticipant: 1.43.0 -> 1.43.23 ``                                             |
| [`17c3e983`](https://github.com/NixOS/nixpkgs/commit/17c3e983ee1ac4d8c0e11109b40ae74196d2800f) | `` python3Packages.mypy-boto3-config: 1.43.0 -> 1.43.23 ``                                                         |
| [`9498fa92`](https://github.com/NixOS/nixpkgs/commit/9498fa928ca4af13ad22463d6d67f496164da476) | `` python3Packages.mypy-boto3-cloudformation: 1.43.0 -> 1.43.23 ``                                                 |
| [`35177510`](https://github.com/NixOS/nixpkgs/commit/3517751093528d9e7ae48efa6c025707030d746f) | `` python3Packages.mypy-boto3-chime-sdk-voice: 1.43.0 -> 1.43.23 ``                                                |
| [`7b1315d0`](https://github.com/NixOS/nixpkgs/commit/7b1315d0a10cbcc298699b8f4e89bf6639a14bce) | `` python3Packages.mypy-boto3-auditmanager: 1.43.0 -> 1.43.23 ``                                                   |
| [`cc9cb366`](https://github.com/NixOS/nixpkgs/commit/cc9cb36684efa85401c96faf98292aec79174c1d) | `` python3Packages.mypy-boto3-appintegrations: 1.43.0 -> 1.43.23 ``                                                |
| [`daee0765`](https://github.com/NixOS/nixpkgs/commit/daee07655b214b6c0a46bb666855c6dbe16d8693) | `` python3Packages.mypy-boto3-appflow: 1.43.0 -> 1.43.23 ``                                                        |
| [`c5dfda2b`](https://github.com/NixOS/nixpkgs/commit/c5dfda2b9f023061b60bf5ab2dc8e8ddbfe056e8) | `` python3Packages.pyexploitdb: 0.3.28 -> 0.3.29 ``                                                                |
| [`daf70ccb`](https://github.com/NixOS/nixpkgs/commit/daf70ccb41dc24abe3df1156d55236a15eee078a) | `` checkov: 3.2.530 -> 3.2.533 ``                                                                                  |
| [`5178c252`](https://github.com/NixOS/nixpkgs/commit/5178c2525f684739fbad64383eab4b6bc1f23324) | `` crystal.buildCrystalPackage: fix {pre,post}InstallCheck skips ``                                                |
| [`881567d3`](https://github.com/NixOS/nixpkgs/commit/881567d3bed40be24eddfe6e1e0055c7f153e496) | `` python3Packages.iamdata: 0.1.202606031 -> 0.1.202606051 ``                                                      |
| [`52b98113`](https://github.com/NixOS/nixpkgs/commit/52b98113779af8e62ff4765817f8716733299791) | `` python3Packages.tencentcloud-sdk-python: 3.1.109 -> 3.1.110 ``                                                  |
| [`55183d51`](https://github.com/NixOS/nixpkgs/commit/55183d514649029a480c2a9c1a78a7fd6149ed75) | `` transmission_4: add nyanloutre as maintainer ``                                                                 |
| [`d2c4a7e1`](https://github.com/NixOS/nixpkgs/commit/d2c4a7e1a30969bec4dcd6eacee3edcb93bae3f0) | `` android-cli: 1.0.15433482 -> 1.0.15498356 ``                                                                    |
| [`9cacfa5a`](https://github.com/NixOS/nixpkgs/commit/9cacfa5a6796f5e41242fdd6e53957ac35ccd97d) | `` jackett: 0.24.1954 -> 0.24.2021 ``                                                                              |
| [`34983754`](https://github.com/NixOS/nixpkgs/commit/3498375482982a2b534968b6cc6bd7925c3a2df7) | `` trezor-suite: 26.5.1 -> 26.5.2 ``                                                                               |
| [`48d341a7`](https://github.com/NixOS/nixpkgs/commit/48d341a797f9c594a55fc6c1f8d3a7cb9ae01d05) | `` nixosTests.pdfding: fix tests on aarch64-linux gha ``                                                           |
| [`fd38c2f3`](https://github.com/NixOS/nixpkgs/commit/fd38c2f3a27ee1ed03edadd7d20e6d9a4b93c436) | `` nixosTests.pixelfed.standard: allow running on aarch64-linux ``                                                 |
| [`d31d4d39`](https://github.com/NixOS/nixpkgs/commit/d31d4d39a8f142fe3e4113aacb7d549ada44207e) | `` pdfding: 1.7.2 -> 1.8.0 ``                                                                                      |
| [`4df285e6`](https://github.com/NixOS/nixpkgs/commit/4df285e6f43cb9a78a49fb380f0c2ae83992dd6a) | `` phpstan: 2.1.56 -> 2.2.1 ``                                                                                     |
| [`c3241eec`](https://github.com/NixOS/nixpkgs/commit/c3241eec3c1f3071288bf67f1a46f8c67cb67366) | `` python3Packages.marko: 2.2.2 -> 2.2.3 ``                                                                        |
| [`868ea216`](https://github.com/NixOS/nixpkgs/commit/868ea216987db170a5acc8138636d9ee054f78a5) | `` librepods: 0.2.0 -> 0.2.5 ``                                                                                    |
| [`7fc066ca`](https://github.com/NixOS/nixpkgs/commit/7fc066ca9e2ff33d6341b5f2f0f5a0df9002e6e2) | `` oelint-adv: 9.8.0 -> 9.8.2 ``                                                                                   |
| [`d7dab351`](https://github.com/NixOS/nixpkgs/commit/d7dab35189f161b03741c04919a29b97bf650296) | `` deck: 1.62.0 -> 1.62.1 ``                                                                                       |
| [`12c40f01`](https://github.com/NixOS/nixpkgs/commit/12c40f014e2eb2c36f38b18194e3fde96d2e8f2e) | `` home-assistant: update component packages ``                                                                    |
| [`fa3ce8cb`](https://github.com/NixOS/nixpkgs/commit/fa3ce8cb22ab096b8f4113d266887940f85d7d5e) | `` python3Packages.aioaquarite: init at 0.6.1 ``                                                                   |
| [`ca68217b`](https://github.com/NixOS/nixpkgs/commit/ca68217b002d3efb8976c23d508c0aaed007ec4c) | `` libretro.fbneo: 0-unstable-2026-05-18 -> 0-unstable-2026-06-04 ``                                               |
| [`e972afeb`](https://github.com/NixOS/nixpkgs/commit/e972afeb0371d4cd2bcad976bab807134ea80c91) | `` victor-mono: use installFonts ``                                                                                |
| [`4fb3bc37`](https://github.com/NixOS/nixpkgs/commit/4fb3bc3717938d501feabbda9dd8baffd1f1723b) | `` libretro.mame: 0-unstable-2026-04-23 -> 0-unstable-2026-05-31 ``                                                |
| [`6c9d53e9`](https://github.com/NixOS/nixpkgs/commit/6c9d53e96c78e034dc9773de7141d87548817870) | `` reqable: 3.1.2 -> 3.1.3 ``                                                                                      |
| [`03752ca7`](https://github.com/NixOS/nixpkgs/commit/03752ca7cad3ff83007b72e4020c9a9a8d7eed9f) | `` lean4, leanPackages.lean4: fix darwin build by adding libtool ``                                                |
| [`7eaa7170`](https://github.com/NixOS/nixpkgs/commit/7eaa7170e4bf69e14de06554b48a18d35d34ff10) | `` python3Packages.azure-storage-file: modernize ``                                                                |
| [`10edff9f`](https://github.com/NixOS/nixpkgs/commit/10edff9f0c0e02f2f596f7a6b672fb2c059cec5e) | `` python3Packages.azure-storage-nspkg: modernize ``                                                               |
| [`139ab9fe`](https://github.com/NixOS/nixpkgs/commit/139ab9feea835b7bf9e583a16fd482e7c1d82efc) | `` python3Packages.azure-storage-common: modernize ``                                                              |
| [`27adac70`](https://github.com/NixOS/nixpkgs/commit/27adac70a63977584a76ccf45112e7896414436b) | `` python3Packages.azure-servicefabric: modernize ``                                                               |
| [`d3c6a58e`](https://github.com/NixOS/nixpkgs/commit/d3c6a58e8941036d298cb2df8d9b55cc4627214d) | `` python3Packages.azure-mgmt-trafficmanager: modernize ``                                                         |
| [`9def3a27`](https://github.com/NixOS/nixpkgs/commit/9def3a27a9e05a0d6f125e18c0451ceba0bb5279) | `` python3Packages.azure-mgmt-sql: modernize ``                                                                    |
| [`95b0332e`](https://github.com/NixOS/nixpkgs/commit/95b0332e982393daeb32b489ca9ea5976fc2ea0a) | `` python3Packages.azure-mgmt-cdn: modernize ``                                                                    |
| [`46534ac5`](https://github.com/NixOS/nixpkgs/commit/46534ac51730c49f9587b1047f5d81ed08244774) | `` python3Packages.azure-mgmt-batchai: modernize ``                                                                |
| [`72166c6d`](https://github.com/NixOS/nixpkgs/commit/72166c6d125937169da685bf8073df40274f85ff) | `` python3Packages.azure-keyvault: modernize ``                                                                    |
| [`ba99d267`](https://github.com/NixOS/nixpkgs/commit/ba99d2677dd638ee2e989e44ee54303e37fd29ff) | `` python3Packages.azure-loganalytics: modernize ``                                                                |
| [`ce53d5ea`](https://github.com/NixOS/nixpkgs/commit/ce53d5ea6f01688c2c73e82fc3adb006d1264c7d) | `` python3Packages.arxiv2bib: modernize ``                                                                         |
| [`7a76dc6e`](https://github.com/NixOS/nixpkgs/commit/7a76dc6eaff77414af77ec0ae9520c1df69c1090) | `` python3Packages.argparse-addons: modernize ``                                                                   |
| [`825a6338`](https://github.com/NixOS/nixpkgs/commit/825a633809e4ac8ad9c4767ab7aec40c9e1dde54) | `` python3Packages.arpeggio: modernize ``                                                                          |
| [`30e80e97`](https://github.com/NixOS/nixpkgs/commit/30e80e973929c4bf2c64b30c90b7517924f581fc) | `` python3Packages.azure-keyvault-nspkg: modernize ``                                                              |
| [`2744bfd8`](https://github.com/NixOS/nixpkgs/commit/2744bfd8645f93e7d10426e82c036bdf1eafd092) | `` grimblast: 0.1-unstable-2026-03-28 -> 0.1-unstable-2026-05-29 ``                                                |
| [`accaddb7`](https://github.com/NixOS/nixpkgs/commit/accaddb7907a8f19b3dbdce8bc9bb3c9adb542fa) | `` wipeout-rewrite: 0-unstable-2026-03-31 -> 0-unstable-2026-06-02 ``                                              |
| [`c166b285`](https://github.com/NixOS/nixpkgs/commit/c166b2855b9ea7b152ebc0d6b85cc8cdeac83f02) | `` python3Packages.area: modernize ``                                                                              |
| [`9de834de`](https://github.com/NixOS/nixpkgs/commit/9de834dea03bbd68bde7a09e7159fa03e82f21cd) | `` fetchtastic: 0.10.9 -> 0.10.10 ``                                                                               |
| [`4190b1c0`](https://github.com/NixOS/nixpkgs/commit/4190b1c0cdb1f5bfd37cc9859e71773116ef71d3) | `` checkstyle: 13.4.2 -> 13.5.0 ``                                                                                 |
| [`dabf00d4`](https://github.com/NixOS/nixpkgs/commit/dabf00d4227470ce35a7362842172f0419c427ac) | `` motrix-next: 3.9.0 -> 3.9.3 ``                                                                                  |
| [`d6853264`](https://github.com/NixOS/nixpkgs/commit/d6853264e5fa60162caaa356846d0726f9cf7352) | `` hcdiag: 0.5.12 -> 0.5.13 ``                                                                                     |
| [`ee347c19`](https://github.com/NixOS/nixpkgs/commit/ee347c19bb9d8275c4c006477450ffd6db498ef6) | `` bpftrace: 0.26.0 -> 0.26.1 ``                                                                                   |
| [`107495be`](https://github.com/NixOS/nixpkgs/commit/107495bee85569c56e4ae660ecdd68cfaf83c496) | `` nom: 3.3.0 -> 3.3.1 ``                                                                                          |
| [`f9a0a7b3`](https://github.com/NixOS/nixpkgs/commit/f9a0a7b3104832cfa171160913275d04e1d7f0cc) | `` mlt: several improvements ``                                                                                    |
| [`b7437fe6`](https://github.com/NixOS/nixpkgs/commit/b7437fe648c79a6dbba4d7f05405a8bfdd2774c9) | `` python3Packages.mkdocs-git-revision-date-localized-plugin: 1.5.2 -> 1.5.3 ``                                    |
| [`85ba174f`](https://github.com/NixOS/nixpkgs/commit/85ba174f1dceaf11dfcd0dcd05debfe1118a1b7b) | `` libsForQt5.mapbox-gl-qml: define with top-level callPackage ``                                                  |
| [`70272995`](https://github.com/NixOS/nixpkgs/commit/702729955cf1e4f0774fbf34e19a363a980b4085) | `` home-assistant-custom-lovelace-modules.auto-entities: 2.2.0 -> 2.3.0 ``                                         |
| [`433ac56b`](https://github.com/NixOS/nixpkgs/commit/433ac56be1bdc5883ad91efac2fa0beb6ab293ad) | `` libsForQt5.qca: remove redundent qt5 inheritence ``                                                             |
| [`64b7e2dd`](https://github.com/NixOS/nixpkgs/commit/64b7e2dd08bbe6240412e30d19b1abe2188d5312) | `` libretro.puae: 0-unstable-2026-05-21 -> 0-unstable-2026-06-03 ``                                                |
| [`dc9a3ff3`](https://github.com/NixOS/nixpkgs/commit/dc9a3ff33afb79a4655f98c9b3f88399e53b9335) | `` enzyme: 0.0.263 -> 0.0.264 ``                                                                                   |
| [`11d907f6`](https://github.com/NixOS/nixpkgs/commit/11d907f6e9825558add64d9b8805ff075b4c018e) | `` labymod-launcher: 2.1.13 -> 3.0.1 ``                                                                            |
| [`68654d76`](https://github.com/NixOS/nixpkgs/commit/68654d7626e4abd2f22c6fadbee7859feaae93d7) | `` grafana: 13.0.1+security-01 -> 13.0.2 ``                                                                        |
| [`83dfa4f0`](https://github.com/NixOS/nixpkgs/commit/83dfa4f04457a2e7ca052423d9ccf9e0814f7224) | `` vimPlugins: update on 2026-06-04 ``                                                                             |
| [`c11e31ad`](https://github.com/NixOS/nixpkgs/commit/c11e31adc9128c9618794f13463331279c117e8d) | `` vscode-extensions.mshr-h.veriloghdl: 1.23.2 -> 1.25.0 ``                                                        |
| [`060edd9c`](https://github.com/NixOS/nixpkgs/commit/060edd9cb759faad35cfaedd5f554e337a8a7a39) | `` betterleaks: 1.3.1 -> 1.4.0 ``                                                                                  |
| [`79158405`](https://github.com/NixOS/nixpkgs/commit/791584058f8a5c87ba6d66f34c476d27f336f7ac) | `` prometheus-klipper-exporter: 0.14.0 -> 0.15.0 ``                                                                |
| [`f3a6890d`](https://github.com/NixOS/nixpkgs/commit/f3a6890d30cfd033e21cc4714461c5fd327eb9ea) | `` otel-desktop-viewer: 0.2.5 -> 0.3.0 ``                                                                          |
| [`2a61b37f`](https://github.com/NixOS/nixpkgs/commit/2a61b37f41b6020bc00f8ff4c83e55446dbedd46) | `` okolors: modernize a bit ``                                                                                     |
| [`8cb4769e`](https://github.com/NixOS/nixpkgs/commit/8cb4769e08fd2473aaa72deeb32f4fe92d6eec40) | `` python3Packages.llama-cloud: 2.7.0 -> 2.8.0 ``                                                                  |
| [`0a562239`](https://github.com/NixOS/nixpkgs/commit/0a562239474c44e0d48ceb8a90e8fa07624c5cb4) | `` dix: meta: add `changelog` & `platforms` ``                                                                     |
| [`a25e9b80`](https://github.com/NixOS/nixpkgs/commit/a25e9b801f03b8214a724f552c6850aebb0c78e9) | `` dix: 1.4.2 -> 2.0.0 ``                                                                                          |
| [`e8c99eb1`](https://github.com/NixOS/nixpkgs/commit/e8c99eb1b96e7c00ab4c3b559eddf9dcafabd61d) | `` qt6Packages.qca: avoid redundent inherit from qt6 ``                                                            |
| [`fbae0397`](https://github.com/NixOS/nixpkgs/commit/fbae0397f24be0bd9d6b9e0e3c1f1703eff5a8fc) | `` python3Packages.bayesian-optimization: 3.2.2 -> 3.3.0 ``                                                        |
| [`bba51cb2`](https://github.com/NixOS/nixpkgs/commit/bba51cb2479b7a23134f69b932811df999b892e1) | `` ollama: fix darwin build for 0.30.5 ``                                                                          |
| [`14b05901`](https://github.com/NixOS/nixpkgs/commit/14b059015826087cb589d6d50b060532e68e7baa) | `` postgresqlPackages.plpgsql_check: 2.9.0 -> 2.9.1 ``                                                             |
| [`4c926e2c`](https://github.com/NixOS/nixpkgs/commit/4c926e2c43dbfa1ba7d11b50ae5f90c1a1c3f8ec) | `` python3Packages.hstspreload: 2026.5.1 -> 2026.6.1 ``                                                            |
| [`caf0d249`](https://github.com/NixOS/nixpkgs/commit/caf0d2495bce3edcf02b48dd39d6743acda8f0e9) | `` github-mcp-server: 1.0.5 -> 1.1.2 ``                                                                            |
| [`4b4b7b24`](https://github.com/NixOS/nixpkgs/commit/4b4b7b24cc4e2498d5ba5d77b328760b252c762e) | `` python3Packages.snakemake-storage-plugin-xrootd: disable tests on darwin ``                                     |
| [`55f21310`](https://github.com/NixOS/nixpkgs/commit/55f2131070bbd691257e68acd2e4766b30696492) | `` tev: 2.12.1 -> 2.12.2 ``                                                                                        |
| [`0e107178`](https://github.com/NixOS/nixpkgs/commit/0e1071782cca9508b318ec71e9836bf46acc2e1e) | `` ollama: 0.30.4 -> 0.30.5 ``                                                                                     |
| [`cac08fcd`](https://github.com/NixOS/nixpkgs/commit/cac08fcd4b5d9cff0497c555612333b93c5a1ac6) | `` firefoxpwa: fix build failure with wrapper ``                                                                   |
| [`9e7efbd9`](https://github.com/NixOS/nixpkgs/commit/9e7efbd9d86b66e8cea6fff1f86663bba937880e) | `` doctl: 1.160.0 -> 1.160.1 ``                                                                                    |
| [`ac4cc7da`](https://github.com/NixOS/nixpkgs/commit/ac4cc7da8f64a2ee621f6669cf02953cb757762b) | `` b612: use installFonts ``                                                                                       |
| [`b95d2aac`](https://github.com/NixOS/nixpkgs/commit/b95d2aac840fd800207ae805e9e5013c79a971b6) | `` codeql: 2.25.5 -> 2.25.6 ``                                                                                     |
| [`6c3ee882`](https://github.com/NixOS/nixpkgs/commit/6c3ee882f0135686510b61e17bc70822f0dde566) | `` ecsk: 0.9.3 -> 0.9.5 ``                                                                                         |
| [`d63d3532`](https://github.com/NixOS/nixpkgs/commit/d63d353258b2124b3757ae770e08c8eae14bebfc) | `` leanPackages.mathlib: add comment for leangz-raw ``                                                             |
| [`bb9df9ff`](https://github.com/NixOS/nixpkgs/commit/bb9df9ffed9ce903e36155013e2dc9cff56bba2c) | `` iio-niri: 2.0.0 -> 2.1.0 ``                                                                                     |
| [`bdea40b4`](https://github.com/NixOS/nixpkgs/commit/bdea40b4edb984318832ebbf14b9a3afac2ff6c1) | `` leanPackages.mathlib: lgz preprocessing ``                                                                      |
| [`b6067868`](https://github.com/NixOS/nixpkgs/commit/b606786817d87fbe2ff85e4ea37d84af65612479) | `` leanPackages: 4.29.1 -> 4.30.0 ``                                                                               |

*... and 1501 more commits (truncated)*