### PR TITLE
chore(flake/nixvim): `fec49e73` -> `e3c908fd`

### DIFF
--- a/features/shell/nvim/default.nix
+++ b/features/shell/nvim/default.nix
@@ -526,7 +526,6 @@ in
               inlayHints = true;
               servers = {
                 bashls.enable = true;
-                norg.enable = true;
                 # Spellcheck
                 harper_ls = {
                   enable = false;

--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1781287415,
-        "narHash": "sha256-e0KtxMotoMhWLw4xi90XvbajZFAv3jzIZqPQJ1F3Du8=",
+        "lastModified": 1781388258,
+        "narHash": "sha256-Kx1zxra9sZ215H3OiWUfkulu8N2v3iu19wqlzpD/Ac0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "fec49e73762ed01f7e7440faf09028c2f767b252",
+        "rev": "e3c908fdf6dff268b04ffb6758bcfc7c018489b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`e3c908fd`](https://github.com/nix-community/nixvim/commit/e3c908fdf6dff268b04ffb6758bcfc7c018489b9) | `` modules/output: add source locations to vimPlugin assertions `` |
| [`a6554084`](https://github.com/nix-community/nixvim/commit/a6554084d7e5c52a8d1e45f9ece0262007a50c02) | `` tests/modules/output: use `pkgs.emptyDirectory` ``              |
| [`56f95d16`](https://github.com/nix-community/nixvim/commit/56f95d165580d4c814955798fa408c66d6843069) | `` wrappers: fix `_module.check` disablement ``                    |
| [`19a4e5ef`](https://github.com/nix-community/nixvim/commit/19a4e5efa14d15aaeb947db6e700591e4acdb295) | `` modules/output: reject vim plugins in extraPackages ``          |
| [`f2029d9a`](https://github.com/nix-community/nixvim/commit/f2029d9a26266eb67f46b0c79bd0a3713839a57a) | `` lib/keymaps: remove `lua` submodule option ``                   |
| [`90ccd43c`](https://github.com/nix-community/nixvim/commit/90ccd43c7185056f544af017c1ca4ca0b16da684) | `` modules/test: add "all" expectation predicates ``               |