### PR TITLE
chore(flake/nixpkgs-stable): `667d5cf1` -> `4062d36e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1782233679,
-        "narHash": "sha256-QyuGP5+QOtmXpy4i2X4DhBVBaySBdDKQEhqKcphcp34=",
+        "lastModified": 1782375420,
+        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "667d5cf1c59585031d743c78b394b0a647537c35",
+        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`13fa8896`](https://github.com/NixOS/nixpkgs/commit/13fa88967f1c42896839ec1f98b457eab19f57cc) | `` librewolf-unwrapped: 152.0.1-2 -> 152.0.2-1 ``                        |
| [`d247ce0b`](https://github.com/NixOS/nixpkgs/commit/d247ce0b6d1a469fe673f6f2c3d3be34c77a9720) | `` perl5Packages.ModuleCPANTSAnalyse: skip failing test ``               |
| [`be04fab4`](https://github.com/NixOS/nixpkgs/commit/be04fab4f22d3250feac44520879b66ae7cb9d3d) | `` ci/treefmt: enable or-identifier rule ``                              |
| [`b4b2dae6`](https://github.com/NixOS/nixpkgs/commit/b4b2dae6671adca867bbfb5c4264c7ad07c24653) | `` psi-plus: 1.5.2139 -> 1.5.2140 ``                                     |
| [`5361ea3c`](https://github.com/NixOS/nixpkgs/commit/5361ea3c007dceed7cbe76de159094f46dfad5d6) | `` fbida: 2.14->2.15 ``                                                  |
| [`236476c9`](https://github.com/NixOS/nixpkgs/commit/236476c9d87430f5e01e3045ef275e7c8d27ed89) | `` cudaPackages.tensorrt-samples: Add support for 10.16.1 ``             |
| [`5d1bf94b`](https://github.com/NixOS/nixpkgs/commit/5d1bf94b7679af02c6ed8f06423e6d0df008ba6c) | `` cudaPackages.tensorrt: Add TensorRT 10.16.1 manifest ``               |
| [`19dea33e`](https://github.com/NixOS/nixpkgs/commit/19dea33e1a4d0447b3aa3962ee6a18f2978517c8) | `` maintainers/matrix: rm inactive people ``                             |
| [`a8a54e88`](https://github.com/NixOS/nixpkgs/commit/a8a54e8888bcca0d3f1306affc716c40213d0d33) | `` maintainers/matrix: rescope the team ``                               |
| [`9d6726fa`](https://github.com/NixOS/nixpkgs/commit/9d6726fa718751c361f8c3cf8595a5bbd38dab02) | `` maintainers/matrix: add transcaffeine ``                              |
| [`880079db`](https://github.com/NixOS/nixpkgs/commit/880079db18c96a2f7cd8128b24c16614a0b07727) | `` home-assistant: ignore install method deprecation ``                  |
| [`0960784a`](https://github.com/NixOS/nixpkgs/commit/0960784a8ca76415f1b9afb153ef458328d2bfcf) | `` home-assistant: backport pyjwt 2.13.0 support ``                      |
| [`919ca6fd`](https://github.com/NixOS/nixpkgs/commit/919ca6fd5ae0ed04b5e209bad78ce9f702980f0e) | `` nixos/lib/utils: fix escapeSystemdPath for paths with "." segments `` |
| [`a3360ac0`](https://github.com/NixOS/nixpkgs/commit/a3360ac07a5559f431d41cb645a75318d533af89) | `` spaceship-prompt: 4.22.3 -> 4.22.4 ``                                 |
| [`cdcc5376`](https://github.com/NixOS/nixpkgs/commit/cdcc5376bcdd78eb0a92cdd828740ec314f3c1b8) | `` chromium,chromedriver: 149.0.7827.155 -> 149.0.7827.196 ``            |
| [`f42f810d`](https://github.com/NixOS/nixpkgs/commit/f42f810d6df50b238c017f4a70c128e0e052f987) | `` glpi-agent: 1.17 -> 1.18 ``                                           |
| [`eb7eb4a7`](https://github.com/NixOS/nixpkgs/commit/eb7eb4a7675407143369ad6109238cd783f1dbe8) | `` filebrowser-quantum: 1.3.3-stable -> 1.4.0-stable ``                  |
| [`20c9f8e7`](https://github.com/NixOS/nixpkgs/commit/20c9f8e7af57e50f20deb3d06d4496792a6032eb) | `` pipeline: 4.0.3 -> 4.0.4 ``                                           |
| [`349aac28`](https://github.com/NixOS/nixpkgs/commit/349aac2878df1969caa7aadd6ab055188f535560) | `` ocamlPackages.melange: 6.0.1 → 7.0.0 ``                               |
| [`4b7e7991`](https://github.com/NixOS/nixpkgs/commit/4b7e79918019668cb7d9620d943adcfdb56daff2) | `` krita: 6.0.1 -> 6.0.2.1 ``                                            |
| [`88b2264e`](https://github.com/NixOS/nixpkgs/commit/88b2264e053804588ace168d8cd6f9e94aa271e9) | `` umami: use finalAttrs pattern on prisma override ``                   |
| [`700498bf`](https://github.com/NixOS/nixpkgs/commit/700498bfbe92542accb0450841360dc02f69d786) | `` reason: 3.17.3 → 3.18.0 ``                                            |
| [`c9fd2bba`](https://github.com/NixOS/nixpkgs/commit/c9fd2bba84f3bfce734b123e2e099fa25b2c08cf) | `` ocamlPackages.pbrt: 2.4 → 4.1 ``                                      |
| [`4fcb12a1`](https://github.com/NixOS/nixpkgs/commit/4fcb12a11d50945b78e37ec40833b0a4897c285c) | `` tauno-monitor: set __structuredAttrs ``                               |
| [`67ee5465`](https://github.com/NixOS/nixpkgs/commit/67ee54651609454a53dc49ded55b7d4f1d34be65) | `` librepods: set __structuredAttrs & strictDeps ``                      |
| [`6934efb5`](https://github.com/NixOS/nixpkgs/commit/6934efb5f5ff31e7fa5b02871750fb041e67e669) | `` jocalsend: set __structuredAttrs ``                                   |
| [`1890b88e`](https://github.com/NixOS/nixpkgs/commit/1890b88ebcff984beb8004896bb561e73bd74239) | `` netpeek: set __structuredAttrs ``                                     |
| [`3705ded2`](https://github.com/NixOS/nixpkgs/commit/3705ded24b2cc54a2983839e42b892b63db60be9) | `` gradia: set __structuredAttrs ``                                      |
| [`8923f991`](https://github.com/NixOS/nixpkgs/commit/8923f991fd3057f0b49561be0739af20716d272c) | `` andcli: set __structuredAttrs ``                                      |
| [`34bed22d`](https://github.com/NixOS/nixpkgs/commit/34bed22d1d87f2fe7673b3d5e3449731d4f60555) | `` beamPackages.elixir_1_20: 1.20.1 -> 1.20.2 ``                         |
| [`7bc05d4c`](https://github.com/NixOS/nixpkgs/commit/7bc05d4cd8fe6a30030f3e7c140108c773689cd5) | `` beamPackages.elixir_1_20: 1.20.0 -> 1.20.1 ``                         |
| [`2b5a0de4`](https://github.com/NixOS/nixpkgs/commit/2b5a0de41bccc9a4b57e32e687e6d957aaacefa7) | `` librewolf-bin-unwrapped: 152.0-1 -> 152.0.2-1 ``                      |
| [`6bf65c09`](https://github.com/NixOS/nixpkgs/commit/6bf65c091b58aaf8d2cd57746422ebca41eb51d7) | `` mysql84: add nixosTests.mysql.mysql84 to passthru.tests ``            |
| [`0fecee37`](https://github.com/NixOS/nixpkgs/commit/0fecee37ee1059f630da142cc55068e9f389cdd3) | `` nixos/mysql: fix initalScript option after security fix ``            |
| [`bd6b44a5`](https://github.com/NixOS/nixpkgs/commit/bd6b44a59da2b1baef0d4c53e5d41c1500e0246e) | `` nono: 0.57.0 -> 0.61.1 ``                                             |
| [`73395186`](https://github.com/NixOS/nixpkgs/commit/733951864f9e0cc6c007d267a8d53a5fbe36e620) | `` nono: 0.53.0 -> 0.57.0 ``                                             |
| [`0e85ceb2`](https://github.com/NixOS/nixpkgs/commit/0e85ceb28656369d6d86f290b2c39370795107b6) | `` zellij-unwrapped: split out from zellij wrapper ``                    |
| [`02a1110f`](https://github.com/NixOS/nixpkgs/commit/02a1110fb1137fffeab352c7e5551d090873f17e) | `` zellijPlugins: init ``                                                |
| [`14b70a3d`](https://github.com/NixOS/nixpkgs/commit/14b70a3d33f96ef409a3d9961c2143cee5604de7) | `` zellij: rename package file name ``                                   |
| [`631af7a0`](https://github.com/NixOS/nixpkgs/commit/631af7a022f183bd8ccbc7a0ab4252f6989a21d0) | `` spire: 1.15.0 -> 1.15.1 ``                                            |
| [`97e8fec4`](https://github.com/NixOS/nixpkgs/commit/97e8fec4c29215c3c9f791ba4b1c8f8f2320b94d) | `` spire: 1.14.6 -> 1.15.0 ``                                            |
| [`f7f7c687`](https://github.com/NixOS/nixpkgs/commit/f7f7c687452f2c6cee9f931ddfec5cd330f57f72) | `` mattermostLatest: 11.7.2 -> 11.7.3 ``                                 |
| [`dbedf641`](https://github.com/NixOS/nixpkgs/commit/dbedf641d8c2de8ebfa16a0348fbd0796c9d935c) | `` stoat-desktop: 1.3.0 -> 1.4.0 ``                                      |
| [`a19c447d`](https://github.com/NixOS/nixpkgs/commit/a19c447dd3306ed4b65e8e11aae7ce5469689702) | `` mattermostLatest: 11.7.0 -> 11.8.1 ``                                 |
| [`cad6ead0`](https://github.com/NixOS/nixpkgs/commit/cad6ead0c17a8a0130634c99b5ad5bdf75a2db7e) | `` blackfire: 2026.6.0 -> 2026.6.1 ``                                    |
| [`726464a2`](https://github.com/NixOS/nixpkgs/commit/726464a29d2f64718868297fe355b534ab1252cd) | `` jackett: 0.24.2066 -> 0.24.2108 ``                                    |
| [`c26dab37`](https://github.com/NixOS/nixpkgs/commit/c26dab37681d99c88d579bd00eb283a9a677c34a) | `` bluesky-pds: 0.4.5001 -> 0.4.5006 ``                                  |
| [`fa44f5d5`](https://github.com/NixOS/nixpkgs/commit/fa44f5d56084f5cfb97eabbb59cadaeba50a75b3) | `` misskey: 2026.5.4 -> 2026.6.0 ``                                      |
| [`02f6cf06`](https://github.com/NixOS/nixpkgs/commit/02f6cf065e51b7933bca88716f189a6f830945c9) | `` repath-studio: 0.4.15 -> 0.4.16 ``                                    |
| [`056d979c`](https://github.com/NixOS/nixpkgs/commit/056d979c2dbac6a5969ce7e62512c31aeba6e4db) | `` ocamlPackages.eliom: 12.0.1 -> 12.1.0 ``                              |
| [`b8366ce1`](https://github.com/NixOS/nixpkgs/commit/b8366ce116010da7a7cba3451f9832397b29a20d) | `` lix: remove broken perf patch from curl ``                            |
| [`18c5cfee`](https://github.com/NixOS/nixpkgs/commit/18c5cfee8502c8e05688b89cd9fdace1e52f4154) | `` sub-store-frontend: 2.17.36 -> 2.26.5 ``                              |
| [`af1765be`](https://github.com/NixOS/nixpkgs/commit/af1765be25024ad313f0d2e52b8ccea74deda995) | `` cuda-modules: Allow SBSA Orin to use CUDA 13+ ``                      |
| [`9b491fa4`](https://github.com/NixOS/nixpkgs/commit/9b491fa4a29bd0bdba0d9abe34cb2e7c323d6b81) | `` nezha-theme-admin: 2.0.4 -> 2.2.4 ``                                  |
| [`d0ccb467`](https://github.com/NixOS/nixpkgs/commit/d0ccb46760f7ddaa247f1d1c7fda58367341e632) | `` nix-eval-jobs: 2.34.1 -> 2.34.3 ``                                    |
| [`89e0f580`](https://github.com/NixOS/nixpkgs/commit/89e0f58061bbae3fb73505d8fd7366bdeca08f28) | `` openblas: disable checks on i686-linux ``                             |
| [`618106be`](https://github.com/NixOS/nixpkgs/commit/618106be0e8bfc657247ab94b00daea5418d1cce) | `` google-chrome: 149.0.7827.155 -> 149.0.7827.196 ``                    |
| [`2b80d342`](https://github.com/NixOS/nixpkgs/commit/2b80d3422c26c84f27ebf091adeb5f1ae8eb6b35) | `` drupal: 11.3.11 -> 11.3.13 ``                                         |
| [`b26de807`](https://github.com/NixOS/nixpkgs/commit/b26de807bb998f6ff5c20f6c1a67cb5aa900c8a4) | `` lighttpd: 1.4.83 -> 1.4.84 ``                                         |
| [`c20a8ad1`](https://github.com/NixOS/nixpkgs/commit/c20a8ad15528e3c5312c65cecb69afa9344374b1) | `` hyprland: 0.55.3 -> 0.55.4 ``                                         |
| [`1514058b`](https://github.com/NixOS/nixpkgs/commit/1514058bccc50066037bc5c48f1d513c80c6b238) | `` nodejs_22: 22.23.0 -> 22.23.1 ``                                      |
| [`94b6ebdf`](https://github.com/NixOS/nixpkgs/commit/94b6ebdff364376173bda6587d9f9451113a3d9c) | `` microsoft-edge: 149.0.4022.69 -> 149.0.4022.80 ``                     |
| [`c259a198`](https://github.com/NixOS/nixpkgs/commit/c259a1984eac5f4fd83bc7859ca9e3794eaa120a) | `` python3Packages.pypdf: 6.13.2 -> 6.14.2 ``                            |
| [`29f04b62`](https://github.com/NixOS/nixpkgs/commit/29f04b62bf4228e62c9ed3821090e50d7be27579) | `` mariadb_118: 11.8.5 -> 11.8.8 ``                                      |
| [`8868f794`](https://github.com/NixOS/nixpkgs/commit/8868f794b9b986141268057646a496a95b96e342) | `` mariadb_114: 11.4.9 -> 11.4.12 ``                                     |
| [`34f87fc2`](https://github.com/NixOS/nixpkgs/commit/34f87fc250155ebb095c12fe7b52c8475e2c26b2) | `` mariadb_1011: 10.11.15 -> 10.11.18 ``                                 |
| [`d30ce91e`](https://github.com/NixOS/nixpkgs/commit/d30ce91effef97f43f6c7760aeaded0af74d7b54) | `` mariadb_106: 10.6.24 -> 10.6.27 ``                                    |
| [`a02b6baa`](https://github.com/NixOS/nixpkgs/commit/a02b6baa5e3b1d4287b8d9c632bb7f1c4424252b) | `` homebank: 5.10.1 -> 5.10.2 ``                                         |
| [`9412a9f3`](https://github.com/NixOS/nixpkgs/commit/9412a9f3b2dfb412e496b807dfc37a3e1a3739a7) | `` firefox-bin-unwrapped: 152.0.1 -> 152.0.2 ``                          |
| [`22394783`](https://github.com/NixOS/nixpkgs/commit/2239478309071e99d8af97f687adfbaa5dafb716) | `` firefox-unwrapped: 152.0.1 -> 152.0.2 ``                              |
| [`285044a0`](https://github.com/NixOS/nixpkgs/commit/285044a06bd14e1d0f2eec1eded15af1a5e82a04) | `` pnpm_11: 11.6.0 -> 11.8.0 ``                                          |
| [`5bffbbd3`](https://github.com/NixOS/nixpkgs/commit/5bffbbd3910519438cdc04b68736eb822dd4785c) | `` python3Packages.pynitrokey: 0.12.2 -> 0.12.3 ``                       |
| [`f50f6ea0`](https://github.com/NixOS/nixpkgs/commit/f50f6ea0f3f4bf5bb044e2438f695bbc386ea228) | `` librenms: 26.5.1 -> 26.6.1 ``                                         |