### PR TITLE
chore(flake/home-manager): `1ac720f0` -> `19d7472a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -530,11 +530,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782231110,
-        "narHash": "sha256-sEP5lBEVsMf//ImkzcQK6Jh5pxPrFtZqSp852rcSpV4=",
+        "lastModified": 1782415272,
+        "narHash": "sha256-Yt4nE/QSk1KRzOIMBK5/OOa7AH1Y0JbxNbgf5VTxQ6g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ac720f007173754b204c2d25fee9a38680bf9bf",
+        "rev": "19d7472aca941c7e3d11e8a91d61be47d70c4ab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`19d7472a`](https://github.com/nix-community/home-manager/commit/19d7472aca941c7e3d11e8a91d61be47d70c4ab5) | `` codex: reorganize module files ``                                      |
| [`2ebe9c0f`](https://github.com/nix-community/home-manager/commit/2ebe9c0fe7ac018b57daf2ed5db30e6374df9a11) | `` codex: sanitize plugin cache paths ``                                  |
| [`64221f9c`](https://github.com/nix-community/home-manager/commit/64221f9c87fc8d7a84b26bfe63d728f971a431e0) | `` codex: add lifecycle hooks option ``                                   |
| [`1c64122e`](https://github.com/nix-community/home-manager/commit/1c64122e70ad8e31067a4aa0a9e8ec7650076479) | `` codex: add context override file ``                                    |
| [`01e23f49`](https://github.com/nix-community/home-manager/commit/01e23f497cca8216f937373353b6df6497c0f19c) | `` codex: update upstream config reference ``                             |
| [`9e3e1d95`](https://github.com/nix-community/home-manager/commit/9e3e1d95beecfe090eb6b902ce5223464966be8d) | `` codex: add maintainer khaneliman ``                                    |
| [`3d8f49f3`](https://github.com/nix-community/home-manager/commit/3d8f49f36073e38c212e515024ef58614dba454d) | `` alacritty: normalize key binding escape sequences ``                   |
| [`085e92b0`](https://github.com/nix-community/home-manager/commit/085e92b04a46f3084040291d07d6788565a7b739) | `` github-copilot-cli: preserve args for local-type MCP servers ``        |
| [`3b3ff176`](https://github.com/nix-community/home-manager/commit/3b3ff176217fcd165a589cb43bc2de411a573cdc) | `` firefox: legacyUserProfileCustomizations when userChrome is present `` |
| [`3a70e333`](https://github.com/nix-community/home-manager/commit/3a70e333f2950c302e875c44cfcfaff3f80f36bc) | `` fish: extract completion generator from the fish binary ``             |
| [`a9232b8b`](https://github.com/nix-community/home-manager/commit/a9232b8b1004a4fca3f188951a53dc6322303659) | `` launchd: use user domain for background agents ``                      |
| [`dc89b0c0`](https://github.com/nix-community/home-manager/commit/dc89b0c0bb4c019e522ee2e2fcbf2e183a3caa5f) | `` launchd: add agent domain option ``                                    |
| [`06258193`](https://github.com/nix-community/home-manager/commit/062581938b4a378a82dfbb294b494808157153a1) | `` claude-code: reject disabled mcp servers instead of dropping ``        |