### PR TITLE
chore(flake/catppuccin): `8b943da8` -> `e98afe2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781857425,
-        "narHash": "sha256-YhFPbCmdGis/4hwwt/ls4IZ8FR159EULbxWvv6U15+I=",
+        "lastModified": 1782117778,
+        "narHash": "sha256-x6vIJpJziw3Hs0JKKDP+AeRPWwqyMDOmK6I26tqbYj4=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "8b943da8a0f8628f3446d2517ea39babcfaf27f3",
+        "rev": "e98afe2dfd950bda4e6a8ef32bb563ec2f04505a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                        |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`e98afe2d`](https://github.com/catppuccin/nix/commit/e98afe2dfd950bda4e6a8ef32bb563ec2f04505a) | `` chore(deps): update actions/checkout action to v7 (#989) `` |