### PR TITLE
chore(flake/home-manager): `c58ead12` -> `74887eae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781009359,
-        "narHash": "sha256-w/mZkRscTatf8NWyUstli8ROzM/eopxZzi0WRjoeYkU=",
+        "lastModified": 1781102921,
+        "narHash": "sha256-RnV6ngnudMp9tmfl9Wyrjnk84NkkzbJpuJKQ7bp0wHE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c58ead12efcac436afffa93a22099a5595eb4157",
+        "rev": "74887eaee2995bbdba1f0fbd64e43c1d14a86eca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`74887eae`](https://github.com/nix-community/home-manager/commit/74887eaee2995bbdba1f0fbd64e43c1d14a86eca) | `` kiro-cli: add module ``                                                                               |
| [`6cf5b64c`](https://github.com/nix-community/home-manager/commit/6cf5b64c126b2d675cb7620d9b3950bbc64d0a71) | `` maintainers: add superflash41 ``                                                                      |
| [`cadadbc6`](https://github.com/nix-community/home-manager/commit/cadadbc6f4aa21e290d3e9dd653bd3e4ed6b9061) | `` claude-code: omit unsupported mcp enabled field ``                                                    |
| [`1ffdc280`](https://github.com/nix-community/home-manager/commit/1ffdc28076a1809ee7c0cf08f06af18f31c480cd) | `` news: add entry for programs.mcp typed schema ``                                                      |
| [`ebc55fd1`](https://github.com/nix-community/home-manager/commit/ebc55fd103473bf559587818c51483dd21a1e508) | `` claude-code, codex, antigravity-cli, github-copilot-cli, opencode, vscode, zed-editor: use mcp lib `` |
| [`6a66db13`](https://github.com/nix-community/home-manager/commit/6a66db1360359ce86fc810339239170fb29dfd0e) | `` mcp: extract helper functions into lib/mcp.nix ``                                                     |
| [`c30f1777`](https://github.com/nix-community/home-manager/commit/c30f177760b872c2697835f1275758d36a667af4) | `` docs: update release notes for 26.05 ``                                                               |
| [`bd427772`](https://github.com/nix-community/home-manager/commit/bd4277722d215970366a405d280301a796a364fc) | `` tests: add nixpkgs-disabled warning/assertion coverage ``                                             |
| [`d6f34138`](https://github.com/nix-community/home-manager/commit/d6f3413874fa18e0de53d6a4ab6ce7220658d7bc) | `` nixpkgs-disabled: show offending definition locations in warning ``                                   |
| [`408a6918`](https://github.com/nix-community/home-manager/commit/408a6918a0958e28391eab3afae063456358f13e) | `` docs: advise contributors to generate module news entries ``                                          |
| [`8ff67d93`](https://github.com/nix-community/home-manager/commit/8ff67d938c5c52f9e68735ec67bd867d4669fc8b) | `` i18n/inputMethod: remove da157 as maintainer ``                                                       |