### PR TITLE
chore(flake/catppuccin): `c3623ae5` -> `036c78ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781180057,
-        "narHash": "sha256-sh5cl74+o7PBUp5igMeqGoofiyUguudIS8Cw6jXlKjw=",
+        "lastModified": 1781255309,
+        "narHash": "sha256-n2P5xkAYGylrJ3feu7L6uaCUw/+jW8rk+HO127gDbFA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "c3623ae5172427612749154de46455d97e1a66ad",
+        "rev": "036c78ea4cd8a42c8546c6316a944fd7d59d4341",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                           |
| ----------------------------------------------------------------------------------------------- | --------------------------------- |
| [`036c78ea`](https://github.com/catppuccin/nix/commit/036c78ea4cd8a42c8546c6316a944fd7d59d4341) | `` chore: update flakes (#981) `` |