### PR TITLE
chore(flake/home-manager): `c1870029` -> `153bad8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -530,11 +530,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781741781,
-        "narHash": "sha256-wtC6GCj3OvUTLj6DbMm1unibc+mbFdMNRHySxoZoGa0=",
+        "lastModified": 1781890084,
+        "narHash": "sha256-0HPkaiZtNBOaA9KsF26YI18sBvp1KDs/o8Ioo2qCqaw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c187002980e3e7dfa584ec1f32d58fc0805945f9",
+        "rev": "153bad8fb58fd3ad9bbfcbdd0a965acc89a869e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`153bad8f`](https://github.com/nix-community/home-manager/commit/153bad8fb58fd3ad9bbfcbdd0a965acc89a869e1) | `` qt: stop rewriting platformTheme name gtk to gtk2 ``                    |
| [`e061b008`](https://github.com/nix-community/home-manager/commit/e061b008856927dacf7adfcd44343f353413cbd8) | `` broot: fix nushell integration br command ``                            |
| [`55730a2e`](https://github.com/nix-community/home-manager/commit/55730a2e34e71fafaf9b95eab98fb7b062b5f194) | `` ssh: document DAG ordering patterns ``                                  |
| [`fea02179`](https://github.com/nix-community/home-manager/commit/fea021792d4e33a2dd55f2a328a8851949d436ec) | `` treefmt: format Python with ruff ``                                     |
| [`6aaf73d1`](https://github.com/nix-community/home-manager/commit/6aaf73d18dca882b8e133f9aec7e299204f8ebe9) | `` docs: build manual with mdbook ``                                       |
| [`9b2afbdd`](https://github.com/nix-community/home-manager/commit/9b2afbdd4783ebcfb2885dad8079f7f37bb0f04e) | `` docs: add contributing pointer ``                                       |
| [`0043376f`](https://github.com/nix-community/home-manager/commit/0043376f4e861a6306cfb0de361cef4ae47bf0eb) | `` docs: clarify module contribution guidance ``                           |
| [`43f9f0ab`](https://github.com/nix-community/home-manager/commit/43f9f0abc60d267585e61400b64a7f55f38a8c54) | `` misc: move modules spanning multiple files into subdirs ``              |
| [`c804fab6`](https://github.com/nix-community/home-manager/commit/c804fab681f03ec772390af4421bcc9bce80c1d9) | `` difftastic: fix typo in example ``                                      |
| [`26621164`](https://github.com/nix-community/home-manager/commit/266211649f4729ce7d52d6249f063c2c78aa8906) | `` hyprland: fix plugin loading when using lua ``                          |
| [`3abeedcf`](https://github.com/nix-community/home-manager/commit/3abeedcf409ecd8fca201646074bfb31797e8cc2) | `` zellij: Avoid starting on dumb terminals ``                             |
| [`0f4a317c`](https://github.com/nix-community/home-manager/commit/0f4a317c06ed69a4b15441490d46cdccd24c98c7) | `` lib.hm.dag: performance improvements ``                                 |
| [`c8f0b8ed`](https://github.com/nix-community/home-manager/commit/c8f0b8ed441c95bfeaf33555e7631044bb09f384) | `` fontconfig: add RFC42-style config file settings ``                     |
| [`44414466`](https://github.com/nix-community/home-manager/commit/44414466726dce8b516048156c7489f5670b3ce1) | `` fontconfig: generate config with `pkgs.formats.xml` ``                  |
| [`27a3154f`](https://github.com/nix-community/home-manager/commit/27a3154f427c17724659df859b54c04126365464) | `` fontconfig: disallow null as config file source ``                      |
| [`4ce68264`](https://github.com/nix-community/home-manager/commit/4ce682641dd935d12562c37ed6d67dcd4cdbf919) | `` fontconfig: add 'configFile.<name>.target' option ``                    |
| [`4666af39`](https://github.com/nix-community/home-manager/commit/4666af39e94395b7ede108807b611ce4d63ecf12) | `` fontconfig: clarify 'configFile.<name>.*' descriptions ``               |
| [`82432731`](https://github.com/nix-community/home-manager/commit/82432731d3251c80a68dee31434aef34023bb989) | `` fontconfig: check warning in legacy default test ``                     |
| [`a7860676`](https://github.com/nix-community/home-manager/commit/a786067676c8f4d4c705e2681448eaaa12679634) | `` mkFirefoxModule: assert managed package for global extensions ``        |
| [`9f9b23ae`](https://github.com/nix-community/home-manager/commit/9f9b23ae218b8484ef183d47ddf588e2def0f7c2) | `` mkFirefox: add policy to accept added extensions ``                     |
| [`8af17160`](https://github.com/nix-community/home-manager/commit/8af17160d162bda6f0861c5c7249347c5df16635) | `` nixgl: preserve `__functionArgs` when forwarding `.override` ``         |
| [`d456f483`](https://github.com/nix-community/home-manager/commit/d456f483f157d4b706416005da226234b9c116ff) | `` codex: add profile config support ``                                    |
| [`6274683e`](https://github.com/nix-community/home-manager/commit/6274683ee49d61bed9432764985eb116447e537b) | `` mkFirefoxModule: add warning for dropped options on wrapped packages `` |
| [`5ccd408c`](https://github.com/nix-community/home-manager/commit/5ccd408ca759e695cde78b0bd9189d5dbde3b57b) | `` dunst: use DAG ordered generator helper ``                              |
| [`b9a29e51`](https://github.com/nix-community/home-manager/commit/b9a29e51c52b4fd4064ed0b4ab93010ab1877e8d) | `` opencode: support ordered settings entries ``                           |
| [`6716d811`](https://github.com/nix-community/home-manager/commit/6716d811e5f6a0b9f014af3dcdfb9571e383e8cc) | `` lib: add DAG-aware format generators ``                                 |
| [`652f7546`](https://github.com/nix-community/home-manager/commit/652f75468661f94b73361f8acbe0a84d4ac312be) | `` difftastic: support difftool-only git integration ``                    |
| [`5bcff431`](https://github.com/nix-community/home-manager/commit/5bcff43156c0eebe68759338b7879c8e1b2e2bd0) | `` antigravity-cli: fix mcp validation error for remote/local servers ``   |