### PR TITLE
chore(flake/catppuccin): `036c78ea` -> `8b943da8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781255309,
-        "narHash": "sha256-n2P5xkAYGylrJ3feu7L6uaCUw/+jW8rk+HO127gDbFA=",
+        "lastModified": 1781857425,
+        "narHash": "sha256-YhFPbCmdGis/4hwwt/ls4IZ8FR159EULbxWvv6U15+I=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "036c78ea4cd8a42c8546c6316a944fd7d59d4341",
+        "rev": "8b943da8a0f8628f3446d2517ea39babcfaf27f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`8b943da8`](https://github.com/catppuccin/nix/commit/8b943da8a0f8628f3446d2517ea39babcfaf27f3) | `` chore: update port sources (#986) `` |
| [`ef842cfa`](https://github.com/catppuccin/nix/commit/ef842cfa58f982900b9422a3f7cbbd5c60808cd8) | `` chore: update flakes (#985) ``       |