### PR TITLE
chore(flake/nixvim): `43a7e6f8` -> `e9fbbd56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780995253,
-        "narHash": "sha256-6Lsoyw2XPvY8YNMCtPnsyw0JVVtHsXP2xtrFJBBTAOQ=",
+        "lastModified": 1781034432,
+        "narHash": "sha256-+UuS36un3lXLtKsGCYQnOn51hDhB+dZ1SHoHXClnV/0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "43a7e6f82978ac975c3bba6728869b231e7a1ba0",
+        "rev": "e9fbbd56eab78751ba4c166c31a1667042528ced",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`e9fbbd56`](https://github.com/nix-community/nixvim/commit/e9fbbd56eab78751ba4c166c31a1667042528ced) | `` plugins/conform: Prefer qt6 as qt5 is deprecated ``                |
| [`4d73571e`](https://github.com/nix-community/nixvim/commit/4d73571e54baad2ea6acd1032453df1bbaa5fdb7) | `` modules/nixpkgs: use `version-info.toml` for `source` assertion `` |
| [`753b1cd6`](https://github.com/nix-community/nixvim/commit/753b1cd663a25145fd75aa1517059fafed0878ee) | `` tests/nixpkgs-fetch: cross-check with `version-info.toml` ``       |