### PR TITLE
chore(flake/apple-fonts): `bb4d5244` -> `ce044f68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         "sf-pro": "sf-pro"
       },
       "locked": {
-        "lastModified": 1781881853,
-        "narHash": "sha256-JawESccafFrnpr1YPYc2Xd7WaBJvbE+4FLZzWY3AfJU=",
+        "lastModified": 1782587760,
+        "narHash": "sha256-I9PRLePA5QNKEyDFsN5eIVk0dxFRGAL0Z/LjOWnA75Y=",
         "owner": "Lyndeno",
         "repo": "apple-fonts.nix",
-        "rev": "bb4d5244052c1f6cae543baea793bf44f3f8bfb4",
+        "rev": "ce044f6829c6b3ccde9624116577ba2c173ca49d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                 |
| -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`ce044f68`](https://github.com/Lyndeno/apple-fonts.nix/commit/ce044f6829c6b3ccde9624116577ba2c173ca49d) | `` feat: README section for overlays `` |
| [`545978be`](https://github.com/Lyndeno/apple-fonts.nix/commit/545978be8a55606df71bcaa0564a94f3415904ee) | `` feat: Formatting ``                  |
| [`bd31c957`](https://github.com/Lyndeno/apple-fonts.nix/commit/bd31c9575e3b49114963efc7fab4038aec6157fa) | `` feat: Add overlay ``                 |
| [`de6c044e`](https://github.com/Lyndeno/apple-fonts.nix/commit/de6c044e84451ac5435aa4ec0e350e8ed7a03ed1) | `` feat: Use callPackage pattern ``     |