### PR TITLE
chore(flake/freminal): `d3ee8a05` -> `d16aed42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781722244,
-        "narHash": "sha256-FD5w2cGpqWIh8ITTvzbLI37AqKEs0F9JDGwlrNzzjwA=",
+        "lastModified": 1781742305,
+        "narHash": "sha256-a/PL1Wc7g9vbtLybhD7urY0nQ5Fr8lwx9LnaUEDX9dQ=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "d3ee8a05982ba72ca6998a51f3f26c45e86e9513",
+        "rev": "d16aed428c02748c72180980254539ca042785e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`a25fa191`](https://github.com/fredsystems/freminal/commit/a25fa191f427ac83c77ff8a1dbcb8ba725174bed) | `` fix: 113.3 -- clear fold extra-rows on new output (Bug E) ``                                |
| [`bc1eecd4`](https://github.com/fredsystems/freminal/commit/bc1eecd40b2927d4bbb3dc5da8c52c83a5e63245) | `` fix: 113.2 -- remap command blocks and prompt rows across reflow (Bug R) ``                 |
| [`a4981e50`](https://github.com/fredsystems/freminal/commit/a4981e50c29dce6a0e0a9d45204ba5faf56d50a3) | `` fix: 113.1 -- grow path reclaims blank padding instead of stranding live content (Bug G) `` |
| [`11cf92a2`](https://github.com/fredsystems/freminal/commit/11cf92a2dae4608607af1f8e7f1d72cfbbe83078) | `` docs: 113 -- add Task 113 plan + commented-out smoke tests ``                               |