### PR TITLE
chore(flake/home-manager): `78e7d8b1` -> `1ac720f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -530,11 +530,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781989573,
-        "narHash": "sha256-npfH7Zv7t1akX/ArqCNro4zU4ViPlghLaPnbEfHbCxk=",
+        "lastModified": 1782231110,
+        "narHash": "sha256-sEP5lBEVsMf//ImkzcQK6Jh5pxPrFtZqSp852rcSpV4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78e7d8b13ecd7f5256a5c11ce216876164099d9f",
+        "rev": "1ac720f007173754b204c2d25fee9a38680bf9bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`1ac720f0`](https://github.com/nix-community/home-manager/commit/1ac720f007173754b204c2d25fee9a38680bf9bf) | `` home: document the 'home.profileDirectory' default `` |
| [`d6b7bf16`](https://github.com/nix-community/home-manager/commit/d6b7bf16955c5a68c5c8a9630ed0e425a62829c2) | `` hyprland-qt-support: add news entry ``                |
| [`16fdc350`](https://github.com/nix-community/home-manager/commit/16fdc3504e9c5d84044fdf7d2a3cca5577a4989e) | `` hyprland-qt-support: add test case ``                 |
| [`83c0e036`](https://github.com/nix-community/home-manager/commit/83c0e036879512d96e8378b24b038f413fdb4021) | `` hyprland-qt-support: init module ``                   |
| [`4b0b9474`](https://github.com/nix-community/home-manager/commit/4b0b9474749820afac53ea30d4ccfef60aba5ce6) | `` zsh: add 'fastSyntaxHighlighting' ``                  |
| [`471a1d2f`](https://github.com/nix-community/home-manager/commit/471a1d2f840eb7fcbdfd541d99c13a64096f46db) | `` news: Add devenv entry ``                             |
| [`6cb9da2a`](https://github.com/nix-community/home-manager/commit/6cb9da2a4deb02b6b7a2956d30002fd191a92dad) | `` devenv: init module ``                                |
| [`351959fc`](https://github.com/nix-community/home-manager/commit/351959fcdbe5cadec1c3434d7abd14dff31af2d5) | `` fzf: Add tests ``                                     |
| [`cb6bcc43`](https://github.com/nix-community/home-manager/commit/cb6bcc43e7367fbfac62fc7ff1ae2d677de3d031) | `` fzf: add nushell integration ``                       |
| [`af11a877`](https://github.com/nix-community/home-manager/commit/af11a877f238208676b596a5b6c3f3d8dcf5a86b) | `` nvibrant: add module ``                               |
| [`66eb0fc1`](https://github.com/nix-community/home-manager/commit/66eb0fc116a8ffce4810e09500d002d7b3ac254a) | `` docs: clarify new module news conditions ``           |
| [`979bfee6`](https://github.com/nix-community/home-manager/commit/979bfee6e1a7996fc395270d54c9b59e88762494) | `` vicinae: add firefox mesaging host ``                 |
| [`d8dac1f6`](https://github.com/nix-community/home-manager/commit/d8dac1f668fd861369571be3678ec75b1573e7e3) | `` ci: build docs in buildbot output ``                  |
| [`f3dc0b85`](https://github.com/nix-community/home-manager/commit/f3dc0b85833c6c9946ad1349ab810d07e0bdf761) | `` docs: update platform module guidance ``              |
| [`db97e414`](https://github.com/nix-community/home-manager/commit/db97e414d5457538f21bb332b972e13c609cbeba) | `` docs: describe embedded module integration ``         |
| [`e731ff60`](https://github.com/nix-community/home-manager/commit/e731ff60ec559ab29f70837561b918a288b37499) | `` docs: correct test command guidance ``                |
| [`e45cc6e1`](https://github.com/nix-community/home-manager/commit/e45cc6e15ada91d078d84bee61819d1e64ec61f1) | `` docs: fix manpage path ``                             |
| [`8f3bc611`](https://github.com/nix-community/home-manager/commit/8f3bc611923787774852b09b556d62dfd97ebaf2) | `` news: remove duplicate module announcements ``        |
| [`5bf17310`](https://github.com/nix-community/home-manager/commit/5bf17310cf3399f6b61f1fdc459a79ccf0f3e4d0) | `` docs: preserve legacy manual links ``                 |
| [`d1ccd072`](https://github.com/nix-community/home-manager/commit/d1ccd0721ec599866622665f3651e19e6e2d4c6a) | `` news: add podman registries v2 entry ``               |
| [`e3e24bfd`](https://github.com/nix-community/home-manager/commit/e3e24bfd0f09cb64435b090409b1c3de820ef16e) | `` podman: generate v2 registries.conf ``                |