### PR TITLE
chore(flake/catppuccin): `e98afe2d` -> `3f3b3511`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782117778,
-        "narHash": "sha256-x6vIJpJziw3Hs0JKKDP+AeRPWwqyMDOmK6I26tqbYj4=",
+        "lastModified": 1782462517,
+        "narHash": "sha256-HPzOASBxx1bAnPREm4syM5oTb8ls2qbudkLW4BTB94s=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "e98afe2dfd950bda4e6a8ef32bb563ec2f04505a",
+        "rev": "3f3b3511f9c433b93f20b24be32de01f675b046d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`3f3b3511`](https://github.com/catppuccin/nix/commit/3f3b3511f9c433b93f20b24be32de01f675b046d) | `` chore: update port sources (#991) `` |
| [`2501ec4b`](https://github.com/catppuccin/nix/commit/2501ec4b1848dd861cb6a5d7d038ebbb36a4f9d3) | `` chore: update flakes (#990) ``       |