### PR TITLE
chore(flake/darwin): `aabb2037` -> `ee9c7b96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781242433,
-        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
+        "lastModified": 1781715441,
+        "narHash": "sha256-yyui90BUxu+A/NjUBO2RV9ubrC0lc/ECzuy2aWGnNEA=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
+        "rev": "ee9c7b96c90bbb23620544201e26de92858b9ce3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                          |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`cd7cf09a`](https://github.com/nix-darwin/nix-darwin/commit/cd7cf09aa3df5acdaea16a183b3df120b34a0567) | `` homebrew: set `trusted` flag in Brewfile directly ``          |
| [`bb9c29c1`](https://github.com/nix-darwin/nix-darwin/commit/bb9c29c19327336fa499fe77bd7ba6d00ccec484) | `` homebrew: address bundle command new CLI flag requirements `` |
| [`08278aff`](https://github.com/nix-darwin/nix-darwin/commit/08278afff6e71266c162f80d980fe851060e2a4c) | `` users: realpath home dirs before comparison ``                |