### PR TITLE
chore(flake/freminal): `21259ced` -> `56b1dd09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1780940979,
-        "narHash": "sha256-4txVd3ZVSYTMsjlyLQd7/qVp5cbG9TWY4pN1gLeXT/w=",
+        "lastModified": 1781031922,
+        "narHash": "sha256-1VmH9XG5OC/f4aIgEDLm8i2wVHNgBA9J6agy5O8G7nw=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "21259ced9c5a2cb9e71321c2174df4324b0a3e3b",
+        "rev": "56b1dd09c9083e09976ccf2b9bcf4eb49eb0a4f0",
         "type": "github"
       },
       "original": {
@@ -384,11 +384,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -713,11 +713,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -863,11 +863,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777597424,
-        "narHash": "sha256-2szcq71hbF+FK4XrJa+sERYVo5rQVjPmxWjTMedLIXM=",
+        "lastModified": 1780504325,
+        "narHash": "sha256-EU52VleXVEQrX/CxqdoeQdJNSoWd1yr+0uyCtNFddYg=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "cb27f0e8312a14e144978fac6963d55897aa6dea",
+        "rev": "0fe4cc46813614423b1cd54c9de1c74a448c7f3d",
         "type": "github"
       },
       "original": {
@@ -930,11 +930,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1777519017,
-        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
+        "lastModified": 1780456895,
+        "narHash": "sha256-CvRZn3Ut0scqLJ1xwQFkZwKGVBUUNBPrFVXRTMZpbfU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
+        "rev": "7cc96a6a3fd6613cafd633250a3934483479b9a1",
         "type": "github"
       },
       "original": {
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778987862,
-        "narHash": "sha256-V3qGt9P1eJP/r/1ONablphfGiH0RP4agQhrRANpDYx8=",
+        "lastModified": 1780975129,
+        "narHash": "sha256-428T1pLXnbVeUgZx2wWEkbvl3ZORjras34ANZ3ACp5A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6f44d8874ac29806c8d5cae42bf8e19ebb5ce0d3",
+        "rev": "fe64e6b409dc513274d2941f8da13bbd0fdcf44e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`7a58c080`](https://github.com/fredsystems/freminal/commit/7a58c080c23133877007e8b3eadbd90b0e579440) | `` fix: 76.4b -- gate notify-rust urgency() off macOS ``                                               |
| [`fee4e3c1`](https://github.com/fredsystems/freminal/commit/fee4e3c1162501a292aa1c35957f3e463d7af42a) | `` docs: 76.8 -- mark Task 76 complete (notification docs) ``                                          |
| [`10838fe4`](https://github.com/fredsystems/freminal/commit/10838fe490288075409698e860baf23db1603fb3) | `` feat: 76.7 -- Settings UI Notifications tab ``                                                      |
| [`fba6b2a4`](https://github.com/fredsystems/freminal/commit/fba6b2a454b52ac1c89a2ba3bcd85fcf8332d774) | `` test: 76.6 -- verify notification capability responders, document TERM_PROGRAM ``                   |
| [`723206fa`](https://github.com/fredsystems/freminal/commit/723206fa8b79c31bbd0ad8ca31ec2e1c91fe85bd) | `` feat: 76.5 -- notification templates and bell on command finished ``                                |
| [`a3ca0531`](https://github.com/fredsystems/freminal/commit/a3ca0531e249b5b2babbfea9d12eb70518746e62) | `` docs: add freminal-config-options skill ``                                                          |
| [`b5ac55bc`](https://github.com/fredsystems/freminal/commit/b5ac55bc8342dc3a217c1281783589597c602b34) | `` fix(nix): mirror notifications/command_blocks/shell_integration/tab_title in home-manager module `` |
| [`6148b915`](https://github.com/fredsystems/freminal/commit/6148b91517b81afa3d87d4e6278778c6abf5f192) | `` test: 76.4c -- self-protecting config load-path guard test ``                                       |
| [`ed60cd84`](https://github.com/fredsystems/freminal/commit/ed60cd843a6be9ea3dbc64992088ef5cba20a115) | `` fix: 76.4b -- silence zbus log spam, set notification urgency/appname ``                            |
| [`d36210b6`](https://github.com/fredsystems/freminal/commit/d36210b613da5dd3360595ddc136c4e06f5524c5) | `` fix: 76.4a -- load [notifications] and sibling sections from user config ``                         |
| [`a74c840a`](https://github.com/fredsystems/freminal/commit/a74c840ad9a6a65fb80e6eee495efd05402c26bc) | `` feat: 76.4 -- GUI notification router for OSC 9/777 and command-finished ``                         |
| [`b7ea0f44`](https://github.com/fredsystems/freminal/commit/b7ea0f443b94e5158de82c361dc88736e0540f29) | `` feat: 76.3 -- forward OSC 9/777 notifications to the GUI ``                                         |
| [`7169f695`](https://github.com/fredsystems/freminal/commit/7169f695542d638286be10cfcbbf8ea03cad0eb6) | `` feat: 76.2 -- parse OSC 9 and OSC 777 desktop notifications ``                                      |
| [`d287d101`](https://github.com/fredsystems/freminal/commit/d287d1012c30178b10a6ab7f5c4b917288064eee) | `` feat: 76.1 -- add notify-rust dep and [notifications] config section ``                             |
| [`f311fd99`](https://github.com/fredsystems/freminal/commit/f311fd99f2e9814d7c577196345ec88af54ab411) | `` docs: update plans ``                                                                               |
| [`1457102a`](https://github.com/fredsystems/freminal/commit/1457102ae506e9d71dad5ff3dc2b60a9d921133d) | `` chore(deps): update rust crate regex to v1.12.4 ``                                                  |
| [`f72313e4`](https://github.com/fredsystems/freminal/commit/f72313e46e63e3cd9b908af96a0743f5f59eb863) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 9adf02b ``                  |
| [`72694aef`](https://github.com/fredsystems/freminal/commit/72694aef7c562ebdc3d025377437ea11c3c60b0e) | `` chore(deps): update determinatesystems/magic-nix-cache-action action to v14 ``                      |
| [`fa1648ce`](https://github.com/fredsystems/freminal/commit/fa1648ce68abc725533fdc450c023cb7601026cf) | `` fix: portablepty test that failed because of tombi linting fixes ``                                 |
| [`a9b7715c`](https://github.com/fredsystems/freminal/commit/a9b7715c67c93a8d5dae73702bf48cebea001a12) | `` feat: 95.1-95.5 -- persist custom tab names in layouts ``                                           |
| [`36ade9f4`](https://github.com/fredsystems/freminal/commit/36ade9f436ba91c244f714348e722204114738a9) | `` fix: use mul_add for line-unit scroll accumulation ``                                               |
| [`e9e6cc27`](https://github.com/fredsystems/freminal/commit/e9e6cc27096e588a3fd53d89b94eb6e731f34d57) | `` feat: 94.2-94.7 -- tab title precedence policy ``                                                   |
| [`b047410e`](https://github.com/fredsystems/freminal/commit/b047410e92ecf5222e9edfda58939d5f9d194db1) | `` feat: 94.1 -- add [tab_title] config section ``                                                     |
| [`ac26b3a5`](https://github.com/fredsystems/freminal/commit/ac26b3a5457fc47125469863bfb0e48b540886bd) | `` chore: update flake inputs and fix deprecation warning ``                                           |
| [`aa0ec1b3`](https://github.com/fredsystems/freminal/commit/aa0ec1b3a204e7a556cfe7c99713f94d32b9b516) | `` chore(deps): update codecov/codecov-action action to v7 ``                                          |
| [`f729d732`](https://github.com/fredsystems/freminal/commit/f729d732d46677824f97f67866957531c14aff43) | `` chore: bump cargo dep versions ``                                                                   |
| [`5d89cd39`](https://github.com/fredsystems/freminal/commit/5d89cd39bdef78bc7ddc2373e35fc7c6a86a8bba) | `` fix: stop tombi/taplo from reformatting cargo.toml file long lines ``                               |
| [`c5979f51`](https://github.com/fredsystems/freminal/commit/c5979f518cc21ca98209568406b4c6b78c8daaf9) | `` ci: add tombi TOML lint pre-commit hook ``                                                          |
| [`09f86afe`](https://github.com/fredsystems/freminal/commit/09f86afe47422dd9a1eb24b3eda7b517474bb0c6) | `` fix: emit RPM-legal Version for pre-release builds ``                                               |
| [`390c877a`](https://github.com/fredsystems/freminal/commit/390c877a5b5ef43b6226100dd8ee6782c69419ab) | `` chore(deps): update taiki-e/install-action action to v2.81.8 ``                                     |
| [`ce2eced6`](https://github.com/fredsystems/freminal/commit/ce2eced6a2f0f26e1dcec0efccce07c5a7cae88c) | `` chore(deps): update codecov/codecov-action action to v6.0.2 ``                                      |
| [`6622c067`](https://github.com/fredsystems/freminal/commit/6622c067673af89ceafd672be0993c0468cec468) | `` chore(deps): update actions/checkout action to v6.0.3 ``                                            |
| [`6e6e0ce7`](https://github.com/fredsystems/freminal/commit/6e6e0ce7b62a49e1d05fbf6780d780527dd61c76) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 4eea0b3 ``                  |
| [`001f87d8`](https://github.com/fredsystems/freminal/commit/001f87d83aff78fef3def19f44aa7402f2775d3a) | `` chore(deps): update actions/checkout digest to df4cb1c ``                                           |