### PR TITLE
chore(flake/home-manager): `5d320ab3` -> `8d8a6cc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -530,11 +530,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782423922,
-        "narHash": "sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4=",
+        "lastModified": 1782522538,
+        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d320ab301cfaaca7d32514f13815d19d109f5f4",
+        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`8d8a6cc5`](https://github.com/nix-community/home-manager/commit/8d8a6cc50ddc60748791a14ee1163c865ec57635) | `` gpg: make package optional ``                  |
| [`6eba758f`](https://github.com/nix-community/home-manager/commit/6eba758fee9d6de3c3e6cedb407423a4174b14e5) | `` uv: prune Python versions and tools by diff `` |