### PR TITLE
chore(flake/home-manager): `5b6f5733` -> `8aec76cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781365335,
-        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
+        "lastModified": 1781533608,
+        "narHash": "sha256-Mgsu/x5cs8EqlhIQ7bMBo14LpkAYtgzDbG/S/eattJA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
+        "rev": "8aec76cc1e045f37b55d82ca3cee4910ae04d3db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`8aec76cc`](https://github.com/nix-community/home-manager/commit/8aec76cc1e045f37b55d82ca3cee4910ae04d3db) | `` mkFirefoxModule: fix unexpected argument error on derivatives ``            |
| [`a813a041`](https://github.com/nix-community/home-manager/commit/a813a0411300c832bcf8c980fe33ec663b498601) | `` antigravity-cli: fix programs.mcp.servers integration for remote servers `` |
| [`1285cd3d`](https://github.com/nix-community/home-manager/commit/1285cd3d6882a9847f2d56ed5541b3350c8a6162) | `` keepassxc: Support macOS KeePassXC configuration ``                         |
| [`ed8263e7`](https://github.com/nix-community/home-manager/commit/ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5) | `` voxtype: fix output mode `paste` ``                                         |
| [`1b7fb5e6`](https://github.com/nix-community/home-manager/commit/1b7fb5e6b42799d94a4ce0c8911b7184b0d10b15) | `` maintainers: dump aguirre-matteo from almost all modules ``                 |