### PR TITLE
chore(flake/freminal): `f49c0860` -> `d760f263`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781198135,
-        "narHash": "sha256-DKxv4nKiLqKH2ZtuSsk+SXIMQuIMMzJwLd60bmOGqRA=",
+        "lastModified": 1781214354,
+        "narHash": "sha256-9lzU5222W2ELRvBEwUj3O/76X3l+BPCscBe8V5WOygg=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "f49c0860e7543e8d7b842f8690c87d0bc039b6ce",
+        "rev": "d760f2632bd4debe53b10bc437aa9724fa8c3d9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`b638af00`](https://github.com/fredsystems/freminal/commit/b638af00fef6521dd4ff2d92445e872ed6a75425) | `` feat: 107.1-107.3 -- embed real build version across cargo, CI, and Nix `` |
| [`8514d63b`](https://github.com/fredsystems/freminal/commit/8514d63b594c87553755ecf773fecd663b6039b1) | `` chore: bump version to 0.9.0-beta.6 ``                                     |