### PR TITLE
chore(flake/home-manager): `8aec76cc` -> `ea0bf49c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -531,11 +531,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781533608,
-        "narHash": "sha256-Mgsu/x5cs8EqlhIQ7bMBo14LpkAYtgzDbG/S/eattJA=",
+        "lastModified": 1781719483,
+        "narHash": "sha256-MC6hWrek1hMewRRRHiAJ8z4sHEodzjizOefS/oHVrsU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8aec76cc1e045f37b55d82ca3cee4910ae04d3db",
+        "rev": "ea0bf49c9d2a9c8f5548d116d63a7a1a35d1193d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`ea0bf49c`](https://github.com/nix-community/home-manager/commit/ea0bf49c9d2a9c8f5548d116d63a7a1a35d1193d) | `` thunderbird: merge account prefs with mergeAttrsList ``                              |
| [`50978d4b`](https://github.com/nix-community/home-manager/commit/50978d4bf61bc70a291a2ea97134b15ffab386af) | `` neomutt: merge account rc files with mergeAttrsList ``                               |
| [`b3f454e5`](https://github.com/nix-community/home-manager/commit/b3f454e5c2bbc111d8d80a2396fdf51485dfe912) | `` zsh: merge plugin home.file entries with mergeAttrsList ``                           |
| [`cbbddc4a`](https://github.com/nix-community/home-manager/commit/cbbddc4a6f9548fcc47a455e80b951dce10690b3) | `` go: merge package src links with mergeAttrsList ``                                   |
| [`b06723c4`](https://github.com/nix-community/home-manager/commit/b06723c4d49310c4e982639d08e3bbe2deefa589) | `` getmail: merge home.file entries with mergeAttrsList ``                              |
| [`9b262cb7`](https://github.com/nix-community/home-manager/commit/9b262cb73852bbdd779b7bc77625fb4e6318b348) | `` browserpass: merge home.file entries with mergeAttrsList ``                          |
| [`71b4b46f`](https://github.com/nix-community/home-manager/commit/71b4b46f23619ec60e18dc70ae2d1117dbae4545) | `` thunderbird: use foldl' for profiles.ini merge ``                                    |
| [`b8818d5a`](https://github.com/nix-community/home-manager/commit/b8818d5a65d34c84178e28e31608946b544b3e19) | `` neovim: collect plugin configs with filter and map ``                                |
| [`ce68ac69`](https://github.com/nix-community/home-manager/commit/ce68ac69583368add045a38630f99d5a828a2199) | `` lib/generators: short-circuit important-field check with any ``                      |
| [`a69e55d0`](https://github.com/nix-community/home-manager/commit/a69e55d05b7448e0f321aa01cf6bb390397b5114) | `` fusuma: use lib.makeBinPath for service PATH ``                                      |
| [`fa4e2f7e`](https://github.com/nix-community/home-manager/commit/fa4e2f7e101c2a656bdd910e49ae485bd2d8a358) | `` modules/kdeconnect: stop overriding PATH, remove support for prehistoric versions `` |
| [`d2d79394`](https://github.com/nix-community/home-manager/commit/d2d79394a41aaa8677a6a8ce96f9ef2e6e694ae6) | `` maintainers: remove adisbladis ``                                                    |
| [`a2e23ee8`](https://github.com/nix-community/home-manager/commit/a2e23ee8f8699f8971b4fde86efc1b7ec1e19681) | `` helix: make package nullable ``                                                      |
| [`89fda224`](https://github.com/nix-community/home-manager/commit/89fda2248ec65b319c3cfc67a0d74f5429553e53) | `` mise: add usage dependency for shell completions ``                                  |
| [`524d73a9`](https://github.com/nix-community/home-manager/commit/524d73a9038e88a6b9c4945c6467da5f4e093b3d) | `` mise: add bash completion to bash integration ``                                     |
| [`7664e05e`](https://github.com/nix-community/home-manager/commit/7664e05e2413d5e2b8c54a884eb8ea0f8a504fc2) | `` maintainers: add ErinaYip ``                                                         |
| [`2a7b54df`](https://github.com/nix-community/home-manager/commit/2a7b54df12f9a7f4971effd162fd0c623ea43a59) | `` prismlauncher: add themes option ``                                                  |
| [`45e97d1e`](https://github.com/nix-community/home-manager/commit/45e97d1e8815564784e2d8fb0d9a429fc8751ddd) | `` television: remove da157 from maintainers ``                                         |
| [`df4e0465`](https://github.com/nix-community/home-manager/commit/df4e0465717a2d34f05b8ccd967275aaf3ceaa01) | `` codex: Add support for installing plugins and marketplaces ``                        |
| [`34dd288e`](https://github.com/nix-community/home-manager/commit/34dd288e65012954cf7170658e0e6a61255b0327) | `` antigravity-cli: update skills deployment path ``                                    |
| [`c03e4752`](https://github.com/nix-community/home-manager/commit/c03e4752899e55705dfa63979abd885c582a5c48) | `` programs/thunderbird: stop writing directory prefs ``                                |
| [`2d4f4e27`](https://github.com/nix-community/home-manager/commit/2d4f4e2788605eb8fe40fa5c7c63f3a7336b2367) | `` maintainers: update all-maintainers.nix ``                                           |