### PR TITLE
chore(flake/freminal): `389c3050` -> `f49c0860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781117815,
-        "narHash": "sha256-Sfb3hNlDDq5pFOfCdlVeTeAqK9AymsKCW8d9JbQ40bo=",
+        "lastModified": 1781198135,
+        "narHash": "sha256-DKxv4nKiLqKH2ZtuSsk+SXIMQuIMMzJwLd60bmOGqRA=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "389c30507cbc93f690e2b2338d496075ce4cd60e",
+        "rev": "f49c0860e7543e8d7b842f8690c87d0bc039b6ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`f49c0860`](https://github.com/fredsystems/freminal/commit/f49c0860e7543e8d7b842f8690c87d0bc039b6ce) | `` docs: more planning ``                                                       |
| [`0009040b`](https://github.com/fredsystems/freminal/commit/0009040b18d5d82a25c1e2277880c05457e97201) | `` chore: bump version to 0.9.0-beta.5 ``                                       |
| [`8f98e73b`](https://github.com/fredsystems/freminal/commit/8f98e73b9efb91b3d2f7ab528c4bfc0bb85ac721) | `` feat: 98.9 -- close guard settings UI ``                                     |
| [`388099b4`](https://github.com/fredsystems/freminal/commit/388099b4eedd487b86d06b88b2497dd30e6ee959) | `` feat: 98.8 -- add KeyAction::ForceClose ``                                   |
| [`7bf83c2b`](https://github.com/fredsystems/freminal/commit/7bf83c2bddcf45ea75e68311a69ab6fd9d4b4ac3) | `` feat: 98.3 + 98.4 + 98.5 + 98.6 + 98.7 -- close guard on running commands `` |
| [`e8a3155d`](https://github.com/fredsystems/freminal/commit/e8a3155d742df1b0666e616113663001dc589ec9) | `` feat: 98.2 -- add [close_guard] config section ``                            |
| [`8d18879a`](https://github.com/fredsystems/freminal/commit/8d18879a84cec8088d7bd77060ee029c4371f3a2) | `` docs: 98.1 -- close-path audit for close-on-running-command guard ``         |
| [`6e2c7e13`](https://github.com/fredsystems/freminal/commit/6e2c7e132714041f437a6d50cdb6f7027ac25e98) | `` test: 75.1 + 75.2 -- verify and document per-pane env round-trip ``          |
| [`c2f9d21f`](https://github.com/fredsystems/freminal/commit/c2f9d21fda7f5009fed7057f1915dd0c6a0d8399) | `` docs: mark Task 74 (broadcast input) complete ``                             |
| [`544eb624`](https://github.com/fredsystems/freminal/commit/544eb624b200e792dcf147633f678b1146cce0f3) | `` feat: 74.5 -- broadcast input settings UI and confirm dialog ``              |
| [`d9f576c1`](https://github.com/fredsystems/freminal/commit/d9f576c1523246c7ae2c9d749f479c1d56760d22) | `` feat: 74.4 -- visual broadcast indicator on panes ``                         |
| [`438b197d`](https://github.com/fredsystems/freminal/commit/438b197d7076048827b3deaa9c95779fdd464818) | `` feat: 74.3 -- broadcast keyboard input to all panes in a tab ``              |
| [`0a1e6aa8`](https://github.com/fredsystems/freminal/commit/0a1e6aa8adb6fd38ba7c2d5dd8c22568801cd380) | `` feat: 74.2 -- add KeyAction::ToggleBroadcastInput ``                         |
| [`4b99b10c`](https://github.com/fredsystems/freminal/commit/4b99b10cf30cdce8a75ac76ae1c5986dd178747d) | `` feat: 74.1 -- add Tab::broadcast_input flag ``                               |
| [`e4dd4b2e`](https://github.com/fredsystems/freminal/commit/e4dd4b2ebb7c42d10c58650459620838fd1edccc) | `` docs: add enriched stubs for v0.13.0-v0.19.0 and deferred DnD ``             |
| [`dd2b9d93`](https://github.com/fredsystems/freminal/commit/dd2b9d9378bc9c88a9924b15fb8bff7bf196af37) | `` docs: decompose kitty versions v0.10.0-v0.12.0; retire parking doc ``        |
| [`d4a910c4`](https://github.com/fredsystems/freminal/commit/d4a910c4980af78be10921510489ec04a6f28ffe) | `` docs: reorder roadmap post-v0.9.0; split kitty across v0.10.0-v0.12.0 ``     |
| [`0405a607`](https://github.com/fredsystems/freminal/commit/0405a607357a11131f23ade01f5f50d73f5e8957) | `` docs: add freminal-version-activation skill ``                               |