### PR TITLE
chore(flake/nixvim): `e3c908fd` -> `bf0ec96c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -830,11 +830,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1781388258,
-        "narHash": "sha256-Kx1zxra9sZ215H3OiWUfkulu8N2v3iu19wqlzpD/Ac0=",
+        "lastModified": 1781536564,
+        "narHash": "sha256-/B/Ok82DMHauzJqtKJmHvH/edVMhnRjIjMslUimCI/E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e3c908fdf6dff268b04ffb6758bcfc7c018489b9",
+        "rev": "bf0ec96c9246ee739160f2a67cac29377ce0aa1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`bf0ec96c`](https://github.com/nix-community/nixvim/commit/bf0ec96c9246ee739160f2a67cac29377ce0aa1b) | `` maintainers: update generated/all-maintainers.nix ``               |
| [`586286af`](https://github.com/nix-community/nixvim/commit/586286af54a314a24566811ce44eb9f380696e6e) | `` modules/output: prevent duplicate vimPlugin assertion locations `` |
| [`1fb6dcca`](https://github.com/nix-community/nixvim/commit/1fb6dccabfbdfa18057a0fd3a2971c20a447db66) | `` modules/output: make vimPlugin assertions lazier ``                |