### PR TITLE
chore(flake/home-manager): `153bad8f` -> `78e7d8b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -530,11 +530,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781890084,
-        "narHash": "sha256-0HPkaiZtNBOaA9KsF26YI18sBvp1KDs/o8Ioo2qCqaw=",
+        "lastModified": 1781989573,
+        "narHash": "sha256-npfH7Zv7t1akX/ArqCNro4zU4ViPlghLaPnbEfHbCxk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "153bad8fb58fd3ad9bbfcbdd0a965acc89a869e1",
+        "rev": "78e7d8b13ecd7f5256a5c11ce216876164099d9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`78e7d8b1`](https://github.com/nix-community/home-manager/commit/78e7d8b13ecd7f5256a5c11ce216876164099d9f) | `` ci: checkout base ref for backports ``                         |
| [`ee6b160b`](https://github.com/nix-community/home-manager/commit/ee6b160bcb1d01307e79fcae5063c5bca2b8ef14) | `` ci: avoid fork head checkout in backport ``                    |
| [`61157d3c`](https://github.com/nix-community/home-manager/commit/61157d3c01f9790e53b9c98c343a0603d36ea8f5) | `` pimsync: have type be the first directive in storage blocks `` |
| [`8695ecb3`](https://github.com/nix-community/home-manager/commit/8695ecb389cb43449fba0494ffc21065c7cde39d) | `` tests/firefox: avoid building librewolf ``                     |
| [`87622620`](https://github.com/nix-community/home-manager/commit/87622620549a8d92caf7e0203dd510071276fbfd) | `` tests/darwinScrublist: add parallel-full ``                    |
| [`72a8bf11`](https://github.com/nix-community/home-manager/commit/72a8bf11c8448e16c94f8e71a5a692ca54f1e371) | `` flake: bump nixpkgs from `ffa10e2` to `3e41b24` ``             |
| [`a4ee5403`](https://github.com/nix-community/home-manager/commit/a4ee5403cafbc708ad0f0d585965f1931ec340a8) | `` home-manager: Pass extraArgs to nix-instantiate ``             |
| [`c3dfce6c`](https://github.com/nix-community/home-manager/commit/c3dfce6c630f22d98fd1976cb55df4b1fd657ab2) | `` ci: bump actions/checkout from 6 to 7 ``                       |
| [`37f21dfa`](https://github.com/nix-community/home-manager/commit/37f21dfa5d27e71b75bacd9418b156f9265e312e) | `` tests: fix integration tests ``                                |