### PR TITLE
chore(flake/sops-nix-stable): `420f8d2e` -> `56b24064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1130,11 +1130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781943681,
-        "narHash": "sha256-NFHmA7H47adqiyp+0iEOyZOQhmigDqA/NBAlf4imB6U=",
+        "lastModified": 1782165805,
+        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "420f8d2e9882911f65cfac15cc706f639ba96cca",
+        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`91e08ca0`](https://github.com/Mic92/sops-nix/commit/91e08ca0556d6531b36a0278b586b1aec362e0e5) | `` Bump actions/checkout from 6 to 7 `` |