### PR TITLE
chore(flake/nixpkgs-stable): `bd0ff2d3` -> `a0374025`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -697,11 +697,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`703421a4`](https://github.com/NixOS/nixpkgs/commit/703421a4778cee49c4cc1d923035e4efde72adc5) | `` openocd-adi: 0.12.0-1.3.1-1 -> 0.12.0-1.3.1-2 ``                                                   |
| [`5dfd75b3`](https://github.com/NixOS/nixpkgs/commit/5dfd75b38fb929c10ba0d10d959c7f2622f9d149) | `` google-chrome: 149.0.7827.102 -> 149.0.7827.114 ``                                                 |
| [`e0625900`](https://github.com/NixOS/nixpkgs/commit/e06259002d503b1ccbfbe202709baba712acd710) | `` pgdog: 0.1.43 -> 0.1.44 ``                                                                         |
| [`66f010b9`](https://github.com/NixOS/nixpkgs/commit/66f010b956013801280497223883ec67177875fc) | `` vimPlugins.orgmode: fix build ``                                                                   |
| [`28f1f0cd`](https://github.com/NixOS/nixpkgs/commit/28f1f0cdf954c8298fd9fb4253a2f41438dcbe75) | `` neovim-unwrapped: 0.12.2 -> 0.12.3 ``                                                              |
| [`b7a72c8b`](https://github.com/NixOS/nixpkgs/commit/b7a72c8b9f31dde9b204f1c2b5c6076b0d15ce96) | `` simplex-chat-desktop: 6.5.2 -> 6.5.4 ``                                                            |
| [`1952d3fa`](https://github.com/NixOS/nixpkgs/commit/1952d3faba382c95bd57e7177aa25e4c9a212220) | `` ci: move Treefmt settings into a separate file ``                                                  |
| [`04259522`](https://github.com/NixOS/nixpkgs/commit/0425952254fe6a4a254914059785a59a9f3782fc) | `` pyfa: 2.66.3 -> 2.67.0 ``                                                                          |
| [`03b86ad4`](https://github.com/NixOS/nixpkgs/commit/03b86ad47cd9a0da371f6ec21f02af4776493958) | `` luaPackages.orgmode: disable flaky UI tests ``                                                     |
| [`7600c6ef`](https://github.com/NixOS/nixpkgs/commit/7600c6efbd45a14872c77e91d7acc5b8d8cf780f) | `` zoom-us: add libxcb-util to FHS dependencies ``                                                    |
| [`01733f7e`](https://github.com/NixOS/nixpkgs/commit/01733f7eff9ffe882b57a3ceee12073f28b30c9d) | `` linux_zen: 7.0.11 -> 7.0.12 ``                                                                     |
| [`18776ee1`](https://github.com/NixOS/nixpkgs/commit/18776ee1ddbdf53df787bfbfbd01c329392114bb) | `` atlantis: 0.43.0 -> 0.44.0 ``                                                                      |
| [`2699ef1f`](https://github.com/NixOS/nixpkgs/commit/2699ef1f5af1e991cdd5c0734414369f9b7f6358) | `` element-{web,desktop}: 1.12.18 -> 1.12.21 ``                                                       |
| [`1041fb01`](https://github.com/NixOS/nixpkgs/commit/1041fb01e5bab42cac9e8e42367cd67ae4d47b66) | `` bootspec: honor boot.kernel.enable ``                                                              |
| [`9f462c9b`](https://github.com/NixOS/nixpkgs/commit/9f462c9b7c63364a2302abcb83e706a810b97a0f) | `` beamPackages.expert: 0.1.3 -> 0.1.5 ``                                                             |
| [`ff2ec7b7`](https://github.com/NixOS/nixpkgs/commit/ff2ec7b73e3a2f6e07ce2e20b4562a5196ff260e) | `` transmission_4: 4.1.1 -> 4.1.2 ``                                                                  |
| [`d5107931`](https://github.com/NixOS/nixpkgs/commit/d5107931b19fcba457e207645992e20d20dcf028) | `` llama-swap: 216 -> 224 ``                                                                          |
| [`928b5ea4`](https://github.com/NixOS/nixpkgs/commit/928b5ea408124d972898ca1ceb90513ff708f609) | `` kdash: add `meta.changelog` ``                                                                     |
| [`bde96dbf`](https://github.com/NixOS/nixpkgs/commit/bde96dbfc1619b72a33d5e48cec9af6155bcdab5) | `` kdash: fix source hash ``                                                                          |
| [`4fb969d2`](https://github.com/NixOS/nixpkgs/commit/4fb969d2ade3b0db1d414ccecbe0006fb08a5ea2) | `` jenkins: 2.555.2 -> 2.555.3 ``                                                                     |
| [`5ee5ac13`](https://github.com/NixOS/nixpkgs/commit/5ee5ac1341a2cbd896553376cea4038ae19b0e57) | `` doc: clarify how 26.05's wpa_supplicant changes affect the ctrl_interface ``                       |
| [`f55d4205`](https://github.com/NixOS/nixpkgs/commit/f55d4205a5c1c0c5e43c4d6e6efbe3548cd9d5bf) | `` jasterix: fix tests ``                                                                             |
| [`a9e14abf`](https://github.com/NixOS/nixpkgs/commit/a9e14abfd3b718a449eea49645c720ceb78feb0b) | `` beamPackages.buildMix: fix install hooks not running ``                                            |
| [`2838c6f7`](https://github.com/NixOS/nixpkgs/commit/2838c6f7c474191604cae6be7e80f1291b064c5e) | `` python3Packages.uefi-firmware-parser: add setuptools-scm and remove wheel to build dependencies `` |
| [`1a7e918d`](https://github.com/NixOS/nixpkgs/commit/1a7e918dcdcd396530b3c5f1ad0d7903d4e35f1b) | `` python3Packages.plover_{4,5}: install desktop entry ``                                             |
| [`f07816aa`](https://github.com/NixOS/nixpkgs/commit/f07816aa13784715e071b7458d2da8b0a7807f36) | `` technitium-dns-server: fix missing DNSSEC DO bit in authoritative responses ``                     |
| [`5fa69fa3`](https://github.com/NixOS/nixpkgs/commit/5fa69fa3657e9dfcaa8c667401b30656236a0ecc) | `` beam.interpreters.erlang_27: 27.3.4.12 -> 27.3.4.13 ``                                             |
| [`a596e609`](https://github.com/NixOS/nixpkgs/commit/a596e609e2b2db545eead87658c329b1bfc3244a) | `` beam.interpreters.erlang_28: 28.5.0.1 -> 28.5.0.2 ``                                               |
| [`8ff3978d`](https://github.com/NixOS/nixpkgs/commit/8ff3978d5fc0a69fbff0e6ac2b8f378245e2c352) | `` beam.interpreters.erlang_29: 29.0.1 -> 29.0.2 ``                                                   |
| [`2ccf54f4`](https://github.com/NixOS/nixpkgs/commit/2ccf54f426c142ecebf48d3c5e34c49c52ea4cc4) | `` oauth2-proxy: 7.15.2 -> 7.15.3 ``                                                                  |
| [`1eff69b7`](https://github.com/NixOS/nixpkgs/commit/1eff69b7f09e024ed3a78123ad5e131e980f1a9d) | `` localsend: set meta.donationPage ``                                                                |
| [`9895960c`](https://github.com/NixOS/nixpkgs/commit/9895960ce2cec7e505c5fb03a10a40b628a6f828) | `` zigbee2mqtt: 2.11.0 -> 2.12.0 ``                                                                   |
| [`97a83e04`](https://github.com/NixOS/nixpkgs/commit/97a83e04f0d2d6cbc5c354300bb511fb0d10c004) | `` python3Packages.pypdf: 6.12.2 -> 6.13.2 ``                                                         |
| [`8de9c7b8`](https://github.com/NixOS/nixpkgs/commit/8de9c7b85c33f2265e3ece6d437d93ad6256bee1) | `` zigbee2mqtt: use pnpm_10 ``                                                                        |
| [`834f739f`](https://github.com/NixOS/nixpkgs/commit/834f739fc5437e8a227be6e651a2b12ae72f31b8) | `` nixosTests.zenohd: fix test flakiness by adding QoS1 to mqtt pub ``                                |
| [`f3ca6e11`](https://github.com/NixOS/nixpkgs/commit/f3ca6e110189db5bb10af0bc0395191c146e02e9) | `` ifstate: 2.3.0 -> 2.4.1 ``                                                                         |
| [`b00ba754`](https://github.com/NixOS/nixpkgs/commit/b00ba754a2c8ef155bd8956d5b1d59af42454577) | `` zigbee2mqtt: 2.10.1 -> 2.11.0 ``                                                                   |
| [`96d850ee`](https://github.com/NixOS/nixpkgs/commit/96d850eec3dd82eb955f0da6711dfd389faed916) | `` xen: patch with XSA-494 ``                                                                         |
| [`aa7b6244`](https://github.com/NixOS/nixpkgs/commit/aa7b6244ec46e5745aedbedc5dc194f883f58f71) | `` xen: patch with XSA-493 ``                                                                         |
| [`0081a619`](https://github.com/NixOS/nixpkgs/commit/0081a619963b71b8bf1895f696260e1a74106ca7) | `` xen: patch with XSA-492 ``                                                                         |
| [`df50bc39`](https://github.com/NixOS/nixpkgs/commit/df50bc395006d7f7780cbe6c534df877e4eced8d) | `` xen: patch with XSA-491 ``                                                                         |
| [`c5efc36b`](https://github.com/NixOS/nixpkgs/commit/c5efc36baa4177b8a7bfae5d88ebce90a337b365) | `` xen: patch with XSA-490 ``                                                                         |
| [`c34b530e`](https://github.com/NixOS/nixpkgs/commit/c34b530e31085e6b30d663f2e073ef86cac94e3f) | `` talosctl: 1.13.3 -> 1.13.4 ``                                                                      |
| [`f8959924`](https://github.com/NixOS/nixpkgs/commit/f8959924dc795a459f58f19404664486f063d88c) | `` yt-dlp: 2026.03.17 -> 2026.06.09 ``                                                                |
| [`fa28ea27`](https://github.com/NixOS/nixpkgs/commit/fa28ea278e18a73f5ad21dbbced28f8cd1de81cf) | `` podofo: 1.1.0 -> 1.1.1 ``                                                                          |
| [`5e8242f9`](https://github.com/NixOS/nixpkgs/commit/5e8242f9a85c25c61754674dcdc6f7f77c809205) | `` ethercat: add kernel module ``                                                                     |
| [`56ac489c`](https://github.com/NixOS/nixpkgs/commit/56ac489c8750450a16bc500972ac4e727b905acd) | `` ethercat: add myself as maintainer, fix license(s) ``                                              |
| [`5337f416`](https://github.com/NixOS/nixpkgs/commit/5337f4162f1aaa158b856dcb9b1421be3924d8cf) | `` forgejo: 15.0.2 -> 15.0.3 ``                                                                       |
| [`e95cf047`](https://github.com/NixOS/nixpkgs/commit/e95cf04710119a158ecdc0eafe9cf793c70f918b) | `` deltachat-desktop: 2.51.0 -> 2.52.0 ``                                                             |
| [`dfd39d5d`](https://github.com/NixOS/nixpkgs/commit/dfd39d5d3abaf9cbc3d8fca61edab86d408b29da) | `` llvmPackages_git: 23.0.0-unstable-2026-05-31 -> 23.0.0-unstable-2026-06-07 ``                      |
| [`d9099252`](https://github.com/NixOS/nixpkgs/commit/d9099252c966693fcb261bb3f952c6020079f879) | `` jetbrains.webstorm: 2026.1.2 -> 2026.1.3 ``                                                        |
| [`ec441829`](https://github.com/NixOS/nixpkgs/commit/ec4418293003c7dd030a77d4679f54412aa018dc) | `` nodetool: init at 2.0.0-alpha.9 ``                                                                 |
| [`3e3df1d8`](https://github.com/NixOS/nixpkgs/commit/3e3df1d80ffccc64e6ed38da2e96eebed8f21a67) | `` dusklight: 1.2.0 -> 1.3.1 ``                                                                       |
| [`21f14458`](https://github.com/NixOS/nixpkgs/commit/21f1445843498f84e40984a3dfb9308adcdd18c5) | `` victoriametrics: 1.144.0 -> 1.145.0 ``                                                             |
| [`8df65258`](https://github.com/NixOS/nixpkgs/commit/8df65258e4d3437755264a78a2d4ec9acc6da08d) | `` nixos/wireless: fix for multiple interfaces ``                                                     |
| [`25055407`](https://github.com/NixOS/nixpkgs/commit/25055407132d152b021381cf118b0c93146a5361) | `` pocket-id: 2.7.0 -> 2.8.0 ``                                                                       |
| [`78ccf946`](https://github.com/NixOS/nixpkgs/commit/78ccf946ce375cbc87f262d049c29a16efee148b) | `` nixos/lauti: fix type on services.lauti.secrets ``                                                 |
| [`7299cb84`](https://github.com/NixOS/nixpkgs/commit/7299cb84682767a323b63e4f3956acd4d6ea6b96) | `` linuxKernel.kernels.linux_zen: 7.0.10 -> 7.0.11 ``                                                 |
| [`a18a66e8`](https://github.com/NixOS/nixpkgs/commit/a18a66e818b336e3779d5f0642edd840583db8de) | `` python3Packages.molecule-plugins: 23.5.3 -> 25.8.12, fetch from github ``                          |
| [`96e93d80`](https://github.com/NixOS/nixpkgs/commit/96e93d8071b5c206eade54ccf403739d115b9833) | `` python3Packages.githubkit: mark as broken ``                                                       |
| [`6fbe8b4a`](https://github.com/NixOS/nixpkgs/commit/6fbe8b4a082db34dff44d0d35fa9cddcf71829d7) | `` deltachat-tauri: inherit from deltachat-desktop ``                                                 |
| [`df88426f`](https://github.com/NixOS/nixpkgs/commit/df88426fe21422d430b89a9c4824ab5defe28904) | `` deltachat-desktop: use __structuredAttrs and strictDeps ``                                         |
| [`263c65f4`](https://github.com/NixOS/nixpkgs/commit/263c65f492f88aefd2a4d25e7e6a3397cac2cef5) | `` deltachat-tauri: use pnpm_10 ``                                                                    |
| [`67a0600a`](https://github.com/NixOS/nixpkgs/commit/67a0600a4c62ca79046acd546562ff3d470094b7) | `` deltachat-desktop: use pnpm_10 ``                                                                  |
| [`b608cbec`](https://github.com/NixOS/nixpkgs/commit/b608cbec502ab5420d48667f72938dec70bcc745) | `` deltachat-tauri: don't depend on cargoDeps internal directory naming ``                            |
| [`952d13bf`](https://github.com/NixOS/nixpkgs/commit/952d13bfaf3dea429eeccad5267e980e69d594d9) | `` deltachat-tauri: 2.49.1 -> 2.51.0 ``                                                               |
| [`6228f8ec`](https://github.com/NixOS/nixpkgs/commit/6228f8ec0b5bb1aed225efb29a6a9486574a1a87) | `` deltachat-desktop: 2.49.1 -> 2.51.0 ``                                                             |
| [`f81e9b16`](https://github.com/NixOS/nixpkgs/commit/f81e9b168083d29528d2110a6297bd93ab9da59a) | `` deltachat-tauri: init at 2.49.1 ``                                                                 |
| [`3eeb3839`](https://github.com/NixOS/nixpkgs/commit/3eeb3839a5b01db1f420c78704d08f68bf33c6d6) | `` qgis: 4.0.2 -> 4.0.3 ``                                                                            |
| [`089d4fc1`](https://github.com/NixOS/nixpkgs/commit/089d4fc10aa3bbe5d26eda53264adab847c4196e) | `` python3Packages.nomadnet: add `drupol` as maintainer ``                                            |
| [`283bbd2c`](https://github.com/NixOS/nixpkgs/commit/283bbd2cccd8db46c902961a656bf7abc813c3e6) | `` python3Packages.rns: add `drupol` as maintainer ``                                                 |
| [`e5f4e073`](https://github.com/NixOS/nixpkgs/commit/e5f4e073dff4b131b4fa67c5ad2ae75b00c5cb2d) | `` python3Packages.lxmf: add `drupol` as maintainer ``                                                |
| [`27d03d63`](https://github.com/NixOS/nixpkgs/commit/27d03d63ee660cb3a9d052737b938d9a132c1b32) | `` linux_xanmod_latest: 7.0.11 -> 7.0.12 ``                                                           |
| [`25809525`](https://github.com/NixOS/nixpkgs/commit/258095255ddeaadbdeeb0ee9bd39599f66556018) | `` linux_xanmod: 6.18.34 -> 6.18.35 ``                                                                |
| [`eed365ed`](https://github.com/NixOS/nixpkgs/commit/eed365ed8bee74d6d92aaa52eb9b030830b01537) | `` uv: 0.11.17 -> 0.11.19 ``                                                                          |
| [`0c0fc296`](https://github.com/NixOS/nixpkgs/commit/0c0fc296853dc28675ae8e5d809cc716d630abaf) | `` uv: 0.11.16 -> 0.11.17 ``                                                                          |
| [`703421a4`](https://github.com/NixOS/nixpkgs/commit/703421a4778cee49c4cc1d923035e4efde72adc5) | `` openocd-adi: 0.12.0-1.3.1-1 -> 0.12.0-1.3.1-2 ``                                                   |
| [`5dfd75b3`](https://github.com/NixOS/nixpkgs/commit/5dfd75b38fb929c10ba0d10d959c7f2622f9d149) | `` google-chrome: 149.0.7827.102 -> 149.0.7827.114 ``                                                 |
| [`e0625900`](https://github.com/NixOS/nixpkgs/commit/e06259002d503b1ccbfbe202709baba712acd710) | `` pgdog: 0.1.43 -> 0.1.44 ``                                                                         |
| [`66f010b9`](https://github.com/NixOS/nixpkgs/commit/66f010b956013801280497223883ec67177875fc) | `` vimPlugins.orgmode: fix build ``                                                                   |
| [`28f1f0cd`](https://github.com/NixOS/nixpkgs/commit/28f1f0cdf954c8298fd9fb4253a2f41438dcbe75) | `` neovim-unwrapped: 0.12.2 -> 0.12.3 ``                                                              |
| [`b7a72c8b`](https://github.com/NixOS/nixpkgs/commit/b7a72c8b9f31dde9b204f1c2b5c6076b0d15ce96) | `` simplex-chat-desktop: 6.5.2 -> 6.5.4 ``                                                            |
| [`1952d3fa`](https://github.com/NixOS/nixpkgs/commit/1952d3faba382c95bd57e7177aa25e4c9a212220) | `` ci: move Treefmt settings into a separate file ``                                                  |
| [`04259522`](https://github.com/NixOS/nixpkgs/commit/0425952254fe6a4a254914059785a59a9f3782fc) | `` pyfa: 2.66.3 -> 2.67.0 ``                                                                          |
| [`03b86ad4`](https://github.com/NixOS/nixpkgs/commit/03b86ad47cd9a0da371f6ec21f02af4776493958) | `` luaPackages.orgmode: disable flaky UI tests ``                                                     |
| [`7600c6ef`](https://github.com/NixOS/nixpkgs/commit/7600c6efbd45a14872c77e91d7acc5b8d8cf780f) | `` zoom-us: add libxcb-util to FHS dependencies ``                                                    |
| [`01733f7e`](https://github.com/NixOS/nixpkgs/commit/01733f7eff9ffe882b57a3ceee12073f28b30c9d) | `` linux_zen: 7.0.11 -> 7.0.12 ``                                                                     |
| [`18776ee1`](https://github.com/NixOS/nixpkgs/commit/18776ee1ddbdf53df787bfbfbd01c329392114bb) | `` atlantis: 0.43.0 -> 0.44.0 ``                                                                      |
| [`2699ef1f`](https://github.com/NixOS/nixpkgs/commit/2699ef1f5af1e991cdd5c0734414369f9b7f6358) | `` element-{web,desktop}: 1.12.18 -> 1.12.21 ``                                                       |
| [`1041fb01`](https://github.com/NixOS/nixpkgs/commit/1041fb01e5bab42cac9e8e42367cd67ae4d47b66) | `` bootspec: honor boot.kernel.enable ``                                                              |
| [`9f462c9b`](https://github.com/NixOS/nixpkgs/commit/9f462c9b7c63364a2302abcb83e706a810b97a0f) | `` beamPackages.expert: 0.1.3 -> 0.1.5 ``                                                             |
| [`ff2ec7b7`](https://github.com/NixOS/nixpkgs/commit/ff2ec7b73e3a2f6e07ce2e20b4562a5196ff260e) | `` transmission_4: 4.1.1 -> 4.1.2 ``                                                                  |
| [`d5107931`](https://github.com/NixOS/nixpkgs/commit/d5107931b19fcba457e207645992e20d20dcf028) | `` llama-swap: 216 -> 224 ``                                                                          |
| [`928b5ea4`](https://github.com/NixOS/nixpkgs/commit/928b5ea408124d972898ca1ceb90513ff708f609) | `` kdash: add `meta.changelog` ``                                                                     |
| [`bde96dbf`](https://github.com/NixOS/nixpkgs/commit/bde96dbfc1619b72a33d5e48cec9af6155bcdab5) | `` kdash: fix source hash ``                                                                          |
| [`4fb969d2`](https://github.com/NixOS/nixpkgs/commit/4fb969d2ade3b0db1d414ccecbe0006fb08a5ea2) | `` jenkins: 2.555.2 -> 2.555.3 ``                                                                     |
| [`5ee5ac13`](https://github.com/NixOS/nixpkgs/commit/5ee5ac1341a2cbd896553376cea4038ae19b0e57) | `` doc: clarify how 26.05's wpa_supplicant changes affect the ctrl_interface ``                       |
| [`f55d4205`](https://github.com/NixOS/nixpkgs/commit/f55d4205a5c1c0c5e43c4d6e6efbe3548cd9d5bf) | `` jasterix: fix tests ``                                                                             |
| [`a9e14abf`](https://github.com/NixOS/nixpkgs/commit/a9e14abfd3b718a449eea49645c720ceb78feb0b) | `` beamPackages.buildMix: fix install hooks not running ``                                            |
| [`2838c6f7`](https://github.com/NixOS/nixpkgs/commit/2838c6f7c474191604cae6be7e80f1291b064c5e) | `` python3Packages.uefi-firmware-parser: add setuptools-scm and remove wheel to build dependencies `` |
| [`1a7e918d`](https://github.com/NixOS/nixpkgs/commit/1a7e918dcdcd396530b3c5f1ad0d7903d4e35f1b) | `` python3Packages.plover_{4,5}: install desktop entry ``                                             |
| [`f07816aa`](https://github.com/NixOS/nixpkgs/commit/f07816aa13784715e071b7458d2da8b0a7807f36) | `` technitium-dns-server: fix missing DNSSEC DO bit in authoritative responses ``                     |
| [`5fa69fa3`](https://github.com/NixOS/nixpkgs/commit/5fa69fa3657e9dfcaa8c667401b30656236a0ecc) | `` beam.interpreters.erlang_27: 27.3.4.12 -> 27.3.4.13 ``                                             |
| [`a596e609`](https://github.com/NixOS/nixpkgs/commit/a596e609e2b2db545eead87658c329b1bfc3244a) | `` beam.interpreters.erlang_28: 28.5.0.1 -> 28.5.0.2 ``                                               |
| [`8ff3978d`](https://github.com/NixOS/nixpkgs/commit/8ff3978d5fc0a69fbff0e6ac2b8f378245e2c352) | `` beam.interpreters.erlang_29: 29.0.1 -> 29.0.2 ``                                                   |
| [`2ccf54f4`](https://github.com/NixOS/nixpkgs/commit/2ccf54f426c142ecebf48d3c5e34c49c52ea4cc4) | `` oauth2-proxy: 7.15.2 -> 7.15.3 ``                                                                  |
| [`1eff69b7`](https://github.com/NixOS/nixpkgs/commit/1eff69b7f09e024ed3a78123ad5e131e980f1a9d) | `` localsend: set meta.donationPage ``                                                                |
| [`9895960c`](https://github.com/NixOS/nixpkgs/commit/9895960ce2cec7e505c5fb03a10a40b628a6f828) | `` zigbee2mqtt: 2.11.0 -> 2.12.0 ``                                                                   |
| [`97a83e04`](https://github.com/NixOS/nixpkgs/commit/97a83e04f0d2d6cbc5c354300bb511fb0d10c004) | `` python3Packages.pypdf: 6.12.2 -> 6.13.2 ``                                                         |
| [`8de9c7b8`](https://github.com/NixOS/nixpkgs/commit/8de9c7b85c33f2265e3ece6d437d93ad6256bee1) | `` zigbee2mqtt: use pnpm_10 ``                                                                        |
| [`834f739f`](https://github.com/NixOS/nixpkgs/commit/834f739fc5437e8a227be6e651a2b12ae72f31b8) | `` nixosTests.zenohd: fix test flakiness by adding QoS1 to mqtt pub ``                                |
| [`f3ca6e11`](https://github.com/NixOS/nixpkgs/commit/f3ca6e110189db5bb10af0bc0395191c146e02e9) | `` ifstate: 2.3.0 -> 2.4.1 ``                                                                         |
| [`b00ba754`](https://github.com/NixOS/nixpkgs/commit/b00ba754a2c8ef155bd8956d5b1d59af42454577) | `` zigbee2mqtt: 2.10.1 -> 2.11.0 ``                                                                   |
| [`96d850ee`](https://github.com/NixOS/nixpkgs/commit/96d850eec3dd82eb955f0da6711dfd389faed916) | `` xen: patch with XSA-494 ``                                                                         |
| [`aa7b6244`](https://github.com/NixOS/nixpkgs/commit/aa7b6244ec46e5745aedbedc5dc194f883f58f71) | `` xen: patch with XSA-493 ``                                                                         |
| [`0081a619`](https://github.com/NixOS/nixpkgs/commit/0081a619963b71b8bf1895f696260e1a74106ca7) | `` xen: patch with XSA-492 ``                                                                         |
| [`df50bc39`](https://github.com/NixOS/nixpkgs/commit/df50bc395006d7f7780cbe6c534df877e4eced8d) | `` xen: patch with XSA-491 ``                                                                         |
| [`c5efc36b`](https://github.com/NixOS/nixpkgs/commit/c5efc36baa4177b8a7bfae5d88ebce90a337b365) | `` xen: patch with XSA-490 ``                                                                         |
| [`c34b530e`](https://github.com/NixOS/nixpkgs/commit/c34b530e31085e6b30d663f2e073ef86cac94e3f) | `` talosctl: 1.13.3 -> 1.13.4 ``                                                                      |
| [`f8959924`](https://github.com/NixOS/nixpkgs/commit/f8959924dc795a459f58f19404664486f063d88c) | `` yt-dlp: 2026.03.17 -> 2026.06.09 ``                                                                |
| [`fa28ea27`](https://github.com/NixOS/nixpkgs/commit/fa28ea278e18a73f5ad21dbbced28f8cd1de81cf) | `` podofo: 1.1.0 -> 1.1.1 ``                                                                          |
| [`5e8242f9`](https://github.com/NixOS/nixpkgs/commit/5e8242f9a85c25c61754674dcdc6f7f77c809205) | `` ethercat: add kernel module ``                                                                     |
| [`56ac489c`](https://github.com/NixOS/nixpkgs/commit/56ac489c8750450a16bc500972ac4e727b905acd) | `` ethercat: add myself as maintainer, fix license(s) ``                                              |
| [`5337f416`](https://github.com/NixOS/nixpkgs/commit/5337f4162f1aaa158b856dcb9b1421be3924d8cf) | `` forgejo: 15.0.2 -> 15.0.3 ``                                                                       |
| [`e95cf047`](https://github.com/NixOS/nixpkgs/commit/e95cf04710119a158ecdc0eafe9cf793c70f918b) | `` deltachat-desktop: 2.51.0 -> 2.52.0 ``                                                             |
| [`dfd39d5d`](https://github.com/NixOS/nixpkgs/commit/dfd39d5d3abaf9cbc3d8fca61edab86d408b29da) | `` llvmPackages_git: 23.0.0-unstable-2026-05-31 -> 23.0.0-unstable-2026-06-07 ``                      |
| [`d9099252`](https://github.com/NixOS/nixpkgs/commit/d9099252c966693fcb261bb3f952c6020079f879) | `` jetbrains.webstorm: 2026.1.2 -> 2026.1.3 ``                                                        |
| [`ec441829`](https://github.com/NixOS/nixpkgs/commit/ec4418293003c7dd030a77d4679f54412aa018dc) | `` nodetool: init at 2.0.0-alpha.9 ``                                                                 |
| [`3e3df1d8`](https://github.com/NixOS/nixpkgs/commit/3e3df1d80ffccc64e6ed38da2e96eebed8f21a67) | `` dusklight: 1.2.0 -> 1.3.1 ``                                                                       |
| [`21f14458`](https://github.com/NixOS/nixpkgs/commit/21f1445843498f84e40984a3dfb9308adcdd18c5) | `` victoriametrics: 1.144.0 -> 1.145.0 ``                                                             |
| [`8df65258`](https://github.com/NixOS/nixpkgs/commit/8df65258e4d3437755264a78a2d4ec9acc6da08d) | `` nixos/wireless: fix for multiple interfaces ``                                                     |
| [`25055407`](https://github.com/NixOS/nixpkgs/commit/25055407132d152b021381cf118b0c93146a5361) | `` pocket-id: 2.7.0 -> 2.8.0 ``                                                                       |
| [`78ccf946`](https://github.com/NixOS/nixpkgs/commit/78ccf946ce375cbc87f262d049c29a16efee148b) | `` nixos/lauti: fix type on services.lauti.secrets ``                                                 |
| [`7299cb84`](https://github.com/NixOS/nixpkgs/commit/7299cb84682767a323b63e4f3956acd4d6ea6b96) | `` linuxKernel.kernels.linux_zen: 7.0.10 -> 7.0.11 ``                                                 |
| [`a18a66e8`](https://github.com/NixOS/nixpkgs/commit/a18a66e818b336e3779d5f0642edd840583db8de) | `` python3Packages.molecule-plugins: 23.5.3 -> 25.8.12, fetch from github ``                          |
| [`96e93d80`](https://github.com/NixOS/nixpkgs/commit/96e93d8071b5c206eade54ccf403739d115b9833) | `` python3Packages.githubkit: mark as broken ``                                                       |
| [`6fbe8b4a`](https://github.com/NixOS/nixpkgs/commit/6fbe8b4a082db34dff44d0d35fa9cddcf71829d7) | `` deltachat-tauri: inherit from deltachat-desktop ``                                                 |
| [`df88426f`](https://github.com/NixOS/nixpkgs/commit/df88426fe21422d430b89a9c4824ab5defe28904) | `` deltachat-desktop: use __structuredAttrs and strictDeps ``                                         |
| [`263c65f4`](https://github.com/NixOS/nixpkgs/commit/263c65f492f88aefd2a4d25e7e6a3397cac2cef5) | `` deltachat-tauri: use pnpm_10 ``                                                                    |
| [`67a0600a`](https://github.com/NixOS/nixpkgs/commit/67a0600a4c62ca79046acd546562ff3d470094b7) | `` deltachat-desktop: use pnpm_10 ``                                                                  |
| [`b608cbec`](https://github.com/NixOS/nixpkgs/commit/b608cbec502ab5420d48667f72938dec70bcc745) | `` deltachat-tauri: don't depend on cargoDeps internal directory naming ``                            |
| [`952d13bf`](https://github.com/NixOS/nixpkgs/commit/952d13bfaf3dea429eeccad5267e980e69d594d9) | `` deltachat-tauri: 2.49.1 -> 2.51.0 ``                                                               |
| [`6228f8ec`](https://github.com/NixOS/nixpkgs/commit/6228f8ec0b5bb1aed225efb29a6a9486574a1a87) | `` deltachat-desktop: 2.49.1 -> 2.51.0 ``                                                             |
| [`f81e9b16`](https://github.com/NixOS/nixpkgs/commit/f81e9b168083d29528d2110a6297bd93ab9da59a) | `` deltachat-tauri: init at 2.49.1 ``                                                                 |
| [`3eeb3839`](https://github.com/NixOS/nixpkgs/commit/3eeb3839a5b01db1f420c78704d08f68bf33c6d6) | `` qgis: 4.0.2 -> 4.0.3 ``                                                                            |
| [`089d4fc1`](https://github.com/NixOS/nixpkgs/commit/089d4fc10aa3bbe5d26eda53264adab847c4196e) | `` python3Packages.nomadnet: add `drupol` as maintainer ``                                            |
| [`283bbd2c`](https://github.com/NixOS/nixpkgs/commit/283bbd2cccd8db46c902961a656bf7abc813c3e6) | `` python3Packages.rns: add `drupol` as maintainer ``                                                 |
| [`e5f4e073`](https://github.com/NixOS/nixpkgs/commit/e5f4e073dff4b131b4fa67c5ad2ae75b00c5cb2d) | `` python3Packages.lxmf: add `drupol` as maintainer ``                                                |
| [`27d03d63`](https://github.com/NixOS/nixpkgs/commit/27d03d63ee660cb3a9d052737b938d9a132c1b32) | `` linux_xanmod_latest: 7.0.11 -> 7.0.12 ``                                                           |
| [`25809525`](https://github.com/NixOS/nixpkgs/commit/258095255ddeaadbdeeb0ee9bd39599f66556018) | `` linux_xanmod: 6.18.34 -> 6.18.35 ``                                                                |
| [`eed365ed`](https://github.com/NixOS/nixpkgs/commit/eed365ed8bee74d6d92aaa52eb9b030830b01537) | `` uv: 0.11.17 -> 0.11.19 ``                                                                          |
| [`0c0fc296`](https://github.com/NixOS/nixpkgs/commit/0c0fc296853dc28675ae8e5d809cc716d630abaf) | `` uv: 0.11.16 -> 0.11.17 ``                                                                          |
| [`608e5a6f`](https://github.com/NixOS/nixpkgs/commit/608e5a6f9933eb8d66fcb30a5fa660a109b4643b) | `` actual-server: 25.5.2 -> 26.0.0 ``                                                                 |
| [`3c7eb888`](https://github.com/NixOS/nixpkgs/commit/3c7eb888cd87ed9d8a8b2889267d1a65da47d7b8) | `` onionshare: 2.6.3 -> 2.6.4 ``                                                                      |
| [`756ecbb9`](https://github.com/NixOS/nixpkgs/commit/756ecbb9ac163449ac4b032002c46728580fea95) | `` mcp-nixos: fix darwin build ``                                                                     |
| [`50dfe8a3`](https://github.com/NixOS/nixpkgs/commit/50dfe8a32ef6913e4a48e0f26a8accbb089ef0b1) | `` gridcoin-research: 5.5.0.0 -> 5.5.1.0 ``                                                           |
| [`761b67dd`](https://github.com/NixOS/nixpkgs/commit/761b67dd869d9828daf622756d24f9d1c050f14e) | `` digikam: 9.0.0 -> 9.1.0 ``                                                                         |
| [`97595638`](https://github.com/NixOS/nixpkgs/commit/97595638b0f0ade263a0c1b79bbe4fac1dfb8313) | `` nixos/sshd: accept path-typed options ``                                                           |
| [`873d65af`](https://github.com/NixOS/nixpkgs/commit/873d65af3632bd2f97798b7003c3fe7aa742efe0) | `` newsflash: add missing glycin dependencies ``                                                      |
| [`80c985d3`](https://github.com/NixOS/nixpkgs/commit/80c985d31dc24809746dd5859fe3cbb444308528) | `` anytype-cli: 0.3.3 -> 0.3.5 ``                                                                     |
| [`616e6b56`](https://github.com/NixOS/nixpkgs/commit/616e6b56ebd266ade56085271847d88f9493371b) | `` sdl_gamecontrollerdb: 0-unstable-2026-05-28 -> 0-unstable-2026-06-07 ``                            |
| [`7f2b551d`](https://github.com/NixOS/nixpkgs/commit/7f2b551da8a43110b20315a8baa4deab649b5cc5) | `` taler-wallet-core: update pnpm & fetcher versions ``                                               |
| [`af967dd9`](https://github.com/NixOS/nixpkgs/commit/af967dd95bf9f1b57c0bdb60d2a9324b3c713f6a) | `` ci: update pinned ``                                                                               |
| [`3cb0aa0a`](https://github.com/NixOS/nixpkgs/commit/3cb0aa0abaa5dbe3f41e82ab7ec2a660a4d1f11e) | `` ci/update-pinned.sh: use nixpkgs from current dir, run npins upgrade too ``                        |
| [`4e2d63ce`](https://github.com/NixOS/nixpkgs/commit/4e2d63ce58ed6bc48e1827ebf6ee4a19ebadba27) | `` google-chrome: 149.0.7827.53 -> 149.0.7827.102 ``                                                  |
| [`bf0f7d28`](https://github.com/NixOS/nixpkgs/commit/bf0f7d2880caa027711cb0caa6fc2fb2cf17c241) | `` rgx: 0.12.6 -> 0.14.1 ``                                                                           |
| [`8cfc80fe`](https://github.com/NixOS/nixpkgs/commit/8cfc80fe49663fc03e2927f44d938edf41ad6a93) | `` python3Packages: uefi-firmware-parser: 1.13 -> 1.16, updateScript, and maintainer ``               |
| [`c3a31871`](https://github.com/NixOS/nixpkgs/commit/c3a318719b7dbedc78f1f44f311225cae6aca66f) | `` maintainers: add elliotberman ``                                                                   |
| [`8a7e6526`](https://github.com/NixOS/nixpkgs/commit/8a7e6526fa326e9d63ea02665561b2766976a730) | `` bird3: 3.3.0 -> 3.3.1 ``                                                                           |
| [`23552e2f`](https://github.com/NixOS/nixpkgs/commit/23552e2f21f69e17d6bf9a4de7ae0474c0d4996f) | `` bird2: 2.19.0 -> 2.19.1 ``                                                                         |
| [`115ca9cf`](https://github.com/NixOS/nixpkgs/commit/115ca9cfab513058331b2b0d51f9325966a577a2) | `` python3Packages.zenoh: 1.6.2 -> 1.9.0 ``                                                           |
| [`51d0bdd3`](https://github.com/NixOS/nixpkgs/commit/51d0bdd3e8eb81cbc908d7a50a3359a50bb2bc22) | `` zenoh: add darwin to meta.platforms ``                                                             |
| [`1b262bc3`](https://github.com/NixOS/nixpkgs/commit/1b262bc32ff911e78eba5ff7b8c205b0b2f53e56) | `` zenoh-plugin-webserver: 1.4.0 -> 1.9.0 ``                                                          |
| [`613551bf`](https://github.com/NixOS/nixpkgs/commit/613551bf9dcad462d6e64212e1fabfb33afe1a04) | `` zenoh-plugin-mqtt: 1.4.0 -> 1.9.0 ``                                                               |
| [`943fde73`](https://github.com/NixOS/nixpkgs/commit/943fde73c7051cca70967da5b672769db6ac83b9) | `` zenoh-plugin-dds: 1.4.0 -> 1.9.0 ``                                                                |
| [`dfcd14b7`](https://github.com/NixOS/nixpkgs/commit/dfcd14b7855f7b7ca4fdc5de1810e2bddbb67d31) | `` zenoh-backend-rocksdb: 1.4.0 -> 1.9.0 ``                                                           |
| [`b7979e03`](https://github.com/NixOS/nixpkgs/commit/b7979e03d7ef3358a89dd6ec29edb888bcd962ee) | `` zenoh-backend-influxdb: 1.4.0 -> 1.9.0 ``                                                          |
| [`a58546a2`](https://github.com/NixOS/nixpkgs/commit/a58546a24e9b740a9d335f666fe09f76a3d63469) | `` zenoh-backend-filesystem: 1.4.0 -> 1.9.0 ``                                                        |
| [`e4e4e4e5`](https://github.com/NixOS/nixpkgs/commit/e4e4e4e5900c2ae33ee2abd0f502ac4d47e8b23d) | `` zenoh-cpp: 1.4.0 -> 1.9.0 ``                                                                       |
| [`4071a424`](https://github.com/NixOS/nixpkgs/commit/4071a42461127a64417867340747f68fe32d0cad) | `` zenoh-c: 1.4.0 -> 1.9.0 ``                                                                         |
| [`cb19c6e1`](https://github.com/NixOS/nixpkgs/commit/cb19c6e1062a700fe03ba3033baa0aa57cd1866e) | `` zenoh: 1.4.0 -> 1.9.0 ``                                                                           |
| [`1c4f5301`](https://github.com/NixOS/nixpkgs/commit/1c4f53010b1652065094a4b0661467f9b50194a6) | `` dateutils: fix build errors ``                                                                     |
| [`705edb33`](https://github.com/NixOS/nixpkgs/commit/705edb330512cd9ad8a55a8a084049940ba1a491) | `` jasterix: init at 0.1.4 ``                                                                         |
| [`be3c79b0`](https://github.com/NixOS/nixpkgs/commit/be3c79b0d92b042fd75c18936260a79b52212afa) | `` docker: 29.5.2 -> 29.5.3 ``                                                                        |
| [`8049cc79`](https://github.com/NixOS/nixpkgs/commit/8049cc7937ec7d803c040ab98041b9055bb7eb09) | `` usbmuxd: 1.1.1+date=2023-05-05 -> 1.1.1+date=2025-12-06 ``                                         |
| [`be4af1a8`](https://github.com/NixOS/nixpkgs/commit/be4af1a858750144185ab127fb81b74d2e350061) | `` usbmuxd: add ProxyVT as maintainer ``                                                              |
| [`d9356277`](https://github.com/NixOS/nixpkgs/commit/d9356277d807c60f856857143e1c31fe92020ffd) | `` scanservjs: 3.0.4 -> 3.1.0 ``                                                                      |
| [`49748460`](https://github.com/NixOS/nixpkgs/commit/497484600844e6dd7887da2b75a05f5dda1f7fe9) | `` senpai: 0.4.1 -> 0.5.0 ``                                                                          |
| [`5ea0b093`](https://github.com/NixOS/nixpkgs/commit/5ea0b093bffbf7b8d46707bb03a3b507a93fb49a) | `` anytype: automatically update bun node_modules ``                                                  |
| [`e31d5244`](https://github.com/NixOS/nixpkgs/commit/e31d52447efb26a14974e7eda4ffba8c86e595e5) | `` pfetch: 1.10.0 -> 1.11.0 ``                                                                        |
| [`75984985`](https://github.com/NixOS/nixpkgs/commit/7598498565392792584df8c4ef9f5ff50ed14c34) | `` rquickshare: pin pnpm to v10 ``                                                                    |
| [`1183c014`](https://github.com/NixOS/nixpkgs/commit/1183c0145b87945dc9350af37b2c8ccd1d785e23) | `` radicle-desktop: 0.11.0 -> 0.12.0 ``                                                               |
| [`6a8429f3`](https://github.com/NixOS/nixpkgs/commit/6a8429f319cffe8a3abd4488cb128d950f008cf4) | `` offlineimap: 8.0.2 -> 8.0.3 ``                                                                     |
| [`cdb51668`](https://github.com/NixOS/nixpkgs/commit/cdb51668f37830219ed4179f96b0ef8362199340) | `` firefox-bin-unwrapped: 151.0.3 -> 151.0.4 ``                                                       |
| [`b8caa496`](https://github.com/NixOS/nixpkgs/commit/b8caa496986389225668c890688ed8fecb964770) | `` firefox-unwrapped: 151.0.3 -> 151.0.4 ``                                                           |
| [`8d92d077`](https://github.com/NixOS/nixpkgs/commit/8d92d077e880bb56e5650d5887f5f889f6ca24bd) | `` chromium,chromedriver: 149.0.7827.53 -> 149.0.7827.102 ``                                          |
| [`7a399fd5`](https://github.com/NixOS/nixpkgs/commit/7a399fd56d955a483d27001c1625f1ea4a84fecd) | `` nixos/rmfakecloud: add martinetd as maintainer ``                                                  |
| [`13005abf`](https://github.com/NixOS/nixpkgs/commit/13005abf24ee4bf8c06ec4ca6dd39353e382e44a) | `` rmfakecloud: remove euxane from maintainers ``                                                     |
| [`cbd07d3b`](https://github.com/NixOS/nixpkgs/commit/cbd07d3b7863a7a78627fcc1b4dfe8c2f9f88eca) | `` oxidized: 0.36.0 -> 0.37.0 ``                                                                      |
| [`5aa762b3`](https://github.com/NixOS/nixpkgs/commit/5aa762b38ed838202efef7ee3c01c0e01009ee5c) | `` rabbitmqadmin-ng: 2.29.0 -> 2.32.0 ``                                                              |
| [`6952ffc4`](https://github.com/NixOS/nixpkgs/commit/6952ffc485f2654a5a75e96cb2f276040effc288) | `` necesse-server: 1.2.0-22728942 -> 1.2.0-23522718 ``                                                |
| [`9b610359`](https://github.com/NixOS/nixpkgs/commit/9b6103595fbea5c3927feb3bfcee2717f5030e5b) | `` pretix: 2026.4.2 -> 2026.4.3 ``                                                                    |
| [`30097c53`](https://github.com/NixOS/nixpkgs/commit/30097c53f5ca2b5f2ad0cbc4e3ff6125e374a3fd) | `` linux_6_12: 6.12.92 -> 6.12.93 ``                                                                  |
| [`7d225321`](https://github.com/NixOS/nixpkgs/commit/7d2253212027d99f306432a31d126f90960e6a9f) | `` linux_6_18: 6.18.34 -> 6.18.35 ``                                                                  |
| [`54263f18`](https://github.com/NixOS/nixpkgs/commit/54263f185854bf22807e2dcdef9ca76d34147b6a) | `` linux_7_0: 7.0.11 -> 7.0.12 ``                                                                     |
| [`349f27bf`](https://github.com/NixOS/nixpkgs/commit/349f27bf136f992c29ed0831e92d8a88cc56f8ea) | `` linux_testing: 7.1-rc6 -> 7.1-rc7 ``                                                               |
| [`9523fef9`](https://github.com/NixOS/nixpkgs/commit/9523fef9bcedd438e9d8a2295ba18bc067230d27) | `` anytype: 0.54.11 -> 0.55.5 ``                                                                      |
| [`06852a2d`](https://github.com/NixOS/nixpkgs/commit/06852a2dc12b71f74fcc0956dd37681d7e7e9f00) | `` anytype-heart: 0.49.0-rc08 -> 0.50.8 ``                                                            |
| [`e2f194f3`](https://github.com/NixOS/nixpkgs/commit/e2f194f3ea16c73afd5fa7cea74387cc13f52c09) | `` anytype: migrate patches to ts ``                                                                  |
| [`ed294a5b`](https://github.com/NixOS/nixpkgs/commit/ed294a5b36e216f380c53cc817ede613fe5cddde) | `` neovim-unwrapped: apply CVE-2026-11487.patch ``                                                    |