### PR TITLE
chore(flake/nixvim): `bf0ec96c` -> `dbf9550d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -809,11 +809,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1780336545,
-        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -846,11 +846,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1781536564,
-        "narHash": "sha256-/B/Ok82DMHauzJqtKJmHvH/edVMhnRjIjMslUimCI/E=",
+        "lastModified": 1782254890,
+        "narHash": "sha256-kjsEECqhpPnJWqhooXp6tWh2qGQftCPAo2G1GvZtKdw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "bf0ec96c9246ee739160f2a67cac29377ce0aa1b",
+        "rev": "dbf9550dba8448b03e11d58e5695d6c44a464554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`dbf9550d`](https://github.com/nix-community/nixvim/commit/dbf9550dba8448b03e11d58e5695d6c44a464554) | `` ci: bump actions/checkout from 6 to 7 ``                              |
| [`c02fd3ed`](https://github.com/nix-community/nixvim/commit/c02fd3edc6c30324d729e9af1e66e4f1719f51d9) | `` docs/lib: use structuredAttrs ``                                      |
| [`9b5157fa`](https://github.com/nix-community/nixvim/commit/9b5157fa16d3aad4ad0b1eebad71bcbf04483bdf) | `` flake: Update ``                                                      |
| [`91df3d9f`](https://github.com/nix-community/nixvim/commit/91df3d9f91c2b6e4c07541903b9d7f80a5b857e1) | `` docs/modules: model page content as sections ``                       |
| [`f60bf473`](https://github.com/nix-community/nixvim/commit/f60bf47332d1564a175ad4b517a83ff0c288f2e7) | `` modules/nixvim-info: flatten and simplify ``                          |
| [`c7ccb896`](https://github.com/nix-community/nixvim/commit/c7ccb896ebdae117b3e11f3afc3b5eaf3077938f) | `` docs/man: simplify using structuredAttrs ``                           |
| [`a0c1a8ff`](https://github.com/nix-community/nixvim/commit/a0c1a8ffd4c62d8498a6c2b5f4e7cbb5f4ca79b6) | `` docs: fixed GaetanLepage nixconfig URL ``                             |
| [`7f813fc7`](https://github.com/nix-community/nixvim/commit/7f813fc7a6a2f92103208a69a98d6afa24f5bb23) | `` flake: Update ``                                                      |
| [`b3e7b2d2`](https://github.com/nix-community/nixvim/commit/b3e7b2d2e568f29becae04217242ed18a90febc4) | `` flake: Update ``                                                      |
| [`2eebc0dd`](https://github.com/nix-community/nixvim/commit/2eebc0dd48c62bd3b3dbcfff1e864119ecad3238) | `` flake: Update ``                                                      |
| [`82a679ab`](https://github.com/nix-community/nixvim/commit/82a679abce4f13f4748dff081990de11a542e309) | `` plugins/sidekick: support non-bool settings.nes.enabled ``            |
| [`24259c0f`](https://github.com/nix-community/nixvim/commit/24259c0f4f6c4ac13960777a3c1ef5a62bbe3527) | `` plugins/sidekick: Amend assertion message to match ``                 |
| [`44ba462b`](https://github.com/nix-community/nixvim/commit/44ba462bece8e5a184a50de9154ecbf92262db86) | `` plugins/sidekick: fix incorrect assertion ``                          |
| [`d31c8c98`](https://github.com/nix-community/nixvim/commit/d31c8c9895d269e87f1ae83310b0e8bf9b5e7e78) | `` flake: Update ``                                                      |
| [`caee4e5d`](https://github.com/nix-community/nixvim/commit/caee4e5d4161778815f522d9ea1c9e3dc42462b7) | `` plugins.lsp: restore `autostart` compatibility ``                     |
| [`aaeb352f`](https://github.com/nix-community/nixvim/commit/aaeb352f3460f52126e29b4c78d82d3e80e55a68) | `` flake: Update ``                                                      |
| [`d43c763f`](https://github.com/nix-community/nixvim/commit/d43c763fd9fae0912bdb4103cd842f26fea5b0ed) | `` plugins/efmls-configs: map available packagings ``                    |
| [`5dddd55a`](https://github.com/nix-community/nixvim/commit/5dddd55a126a52d4c3f551fe10b09c2517b246f9) | `` plugins/none-ls: map packaged tools ``                                |
| [`d40cfe3a`](https://github.com/nix-community/nixvim/commit/d40cfe3ab4e7b224f9bfb26e954dc640905a9535) | `` plugins/conform-nvim: map available formatter packages ``             |
| [`157cbcb4`](https://github.com/nix-community/nixvim/commit/157cbcb47b4ebae3dd80ac3c492185b2de0a4c34) | `` modules/lsp/packages: map newly packaged servers ``                   |
| [`cd53e7ae`](https://github.com/nix-community/nixvim/commit/cd53e7ae1f05b8030245e341ac33fb902ec7d0b7) | `` flake: Update ``                                                      |
| [`0ddc79c6`](https://github.com/nix-community/nixvim/commit/0ddc79c6609612af3180238bd3cf1e732a21737e) | `` dev: update search ``                                                 |
| [`1d91fc6f`](https://github.com/nix-community/nixvim/commit/1d91fc6f88e1bda1f36fc4cf261e77458a125926) | `` modules/lsp/packages: add dexter packaged ``                          |
| [`af139aaa`](https://github.com/nix-community/nixvim/commit/af139aaae92bfac953d36231447a27f025cc2c1a) | `` tests/plugins/obsidian: migrate legacy commands ``                    |
| [`0065d0b5`](https://github.com/nix-community/nixvim/commit/0065d0b5e670f85072fa572017844b90663de2b8) | `` plugins/obsidian: deprecate `completion.{blink,nvim-cmp}` settings `` |
| [`047bffb0`](https://github.com/nix-community/nixvim/commit/047bffb020ac73ee90ce45dc0154bd6caa9bfc46) | `` plugins/coq-nvim: remove `settings.auto_start` option ``              |
| [`6542cdf3`](https://github.com/nix-community/nixvim/commit/6542cdf36e432aa569dada9c17fb318836482f84) | `` plugins/coq-nvim: remove `settings.xdg` option ``                     |
| [`2414f3d8`](https://github.com/nix-community/nixvim/commit/2414f3d85d5e96f8b6e7c3a5404b6719fbf8e4a4) | `` tests/claudecode: skip running nvim in `example` test ``              |
| [`8152a24e`](https://github.com/nix-community/nixvim/commit/8152a24e66fd319f42f44966513cc3040c070c0a) | `` tests/all-package-defaults: disable semgrep on aarch64 ``             |
| [`55ae671d`](https://github.com/nix-community/nixvim/commit/55ae671d6899a57efa454b987012c453c123c7b3) | `` modules/lsp/packages: update unpackaged LSPs ``                       |
| [`a21edd38`](https://github.com/nix-community/nixvim/commit/a21edd38f4000700486b507530298594049f1e4f) | `` generated: Updated lspconfig-servers.json ``                          |
| [`0aca8cdf`](https://github.com/nix-community/nixvim/commit/0aca8cdf623a40d1e59d7ffc2231918648b48f0f) | `` flake: Update ``                                                      |