### PR TITLE
chore(flake/nixvim): `82f2ec36` -> `43a7e6f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780884186,
-        "narHash": "sha256-ueTLp7DofvIZ0BXEWwi8AjP1cCsuEfO445dk6DtmfKc=",
+        "lastModified": 1780995253,
+        "narHash": "sha256-6Lsoyw2XPvY8YNMCtPnsyw0JVVtHsXP2xtrFJBBTAOQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "82f2ec369eb597554a71ec82f33922d01b7dba8f",
+        "rev": "43a7e6f82978ac975c3bba6728869b231e7a1ba0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`43a7e6f8`](https://github.com/nix-community/nixvim/commit/43a7e6f82978ac975c3bba6728869b231e7a1ba0) | `` plugins/conflict.nvim: init `` |
| [`5dac467f`](https://github.com/nix-community/nixvim/commit/5dac467f1ca6b506bba95d25f6def2497d7a0af4) | `` plugins/dap-disasm: init ``    |
| [`c90e6b50`](https://github.com/nix-community/nixvim/commit/c90e6b5016ad6bb80cc240999438a5882804c8bf) | `` plugins/filemention: init ``   |