### PR TITLE
chore(flake/home-manager-stable): `8355f0a1` -> `7bfff44b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781319724,
-        "narHash": "sha256-ZGuxexEMo4Xv28KJ0dX/m/PHN4oZIOnxHZpNTyrvx4M=",
+        "lastModified": 1781981105,
+        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8355f0a16b2dbb06a97959a918af5b239bbe05ae",
+        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`7bfff44b`](https://github.com/nix-community/home-manager/commit/7bfff44b465909f69a442701293bc0badcf476dc) | `` tests/darwinScrublist: add parallel-full ``        |
| [`78671d3c`](https://github.com/nix-community/home-manager/commit/78671d3ce3dc9053a8b0f249866690111635c4be) | `` flake: bump nixpkgs from `bd0ff2d` to `a037402` `` |
| [`ad026da5`](https://github.com/nix-community/home-manager/commit/ad026da57b154db4794f7b7f54c6c966ad7f4e86) | `` ci: bump actions/checkout from 6 to 7 ``           |