### PR TITLE
chore(flake/home-manager): `74887eae` -> `486595d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781102921,
-        "narHash": "sha256-RnV6ngnudMp9tmfl9Wyrjnk84NkkzbJpuJKQ7bp0wHE=",
+        "lastModified": 1781189114,
+        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74887eaee2995bbdba1f0fbd64e43c1d14a86eca",
+        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`486595d2`](https://github.com/nix-community/home-manager/commit/486595d2cf49cfcd649b58a284fa11ac0e34da22) | `` zsh: make sure siteFunction names don't contain slashes ``       |
| [`19c41a5a`](https://github.com/nix-community/home-manager/commit/19c41a5a6d07fcbe585f42ab64bff6f95da5de25) | `` zsh: escape siteFunction names ``                                |
| [`d29e0ab7`](https://github.com/nix-community/home-manager/commit/d29e0ab7c27d95ad49094dba79ec7141f1d3378e) | `` zsh: correctly handle autoloading functions starting with '-' `` |
| [`bb68a1a2`](https://github.com/nix-community/home-manager/commit/bb68a1a2e773050d64b18f5b23811c8f212c46c8) | `` docs: add release notes contributing guidance ``                 |
| [`7dbd305f`](https://github.com/nix-community/home-manager/commit/7dbd305f8b81050f223f00bcfbc8a6b74e048806) | `` darcs: add defaults ``                                           |
| [`f96f717a`](https://github.com/nix-community/home-manager/commit/f96f717a47589c9d0b6e21f1a0d0d42d2c576f18) | `` vscode: support path literals in userSettings ``                 |
| [`2b394bec`](https://github.com/nix-community/home-manager/commit/2b394beca7413dc4e6050960666f261471c9aa0e) | `` docs: fix sshAuthSock reference in rl-2605 ``                    |