### PR TITLE
chore(flake/freminal): `56b1dd09` -> `8502575a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781031922,
-        "narHash": "sha256-1VmH9XG5OC/f4aIgEDLm8i2wVHNgBA9J6agy5O8G7nw=",
+        "lastModified": 1781110469,
+        "narHash": "sha256-02g8/VEZ4+kIc1zaNlum4lCvjDxmOy4MyzHB8TnhPFw=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "56b1dd09c9083e09976ccf2b9bcf4eb49eb0a4f0",
+        "rev": "8502575a5f8544be4d701ef888b8f9d680d4fe10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`6a47d9f1`](https://github.com/fredsystems/freminal/commit/6a47d9f1249b8709fa6c441b743b86303e23d751) | `` chore(version): update version for next beta ``                          |
| [`54570184`](https://github.com/fredsystems/freminal/commit/545701843f255210b3dce5af61c967cefc6f1f14) | `` docs: mark Task 77 (Smart Paste Guard) complete in MASTER_PLAN ``        |
| [`2d2e6eec`](https://github.com/fredsystems/freminal/commit/2d2e6eec3a9df12231778fd582514d42e74bcfed) | `` docs: 77.6 + benchmark -- mark Task 77 complete ``                       |
| [`406f7d81`](https://github.com/fredsystems/freminal/commit/406f7d81c82cba61510c615bbd517b014c789855) | `` perf: 77 -- paste guard analyzer benchmark ``                            |
| [`15107b78`](https://github.com/fredsystems/freminal/commit/15107b785d7356e20dd42d5481699c5852ee596f) | `` feat: 77.6 -- Paste Guard settings UI ``                                 |
| [`065a3c43`](https://github.com/fredsystems/freminal/commit/065a3c4307a19890827b267479c1988156459ff3) | `` docs: 77.5 -- mark complete with completion notes ``                     |
| [`2ab8caae`](https://github.com/fredsystems/freminal/commit/2ab8caaec9e51287a9fd05a6f015badc4af1eed9) | `` feat: 77.5 -- KeyAction::PasteUnsafe (bypass the paste guard) ``         |
| [`592e2000`](https://github.com/fredsystems/freminal/commit/592e2000964988dad9d53f86c9b782f34256d079) | `` docs: list freminal-modal-input-suppression in agents.md skills table `` |
| [`7595a634`](https://github.com/fredsystems/freminal/commit/7595a63416a3da28cbaac295deec915f2ee54fcd) | `` docs: add freminal-modal-input-suppression skill ``                      |
| [`cd417c7c`](https://github.com/fredsystems/freminal/commit/cd417c7c5da0833a6c057045bb67f920efc217c3) | `` docs: 77.4 -- record dialog-focus follow-up fix ``                       |
| [`7dbf5388`](https://github.com/fredsystems/freminal/commit/7dbf5388984689a4c4837f12360236eb200aed8d) | `` fix: 77.4 -- suppress terminal input while paste dialog is open ``       |
| [`b2b5e532`](https://github.com/fredsystems/freminal/commit/b2b5e5329270077fe005574367564948c4904c50) | `` docs: 77.4 -- record paste-regression follow-up fix ``                   |
| [`9dbc433f`](https://github.com/fredsystems/freminal/commit/9dbc433f1ec317a8457dad476daab22b382d7815) | `` fix: 77.4 -- use windowing-injected paste text, not arboard re-read ``   |
| [`e3d0acf5`](https://github.com/fredsystems/freminal/commit/e3d0acf53ab1bee5232a8159180f489fd72f3084) | `` docs: 77.4 -- mark complete with completion notes ``                     |
| [`962a2102`](https://github.com/fredsystems/freminal/commit/962a210276897e8892422b993dfcb900d775bf62) | `` feat: 77.4 -- wire paste guard into the paste path ``                    |
| [`241d8a0f`](https://github.com/fredsystems/freminal/commit/241d8a0f28fda24c59b589a827ae81e732a49e50) | `` docs: 77.3 -- mark complete with completion notes ``                     |
| [`d62faaff`](https://github.com/fredsystems/freminal/commit/d62faaff8492231c4b16490d94e9987bd6c0eb0b) | `` feat: 77.3 -- confirm-paste preview dialog ``                            |
| [`d8e80565`](https://github.com/fredsystems/freminal/commit/d8e80565a824374fdd4279a181b175c1a2dbb603) | `` docs: 77.2 -- mark complete with completion notes ``                     |
| [`ee159749`](https://github.com/fredsystems/freminal/commit/ee15974949809d2fd9478bdb34a96c20c97f7c05) | `` feat: 77.2 -- paste guard analyzer ``                                    |
| [`061848c8`](https://github.com/fredsystems/freminal/commit/061848c853fd31e6e1dc32bac90085319a9bab51) | `` docs: 77.1 -- mark complete with completion notes ``                     |
| [`4eeb8b89`](https://github.com/fredsystems/freminal/commit/4eeb8b8953fb81e0d32499b0e1c8894bf5545ea1) | `` feat: 77.1 -- [paste_guard] config section and schema ``                 |
| [`5fd4ed56`](https://github.com/fredsystems/freminal/commit/5fd4ed56571b04bba1431de47e3a57c0cf1a4a16) | `` docs: correct v0.9.0 task summary status for 72/73/76 ``                 |