### PR TITLE
chore(flake/freminal): `76877a5d` -> `2fa7791a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -376,11 +376,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781898107,
-        "narHash": "sha256-SMZkuCiMPhhCLtIcZXU+OrdGKDOTgATRPhNukp+M9m8=",
+        "lastModified": 1782620987,
+        "narHash": "sha256-IkZ7jeCB8cIP4HcRnP0x/vUUewuGyuRPkb4ttOHhPww=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "76877a5d1a59b0abde78ec74374fd432eb6df668",
+        "rev": "2fa7791a25ac96d93b9ffcd70ab753c459d897fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`e315c9e9`](https://github.com/fredsystems/freminal/commit/e315c9e9737265f2595e3cfbdf2eff757be1631e) | `` fix: harden last_session.toml against corruption and startup failure `` |
| [`3523e782`](https://github.com/fredsystems/freminal/commit/3523e7820f5494344b56bd8603eb191f7dea2003) | `` build: bump egui to 0.35 and release 0.10.1 ``                          |