### PR TITLE
chore(flake/darwin): `ee9c7b96` -> `a1fa429e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781715441,
-        "narHash": "sha256-yyui90BUxu+A/NjUBO2RV9ubrC0lc/ECzuy2aWGnNEA=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "ee9c7b96c90bbb23620544201e26de92858b9ce3",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                  |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`d8a6661f`](https://github.com/nix-darwin/nix-darwin/commit/d8a6661f78281431f182f222c7df96e2c9480fc5) | `` homebrew: use brewBundleCmd also for system.checks `` |
| [`5138eaf8`](https://github.com/nix-darwin/nix-darwin/commit/5138eaf896e1b800f6eb3a7fba9af45f0ed85e42) | `` homebrew: mv PATH & sudo setup to brewBundleCmd ``    |
| [`e636bf16`](https://github.com/nix-darwin/nix-darwin/commit/e636bf16640beba5b9cb9ac1ae4e773966a80a78) | `` homebrew: pass onActivation.extraEnv to checks ``     |