### PR TITLE
chore(flake/solaar): `55fe232b` -> `7229b334`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1091,11 +1091,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1780933184,
-        "narHash": "sha256-xuqVsDmJf7fhj9Khn1EKDIfhHZ4C7cA6nWVyN1yGlgk=",
+        "lastModified": 1781721497,
+        "narHash": "sha256-Qt4bx0zxdZBPWrDJV0RB2CwqYKlSzQRIpdSi0i2Nq0I=",
         "owner": "Svenum",
         "repo": "Solaar-Flake",
-        "rev": "55fe232b6762aada1d12e8cf7d5307004048e3c2",
+        "rev": "7229b334cad772a5fef7326e7086ec63a6ba421e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`7229b334`](https://github.com/Svenum/Solaar-Flake/commit/7229b334cad772a5fef7326e7086ec63a6ba421e) | `` update to 1.1.20rc3 (#27) `` |