### PR TITLE
chore(flake/freminal): `7a6b7b56` -> `d3ee8a05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781548589,
-        "narHash": "sha256-60mBTXLBIQ1iGPbIGG91YzNWgHc/RMI7Qa2I/51IFkk=",
+        "lastModified": 1781722244,
+        "narHash": "sha256-FD5w2cGpqWIh8ITTvzbLI37AqKEs0F9JDGwlrNzzjwA=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "7a6b7b561be5b3f197e41a8a9f540aa654268cd2",
+        "rev": "d3ee8a05982ba72ca6998a51f3f26c45e86e9513",
         "type": "github"
       },
       "original": {
@@ -968,11 +968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780975129,
-        "narHash": "sha256-428T1pLXnbVeUgZx2wWEkbvl3ZORjras34ANZ3ACp5A=",
+        "lastModified": 1781666412,
+        "narHash": "sha256-Tzgol+o9+V4lK99r4AERI4pyFoZwg6Si2xUd1wc/WQU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fe64e6b409dc513274d2941f8da13bbd0fdcf44e",
+        "rev": "d0e019d9543f0f1215a3d961fc4dca59aa29c638",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| [`71298bfa`](https://github.com/fredsystems/freminal/commit/71298bfa53d1d7523003f2ce0128116b28f32273) | `` fix: 111.10 -- backspace moves exactly one column over wide glyphs ``                                      |
| [`e881ff8f`](https://github.com/fredsystems/freminal/commit/e881ff8f1a98e826c55f4283751af1015581318b) | `` fix: 111.9 -- open display-width columns for wide chars in IRM insert ``                                   |
| [`6d38e725`](https://github.com/fredsystems/freminal/commit/6d38e725cb8eeca06141019c9b768132661bde64) | `` fix: scale color emoji to the cell + premultiply emoji alpha ``                                            |
| [`c85ac16f`](https://github.com/fredsystems/freminal/commit/c85ac16f99c81f84bdc0f8abfd79d7688d12e7dd) | `` docs: mark Task 111 (Bundled Font) complete ``                                                             |
| [`291c8e74`](https://github.com/fredsystems/freminal/commit/291c8e74475f468b538bd2dd9597ae17534aee76) | `` feat: 111.7 -- annotate bundled default in font picker + disambiguate system duplicate ``                  |
| [`cdb412ab`](https://github.com/fredsystems/freminal/commit/cdb412ab086c509fca6e2fca946cb0dec77e339f) | `` test: 111.6 -- ligature smoke test against the bundled font ``                                             |
| [`928e2deb`](https://github.com/fredsystems/freminal/commit/928e2debfa556d5f124d856b5d22eb6db0458aec) | `` docs: 111.5 -- add CaskaydiaCove to ATTRIBUTIONS.md ``                                                     |
| [`84f9133f`](https://github.com/fredsystems/freminal/commit/84f9133f245102746851c5020771d3bd7f9b65f9) | `` feat: 111.4 -- delete the unused Hack font + its attribution ``                                            |
| [`fa6f90d4`](https://github.com/fredsystems/freminal/commit/fa6f90d429dfb1fc44a9a093ef86b55ca4f54397) | `` feat: 111.3 -- delete the Meslo font files ``                                                              |
| [`9be89c78`](https://github.com/fredsystems/freminal/commit/9be89c780e41b4faf91f984922f37ff800235055) | `` feat: 111.2 -- swap bundled-font references from Meslo to CaskaydiaCove ``                                 |
| [`7583c802`](https://github.com/fredsystems/freminal/commit/7583c8022280cbde7a95733f9d0be68a3f1463f6) | `` feat: 111.1 -- vendor CaskaydiaCove NF font files + license ``                                             |
| [`02d61f23`](https://github.com/fredsystems/freminal/commit/02d61f233892f9820a5b6ece4835bf0ffc370cd2) | `` chore: bump to v0.10.0-beta.1, update deps, fix lint config ``                                             |
| [`0bf6c0fe`](https://github.com/fredsystems/freminal/commit/0bf6c0fef03bb5c37ef6808f85a7e890a9bf77ad) | `` [38;2;127;132;156m─────┬──────────────────────────────────────────────────────────────────────────[0m `` |