### PR TITLE
chore(flake/home-manager-stable): `baa46aeb` -> `ea6d221d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781063120,
-        "narHash": "sha256-1UIF/mDJluwJQjmmcZ2j1L2+mjYsefe82QCLj0TYSOg=",
+        "lastModified": 1781184346,
+        "narHash": "sha256-cZRlW47U6A2nWvAmnZeeO6Xvq23gxYbVLel4KxqOrcQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "baa46aeb6d02e0ba13de67cd35e3d57aedfacf01",
+        "rev": "ea6d221d7aa85652d014b6f719dddf036037515b",
         "type": "github"
       },
       "original": {

--- a/modules/base/home.nix
+++ b/modules/base/home.nix
@@ -12,6 +12,20 @@
 let
   isLinux = !isDarwin;
 
+  # home-manager renamed `programs.gemini-cli` to `programs.antigravity-cli`.
+  # The release-25.11 catppuccin input (server hosts) still ships a functional
+  # `gemini-cli` module that sets the now-renamed `programs.gemini-cli` option,
+  # tripping a fatal "option has been renamed" evaluation warning. Setting
+  # `catppuccin.gemini-cli.enable = false` suppresses it there. The unstable
+  # catppuccin input (desktop/darwin) replaced that module with a
+  # `mkRemovedOptionModule` stub, so *defining* the option there is a fatal
+  # assertion. Detect which variant is present by reading the module source:
+  # the functional module references `programs.gemini-cli`, the stub does not.
+  geminiCliModule = "${catppuccinInput}/modules/home-manager/gemini-cli.nix";
+  catppuccinHasFunctionalGeminiCli =
+    builtins.pathExists geminiCliModule
+    && lib.hasInfix "programs.gemini-cli" (builtins.readFile geminiCliModule);
+
   yubikeyMap = {
     "13380413" = "~/.ssh/id_ed25519_sk.pub";
     "35681557" = "~/.ssh/id_ed25519_sk_github.pub";
@@ -49,13 +63,10 @@ in
   // lib.optionalAttrs (options.catppuccin ? autoEnable) {
     autoEnable = true;
   }
-  // lib.optionalAttrs (options.catppuccin ? gemini-cli) {
-    # home-manager renamed `programs.gemini-cli` to `programs.antigravity-cli`.
-    # The release-25.11 catppuccin input used by server hosts still ships the
-    # `gemini-cli` module, which sets the renamed option and trips an
-    # "option has been renamed" evaluation warning (fatal in CI). Disable it
-    # where the option still exists; unstable catppuccin dropped the module
-    # entirely, so the guard keeps this from breaking desktop/darwin builds.
+  // lib.optionalAttrs catppuccinHasFunctionalGeminiCli {
+    # See `geminiCliModule` note above: only disable where the functional
+    # module exists (stable). On unstable it is a removed-option stub and
+    # defining it would be a fatal assertion.
     gemini-cli.enable = false;
   };
 

--- a/modules/base/home.nix
+++ b/modules/base/home.nix
@@ -48,6 +48,15 @@ in
   }
   // lib.optionalAttrs (options.catppuccin ? autoEnable) {
     autoEnable = true;
+  }
+  // lib.optionalAttrs (options.catppuccin ? gemini-cli) {
+    # home-manager renamed `programs.gemini-cli` to `programs.antigravity-cli`.
+    # The release-25.11 catppuccin input used by server hosts still ships the
+    # `gemini-cli` module, which sets the renamed option and trips an
+    # "option has been renamed" evaluation warning (fatal in CI). Disable it
+    # where the option still exists; unstable catppuccin dropped the module
+    # entirely, so the guard keeps this from breaking desktop/darwin builds.
+    gemini-cli.enable = false;
   };
 
   ##########################################################################


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`ea6d221d`](https://github.com/nix-community/home-manager/commit/ea6d221d7aa85652d014b6f719dddf036037515b) | `` news: add entry for programs.mcp typed schema ``                                                      |
| [`005c72cc`](https://github.com/nix-community/home-manager/commit/005c72cc1a6a94647b5c5e168b5f78be30603f8a) | `` claude-code, codex, antigravity-cli, github-copilot-cli, opencode, vscode, zed-editor: use mcp lib `` |
| [`22d5ec3d`](https://github.com/nix-community/home-manager/commit/22d5ec3d121316d46bac61fb7bc61e736be8cb01) | `` mcp: extract helper functions into lib/mcp.nix ``                                                     |
| [`d899b017`](https://github.com/nix-community/home-manager/commit/d899b01766784bcc9a141ee13bad6dc689d47c37) | `` opencode: use lib.hm.strings.isPathLike ``                                                            |
| [`d136d10d`](https://github.com/nix-community/home-manager/commit/d136d10d613de972aed76627f4bbc8b664c1309d) | `` github-copilot-cli: use lib.hm.strings.isPathLike ``                                                  |
| [`55cf7c94`](https://github.com/nix-community/home-manager/commit/55cf7c9428bc6f66db1d9156b06e8f13b0197f4b) | `` codex: use lib.hm.strings.isPathLike ``                                                               |
| [`c88f017a`](https://github.com/nix-community/home-manager/commit/c88f017a224c749e28ed3b51b5d309b4de4e9a48) | `` claude-code: use lib.hm.strings.isPathLike ``                                                         |
| [`d48a1e6a`](https://github.com/nix-community/home-manager/commit/d48a1e6ad6313f1ffc0a970e0bb8ed43506b957f) | `` antigravity-cli: use lib.hm.strings.isPathLike ``                                                     |
| [`8982f451`](https://github.com/nix-community/home-manager/commit/8982f45135b038f2d8b559f7f9ae55db6883baaa) | `` lib/strings: add isPathLike helper ``                                                                 |
| [`ba6a244f`](https://github.com/nix-community/home-manager/commit/ba6a244f3b5bde3a2a5e97db50f9b00f2b048cd8) | `` antigravity-cli: add migration news ``                                                                |
| [`cbc74b93`](https://github.com/nix-community/home-manager/commit/cbc74b9371c3565c92a1edd5202687b81b5a2eaf) | `` antigravity-cli: rename gemini-cli module ``                                                          |
| [`fcbbf548`](https://github.com/nix-community/home-manager/commit/fcbbf5484ab2c733e886ef4fa91e8da1c8c028f5) | `` docs: fix sshAuthSock reference in rl-2605 ``                                                         |