### PR TITLE
chore(flake/freminal): `d16aed42` -> `76877a5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -376,11 +376,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781742305,
-        "narHash": "sha256-a/PL1Wc7g9vbtLybhD7urY0nQ5Fr8lwx9LnaUEDX9dQ=",
+        "lastModified": 1781898107,
+        "narHash": "sha256-SMZkuCiMPhhCLtIcZXU+OrdGKDOTgATRPhNukp+M9m8=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "d16aed428c02748c72180980254539ca042785e1",
+        "rev": "76877a5d1a59b0abde78ec74374fd432eb6df668",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`be49ea25`](https://github.com/fredsystems/freminal/commit/be49ea25e59ef31dd88ba032acba55953306f46c) | `` chore: bump version to 0.10.0 ``                                                                 |
| [`5ecf5aa6`](https://github.com/fredsystems/freminal/commit/5ecf5aa6961c55965ff4a8fd37fabf8f6cf457a9) | `` fix: live theme preview + tab bar styling in settings ``                                         |
| [`aa96bc3c`](https://github.com/fredsystems/freminal/commit/aa96bc3c317c76456b0ba168486b2ae7d5b8f753) | `` feat: 112.10-112.13 -- bundled chrome icons + [chrome] profile config ``                         |
| [`6a5a9335`](https://github.com/fredsystems/freminal/commit/6a5a9335b0eb9d11ee677b6dff31c25d1154e6d6) | `` feat: 112.4-112.9 -- apply centralized chrome Visuals app-wide + adopt per surface ``            |
| [`f7b14696`](https://github.com/fredsystems/freminal/commit/f7b1469629d5966b47920ef422bb83606d1a46c4) | `` fix: 112.3g -- route Accent/OnAccent into visuals.selection; drop override_text_color ``         |
| [`f65d2386`](https://github.com/fredsystems/freminal/commit/f65d2386face3fdb4d0e87fbdce6aafdc2e78b36) | `` fix: 112.3g audit -- enforce text legibility + fill separation; Solarized roles; toast layout `` |
| [`859ea703`](https://github.com/fredsystems/freminal/commit/859ea703452f10545ea018ef5724d9890d28daab) | `` docs: 112.3c-f complete, 112.3g awaiting maintainer audit ``                                     |
| [`30602a2e`](https://github.com/fredsystems/freminal/commit/30602a2e55c41909254dbb6fb60141100b743f24) | `` feat: 112.3f -- gallery loads all built-in themes for per-theme audit ``                         |
| [`fff2fe1f`](https://github.com/fredsystems/freminal/commit/fff2fe1fffb85d48cc18cd6d36bebab77a1cc451) | `` feat: 112.3e -- build_visuals consumes resolved chrome roles + padding ``                        |
| [`87e24272`](https://github.com/fredsystems/freminal/commit/87e24272e09d42b06764a57a81477610a0ef9110) | `` feat: 112.3d -- transcribe authored chrome roles for vetted themes ``                            |
| [`bc5887cc`](https://github.com/fredsystems/freminal/commit/bc5887cc9e61f1ce2a44d020b359732620cb453b) | `` feat: 112.3c -- add chrome-role colors to ThemePalette + resolver ``                             |
| [`8941bfdf`](https://github.com/fredsystems/freminal/commit/8941bfdfa59150b07eb9aafab8c4edbbb302ad14) | `` docs: 112.3c-g -- explicit theme-authored chrome roles + per-theme audit ``                      |
| [`6b38de61`](https://github.com/fredsystems/freminal/commit/6b38de6129a86fb54710aa5dc7d03dbffae0a99f) | `` docs: 112.3b -- add UI chrome font control subtask; record 112.3 amendment ``                    |
| [`82b16f76`](https://github.com/fredsystems/freminal/commit/82b16f76aae6fdeb66d79065ba52796606f9092a) | `` feat: 112.3 -- theme surface backgrounds, semantic colors, shadows; gallery previews menus ``    |
| [`5251ccad`](https://github.com/fredsystems/freminal/commit/5251ccad4cd11d4e237fb87789c1f70f9efcb228) | `` feat: 112.3a -- add chrome_gallery example for style-profile tuning ``                           |
| [`23270b2f`](https://github.com/fredsystems/freminal/commit/23270b2f6eaf234f69c8bce14d13d398e2104871) | `` docs: 112.3a -- re-scope preview gallery as standalone example binary ``                         |
| [`c31e3a19`](https://github.com/fredsystems/freminal/commit/c31e3a195db9f307695f93e799bb6ea7889125a7) | `` feat: 112.3 -- add chrome_style build_visuals mapping ``                                         |
| [`cc95f8de`](https://github.com/fredsystems/freminal/commit/cc95f8de9793acc716c804e4467abd5de32ffc53) | `` feat: 112.2 -- add GuiTheme + StyleProfile to freminal-common ``                                 |
| [`d0ce06a8`](https://github.com/fredsystems/freminal/commit/d0ce06a8a10ae2559485ff8b9ac549ab6bf0035a) | `` chore: bump version ``                                                                           |