### PR TITLE
chore(flake/sops-nix): `9ed65852` -> `420f8d2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1110,11 +1110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780547341,
-        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
+        "lastModified": 1781943681,
+        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
+        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                      |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`77043f5c`](https://github.com/Mic92/sops-nix/commit/77043f5c3001f9aec4270ca475a9f0112a669fdd) | `` update vendorHash ``                                      |
| [`9122c2cc`](https://github.com/Mic92/sops-nix/commit/9122c2cc01900e830c2278ce100246502efda83e) | `` Bump go.mongodb.org/mongo-driver from 1.13.1 to 1.17.7 `` |