### PR TITLE
chore(flake/nixpkgs-stable): `a0374025` -> `34268251`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1781216227,
-        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`4ec8fa78`](https://github.com/NixOS/nixpkgs/commit/4ec8fa78d9d68c85d88f931e24c24cd36f3c19aa) | `` youtrack: 2026.1.13570 -> 2026.1.13757 ``                                          |
| [`f6526ce1`](https://github.com/NixOS/nixpkgs/commit/f6526ce18135eb0afa2e84d60bd2ccc908d77949) | `` kvrocks: 2.15.0 -> 2.16.0 ``                                                       |
| [`5ac3bef3`](https://github.com/NixOS/nixpkgs/commit/5ac3bef36623ebb51850d0a6419579f5ddbfd067) | `` bcachefs-tools: mark as working on kernel 7.1 ``                                   |
| [`0c8249f7`](https://github.com/NixOS/nixpkgs/commit/0c8249f7ecc32ff91c3b9dbfd2240de24b07c1b5) | `` pyrefly: 1.0.0 -> 1.1.1 ``                                                         |
| [`bec43db0`](https://github.com/NixOS/nixpkgs/commit/bec43db02ce1490a6642ccbb860c5af3f0ce9201) | `` realm: 2.8.0 -> 2.9.4 ``                                                           |
| [`27e6066d`](https://github.com/NixOS/nixpkgs/commit/27e6066d441af22845d85981aa38169c549d7d3d) | `` matrix-continuwuity: 0.5.9 -> 0.5.10 ``                                            |
| [`9fe971ec`](https://github.com/NixOS/nixpkgs/commit/9fe971ec519e0473ddc54760d6d236832e7f2edc) | `` eigenwallet: 4.4.1 -> 4.10.0 ``                                                    |
| [`b4cada6e`](https://github.com/NixOS/nixpkgs/commit/b4cada6e8da766d0506417d37b76c182285df2ef) | `` turn-rs: 4.1.2 -> 4.1.3 ``                                                         |
| [`5ecf727b`](https://github.com/NixOS/nixpkgs/commit/5ecf727bd21100a964a261fa5fbdd8cc795bc724) | `` gitea: fix darwin build ``                                                         |
| [`2f6be3b2`](https://github.com/NixOS/nixpkgs/commit/2f6be3b212dfe0be76a181b5ae2d8a933bd6137b) | `` gitea: switch to finalAttrs, add meta.changelog ``                                 |
| [`4214ef23`](https://github.com/NixOS/nixpkgs/commit/4214ef23cde4f2c0d9866ea231bf0226667e7e37) | `` gitea: 1.26.3 -> 1.26.4 ``                                                         |
| [`1600baf7`](https://github.com/NixOS/nixpkgs/commit/1600baf79405423d9642a4db37a8b7d7fa403c2a) | `` gitea: 1.26.2 -> 1.26.3 ``                                                         |
| [`49cf6214`](https://github.com/NixOS/nixpkgs/commit/49cf621495e6691fc312adee9bb0f14378158ca5) | `` gopher64: 1.0.17 -> 1.1.20 ``                                                      |
| [`d53d3a71`](https://github.com/NixOS/nixpkgs/commit/d53d3a711536a94500f004377d25d721672ee0f6) | `` backrest: add maintainer phanirithvij ``                                           |
| [`bce6a90d`](https://github.com/NixOS/nixpkgs/commit/bce6a90d3f4a55c583a4c904250a0b76a2222541) | `` backrest: add maintainer alexandru0-dev ``                                         |
| [`4865515a`](https://github.com/NixOS/nixpkgs/commit/4865515aa6e74ed8498437333e45f78158100a04) | `` backrest: 1.10.1 -> 1.13.0 ``                                                      |
| [`70507eda`](https://github.com/NixOS/nixpkgs/commit/70507edaaf97c6dd911aadba439b868b644bb7f8) | `` maintainers: remove aherrmann ``                                                   |
| [`e13dd420`](https://github.com/NixOS/nixpkgs/commit/e13dd420564ca0df4c11d1a60e6d47ddb87be70a) | `` maintainers: remove ethercrow ``                                                   |
| [`f3db0ada`](https://github.com/NixOS/nixpkgs/commit/f3db0adabec695ca1dced0e2325648876859cbcb) | `` maintainers: remove ylecornec ``                                                   |
| [`221e403c`](https://github.com/NixOS/nixpkgs/commit/221e403c14dae90c803e4a8461b12edacf370638) | `` maintainers: remove mboes ``                                                       |
| [`8b1b0972`](https://github.com/NixOS/nixpkgs/commit/8b1b0972b4e8c887fa73e1ae773e7abed67ad3e3) | `` linuxPackages.bcachefs: fix vmlinux path ``                                        |
| [`ae2947eb`](https://github.com/NixOS/nixpkgs/commit/ae2947eba29bd6563a1c7bdd3b23a93f7866682d) | `` simplex-chat-desktop: 6.5.4 -> 6.5.5 ``                                            |
| [`5b8e62be`](https://github.com/NixOS/nixpkgs/commit/5b8e62be031f59382e31300d9893129eb382f364) | `` mumble: 1.5.857 -> 1.5.901 ``                                                      |
| [`4234f5e7`](https://github.com/NixOS/nixpkgs/commit/4234f5e7e8d5e61e573a90e6e35e7044e873fac7) | `` bcachefs-tools: 1.38.5 -> 1.38.6 ``                                                |
| [`399c81cb`](https://github.com/NixOS/nixpkgs/commit/399c81cb38c575c55cd5a971198e8e2b7957dada) | `` pgdog: 0.1.44 -> 0.1.45 ``                                                         |
| [`5f8b974b`](https://github.com/NixOS/nixpkgs/commit/5f8b974b4a163ff7af8d7b8ac1fb6b6a1b7ca9be) | `` nezha-agent: 2.2.2 -> 2.2.3 ``                                                     |
| [`05a855c2`](https://github.com/NixOS/nixpkgs/commit/05a855c27957975430aa7079f27f5a5342462b7d) | `` wivrn: remove cudatoolkit ``                                                       |
| [`374f814e`](https://github.com/NixOS/nixpkgs/commit/374f814e55d7514c7c29db8f0618473e7806dd3a) | `` wivrn: 26.2.3 -> 26.6.1 ``                                                         |
| [`f8a56367`](https://github.com/NixOS/nixpkgs/commit/f8a56367642a2e4275c31270f9346228b76ebbb3) | `` whichllm: 0.5.9 -> 0.5.12 ``                                                       |
| [`6ad4b569`](https://github.com/NixOS/nixpkgs/commit/6ad4b56948d9e13b9e2205e78948b26972318ec6) | `` bcachefs-tools: 1.38.4 -> 1.38.5 ``                                                |
| [`9c438255`](https://github.com/NixOS/nixpkgs/commit/9c43825560b06cfe9434bcbd8440a811d67140ae) | `` bcachefs-tools: 1.38.3 -> 1.38.4 ``                                                |
| [`b94b5749`](https://github.com/NixOS/nixpkgs/commit/b94b5749679a8ec1daea5e6c0a2a4f9466f2e7c2) | `` filebrowser: 2.63.5 -> 2.63.14 ``                                                  |
| [`998ba060`](https://github.com/NixOS/nixpkgs/commit/998ba0600d6c614629d1e86493c1c047fcb6ed46) | `` coturn: 4.9.0 -> 4.13.1 ``                                                         |
| [`29e61199`](https://github.com/NixOS/nixpkgs/commit/29e61199e0e7de2ccff12f8ecd02cd20960bc3da) | `` whichllm: 0.5.7 -> 0.5.9 ``                                                        |
| [`0a42b3e0`](https://github.com/NixOS/nixpkgs/commit/0a42b3e01a0b21ed53e41a362aa0fcab8e2d1fd4) | `` filebrowser: 2.63.3 -> 2.63.5 ``                                                   |
| [`950ecc59`](https://github.com/NixOS/nixpkgs/commit/950ecc59db701421abeb194a4ccab17b4878f954) | `` sqlpage: 0.44.0 -> 0.44.1 ``                                                       |
| [`5daf4efd`](https://github.com/NixOS/nixpkgs/commit/5daf4efda42bca438461e1ecf1c8e6a224173e0e) | `` sqlpage: add hythera as maintainer ``                                              |
| [`12882f3b`](https://github.com/NixOS/nixpkgs/commit/12882f3b4d392ba56f138226cd27d6e1df71b731) | `` sqlpage: modernize ``                                                              |
| [`d684f394`](https://github.com/NixOS/nixpkgs/commit/d684f394e43bea8f32f1a470065b595cc9b4fc5f) | `` sqlpage: 0.41.0 -> 0.44.0 ``                                                       |
| [`18a1ef95`](https://github.com/NixOS/nixpkgs/commit/18a1ef95cd42d379ffc937dc9a68c7a12f59d16d) | `` python3Packages.fasthtml: 0.12.48 -> 0.13.3 ``                                     |
| [`46d3d8cb`](https://github.com/NixOS/nixpkgs/commit/46d3d8cb0af3922270836b17800da38654583e46) | `` reaction: 2.4.1 -> 2.5.1 ``                                                        |
| [`155945a6`](https://github.com/NixOS/nixpkgs/commit/155945a61e6f120726286edc71174e6b609a0b17) | `` openlinkhub: 0.8.4 -> 0.8.8 ``                                                     |
| [`44aa820e`](https://github.com/NixOS/nixpkgs/commit/44aa820e84c85ef6cc71904370298358d6a00c4a) | `` worldpainter: 2.26.1 -> 2.26.2 ``                                                  |
| [`0f6a7ee3`](https://github.com/NixOS/nixpkgs/commit/0f6a7ee3741b5addf8429a9fe4f8b4def2e34e5d) | `` sway-unwrapped: 1.11 -> 1.12 ``                                                    |
| [`1c9fa1f4`](https://github.com/NixOS/nixpkgs/commit/1c9fa1f456bff019ec3097900a7aeca3ca577834) | `` maintainers: add c6rg0 ``                                                          |
| [`aa7e4f27`](https://github.com/NixOS/nixpkgs/commit/aa7e4f27ce2c9e0be662fb37687a6ae8c15903cc) | `` vicinae: 0.21.6 -> 0.21.7 ``                                                       |
| [`edf64891`](https://github.com/NixOS/nixpkgs/commit/edf64891bfe92a7d1955de004862dd22431a962b) | `` mozillavpn: 2.37.0 -> 2.38.0 ``                                                    |
| [`a7e477c7`](https://github.com/NixOS/nixpkgs/commit/a7e477c7210fffa563b0dcdcc656c04a8a1072a6) | `` gogup: 1.2.0 -> 1.3.0 ``                                                           |
| [`91a94763`](https://github.com/NixOS/nixpkgs/commit/91a94763877aa6a0ab0619c121710acb1fa38bd5) | `` maintainers/scripts/update.nix: allow `true` for boolean args along w/ `"true"` `` |
| [`28de615f`](https://github.com/NixOS/nixpkgs/commit/28de615f45d1cff9165ebe010ee6710d1acf45e1) | `` desync: add matshch to maintainers ``                                              |
| [`6ed8f035`](https://github.com/NixOS/nixpkgs/commit/6ed8f0351e8ae8ae2aad7f6a56491599d5909681) | `` maintainers: add matshch ``                                                        |
| [`1aac23ed`](https://github.com/NixOS/nixpkgs/commit/1aac23ed4c1594ddac77883fd4e72a3319c3ae5c) | `` maintainers/github-teams.json: Automated sync ``                                   |
| [`dae377b7`](https://github.com/NixOS/nixpkgs/commit/dae377b747ce9856b81b55f3d8bf2e673561f604) | `` vicinae: 0.21.3 -> 0.21.6 ``                                                       |
| [`d79ba580`](https://github.com/NixOS/nixpkgs/commit/d79ba580523f6f8073d90b19a6d1429d9a379a68) | `` ci/treefmt: sort formatters alphabetically ``                                      |
| [`a842821a`](https://github.com/NixOS/nixpkgs/commit/a842821add56a88348f15c310eee3c41c4b2595f) | `` ci/treefmt: use pkgs.treefmt.withConfig ``                                         |
| [`8fc28c53`](https://github.com/NixOS/nixpkgs/commit/8fc28c53d456e12c90d1eedaf41390b6ea0a0f2a) | `` waywall: 0.2026.02.06 -> 0.2026.06.13 ``                                           |
| [`12a981c8`](https://github.com/NixOS/nixpkgs/commit/12a981c8c77e19076f488eb82fcb1dfbe6d695cd) | `` oggvideotools: unbreak on Darwin, add patches ``                                   |
| [`62e4925e`](https://github.com/NixOS/nixpkgs/commit/62e4925ea5624984cabc1cd50ba5da1388118bf5) | `` diffoscope: fix hdf5 tools on Darwin ``                                            |
| [`3d9f3d70`](https://github.com/NixOS/nixpkgs/commit/3d9f3d708078dbf7e23b67e1b89d3e536c8cd982) | `` tests.replaceVars: fix group mismatches ``                                         |
| [`7c37a013`](https://github.com/NixOS/nixpkgs/commit/7c37a0134069d9fe8f7e3c534233d17a8e602413) | `` tests.trivial-builders.symlinkJoin: fix group mismatches ``                        |
| [`d5b7ca23`](https://github.com/NixOS/nixpkgs/commit/d5b7ca23f97d021b6c68694cf8326b4eeab7fb65) | `` switch-to-configuration-ng: Handle dbus errors ``                                  |
| [`73d3519f`](https://github.com/NixOS/nixpkgs/commit/73d3519f8baa009a0043e5bb3ab1b00eef400b87) | `` gtree: 1.13.6 -> 1.14.2 ``                                                         |
| [`f40beec9`](https://github.com/NixOS/nixpkgs/commit/f40beec906c6efe17bb7f6b689ed1dddf000b397) | `` nixos/zigbee2mqtt: add AF_UNIX to RestrictAddressFamilies ``                       |
| [`fba7aa3d`](https://github.com/NixOS/nixpkgs/commit/fba7aa3d632a3b69a41999704dcf2636d9581a01) | `` modrinth-app-unwrapped: 0.14.2 -> 0.14.8 ``                                        |
| [`7de7e85c`](https://github.com/NixOS/nixpkgs/commit/7de7e85c1d2b51190a36a43ce31719a1df866ff0) | `` victoriatraces: 0.9.2 -> 0.9.3 ``                                                  |
| [`2ff6dcfd`](https://github.com/NixOS/nixpkgs/commit/2ff6dcfdcb8d76b3883fb1bdfdf1783b3a1fc1e7) | `` osu-lazer: 2026.518.0 -> 2026.620.0 ``                                             |
| [`c9ecf2cd`](https://github.com/NixOS/nixpkgs/commit/c9ecf2cdea6ed11850c45e8c494fdeb89c823644) | `` osu-lazer-bin: 2026.518.0 -> 2026.620.0 ``                                         |
| [`68dafab0`](https://github.com/NixOS/nixpkgs/commit/68dafab066c8d809a5483b25cf7092b4066cbcd2) | `` spotify: fix wayland when NIXOS_OZONE_WL is set ``                                 |
| [`75f5397f`](https://github.com/NixOS/nixpkgs/commit/75f5397fcf5039a0dc7d74e1c2c734b41a4d3097) | `` eom: Support avif, heif, jxl, webp ``                                              |
| [`0d3b1939`](https://github.com/NixOS/nixpkgs/commit/0d3b1939a6e90602372c00f72ba41012700352dc) | `` faugus-launcher: 1.20.4 -> 1.22.4 ``                                               |
| [`6b4d4a8d`](https://github.com/NixOS/nixpkgs/commit/6b4d4a8d1a5fcde4c3949ae9197163b8ce94dfab) | `` python3.pkgs.fakeredis: 2.35.1 -> 2.36.2 ``                                        |
| [`3b259181`](https://github.com/NixOS/nixpkgs/commit/3b259181189828f399e607a2261be55c9ec639dd) | `` teams/ngi: drop wegank ``                                                          |
| [`e48f3bba`](https://github.com/NixOS/nixpkgs/commit/e48f3bbabfdf759fa6daaff032b6ed11b9b93b53) | `` grafana-image-renderer: 5.7.3 -> 5.8.11 ``                                         |
| [`7c37401d`](https://github.com/NixOS/nixpkgs/commit/7c37401dff4bae5d4b979441a1057b144785a888) | `` meshcentral: 1.1.58 -> 1.2.0 ``                                                    |
| [`ceeb1004`](https://github.com/NixOS/nixpkgs/commit/ceeb100443572239aade741f05a544f316f01755) | `` gelly: 1.4.0 -> 1.6.2 ``                                                           |
| [`39938d65`](https://github.com/NixOS/nixpkgs/commit/39938d6536130c449916054b01df41f09ab942e4) | `` golds: 0.8.3 -> 0.8.4 ``                                                           |
| [`63a440ee`](https://github.com/NixOS/nixpkgs/commit/63a440ee21b501093a83b33c939d96b7454847fa) | `` nixos/sniffnet: install package when enabled ``                                    |
| [`54d53309`](https://github.com/NixOS/nixpkgs/commit/54d5330934c66c0b49bf35922f7e4239ffa2d4b7) | `` python3Packages.py7zr: 1.1.0 -> 1.1.3 ``                                           |
| [`91a41168`](https://github.com/NixOS/nixpkgs/commit/91a41168385d853b0bf8bbd2e0e85877d075120e) | `` nixos/luksroot: Clarify preLVM with systemd stage 1 ``                             |
| [`40ff6979`](https://github.com/NixOS/nixpkgs/commit/40ff6979d4cb0e3749c5d05dc5b5b3c226245f29) | `` nodejs_24: fix riscv64-linux build ``                                              |
| [`3725e26f`](https://github.com/NixOS/nixpkgs/commit/3725e26fda7a82d0eebce21fc48097dae695e824) | `` gpclient: restore gpgui.desktop for globalprotectcallback scheme handler ``        |
| [`d29ed273`](https://github.com/NixOS/nixpkgs/commit/d29ed273226d7f70ba66989fe0a10cb6fdc3df8b) | `` ketesa: 1.2.1 -> 1.3.0 ``                                                          |
| [`3bd1f173`](https://github.com/NixOS/nixpkgs/commit/3bd1f17394ed34ebe01e0cc715d183fcf1ed389a) | `` librewolf-unwrapped: add wolfgangwalther as maintainer ``                          |
| [`9a068487`](https://github.com/NixOS/nixpkgs/commit/9a0684874c75bab52ff00311ee95713892c9d94f) | `` switch-to-configuration-ng: handle socket-activated Accept=yes services ``         |
| [`05c10f58`](https://github.com/NixOS/nixpkgs/commit/05c10f5840b32291192d00521f489920642756a0) | `` openocd-rp2040: move override to pkgs/by-name ``                                   |
| [`3dc94b8e`](https://github.com/NixOS/nixpkgs/commit/3dc94b8ecad9090d18186d9b70010c62c3e44028) | `` freerdp: 3.26.0 -> 3.27.1 ``                                                       |
| [`8d549ac7`](https://github.com/NixOS/nixpkgs/commit/8d549ac703658900e32acc88050ede5db08566a4) | `` matrix-synapse-unwrapped: 1.154.0 -> 1.155.0 ``                                    |
| [`5aabb27f`](https://github.com/NixOS/nixpkgs/commit/5aabb27f9b05096ec4b098b8248c6f9f7c120697) | `` nextcloudPackages: update ``                                                       |
| [`56fc3320`](https://github.com/NixOS/nixpkgs/commit/56fc3320858e3ac053efef1a798903811aa8422c) | `` mautrix-signal: 26.05 -> 26.06 ``                                                  |
| [`5a3138bf`](https://github.com/NixOS/nixpkgs/commit/5a3138bf1d067c19f6cfe76fa6136f149c1e547d) | `` libsignal-ffi: 0.93.2 -> 0.94.4 ``                                                 |
| [`dca378dd`](https://github.com/NixOS/nixpkgs/commit/dca378dd6bfdf1d50a93172ba85f724c93018db5) | `` strace: 7.0 -> 7.1 ``                                                              |
| [`141117a3`](https://github.com/NixOS/nixpkgs/commit/141117a3d0d56b6cf47986f6daf3a241e9ade5ba) | `` linux_5_10: 5.10.258 -> 5.10.259 ``                                                |
| [`21a8a81d`](https://github.com/NixOS/nixpkgs/commit/21a8a81d2400597b88c4d69c95cac250497bd485) | `` linux_5_15: 5.15.209 -> 5.15.210 ``                                                |
| [`ff0b527b`](https://github.com/NixOS/nixpkgs/commit/ff0b527b878db5b4fead356e3eea43d6f0c8e92c) | `` linux_6_1: 6.1.175 -> 6.1.176 ``                                                   |
| [`be12004c`](https://github.com/NixOS/nixpkgs/commit/be12004c9feade01942d5cc15e15214bf3839768) | `` linux_6_6: 6.6.142 -> 6.6.143 ``                                                   |
| [`da32da43`](https://github.com/NixOS/nixpkgs/commit/da32da43eed7a1c5711f8bddd0b572b767b1da6c) | `` linux_6_12: 6.12.93 -> 6.12.94 ``                                                  |
| [`95ab4c5c`](https://github.com/NixOS/nixpkgs/commit/95ab4c5c4d3b5bdd535b1de5a11f572d546b3668) | `` linux_6_18: 6.18.35 -> 6.18.36 ``                                                  |
| [`efdb9a75`](https://github.com/NixOS/nixpkgs/commit/efdb9a75dc787dbabf391a843bca3afbab6aa350) | `` linux_7_0: 7.0.12 -> 7.0.13 ``                                                     |
| [`c6151786`](https://github.com/NixOS/nixpkgs/commit/c6151786112f2c1539cc4ceaf685ccfb859e74bb) | `` linux_7_1: 7.1 -> 7.1.1 ``                                                         |
| [`26ea64ff`](https://github.com/NixOS/nixpkgs/commit/26ea64ffb22aab76bf84c92be64808caa400956f) | `` openlinkhub: 0.7.5 -> 0.8.4 ``                                                     |
| [`cde429b1`](https://github.com/NixOS/nixpkgs/commit/cde429b1d33acf60d270201b4059847dae81d843) | `` mautrix-whatsapp: 26.05 -> 26.06 ``                                                |
| [`0e60a13b`](https://github.com/NixOS/nixpkgs/commit/0e60a13bdc13a02e193bddf3572edb203f1c9896) | `` slimserver: 9.1.0 -> 9.1.1 ``                                                      |
| [`71230947`](https://github.com/NixOS/nixpkgs/commit/712309473113304160519ec2d1d6ce1ce37bc002) | `` ledger-live-desktop: 4.6.1 -> 4.8.0 ``                                             |
| [`05c5032c`](https://github.com/NixOS/nixpkgs/commit/05c5032c84acf5e99d68962f7ece0b5b3e4009f3) | `` ripplerx: 1.5.18 -> 1.5.19 ``                                                      |
| [`a978d74e`](https://github.com/NixOS/nixpkgs/commit/a978d74e6de68326a0c39efcd87835932002f74f) | `` mochi: 1.21.14 -> 1.21.16 ``                                                       |
| [`09fcc445`](https://github.com/NixOS/nixpkgs/commit/09fcc445799f3273429039be7cdd00f4a9f2bc17) | `` librewolf-unwrapped: 152.0-1 -> 152.0.1-2 ``                                       |
| [`1ba0f34b`](https://github.com/NixOS/nixpkgs/commit/1ba0f34bb874c9c25115d4ce9c97aa5ac1742b6b) | `` knot-resolver_6: 6.3.0 -> 6.4.0 ``                                                 |
| [`675d6570`](https://github.com/NixOS/nixpkgs/commit/675d6570606f4eeff6d6e89fda4d3753d5fcede0) | `` sing-box: allow empty settings ``                                                  |
| [`4cc721d5`](https://github.com/NixOS/nixpkgs/commit/4cc721d524f065b9f55baf0e24ee8f59858199bc) | `` nixfmt-tree: fix passthru ``                                                       |
| [`eb643cb1`](https://github.com/NixOS/nixpkgs/commit/eb643cb18ca43227504637f5c5d6e93234510abb) | `` python3Packages.cnf-lint: disable failing tests ``                                 |
| [`bc0aaa64`](https://github.com/NixOS/nixpkgs/commit/bc0aaa64af0deb093f0c8fff7e9c18aafabb833c) | `` v2ray-rules-dat: 202606122311 -> 202606172318 ``                                   |
| [`4088776d`](https://github.com/NixOS/nixpkgs/commit/4088776d40f75c57e8e4f70111dffd87c2cebb44) | `` v2ray-rules-dat: add updateScript ``                                               |
| [`b0f28e8d`](https://github.com/NixOS/nixpkgs/commit/b0f28e8d48c83dbc137b9410cba1106ab88a3552) | `` v2ray-rules-dat: use finalAttrs, modernize ``                                      |
| [`80598cf4`](https://github.com/NixOS/nixpkgs/commit/80598cf41f320551dfd8b856281d70f0eeed4c27) | `` v2ray-rules-dat: correct license ``                                                |
| [`446af151`](https://github.com/NixOS/nixpkgs/commit/446af15196f72f8f3d882317717a684a118446b3) | `` libmirage: 3.3.1 -> 3.3.2 ``                                                       |
| [`c5667c70`](https://github.com/NixOS/nixpkgs/commit/c5667c708f4908905727af30205ca4b5bc0bc028) | `` gcdemu: 3.3.0 -> 3.3.1 ``                                                          |
| [`de016f14`](https://github.com/NixOS/nixpkgs/commit/de016f14aaaf84b056d65eb56ce1fdc562ef0def) | `` cdemu-client: 3.3.0 -> 3.3.1 ``                                                    |
| [`c4d7a546`](https://github.com/NixOS/nixpkgs/commit/c4d7a54601e057c9d02d5a7a7e71de0aeef2b9c7) | `` cdemu-*: update to latest versions ``                                              |
| [`31036f67`](https://github.com/NixOS/nixpkgs/commit/31036f6731e35b85e6d395d94750b01a3160fa3a) | `` cdemu-*: add updateScript ``                                                       |
| [`f17b852d`](https://github.com/NixOS/nixpkgs/commit/f17b852d81eabed34759dd4cb65d4d389a6264b0) | `` cdemu-*: migrate to by-name ``                                                     |
| [`4ebd45c2`](https://github.com/NixOS/nixpkgs/commit/4ebd45c2ab61a81fe9e7e46d63c7102e77987380) | `` cdemu: inline common-drv-attrs and refactor ``                                     |
| [`61146033`](https://github.com/NixOS/nixpkgs/commit/611460333e4b372b782dc9c3e77e3fe2662e3fc4) | `` sdl_gamecontrollerdb: 0-unstable-2026-06-07 -> 0-unstable-2026-06-12 ``            |
| [`48078724`](https://github.com/NixOS/nixpkgs/commit/48078724750d2dc69bd939078b2b4670a1d05818) | `` nixos/tests/hedgedoc: migrate to nspawn containers ``                              |
| [`850365fa`](https://github.com/NixOS/nixpkgs/commit/850365fa7c1665c6ed14b57d3bd577ff990f1004) | `` librewolf-bin-unwrapped: unmark as vulnerable ``                                   |
| [`1551cd02`](https://github.com/NixOS/nixpkgs/commit/1551cd028f7819c6d243bd90b06a4bb64f810fbb) | `` librewolf-bin-unwrapped: add eclairevoyant to maintainers ``                       |
| [`d73b4184`](https://github.com/NixOS/nixpkgs/commit/d73b4184a66818d90eaa355559409c1a66c11006) | `` hedgedoc: 1.10.8 -> 1.11.0 ``                                                      |
| [`a6306616`](https://github.com/NixOS/nixpkgs/commit/a6306616d81df7074c106c32e5bebff9865dddf0) | `` skim: 4.0.0 → 4.7.0 ``                                                             |
| [`981ea96f`](https://github.com/NixOS/nixpkgs/commit/981ea96f0e15d67eeedb77f682e7b5f70232353b) | `` firefox-bin-unwrapped: 152.0 -> 152.0.1 ``                                         |
| [`e35c65b4`](https://github.com/NixOS/nixpkgs/commit/e35c65b4b601178cc29f18a96a992692dddb176c) | `` firefox-unwrapped: 152.0 -> 152.0.1 ``                                             |
| [`fa674cd8`](https://github.com/NixOS/nixpkgs/commit/fa674cd87b9ff5d6115c9e991118c42d7765a108) | `` python3Packages.python-statemachine: 3.0.0 -> 3.2.0 ``                             |
| [`42a18881`](https://github.com/NixOS/nixpkgs/commit/42a1888117e859b7dfb6baf72fe0b85b1971a8e5) | `` qdl: 2.6 -> 2.7 ``                                                                 |
| [`48083722`](https://github.com/NixOS/nixpkgs/commit/48083722f360e8480727db409b4f061a7d209d75) | `` librewolf-unwrapped: unmark as vulnerable ``                                       |
| [`9dcefdcd`](https://github.com/NixOS/nixpkgs/commit/9dcefdcd77b11a99561b8179ad5d53ff54e6d9f4) | `` librewolf-bin-unwrapped: add azahi to maintainers ``                               |
| [`09089ace`](https://github.com/NixOS/nixpkgs/commit/09089ace19ed41cca839dcf66cafbcc0ab3392ba) | `` librewolf-unwrapped: add azahi to maintainers ``                                   |
| [`8a20fa08`](https://github.com/NixOS/nixpkgs/commit/8a20fa08bcab8bd1848f657e92875da592aa8f45) | `` mimir: 3.0.6 -> 3.0.7 ``                                                           |
| [`37747a13`](https://github.com/NixOS/nixpkgs/commit/37747a1327103b260c5a52b282f5cc8eb87c3299) | `` librewolf-unwrapped: add mBornand as maintainer ``                                 |
| [`71ebf7c5`](https://github.com/NixOS/nixpkgs/commit/71ebf7c5f33952098cc56abd92e263f890615c87) | `` brave: 1.91.171 -> 1.91.175 ``                                                     |
| [`dd7cc104`](https://github.com/NixOS/nixpkgs/commit/dd7cc10443dafc6b6a017ae1e8e98b09cb7a9d56) | `` ocaml-ng.ocamlPackages_4_14.ocaml: 4.14.3 → 4.14.4 ``                              |
| [`98ffa5a7`](https://github.com/NixOS/nixpkgs/commit/98ffa5a77e188d6a292b2f21f79b1c2466161536) | `` texlive: use texhistoric mirror list ``                                            |
| [`35e74984`](https://github.com/NixOS/nixpkgs/commit/35e749842234edde59ebbf42436aaf647529cfc0) | `` fetchurl: add TeX historic archive mirrors ``                                      |
| [`860069d1`](https://github.com/NixOS/nixpkgs/commit/860069d15bf19bffd9ae647fdb77148360275923) | `` python3Packages.langgraph-checkpoint: 4.0.3 -> 4.1.1 ``                            |
| [`1c169c98`](https://github.com/NixOS/nixpkgs/commit/1c169c983a1aaac7f24c409434304484f4585119) | `` hplip: 3.25.2 -> 3.26.4 ``                                                         |
| [`c30c0daa`](https://github.com/NixOS/nixpkgs/commit/c30c0daa725d37af0db7c75fccac3e6376f5c0e8) | `` librewolf-unwrapped: add thbemme to maintainers ``                                 |
| [`0db1dae0`](https://github.com/NixOS/nixpkgs/commit/0db1dae0ff3fdf2fa8e86ea035b39bb8fd7878e0) | `` maintainers: add thbemme ``                                                        |
| [`a7f7d78e`](https://github.com/NixOS/nixpkgs/commit/a7f7d78e7dcc6e9e083496589f61142d88666427) | `` librewolf-bin-unwrapped: 151.0.1-2 -> 152.0-1 ``                                   |
| [`e28593e1`](https://github.com/NixOS/nixpkgs/commit/e28593e1c09a82c5da7812999d7ba72d0f51c658) | `` librewolf-unwrapped: 151.0.2-1 -> 152.0-1 ``                                       |
| [`863d02eb`](https://github.com/NixOS/nixpkgs/commit/863d02eb5e8d0bea78276b1d541cc707c6ecc371) | `` maintainers: update daskladas email ``                                             |
| [`b740a379`](https://github.com/NixOS/nixpkgs/commit/b740a379bc01f900eff8c429e4c79671a961fc0f) | `` nixos/davis: fix typo in option description ``                                     |
| [`8145e4be`](https://github.com/NixOS/nixpkgs/commit/8145e4bed0a0870349033e148a4657e813cbdaeb) | `` v2ray-rules-dat: init at 202606122311 ``                                           |
| [`470303d2`](https://github.com/NixOS/nixpkgs/commit/470303d20c9e28a65faca91999ca8a6e9859499f) | `` victorialogs: 1.50.0 -> 1.51.0 ``                                                  |
| [`608381e5`](https://github.com/NixOS/nixpkgs/commit/608381e594e3dbbe67a4a5a19a618d0fa806e951) | `` ledger-live-desktop: 4.6.0 -> 4.6.1 ``                                             |
| [`ae038123`](https://github.com/NixOS/nixpkgs/commit/ae0381238bfd6063e189090bfdff2e25d16c0c72) | `` wemeet: fix camera preview on Wayland ``                                           |
| [`fa456545`](https://github.com/NixOS/nixpkgs/commit/fa456545874ac41e51d09b7f87ff9892adfb045d) | `` nodejs_26: 26.3.0 -> 26.3.1 ``                                                     |
| [`ba178475`](https://github.com/NixOS/nixpkgs/commit/ba17847528bd020c48752e4be1dd553269df2541) | `` nodejs_22: 22.22.3 -> 22.23.0 ``                                                   |
| [`dd75e106`](https://github.com/NixOS/nixpkgs/commit/dd75e106e9a19e8fa552562646c87ccdf99a8201) | `` anytype: Raise memory limit for Node.js build ``                                   |
| [`ad9d955e`](https://github.com/NixOS/nixpkgs/commit/ad9d955ef6e6006bd6ea81eac47f138507151b5e) | `` mullvad-browser: 15.0.14 -> 15.0.16 ``                                             |
| [`0b3f2864`](https://github.com/NixOS/nixpkgs/commit/0b3f2864f6958f6495d27fa5b5a84738c7c41669) | `` tor-browser: 15.0.15 -> 15.0.16 ``                                                 |
| [`0d350001`](https://github.com/NixOS/nixpkgs/commit/0d3500016a49941df64d1110760ff1155db60e1a) | `` openbao: 2.5.4 -> 2.5.5 ``                                                         |
| [`edd79565`](https://github.com/NixOS/nixpkgs/commit/edd795658e9c77c022a0f9aeb4f1f60c8c6ed638) | `` navidrome: 0.61.2 -> 0.62.0 ``                                                     |
| [`61d3c16b`](https://github.com/NixOS/nixpkgs/commit/61d3c16b11dd90931008550fea9b44db6ecc9818) | `` viddy: 1.3.0 -> 1.3.1 ``                                                           |
| [`3b15be64`](https://github.com/NixOS/nixpkgs/commit/3b15be644ee444aaa4d0e6dfcb040cb023961161) | `` mastodon: 4.5.11 -> 4.6.0 ``                                                       |
| [`1071706e`](https://github.com/NixOS/nixpkgs/commit/1071706e747fa164f2a4f4639069520d4c955cd6) | `` ungoogled-chromium: 149.0.7827.114-1 -> 149.0.7827.155-1 ``                        |
| [`a5da3fbc`](https://github.com/NixOS/nixpkgs/commit/a5da3fbc47d2576bfb7780962ef8bd9b0b07622e) | `` mprisence: 1.6.0 -> 1.7.0 ``                                                       |
| [`db0a8f4d`](https://github.com/NixOS/nixpkgs/commit/db0a8f4d83b71b04dbaaae74c3195c28b41c7fec) | `` sabnzbd: 5.0.3 -> 5.0.4 ``                                                         |
| [`9682a75c`](https://github.com/NixOS/nixpkgs/commit/9682a75c7e0c1f70e5c3e74b3f198b92e4a2c46a) | `` zapzap: 6.5.1 -> 6.5.2.1 ``                                                        |
| [`8ccc564d`](https://github.com/NixOS/nixpkgs/commit/8ccc564d1f8ca3ee8690eef219c8100fea1da590) | `` mullvad-compass: 0.0.3 -> 0.0.4 ``                                                 |
| [`64299d2f`](https://github.com/NixOS/nixpkgs/commit/64299d2f374825ba14003b5c1ab696b313aa4a37) | `` rocqPackages.mathcomp-analysis: now depends on real-closed ``                      |
| [`0f40a483`](https://github.com/NixOS/nixpkgs/commit/0f40a48351965b8a8cb218138d6a183b71bb1b1b) | `` rocqPackage.mathcomp-real-closed: init at 2.0.5 ``                                 |
| [`a3beda23`](https://github.com/NixOS/nixpkgs/commit/a3beda2301e96cca1fd35fc3f586fafc33500f65) | `` chromium,chromedriver: 149.0.7827.114 -> 149.0.7827.155 ``                         |
| [`1ebf3cdf`](https://github.com/NixOS/nixpkgs/commit/1ebf3cdfda8fedbf0d27717ec33594f78f64cc10) | `` nezha: add nixosTest ``                                                            |
| [`1b0bd1d8`](https://github.com/NixOS/nixpkgs/commit/1b0bd1d86b60bcf1094835af3363c97b4ee02ebc) | `` nixosTests.nezha: init ``                                                          |
| [`92a55a59`](https://github.com/NixOS/nixpkgs/commit/92a55a592937f70b230b9ebb33ce53003d027669) | `` nixos/doc/rl-2611: new module nezha ``                                             |
| [`69b5cae8`](https://github.com/NixOS/nixpkgs/commit/69b5cae897fe071f838a72cf18f86e34eff3cdf3) | `` nixos/nezha: init ``                                                               |
| [`20b9600a`](https://github.com/NixOS/nixpkgs/commit/20b9600aae5febb9fdba8f1338b5f64a306c5f1a) | `` nezha-theme-user: correct license ``                                               |
| [`814e40ea`](https://github.com/NixOS/nixpkgs/commit/814e40ea9c77889fd9efc779443bbed2547ab3f3) | `` nezha-theme-user: update upstream repo name ``                                     |
| [`30ff4f72`](https://github.com/NixOS/nixpkgs/commit/30ff4f721caeed9515ded5da8f4c22478a0850fe) | `` nezha-theme-user: switch to pnpm ``                                                |
| [`d5e9f091`](https://github.com/NixOS/nixpkgs/commit/d5e9f091b8e67b00fdd40f91e8766f567836eecc) | `` nezha-theme-user: 2.0.1 -> 2.2.1 ``                                                |
| [`a7a76f1f`](https://github.com/NixOS/nixpkgs/commit/a7a76f1f50e67d2f2feb93e263479c793f0bca20) | `` ocamlPackages.ocaml-version: 4.1.0 -> 4.1.2 ``                                     |
| [`05dc2dd9`](https://github.com/NixOS/nixpkgs/commit/05dc2dd904495535ddab5f1eb777b9130ae645f6) | `` uv: 0.11.19 -> 0.11.21 ``                                                          |
| [`ee45ca1c`](https://github.com/NixOS/nixpkgs/commit/ee45ca1c968bca0573a24a0b47d8157dd8a6b635) | `` ocamlPackages.{camlpdf,cpdf}: add ngi team, update script & changelog ``           |
| [`6138fa5e`](https://github.com/NixOS/nixpkgs/commit/6138fa5ef58e6c0aa1d7ab734ca67e8ec2ea2a79) | `` ocamlPackages.{camlpdf,cpdf}: 2.9 -> 2.9.1 ``                                      |
| [`b270f0c4`](https://github.com/NixOS/nixpkgs/commit/b270f0c4f8b14b7aaabe4ae5685492634667a5d1) | `` ledger-live-desktop: 4.4.0 -> 4.6.0 ``                                             |
| [`a8b82161`](https://github.com/NixOS/nixpkgs/commit/a8b82161e593ae6b16e28cc56485e3beac23d7c5) | `` croaring: 4.7.0 -> 4.7.1 ``                                                        |
| [`124d676b`](https://github.com/NixOS/nixpkgs/commit/124d676b887409eea6bdd9af80b27c6ed976d5df) | `` ci/eval: name the base branch in the performance comparison summary ``             |
| [`6a42571b`](https://github.com/NixOS/nixpkgs/commit/6a42571bf52984698e6a69446bee3d0cbf79c65e) | `` clamav: 1.4.3 -> 1.4.4 ``                                                          |
| [`bb3c343b`](https://github.com/NixOS/nixpkgs/commit/bb3c343b2c3281684ba16f329ea560588e54a714) | `` rocqPackages.parseque: release v0.3.1 ``                                           |
| [`a96a272f`](https://github.com/NixOS/nixpkgs/commit/a96a272fdf75e6b53d403299a4ec44449b7724b7) | `` lldap: 0.6.2 -> 0.6.3 ``                                                           |
| [`11800819`](https://github.com/NixOS/nixpkgs/commit/11800819ff6db353a019663d565e7ac7f1779e98) | `` kopia: 0.23.0 -> 0.23.1 ``                                                         |
| [`ad4f726d`](https://github.com/NixOS/nixpkgs/commit/ad4f726df06e68826ae39c35a6b8dee47da49585) | `` fluent-bit: 5.0.6 -> 5.0.7 ``                                                      |
| [`214e71da`](https://github.com/NixOS/nixpkgs/commit/214e71daa48c88166e71440c796223fab592d3ad) | `` amazon-ssm-agent: 3.3.3598.0 -> 3.3.4515.0 ``                                      |
| [`dac07c9f`](https://github.com/NixOS/nixpkgs/commit/dac07c9f4c9dd8abcba1490b282e5b2cb110c0ec) | `` filebrowser-quantum: 1.2.2-stable -> 1.3.3-stable ``                               |
| [`9342639a`](https://github.com/NixOS/nixpkgs/commit/9342639a4a6d5de6c8654f13e60ecbf13cd2f010) | `` ardour: 9.5 -> 9.7 ``                                                              |
| [`4c331d72`](https://github.com/NixOS/nixpkgs/commit/4c331d72e0afc72d1acf69d17fcf9a7cb45f27c4) | `` envoy-bin: 1.37.2 -> 1.37.4 ``                                                     |
| [`707c96be`](https://github.com/NixOS/nixpkgs/commit/707c96be37434c12d913dc38c9fc4cae5266bddb) | `` spotify: (linux) 1.2.86.502.g8cd7fb22 -> 1.2.90.451.gb094aab0 ``                   |
| [`f2e6c0f5`](https://github.com/NixOS/nixpkgs/commit/f2e6c0f5eb0f7b9b68756da9859f9fe3fe0ffb1f) | `` spotify: (darwin) 1.2.89.539 -> 1.2.92.147 ``                                      |
| [`4d69faf1`](https://github.com/NixOS/nixpkgs/commit/4d69faf1a9667b72c6a82c2830c42d3ad224b14c) | `` nezha: 2.2.2 -> 2.2.3 ``                                                           |
| [`8f42d612`](https://github.com/NixOS/nixpkgs/commit/8f42d612ec1f712d6fede01e31b7bf47cf2cb2a3) | `` hmcl: 3.14.1 -> 3.15.1 ``                                                          |
| [`7fdc4f2b`](https://github.com/NixOS/nixpkgs/commit/7fdc4f2b4ed4a2042ae3e025e1e24c56cafcfb14) | `` google-chrome: 149.0.7827.114 -> 149.0.7827.155 ``                                 |
| [`3ce307d1`](https://github.com/NixOS/nixpkgs/commit/3ce307d116992b324e76ecdb3eb2056adf43b8ee) | `` simple64: fix strictDeps typo, enable __structuredAttrs ``                         |
| [`b4e2a9c3`](https://github.com/NixOS/nixpkgs/commit/b4e2a9c3f39a41ee22084ad457334d400e21c33a) | `` matrix-tuwunel: 1.7.0 -> 1.7.1 ``                                                  |
| [`e8bb719e`](https://github.com/NixOS/nixpkgs/commit/e8bb719ed6d448f7f4b1628cdbcacce97e81805c) | `` re-Isearch: fix buildInputs attribute ``                                           |
| [`eb6e31e2`](https://github.com/NixOS/nixpkgs/commit/eb6e31e2db75d85c37b42191dbfcf60084623fb3) | `` sunshine: 2025.924.154138 -> 2026.516.143833 ``                                    |
| [`4c14f3f2`](https://github.com/NixOS/nixpkgs/commit/4c14f3f2aba39329d060a074fa1034d6f72360e3) | `` sunshine: fix updater script ``                                                    |
| [`019d93da`](https://github.com/NixOS/nixpkgs/commit/019d93da59d3e3a9b3d87029adf0999cabb16f8f) | `` {palemoon-bin,palemoon-gtk2-bin}: 34.3.0 -> 34.3.0.1 ``                            |
| [`0e1dec9a`](https://github.com/NixOS/nixpkgs/commit/0e1dec9ac46a5b0560f14ed4d1dd7e3f665413ec) | `` n8n: 2.23.4 -> 2.25.7 ``                                                           |
| [`570346cb`](https://github.com/NixOS/nixpkgs/commit/570346cb076bcbc6f08d9c9a8cd22bf28e2211f2) | `` ed-odyssey-materials-helper: 3.6.6 -> 3.7.0 ``                                     |
| [`82146745`](https://github.com/NixOS/nixpkgs/commit/8214674537292bd742aa5adca160077508515edb) | `` nixos/release: remove tests.allDrivers ``                                          |
| [`386ba418`](https://github.com/NixOS/nixpkgs/commit/386ba418a074ecbec81f049126b4a813b508df58) | `` python3Packages.exllamav3: 0.0.42 -> 0.0.43 ``                                     |
| [`ef19506a`](https://github.com/NixOS/nixpkgs/commit/ef19506a9bab7e3d424985b60b84bbff3eb8f836) | `` cocoon: 0.9.0 -> 0.10 ``                                                           |
| [`8336f9a8`](https://github.com/NixOS/nixpkgs/commit/8336f9a8653ea80666d57ddb8d4617fc1e3a5bb0) | `` mullvad-vpn: 2026.2 -> 2026.3 ``                                                   |
| [`cdef3626`](https://github.com/NixOS/nixpkgs/commit/cdef36260a7dfe2f35df95853a80f142a3c1725b) | `` python3Packages.ansible: 13.6.0 -> 13.7.0 ``                                       |
| [`bb245a0d`](https://github.com/NixOS/nixpkgs/commit/bb245a0d50e9142a2e4c2d565ced3cc777a3389b) | `` weblate: make pythonRelaxDeps more robust ``                                       |
| [`2db12259`](https://github.com/NixOS/nixpkgs/commit/2db122599bfd4ec497a359851e26b96a01d85310) | `` weblate: skip null packages in relaxDeps logic ``                                  |
| [`18ff1437`](https://github.com/NixOS/nixpkgs/commit/18ff143758e071b0af4f92631a5d0b072c37b0f7) | `` buildRustCrate: prevent pulling in two rustc variants ``                           |
| [`37d342ce`](https://github.com/NixOS/nixpkgs/commit/37d342ce6ff04bde43a92e25f11900a014581878) | `` n8n: 2.22.5 -> 2.23.4 ``                                                           |
| [`8d73ac63`](https://github.com/NixOS/nixpkgs/commit/8d73ac631a2afe233565e491e377cb7be47a3ef1) | `` kubectl: 1.36.1 -> 1.36.2 ``                                                       |
| [`58246e66`](https://github.com/NixOS/nixpkgs/commit/58246e660f907dfc261b175ecb84ef85ab37cc7f) | `` qlever-control: 0.5.47 -> 0.5.48 ``                                                |
| [`07bce542`](https://github.com/NixOS/nixpkgs/commit/07bce542e3f6f269bcd64c0c364458e8f1f7e8ff) | `` maintainers/github-teams.json: Automated sync ``                                   |
| [`a948bead`](https://github.com/NixOS/nixpkgs/commit/a948bead33babb75a6775db61dd1752834073c22) | `` qbittorrent-nox: 5.2.1 -> 5.2.2 ``                                                 |
| [`1657c7f0`](https://github.com/NixOS/nixpkgs/commit/1657c7f05383ac5b72379984b2a754189794ce0b) | `` radarr: 6.1.1.10360 -> 6.2.1.10461 ``                                              |
| [`a8a839ac`](https://github.com/NixOS/nixpkgs/commit/a8a839ac228bd68a25775fe23b5f9384eeb914a9) | `` unofficial-homestuck-collection: upgrade Electron requirement to 14 ``             |
| [`ae3ccb50`](https://github.com/NixOS/nixpkgs/commit/ae3ccb50a84a91ce7732deba833d80ff7fa248e9) | `` chhoto-url: Enable git LFS for pulling the images ``                               |
| [`16b0663b`](https://github.com/NixOS/nixpkgs/commit/16b0663b29ae66ec09633aad9646b06c408bf73e) | `` llvmPackages_git: 23.0.0-unstable-2026-06-07 -> 23.0.0-unstable-2026-06-14 ``      |
| [`747e1cdd`](https://github.com/NixOS/nixpkgs/commit/747e1cdd1bb3902ffcbb4653578b51215b1b5b1f) | `` pnpm_11: 11.5.3 -> 11.6.0 ``                                                       |
| [`ff2c3f74`](https://github.com/NixOS/nixpkgs/commit/ff2c3f74755f0605a5fdcbe52f9f4b87f04382c1) | `` simulide: use correct license above 1.1.0 ``                                       |
| [`46abf328`](https://github.com/NixOS/nixpkgs/commit/46abf328c49659f3d2a1ee4a3052950a9ec03c99) | `` simulide: 1.1.0-SR1 -> 1.1.0-SR2 ``                                                |
| [`61579709`](https://github.com/NixOS/nixpkgs/commit/61579709f99b96cae1973f028c803a04e00f3737) | `` python3Packages.wasmtime: 44.0.0 -> 45.0.0 ``                                      |
| [`e68b54de`](https://github.com/NixOS/nixpkgs/commit/e68b54decab804dcf54c681ee3699ace58497d63) | `` wasmtime: 44.0.1 -> 45.0.0 ``                                                      |
| [`ef6ee58b`](https://github.com/NixOS/nixpkgs/commit/ef6ee58b593a4507e0790a0b437bd02a861c074d) | `` mcaselector: 2.7 -> 2.8 ``                                                         |
| [`38f71736`](https://github.com/NixOS/nixpkgs/commit/38f71736ab66eb60d829213216deba849ad304a4) | `` space-station-14-launcher: 0.37.1 -> 0.38.0 ``                                     |
| [`f4323484`](https://github.com/NixOS/nixpkgs/commit/f43234842cfbcedc8a19e7de81740eedb17aef16) | `` pizauth: fix systemd feature ``                                                    |
| [`be69d504`](https://github.com/NixOS/nixpkgs/commit/be69d504b6b4853cb92a321a899bdd94e5f4904a) | `` pizauth: fix systemd units substitutions ``                                        |
| [`c2aa9122`](https://github.com/NixOS/nixpkgs/commit/c2aa912296a32056daf0683de6a4688958265049) | `` matlab-language-server: 1.3.11 -> 1.3.12 ``                                        |
| [`403eece0`](https://github.com/NixOS/nixpkgs/commit/403eece08a11d619a669da77100161300c1b6685) | `` rocqPackages.micromega-plugin: fix hash ``                                         |
| [`e4029313`](https://github.com/NixOS/nixpkgs/commit/e4029313737a6d6283fa311bc9981c4ba595b905) | `` maintainers: update ryand56 ``                                                     |
| [`24450896`](https://github.com/NixOS/nixpkgs/commit/2445089637036a48f54e3da9e4ebd505bece9c9a) | `` nezha: fix build on darwin ``                                                      |
| [`a149ff98`](https://github.com/NixOS/nixpkgs/commit/a149ff98678ae82f212340822fda2422148adba8) | `` sing-box: 1.13.12 -> 1.13.13 ``                                                    |
| [`1b8673dd`](https://github.com/NixOS/nixpkgs/commit/1b8673ddb36e4c71e5b8d97a5f86b10717a65fc1) | `` limine{,-full}: 12.3.2 -> 12.3.3 ``                                                |
| [`140c895c`](https://github.com/NixOS/nixpkgs/commit/140c895ce5abdd11d60fb5595e7a372db3eba9c3) | `` hyprland: 0.55.2 -> 0.55.3 ``                                                      |
| [`7c09fe54`](https://github.com/NixOS/nixpkgs/commit/7c09fe54dba702dc59cd3a537c987e88748a5f6d) | `` perlPackages.CatalystPluginAuthentication: 0.10023 -> 0.10_027 ``                  |
| [`d2699b47`](https://github.com/NixOS/nixpkgs/commit/d2699b476f743b66caed4a6515a071f376e7a526) | `` rke2_1_35: 1.35.5+rke2r1 -> 1.35.5+rke2r2 ``                                       |
| [`bbe97a29`](https://github.com/NixOS/nixpkgs/commit/bbe97a296bc29fab7a425da94f22c3c1ba2f039a) | `` rke2_1_35: 1.35.4+rke2r1 -> 1.35.5+rke2r1 ``                                       |
| [`0652fd83`](https://github.com/NixOS/nixpkgs/commit/0652fd83234779e7cca6c7a428952d69fe255abd) | `` rke2_1_34: 1.34.8+rke2r1 -> 1.34.8+rke2r2 ``                                       |
| [`069d27fc`](https://github.com/NixOS/nixpkgs/commit/069d27fc9119a7aadbff2fee085c3246a6f74678) | `` rke2_1_34: 1.34.7+rke2r1 -> 1.34.8+rke2r1 ``                                       |
| [`82a7c342`](https://github.com/NixOS/nixpkgs/commit/82a7c342a2f5a4d7f0aada0f1182845153ce1d16) | `` nixseparatedebuginfod2: 2.0.0 -> 2.0.1 ``                                          |
| [`b86a4a8b`](https://github.com/NixOS/nixpkgs/commit/b86a4a8b7f701d44756ce6237c5f58e84c33a945) | `` rke2_1_33: 1.33.12+rke2r1 -> 1.33.12+rke2r2 ``                                     |
| [`f1b0157c`](https://github.com/NixOS/nixpkgs/commit/f1b0157c7104b94ce8b2ed47915eaa5e1a2375fd) | `` rke2_1_33: 1.33.11+rke2r1 -> 1.33.12+rke2r1 ``                                     |
| [`58a68f29`](https://github.com/NixOS/nixpkgs/commit/58a68f290b1627af4e411b8fd49987b4e97c503a) | `` firefox-esr-140-unwrapped: 141.11.0esr -> 140.12.0esr ``                           |
| [`eda32f8b`](https://github.com/NixOS/nixpkgs/commit/eda32f8be058fd137db783a4fb5a8afe00121ef8) | `` firefox-bin-unwrapped: 151.0.4 -> 152.0 ``                                         |
| [`f2302ce6`](https://github.com/NixOS/nixpkgs/commit/f2302ce654c0c648ac8b4236d8c43e016844f524) | `` firefox-unwrapped: 151.0.4 -> 152.0 ``                                             |
| [`9857afe6`](https://github.com/NixOS/nixpkgs/commit/9857afe649e0603211c40c774fd6f26c734c2c86) | `` nss_latest: 3.124 -> 3.125 ``                                                      |
| [`b4feed68`](https://github.com/NixOS/nixpkgs/commit/b4feed683fbada64a74ab0d282c8f984a29a1e73) | `` cm-rgb: migrate to by-name ``                                                      |
| [`2e463ba0`](https://github.com/NixOS/nixpkgs/commit/2e463ba0c1d330e960b80cb3730aa6afbdf1f3f6) | `` pass2csv: migrate to by-name ``                                                    |
| [`742fda87`](https://github.com/NixOS/nixpkgs/commit/742fda875ef24cee98a4cd878eeba634e819c263) | `` nitrokey-app2: migrate to by-name ``                                               |
| [`9f7f2986`](https://github.com/NixOS/nixpkgs/commit/9f7f29865001a44230931e4f57f2eda29f7d41c8) | `` cve-bin-tool: migrate to by-name ``                                                |
| [`2396dea8`](https://github.com/NixOS/nixpkgs/commit/2396dea895c26a3621efe444e8f1f880193bd55c) | `` vpn-slice: migrate to by-name ``                                                   |
| [`49071a17`](https://github.com/NixOS/nixpkgs/commit/49071a1731a084f351e327267796da3d73874a24) | `` s3cmd: migrate to by-name ``                                                       |
| [`6845c6ef`](https://github.com/NixOS/nixpkgs/commit/6845c6efceae62c0ed319e626ebd444813f205cc) | `` namespaced-openvpn: migrate to by-name ``                                          |
| [`11938aa6`](https://github.com/NixOS/nixpkgs/commit/11938aa6d0efbba33b3b7e1d3b10b590fcd865e7) | `` vimwiki-markdown: migrate to by-name ``                                            |
| [`c5ddca4a`](https://github.com/NixOS/nixpkgs/commit/c5ddca4af02a38ffdf556cc814d380a7a6d3685f) | `` remote-exec: migrate to by-name ``                                                 |
| [`e6e0859d`](https://github.com/NixOS/nixpkgs/commit/e6e0859d16196f0b35f3756b1f8d25c6f7501957) | `` pdd: migrate to by-name ``                                                         |
| [`2c12507f`](https://github.com/NixOS/nixpkgs/commit/2c12507f598170bb959bae24f12bf1ad6e907647) | `` pandoc-tablenos: migrate to by-name ``                                             |
| [`47c512b8`](https://github.com/NixOS/nixpkgs/commit/47c512b83e91c78c3832fdb2863759182bde96a6) | `` pandoc-secnos: migrate to by-name ``                                               |
| [`85dee78e`](https://github.com/NixOS/nixpkgs/commit/85dee78e375201aa6a8497b5c9d8d7b17688bd9e) | `` pandoc-fignos: migrate to by-name ``                                               |
| [`353d22bf`](https://github.com/NixOS/nixpkgs/commit/353d22bffe1f7c0ec539ec866b2572c864cd4add) | `` pandoc-eqnos: migrate to by-name ``                                                |
| [`60bd3efa`](https://github.com/NixOS/nixpkgs/commit/60bd3efa278c0a44e7034a2b4c39cf3c06e42235) | `` pandoc-plantuml-filter: migrate to by-name ``                                      |
| [`3c1f1a05`](https://github.com/NixOS/nixpkgs/commit/3c1f1a0576bba12b998f90c6cd381eaddd68cc58) | `` pandoc-drawio-filter: migrate to by-name ``                                        |
| [`303d95e4`](https://github.com/NixOS/nixpkgs/commit/303d95e423c8ab6029efab38a3f98f390ad26423) | `` pandoc-include: migrate to by-name ``                                              |
| [`6cd39fea`](https://github.com/NixOS/nixpkgs/commit/6cd39fea9da6220c9d48271dbc95a11695957626) | `` pandoc-imagine: migrate to by-name ``                                              |
| [`6dea5dec`](https://github.com/NixOS/nixpkgs/commit/6dea5dec3e61d4de9e87fe875a45bc9881a03932) | `` pandoc-acro: migrate to by-name ``                                                 |
| [`90c939fa`](https://github.com/NixOS/nixpkgs/commit/90c939faae3822fe94d769550ff89adb3adf67a7) | `` online-judge-template-g-generator: migrate to by-name ``                           |
| [`a48f6972`](https://github.com/NixOS/nixpkgs/commit/a48f69729ffda90bf205eb4f9462dc39a2d6b079) | `` input-remapper: migrate to by-name ``                                              |
| [`059fdf48`](https://github.com/NixOS/nixpkgs/commit/059fdf48da58801b190c208beb09ef0d97a9b983) | `` cpupower-gui: migrate to by-name ``                                                |
| [`ab9726fe`](https://github.com/NixOS/nixpkgs/commit/ab9726fe5f49247ab74c8738ca30b5f796d590a3) | `` yakut: migrate to by-name ``                                                       |
| [`2c300740`](https://github.com/NixOS/nixpkgs/commit/2c3007401e1528fb3adb21dc78ce86846fdcbe1c) | `` gdbgui: migrate to by-name ``                                                      |
| [`1081087c`](https://github.com/NixOS/nixpkgs/commit/1081087c1275a624b7907b068b6ca16258c45e15) | `` enochecker-test: migrate to by-name ``                                             |
| [`f1411b53`](https://github.com/NixOS/nixpkgs/commit/f1411b5382c74e315fc92e2116c5152962750a4a) | `` asn2quickder: migrate to by-name ``                                                |
| [`157fd31b`](https://github.com/NixOS/nixpkgs/commit/157fd31b479fb6d087a86e143320b678720e95d8) | `` hyprshade: migrate to by-name ``                                                   |
| [`d4d55dd6`](https://github.com/NixOS/nixpkgs/commit/d4d55dd65a2296f75b13db06c708e0db16fdecd7) | `` plex-mpv-shim: migrate to by-name ``                                               |
| [`d3f052b2`](https://github.com/NixOS/nixpkgs/commit/d3f052b28cc469da20bc46ad42b9622423336fbd) | `` jellyfin-mpv-shim: migrate to by-name ``                                           |
| [`e64d8d1a`](https://github.com/NixOS/nixpkgs/commit/e64d8d1a05d5085a815107b8ebb1bf52b8ee3f91) | `` sumorobot-manager: migrate to by-name ``                                           |
| [`dc9a586c`](https://github.com/NixOS/nixpkgs/commit/dc9a586ca9c4e2147b8e429dc41ff683251dfcec) | `` mavproxy: migrate to by-name ``                                                    |
| [`a5631b2a`](https://github.com/NixOS/nixpkgs/commit/a5631b2a1be8e003e926602e393bffc953a75d0d) | `` matrix-commander: migrate to by-name ``                                            |
| [`e1803e72`](https://github.com/NixOS/nixpkgs/commit/e1803e72c400b43753f4cb5bf4751ac863b369b0) | `` droopy: migrate to by-name ``                                                      |
| [`9de94f08`](https://github.com/NixOS/nixpkgs/commit/9de94f0812ee54f1dab7518af2fa1cf428ef01f4) | `` yokadi: migrate to by-name ``                                                      |
| [`f7460025`](https://github.com/NixOS/nixpkgs/commit/f7460025e5b38b69fe7c1a24055fe3bb4de0adfa) | `` termpdfpy: migrate to by-name ``                                                   |
| [`1e934686`](https://github.com/NixOS/nixpkgs/commit/1e9346860e9b8cabc38256e9084ddcafcfef69c3) | `` remarkable-mouse: migrate to by-name ``                                            |
| [`54a2faff`](https://github.com/NixOS/nixpkgs/commit/54a2faff09a366678c8e9f315e79eccf7aed370a) | `` bluetooth_battery: migrate to by-name ``                                           |
| [`446f30c7`](https://github.com/NixOS/nixpkgs/commit/446f30c7d7c9588e04f744158168fcda1142e386) | `` bitwarden-menu: migrate to by-name ``                                              |
| [`653b43f2`](https://github.com/NixOS/nixpkgs/commit/653b43f22f8c9c1bc452eedaa19c234313f00212) | `` python3Packages.valkey: fix valkey 9.1 compat ``                                   |
| [`ff328071`](https://github.com/NixOS/nixpkgs/commit/ff328071a5ff9766b29030b5c27c48eeb620e1d8) | `` p2pool: 4.14 -> 4.16 ``                                                            |
| [`0a4059a6`](https://github.com/NixOS/nixpkgs/commit/0a4059a6c34e781df8c0c7903b190558b3064b24) | `` xdg-desktop-portal-cosmic: 1.0.13 -> 1.0.16 ``                                     |
| [`39175ee1`](https://github.com/NixOS/nixpkgs/commit/39175ee1c6af94cf29a03191913c56287bc1e4e7) | `` cosmic-workspaces-epoch: 1.0.13 -> 1.0.16 ``                                       |
| [`2c290b56`](https://github.com/NixOS/nixpkgs/commit/2c290b56b0dddd6692b5782473ca67530b57ea86) | `` cosmic-wallpapers: 1.0.13 -> 1.0.16 ``                                             |
| [`f34ce244`](https://github.com/NixOS/nixpkgs/commit/f34ce24466d71a08d3dedcac5c08d983916c06d1) | `` cosmic-term: 1.0.13 -> 1.0.16 ``                                                   |
| [`ed997efa`](https://github.com/NixOS/nixpkgs/commit/ed997efa5370200b109d0546b7d9d7daf2b42b96) | `` cosmic-store: 1.0.13 -> 1.0.16 ``                                                  |
| [`277b6ad3`](https://github.com/NixOS/nixpkgs/commit/277b6ad3484343362f48ab30eee2186a5d6bc703) | `` cosmic-settings-daemon: 1.0.13 -> 1.0.16 ``                                        |
| [`26899608`](https://github.com/NixOS/nixpkgs/commit/2689960853d74cc851422adc28daf188898940f1) | `` cosmic-settings: 1.0.13 -> 1.0.16 ``                                               |
| [`d5a49b81`](https://github.com/NixOS/nixpkgs/commit/d5a49b81e690d1eff435b45bf88e6f4edb54f484) | `` cosmic-session: 1.0.13 -> 1.0.16 ``                                                |
| [`eaaae1b3`](https://github.com/NixOS/nixpkgs/commit/eaaae1b30dbd20a5da96fbe7b7254252e35b3674) | `` cosmic-screenshot: 1.0.13 -> 1.0.16 ``                                             |
| [`e773a218`](https://github.com/NixOS/nixpkgs/commit/e773a218759aa450b30d5e30616794271000a0ac) | `` cosmic-reader: 0-unstable-2026-05-12 -> 0-unstable-2026-06-06 ``                   |
| [`5f796d0a`](https://github.com/NixOS/nixpkgs/commit/5f796d0a6a852008528c624431052f5f3efa4362) | `` weblate: 5.17 -> 2026.6.1 ``                                                       |
| [`bee94ccc`](https://github.com/NixOS/nixpkgs/commit/bee94ccc0bcc257ad47a720422720948564c7881) | `` python3Packages.translation-finder: 2.24 -> 3.1 ``                                 |
| [`61124f8b`](https://github.com/NixOS/nixpkgs/commit/61124f8b81f868105ae2bd897597ed94a82cf97a) | `` python3Packages.translate-toolkit: 3.19.10 -> 3.19.11 ``                           |
| [`58ded50d`](https://github.com/NixOS/nixpkgs/commit/58ded50dc7f1dd6dde8b17a9e968d0e5e4becd53) | `` python3Packages.weblate-schemas: 2025.6 -> 2026.4, use fetchFromGitHub ``          |
| [`b02188fa`](https://github.com/NixOS/nixpkgs/commit/b02188fa0e086777b4919aeb10cf41b4a6ab871c) | `` python3Packages.social-auth-app-django: 5.8.0 -> 5.9.0 ``                          |
| [`eebbedf2`](https://github.com/NixOS/nixpkgs/commit/eebbedf27293edc23c83d7191470da4a466ffafb) | `` python3Packages.social-auth-core: 4.8.5 -> 4.9.1 ``                                |
| [`134d5163`](https://github.com/NixOS/nixpkgs/commit/134d51630ec8ef87f1ebcd713db218df203e3419) | `` python3Packages.translate-toolkit: 3.19.5 -> 3.19.10 ``                            |
| [`be3b7a32`](https://github.com/NixOS/nixpkgs/commit/be3b7a32fecd8e45a7370d0113f664c8604b5436) | `` python3Packages.opentelemetry-instrumentation-psycopg: init at 0.63b1 ``           |
| [`58ef2547`](https://github.com/NixOS/nixpkgs/commit/58ef254779aea3553a017063585b1b2da14db61e) | `` cosmic-randr: 1.0.13 -> 1.0.16 ``                                                  |
| [`8d92413f`](https://github.com/NixOS/nixpkgs/commit/8d92413fef5b0ffeabad8115cf10530a8531d0b9) | `` cosmic-player: 1.0.13 -> 1.0.16 ``                                                 |
| [`11051fd6`](https://github.com/NixOS/nixpkgs/commit/11051fd6cefb75faa7ab282bac1000978a017c2a) | `` cosmic-panel: 1.0.13 -> 1.0.16 ``                                                  |
| [`b8348fb3`](https://github.com/NixOS/nixpkgs/commit/b8348fb31cca6acdb2ec6bad8816249f24de2af6) | `` cosmic-osd: deduplicate the dual sources for the cosmic-settings crate ``          |
| [`79c89e85`](https://github.com/NixOS/nixpkgs/commit/79c89e856f42da1ced39a2da166c61f3da650383) | `` cosmic-osd: 1.0.13 -> 1.0.16 ``                                                    |
| [`aaa90d77`](https://github.com/NixOS/nixpkgs/commit/aaa90d775af49d4b7885afbc10c7214a4bc1af09) | `` cosmic-notifications: 1.0.13 -> 1.0.16 ``                                          |
| [`06850093`](https://github.com/NixOS/nixpkgs/commit/0685009371a1d742b6e56af19c5dad5d877b815c) | `` cosmic-launcher: 1.0.13 -> 1.0.16 ``                                               |
| [`c550be11`](https://github.com/NixOS/nixpkgs/commit/c550be115cb330a24fc65d7aeb74199d5a8e90bc) | `` cosmic-initial-setup: 1.0.13 -> 1.0.16 ``                                          |
| [`765ed026`](https://github.com/NixOS/nixpkgs/commit/765ed026ed9351ba4c6e18cbc758a201b4a48315) | `` cosmic-idle: 1.0.13 -> 1.0.16 ``                                                   |
| [`9125e637`](https://github.com/NixOS/nixpkgs/commit/9125e637c577f9ca203a3c55bd8e1b87476bcd38) | `` cosmic-icons: 1.0.13 -> 1.0.16 ``                                                  |
| [`10dbd238`](https://github.com/NixOS/nixpkgs/commit/10dbd238a0bcde80c98ff66f385a3892291612b7) | `` cosmic-greeter: 1.0.13 -> 1.0.16 ``                                                |
| [`f8a9a431`](https://github.com/NixOS/nixpkgs/commit/f8a9a4312bf8f491f19c82b7b061d02af85eeb38) | `` cosmic-files: 1.0.13 -> 1.0.16 ``                                                  |
| [`786a72f9`](https://github.com/NixOS/nixpkgs/commit/786a72f9cd85cb1442352bbf6515385b3286529a) | `` cosmic-edit: 1.0.13 -> 1.0.16 ``                                                   |
| [`4bd7c0b5`](https://github.com/NixOS/nixpkgs/commit/4bd7c0b560c6845a2188cc3bca0d1b1f0b249e5b) | `` cosmic-comp: 1.0.13 -> 1.0.16 ``                                                   |
| [`7019707f`](https://github.com/NixOS/nixpkgs/commit/7019707fae56deabc67837d3e746bb0264d4eee6) | `` cosmic-bg: 1.0.13 -> 1.0.16 ``                                                     |
| [`efae094a`](https://github.com/NixOS/nixpkgs/commit/efae094a946184f5dd32d63c04a6c778fcf3c0c5) | `` cosmic-applibrary: 1.0.13 -> 1.0.16 ``                                             |
| [`bc41de8d`](https://github.com/NixOS/nixpkgs/commit/bc41de8d83f12df48bc43b545f784f9925d6ed19) | `` cosmic-applets: 1.0.13 -> 1.0.16 ``                                                |
| [`62903162`](https://github.com/NixOS/nixpkgs/commit/62903162a5d9b63ae7853b459d62151c681fd824) | `` faugus-launcher: 1.16.6 -> 1.20.4 ``                                               |
| [`bc613811`](https://github.com/NixOS/nixpkgs/commit/bc613811d80ec81d382a2a136aca3bbda4f18c77) | `` jackett: 0.24.2021 -> 0.24.2066 ``                                                 |
| [`9e48d536`](https://github.com/NixOS/nixpkgs/commit/9e48d5360e4b78537a232a517f373c95a46c4f97) | `` vcmi: fix build ``                                                                 |
| [`824adfa0`](https://github.com/NixOS/nixpkgs/commit/824adfa0427e89dea16e035d88fc9bc2148b18c7) | `` ocqPackages.mathcomp-analysis: change how to specify dependencies ``               |
| [`d517856e`](https://github.com/NixOS/nixpkgs/commit/d517856ea1d6c71fd2f5e35e1e3ae6dcb0eb993f) | `` rocqPackages.mathcomp-analysis: update dependencies ``                             |
| [`535764d9`](https://github.com/NixOS/nixpkgs/commit/535764d901b362266c2ae765134ce224a6b76b01) | `` maintainers: add spk ``                                                            |
| [`8f5caeca`](https://github.com/NixOS/nixpkgs/commit/8f5caeca42e86f72bf4f899c3a81b88ae57b635a) | `` sub-store-frontend: 2.17.31 -> 2.17.36 ``                                          |
| [`bd041eb3`](https://github.com/NixOS/nixpkgs/commit/bd041eb33d60619eb01db3dba1a2d59a5ee66c98) | `` blackfire: 2.29.7 -> 2026.6.0 ``                                                   |
| [`1baf1ce6`](https://github.com/NixOS/nixpkgs/commit/1baf1ce6a73e61f345306052c913f2b30e2d0bdd) | `` foks: add phanirithvij as maintainer ``                                            |
| [`3efb545a`](https://github.com/NixOS/nixpkgs/commit/3efb545a1a011b3fb7204ef5fef51e283a4e356c) | `` foks: 0.1.7 -> 0.1.8 ``                                                            |
| [`24171410`](https://github.com/NixOS/nixpkgs/commit/2417141031a1499a379a9af1a6be93cb6d769b71) | `` foks-server: convert to an alias ``                                                |
| [`a54ba3ae`](https://github.com/NixOS/nixpkgs/commit/a54ba3ae834e2c4c107aaae609bed2cec0239f04) | `` foks: dedup foks, foks-server derivations ``                                       |
| [`f35f4227`](https://github.com/NixOS/nixpkgs/commit/f35f4227f3e7700d86c07129a4827a535716c2e7) | `` lighttpd: 1.4.82 -> 1.4.83 ``                                                      |
| [`2a5d6667`](https://github.com/NixOS/nixpkgs/commit/2a5d6667c25a241333e6524f64b67e60569fc74b) | `` diffoscope: add mdaniels5757 as co-maintainer ``                                   |
| [`34b3736f`](https://github.com/NixOS/nixpkgs/commit/34b3736f0f46a4f6b967c05eaf0e2047c8ba8ac3) | `` easycrypt: 2026.05 -> 2026.06 ``                                                   |
| [`4315267b`](https://github.com/NixOS/nixpkgs/commit/4315267b9d45e39b756c9b4596293e27145c65e2) | `` bitwarden-desktop: don't sign builds on macOS ``                                   |
| [`e322fe3f`](https://github.com/NixOS/nixpkgs/commit/e322fe3f240939fddcd9ddd08bf6f8882fe18ebf) | `` voicevox: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                           |
| [`d037cb1c`](https://github.com/NixOS/nixpkgs/commit/d037cb1c3560b08348909363a828585bbc988cd6) | `` teams-for-linux: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                    |
| [`a9fe2c89`](https://github.com/NixOS/nixpkgs/commit/a9fe2c892876175a36a98dc728f36119178fffed) | `` super-productivity: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                 |
| [`04579a34`](https://github.com/NixOS/nixpkgs/commit/04579a34b0af1a873d749b20d180f666c2317de2) | `` signal-desktop: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                     |
| [`2a67c06e`](https://github.com/NixOS/nixpkgs/commit/2a67c06e169fc0e8f0cc769e3b4f1ace48909869) | `` opencode-desktop: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                   |
| [`261edf05`](https://github.com/NixOS/nixpkgs/commit/261edf05ff456d12c929c15c8fe0490dcbdb25fa) | `` mqtt-explorer: remove usage of CSC_IDENTITY_AUTO_DISCOVERY ``                      |

*... and 274 more commits (truncated)*