### PR TITLE
chore(flake/darwin): `d0d0978f` -> `aabb2037`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781196189,
-        "narHash": "sha256-8ZFs9+ylq+YRDnkw9/ITEcxcl1GjMvIDgWUFIsKwJH8=",
+        "lastModified": 1781242433,
+        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "d0d0978f34fbd7da190801f7549992718057a8d6",
+        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                             |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------- |
| [`9f8122dd`](https://github.com/nix-darwin/nix-darwin/commit/9f8122dd2beb42f8eaf80f18b2da64e38c660873) | `` time: remove double condition `` |
| [`818b88b7`](https://github.com/nix-darwin/nix-darwin/commit/818b88b75f149a0082bd29feb7720e5c7d40ba86) | `` flake.lock: update nixpkgs ``    |