### PR TITLE
chore(flake/niri): `ba9f0b1b` -> `b66e20b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1782484870,
-        "narHash": "sha256-jHXeI3bN4i6YACmv5Zcvu/OscRd7F6EjNSdOzr7H9Gg=",
+        "lastModified": 1782515860,
+        "narHash": "sha256-7vtZ/hzih/wwFGWS4G9SLKGNWBMyOE2qBkVO0NRcWdU=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "ba9f0b1bf70a3d25839432558f4b666b5e764583",
+        "rev": "b66e20b38c3dca6f1f3d950ece62cb8a6fcad354",
         "type": "github"
       },
       "original": {
@@ -697,11 +697,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1782233679,
-        "narHash": "sha256-QyuGP5+QOtmXpy4i2X4DhBVBaySBdDKQEhqKcphcp34=",
+        "lastModified": 1782375420,
+        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "667d5cf1c59585031d743c78b394b0a647537c35",
+        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`b66e20b3`](https://github.com/epireyn/niri-flake/commit/b66e20b38c3dca6f1f3d950ece62cb8a6fcad354) | `` Update flake.lock `` |