### PR TITLE
chore(flake/colmena): `349b035a` -> `938cb5cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -128,11 +128,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1762034856,
-        "narHash": "sha256-QVey3iP3UEoiFVXgypyjTvCrsIlA4ecx6Acaz5C8/PQ=",
+        "lastModified": 1781446832,
+        "narHash": "sha256-/6+NHQstxRqkbNjtNcQgCojzu59SEbdwwpWqBw7Fm9s=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "349b035a5027f23d88eeb3bc41085d7ee29f18ed",
+        "rev": "938cb5cdd9b25d9774b6168e5f03d0afd04d321f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                 |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`938cb5cd`](https://github.com/nix-community/colmena/commit/938cb5cdd9b25d9774b6168e5f03d0afd04d321f) | `` ci: fix "no space left on device" `` |