### PR TITLE
chore(flake/nixpkgs-stable): `34268251` -> `667d5cf1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1782116945,
-        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
+        "lastModified": 1782233679,
+        "narHash": "sha256-QyuGP5+QOtmXpy4i2X4DhBVBaySBdDKQEhqKcphcp34=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
+        "rev": "667d5cf1c59585031d743c78b394b0a647537c35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`a4efe38d`](https://github.com/NixOS/nixpkgs/commit/a4efe38d7d2a30cad78d542fd40a61b513a1b29e) | `` vscode-langservers-extracted: extract directly from vscodium ``                           |
| [`41fd23ef`](https://github.com/NixOS/nixpkgs/commit/41fd23ef1c3932b48b5bd7bbe8d687a14461e1b2) | `` tor: 0.4.9.9 -> 0.4.9.10 ``                                                               |
| [`23b31774`](https://github.com/NixOS/nixpkgs/commit/23b3177402dfc0ed8228bf9f5fecd1672d5f7ec3) | `` lib.attrsets.concatMapAttrs: add test for handling duplicates ``                          |
| [`aed9f7b9`](https://github.com/NixOS/nixpkgs/commit/aed9f7b95dad7e9b32715f7a8055c746e92328d5) | `` lib.attrsets.concatMapAttrs: rewrite for efficiency ``                                    |
| [`6370a6a0`](https://github.com/NixOS/nixpkgs/commit/6370a6a0ab205939cc607fcf8387f7cfbb94572c) | `` forgejo-runner: 12.11.1 -> 12.12.0 ``                                                     |
| [`444745b8`](https://github.com/NixOS/nixpkgs/commit/444745b8653977f368957cc64cb2c6183c2d6cb8) | `` sudo-rs: 0.2.13 -> 0.2.14 ``                                                              |
| [`6f8f130a`](https://github.com/NixOS/nixpkgs/commit/6f8f130aeb649200b1f07337dce0526d751fd481) | `` ocamlPackages.windtrap: init at 0.1.0 ``                                                  |
| [`bb50eb03`](https://github.com/NixOS/nixpkgs/commit/bb50eb03518069eebf6de802296a9a4ae35fb20d) | `` kopia-ui: 0.23.0 -> 0.23.1 ``                                                             |
| [`220e781e`](https://github.com/NixOS/nixpkgs/commit/220e781eee89fa86f26d05c40a57eea1c691adec) | `` linux-firmware: 20260519 -> 20260622 ``                                                   |
| [`ffc14d3c`](https://github.com/NixOS/nixpkgs/commit/ffc14d3c7bfbe856abae1c222afc3868b06500bb) | `` prl-tools: 26.3.3-57507 -> 26.4.0-57513 ``                                                |
| [`6f3261e0`](https://github.com/NixOS/nixpkgs/commit/6f3261e0cd8d3648be333f361e59e25b3aa1131e) | `` kubevirt: 1.8.2 -> 1.8.4 ``                                                               |
| [`38357f14`](https://github.com/NixOS/nixpkgs/commit/38357f14e1e624803c00eed04853424199adbd54) | `` viddy: add versionCheckHook ``                                                            |
| [`88404dd1`](https://github.com/NixOS/nixpkgs/commit/88404dd1b1bcae50a32eb6c6a83b66678c464fac) | `` ghostfolio: 3.10.0 -> 3.13.0 ``                                                           |
| [`e36354e1`](https://github.com/NixOS/nixpkgs/commit/e36354e1c1c962ea49e891a4dbe9bac06bf21f14) | `` nixos/mysql: fix default MySQL/Percona Server insecure authentication ``                  |
| [`408636ba`](https://github.com/NixOS/nixpkgs/commit/408636ba235e25543862841429d97e282e588359) | `` nezha: 2.2.3 -> 2.2.6 ``                                                                  |
| [`287f7d50`](https://github.com/NixOS/nixpkgs/commit/287f7d50d7870bf0ffe83deb768d391645f2ff8a) | `` nezha-theme-user: 2.2.1 -> 2.3.1 ``                                                       |
| [`055175cd`](https://github.com/NixOS/nixpkgs/commit/055175cde1e45eda143f3be12254c6ad7592d34a) | `` kanidm_1_10: 1.10.3 -> 1.10.4 ``                                                          |
| [`0a84a94e`](https://github.com/NixOS/nixpkgs/commit/0a84a94e3fec36a776163b9efb5d4cce7b318ba5) | `` lima-full: 2.1.2 -> 2.1.3 ``                                                              |
| [`41737ab4`](https://github.com/NixOS/nixpkgs/commit/41737ab438e838665e7a776be07a9421270cafe8) | `` lockbook-desktop: 26.6.1 -> 26.6.16 ``                                                    |
| [`a7eec012`](https://github.com/NixOS/nixpkgs/commit/a7eec0128abeb568527b6f55df855bbed1bdc800) | `` steam-devices-udev-rules: 1.0.0.61-unstable-2026-04-16 -> 1.0.0.61-unstable-2026-06-11 `` |
| [`9fe9a6ad`](https://github.com/NixOS/nixpkgs/commit/9fe9a6adc3160bf4a359eb1a697b8b3ede640232) | `` checkstyle: 13.5.0 -> 13.6.0 ``                                                           |
| [`7ce82440`](https://github.com/NixOS/nixpkgs/commit/7ce82440002989af7f0d3f8c314978fe1fc1a959) | `` gitoxide: 0.54.0 -> 0.55.0 ``                                                             |
| [`71ac1710`](https://github.com/NixOS/nixpkgs/commit/71ac1710ea54fa6afbc7575e75b54827e2701385) | `` workflows/build: stop building for `x86_64-darwin` ``                                     |
| [`ffe04b39`](https://github.com/NixOS/nixpkgs/commit/ffe04b394fedac1de9bf12037fddd623e0f02e95) | `` .github/PULL_REQUEST_TEMPLATE: drop `x86_64-darwin` checkbox ``                           |
| [`bc5ad2a4`](https://github.com/NixOS/nixpkgs/commit/bc5ad2a4165af9c05f714e6d967e1cdbf83b386e) | `` authentik: 2025.12.5 -> 2025.12.6 ``                                                      |
| [`23aea951`](https://github.com/NixOS/nixpkgs/commit/23aea9512cc29da385aa8c93f0296155a542e816) | `` floorp-bin: 12.14.2 -> 12.15.2 ``                                                         |
| [`3b20c8b6`](https://github.com/NixOS/nixpkgs/commit/3b20c8b6cdf3bc5e508caf3e8f85f8e2547a9052) | `` irpf: 2026-1.4 -> 2026-1.5 ``                                                             |
| [`2b65d753`](https://github.com/NixOS/nixpkgs/commit/2b65d7539a0014f0d826e57fcbd5c0d1921efc53) | `` mailpit: 1.30.1 -> 1.30.2 ``                                                              |
| [`bf763f0e`](https://github.com/NixOS/nixpkgs/commit/bf763f0eed1fa78c5c348aa79c0cd42a187ec2d8) | `` mdns-scanner: 0.27.1 -> 0.27.2 ``                                                         |
| [`507d9044`](https://github.com/NixOS/nixpkgs/commit/507d90440e33ab9ac79aa68d9a509e09e8ce7251) | `` [Backport release-26.05] pdfding: 1.8.0 -> 1.9.0 ``                                       |
| [`350f26db`](https://github.com/NixOS/nixpkgs/commit/350f26db9724910940f0f75846b7997b0a10f0d4) | `` python3Packages.slowapi: backport starlette 1.0 compat ``                                 |
| [`3ac3fd24`](https://github.com/NixOS/nixpkgs/commit/3ac3fd2490db3017c028b04d608eda1a54f65438) | `` mesa: 26.1.2 -> 26.1.3 ``                                                                 |
| [`ab88b0e1`](https://github.com/NixOS/nixpkgs/commit/ab88b0e153e900bfe2aaccff5f8a4f725efe3d15) | `` vivaldi: 8.0.4033.46 -> 8.0.4033.50 ``                                                    |
| [`c8715816`](https://github.com/NixOS/nixpkgs/commit/c87158160b2186a48a9b8f749b1a982819d7a87a) | `` llvmPackages_git: 23.0.0-unstable-2026-06-14 -> 23.0.0-unstable-2026-06-21 ``             |
| [`f1091a72`](https://github.com/NixOS/nixpkgs/commit/f1091a72dcbe6c0cc521287f2f97e5369538dee3) | `` nixosTests: remove deprecated config attribute access ``                                  |
| [`44de0d0d`](https://github.com/NixOS/nixpkgs/commit/44de0d0deaf7f04ab8ced78d0976800529a47e53) | `` Revert "doc: don't use sha256 and non-sri hashes in user docs" ``                         |
| [`6a7b33dc`](https://github.com/NixOS/nixpkgs/commit/6a7b33dcf02c0272d2f2dad9c53276918ef56525) | `` python314Packages.python-openstackclient: remove no longer failing tests ``               |
| [`9213c584`](https://github.com/NixOS/nixpkgs/commit/9213c58403e2ca073d7352f98c8e80f90c8819d3) | `` python314Packages.osc-lib: fix hash which was forgotten to be updated ``                  |
| [`ed0adc00`](https://github.com/NixOS/nixpkgs/commit/ed0adc003d94f439a8b0983066457ea8d543677d) | `` Revert "linuxPackages_7_0.virtualboxGuestAdditions: do not install vboxvideo" ``          |
| [`d8c9cadc`](https://github.com/NixOS/nixpkgs/commit/d8c9cadc232bd8a8fbe8c21c392e2e974a4f1370) | `` virtualbox: 7.2.8 -> 7.2.10 ``                                                            |
| [`b9db3d1a`](https://github.com/NixOS/nixpkgs/commit/b9db3d1af6855198a4e995cd8505b35c7b36e6fd) | `` pulsar: fix crash reporter ``                                                             |
| [`3f17a974`](https://github.com/NixOS/nixpkgs/commit/3f17a9749bbe092e4757017771d5f85f6e49b04a) | `` halloy: 2026.7.1 -> 2026.7.2 ``                                                           |
| [`0e38b1da`](https://github.com/NixOS/nixpkgs/commit/0e38b1daf91513ef5f8c72a8a50d5099f2a12e6e) | `` thunderbird-latest-bin-unwrapped: 151.0.1 -> 152.0 ``                                     |
| [`3e2e2497`](https://github.com/NixOS/nixpkgs/commit/3e2e2497a9c97ac4750243371fab9cd4fca4d90d) | `` squid: 7.5 -> 7.6 ``                                                                      |
| [`3fd910f9`](https://github.com/NixOS/nixpkgs/commit/3fd910f9dafcdeaa5ee19e850a60bb83a898829b) | `` nocturne: 1.2.2 -> 1.3.0 ``                                                               |
| [`ea043f1c`](https://github.com/NixOS/nixpkgs/commit/ea043f1ce4a2c6d0f179684c9543a206420a4406) | `` nocturne: add a gdk-pixbuf module ``                                                      |
| [`2370847e`](https://github.com/NixOS/nixpkgs/commit/2370847e2dcb17f7dad7d7f710c2651026bb7a68) | `` nocturne: 1.2.1 -> 1.2.2 ``                                                               |
| [`84bcfa41`](https://github.com/NixOS/nixpkgs/commit/84bcfa41da3f7a337be3e840e797be08e1cc1b36) | `` octave.pkgs.optim: 1.6.2 -> 1.6.3, unbreak ``                                             |
| [`ac7ded93`](https://github.com/NixOS/nixpkgs/commit/ac7ded930367f88c104959a59439c98db1ba5fa5) | `` finamp: 0.9.23-beta -> 0.9.24-beta ``                                                     |
| [`3ec486fd`](https://github.com/NixOS/nixpkgs/commit/3ec486fddd591400bf8d04a7659eaae40ab12a7e) | `` proxyauth: add structuredAttrs ``                                                         |
| [`46d990fc`](https://github.com/NixOS/nixpkgs/commit/46d990fc050027c1a21f822b9327fb20dd044f2c) | `` proxyauth: fix 404 ``                                                                     |
| [`ea4782d3`](https://github.com/NixOS/nixpkgs/commit/ea4782d310ebebbba8550dfdc2bb38dcd5f1f50e) | `` zammad: 7.0.1 -> 7.1.0 ``                                                                 |
| [`762761c4`](https://github.com/NixOS/nixpkgs/commit/762761c420a7094816089c796ea5425779ef182c) | `` pnpm-fixup-state-db: make it depend on `nodejs-slim` ``                                   |
| [`42214e85`](https://github.com/NixOS/nixpkgs/commit/42214e85ea3e65b70473f7fc7b1652b3f2c31f50) | `` nodejs: remove `npm` and `corepack` passthru ``                                           |
| [`5df70804`](https://github.com/NixOS/nixpkgs/commit/5df708044eb7dd0e1b458cd68b4962cde3723967) | `` srcOnly: disable `outputChecks` ``                                                        |
| [`e33448f6`](https://github.com/NixOS/nixpkgs/commit/e33448f6f37d1813a526b4cd250bb9883fb2a96e) | `` pnpm: switch to nodejs-slim ``                                                            |