### PR TITLE
chore(flake/freminal): `d760f263` -> `7a6b7b56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,6 +54,22 @@
         "type": "github"
       }
     },
+    "cargo-bundle-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780169337,
+        "narHash": "sha256-jYSYR430gKJDcKKu+Kmc3VzpuQBvU80ydNRvJBTeFec=",
+        "owner": "burtonageo",
+        "repo": "cargo-bundle",
+        "rev": "739f92c37c789b5511a448a389cbc76fcebd99df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "burtonageo",
+        "repo": "cargo-bundle",
+        "type": "github"
+      }
+    },
     "catppuccin": {
       "inputs": {
         "nixpkgs": [
@@ -353,6 +369,7 @@
     },
     "freminal": {
       "inputs": {
+        "cargo-bundle-src": "cargo-bundle-src",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -360,11 +377,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781214354,
-        "narHash": "sha256-9lzU5222W2ELRvBEwUj3O/76X3l+BPCscBe8V5WOygg=",
+        "lastModified": 1781548589,
+        "narHash": "sha256-60mBTXLBIQ1iGPbIGG91YzNWgHc/RMI7Qa2I/51IFkk=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "d760f2632bd4debe53b10bc437aa9724fa8c3d9a",
+        "rev": "7a6b7b561be5b3f197e41a8a9f540aa654268cd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`43162d18`](https://github.com/fredsystems/freminal/commit/43162d1859fb6baf76412c551f3b8d043f937fbe) | `` fix: show Freminal app icon in taskbars, launchers, and Linux packages ``         |
| [`590605c5`](https://github.com/fredsystems/freminal/commit/590605c5c561addd7a1b3ddab2b608e2e7c20cf7) | `` feat: 106.7 -- surface fatal error window when last shell fails to spawn ``       |
| [`6743982f`](https://github.com/fredsystems/freminal/commit/6743982f951041b51301e0ae3120b48a45efd2a4) | `` fix: 106.7 -- bash shell-integration injection breaks PTY spawn ``                |
| [`332d4ac1`](https://github.com/fredsystems/freminal/commit/332d4ac18bc7a5268730adc024234e10285c83b6) | `` docs: add security policy ``                                                      |
| [`6e77cca0`](https://github.com/fredsystems/freminal/commit/6e77cca04d226cca3c39044d8c4fc01d4dae3f9c) | `` fix: remove stray nested freminal/Cargo.lock breaking Dependabot ``               |
| [`ae6c9998`](https://github.com/fredsystems/freminal/commit/ae6c99985bc47ad9951b75738dd2e2cf87c9b94d) | `` fix: 106.5 -- sort command history palette most-recent-first ``                   |
| [`f97e2611`](https://github.com/fredsystems/freminal/commit/f97e2611dbfd1956ebc5e1c1fe4c38a68275df64) | `` fore: bump MSRV in CI and version ``                                              |
| [`9b5cb9b2`](https://github.com/fredsystems/freminal/commit/9b5cb9b2bb797bb1897498f7026f1a2a7310eafc) | `` docs: 106.4 -- record teardown & lifecycle ordering completion notes ``           |
| [`d752acc8`](https://github.com/fredsystems/freminal/commit/d752acc8fd1062ed69d208f4adc08388590b8a3e) | `` fix: 106.4 -- correct pane/tab close focus and active-tab restore ``              |
| [`7149c09e`](https://github.com/fredsystems/freminal/commit/7149c09ef686414f746ae44bc2fb9e63e57ddc92) | `` fix: 106.4 -- distinguish expected PTY reader shutdown from anomaly ``            |
| [`d19dd060`](https://github.com/fredsystems/freminal/commit/d19dd0600656acee3c0f854671cfaa7c2f579d00) | `` fix: 106.4 -- destroy egui-glow painter on window close and exit ``               |
| [`8b965015`](https://github.com/fredsystems/freminal/commit/8b965015826654f7e3b6bc7a6b4f241e9c4fbb88) | `` fix: 106.2 + 106.3 -- command duration, gutter extent, and Ctrl-C notification `` |
| [`58bda90c`](https://github.com/fredsystems/freminal/commit/58bda90c161496d6663f1b818697092957ab2d8f) | `` fix: 106.6 -- paste-guard modal routes to originating pane ``                     |
| [`5c4c1393`](https://github.com/fredsystems/freminal/commit/5c4c1393ca321360031ecad9f9f2e9548618bce8) | `` fix: 106.1 -- restore right-click paste in terminal buffer ``                     |
| [`8f5afaad`](https://github.com/fredsystems/freminal/commit/8f5afaade0375c91bb76faa0c6397b24aa6e91bd) | `` chore: update docs ``                                                             |
| [`22d38089`](https://github.com/fredsystems/freminal/commit/22d3808965f2d10a59f3280be78770c0a4c506ba) | `` feat: 109.1 + 109.2 -- surround-the-active-pane highlight ``                      |
| [`f635b050`](https://github.com/fredsystems/freminal/commit/f635b0503f982ba5bbab237ab801bfe852c230e7) | `` docs: 110 -- mark Focus Follows Mouse complete ``                                 |
| [`1f689e97`](https://github.com/fredsystems/freminal/commit/1f689e9781bcbdceebaf5ba6710e1004d173dad7) | `` feat: 110.2 -- pane focus follows mouse ``                                        |
| [`1b605fd2`](https://github.com/fredsystems/freminal/commit/1b605fd2e272e488a0ae1dd63d3a0099b5c28b13) | `` feat: 110.1 -- focus-follows-mouse config option + wiring ``                      |
| [`1819e9ea`](https://github.com/fredsystems/freminal/commit/1819e9ea1acb54373cbae4b1d9dad921a18087b6) | `` chore(deps): update taiki-e/install-action action to v2.81.10 ``                  |
| [`09003111`](https://github.com/fredsystems/freminal/commit/09003111c1a4dc7ff4edbbf88d852d7b5b922e08) | `` chore(deps): update rust crate swash to v0.2.9 ``                                 |
| [`932ed856`](https://github.com/fredsystems/freminal/commit/932ed856404c0cc36486fe42cd91cd20c4f09129) | `` feat: 108.3 -- link attributions from the About modal ``                          |
| [`8b728d83`](https://github.com/fredsystems/freminal/commit/8b728d8334181c32d67e990e31133a96ceb064c4) | `` docs: 108.2 -- add ATTRIBUTIONS.md and bundle font license texts ``               |
| [`55400f50`](https://github.com/fredsystems/freminal/commit/55400f50b904b40c7d414b52ebf4b98df4b63f22) | `` docs: 108.1 -- attribution audit for About modal & NOTICE ``                      |