### PR TITLE
chore(flake/darwin): `f73cbf1f` -> `d0d0978f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781160382,
-        "narHash": "sha256-rK6/8hoDWZe64npiBEIcrJ5JLv1zBnn6HBZGbVj/nDU=",
+        "lastModified": 1781196189,
+        "narHash": "sha256-8ZFs9+ylq+YRDnkw9/ITEcxcl1GjMvIDgWUFIsKwJH8=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "f73cbf1f6549f1bf349398f8276801a9c1a17aa7",
+        "rev": "d0d0978f34fbd7da190801f7549992718057a8d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                  |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`ace75766`](https://github.com/nix-darwin/nix-darwin/commit/ace757665e84f690eb7c70ee1e0b2d4898b5696d) | `` Fix typo ``                                           |
| [`b317d77b`](https://github.com/nix-darwin/nix-darwin/commit/b317d77bbf8cec17c09cf2297ec43c1243be5f37) | `` github-runner: remove node20 runtime from defaults `` |