### PR TITLE
chore(flake/home-manager): `e9cbe698` -> `c58ead12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780938273,
-        "narHash": "sha256-jWV4rIH90Sy/Q8eakQwCuboTztx7D8HnoGpRUfij1gM=",
+        "lastModified": 1781009359,
+        "narHash": "sha256-w/mZkRscTatf8NWyUstli8ROzM/eopxZzi0WRjoeYkU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e9cbe69850d67c2b472db8416faca7292960f99f",
+        "rev": "c58ead12efcac436afffa93a22099a5595eb4157",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`c58ead12`](https://github.com/nix-community/home-manager/commit/c58ead12efcac436afffa93a22099a5595eb4157) | `` voxtype: assert full service file in test ``           |
| [`44901283`](https://github.com/nix-community/home-manager/commit/449012836eb1481b75e4c9db581366fb41fe89a3) | `` voxtype: restart service when configuration changes `` |
| [`df391424`](https://github.com/nix-community/home-manager/commit/df39142474950e42d5fc3bf2fef9d6c62abbe8d7) | `` nushell: remove redundant abbreviations option ``      |