### PR TITLE
chore(flake/home-manager): `486595d2` -> `5b6f5733`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781189114,
-        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
+        "lastModified": 1781365335,
+        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
+        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`5b6f5733`](https://github.com/nix-community/home-manager/commit/5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c) | `` zed-editor: fix programs.mcp.servers compatibility `` |
| [`c87a39aa`](https://github.com/nix-community/home-manager/commit/c87a39aa979acc4848016d2220c6238390d84779) | `` Translate using Weblate (Italian) ``                  |