### PR TITLE
chore(flake/home-manager-stable): `ea6d221d` -> `8355f0a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781184346,
-        "narHash": "sha256-cZRlW47U6A2nWvAmnZeeO6Xvq23gxYbVLel4KxqOrcQ=",
+        "lastModified": 1781319724,
+        "narHash": "sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ea6d221d7aa85652d014b6f719dddf036037515b",
+        "rev": "8355f0a16b2dbb06a97959a918af5b239bbe05ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`8355f0a1`](https://github.com/nix-community/home-manager/commit/8355f0a16b2dbb06a97959a918af5b239bbe05ae) | `` flake: bump nixpkgs from `6b31628` to `bd0ff2d` `` |