### PR TITLE
chore(flake/home-manager): `ea0bf49c` -> `c1870029`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -531,11 +531,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781719483,
-        "narHash": "sha256-MC6hWrek1hMewRRRHiAJ8z4sHEodzjizOefS/oHVrsU=",
+        "lastModified": 1781741781,
+        "narHash": "sha256-wtC6GCj3OvUTLj6DbMm1unibc+mbFdMNRHySxoZoGa0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ea0bf49c9d2a9c8f5548d116d63a7a1a35d1193d",
+        "rev": "c187002980e3e7dfa584ec1f32d58fc0805945f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`c1870029`](https://github.com/nix-community/home-manager/commit/c187002980e3e7dfa584ec1f32d58fc0805945f9) | `` television: add themes option ``            |
| [`eb0eb170`](https://github.com/nix-community/home-manager/commit/eb0eb170bb0ec9eb27d3e46d3d2bf0085b642139) | `` television: add csanthiago as maintainer `` |
| [`a20c21b2`](https://github.com/nix-community/home-manager/commit/a20c21b2fedb701059d4416c21f84c57c37f90d7) | `` maintainers: add csanthiago ``              |
| [`c51ac59e`](https://github.com/nix-community/home-manager/commit/c51ac59e59f2a7362d71d1d01ab68b2c09d09347) | `` uv: manage Python versions and tools ``     |
| [`a6931787`](https://github.com/nix-community/home-manager/commit/a69317872e58b84baf8c509a408fbcf7bf46a6aa) | `` uv: add bittner as a maintainer ``          |
| [`bfc00317`](https://github.com/nix-community/home-manager/commit/bfc003171bf09b633b1f3740d0de9f9bb203d45b) | `` maintainers: add bittner ``                 |