### PR TITLE
feat: add libvirt/QEMU virtualization for maranello

### DIFF
--- a/features/default.nix
+++ b/features/default.nix
@@ -10,7 +10,10 @@
     ./media
     ./shell
   ]
-  ++ lib.optional isDesktop ./desktop;
+  ++ lib.optionals isDesktop [
+    ./desktop
+    ./virtualization
+  ];
 
   config = {
     services.xserver.xkb = {

--- a/features/virtualization/default.nix
+++ b/features/virtualization/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  user,
+  extraUsers ? [ ],
+  ...
+}:
+let
+  allUsers = [ user ] ++ extraUsers;
+in
+{
+  imports = [
+    ./libvirt
+  ];
+
+  options.virtualization.libvirt = {
+    enable = lib.mkEnableOption "libvirt/QEMU/KVM virtualization with virt-manager";
+
+    enableVirtManager = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Install the virt-manager graphical VM management GUI.";
+    };
+
+    enableUsbRedirection = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable SPICE USB redirection for host-to-guest USB passthrough.";
+    };
+
+    enableTpm = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable swtpm (TPM emulation) for guests.";
+    };
+
+    autoconnect = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Auto-connect virt-manager to qemu:///system on launch (per-user dconf).";
+    };
+
+    defaultNetwork.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Define and autostart the default libvirt NAT network (virbr0), plus trust the bridge in the firewall.";
+    };
+
+    users = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = allUsers;
+      description = "Users to add to the libvirtd group for VM management without root.";
+    };
+  };
+}

--- a/features/virtualization/libvirt/default.nix
+++ b/features/virtualization/libvirt/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.virtualization.libvirt;
+
+  # XML definition of the stock libvirt "default" NAT network (virbr0).
+  # libvirt does not start or autostart this network on a fresh NixOS host,
+  # and there is no native NixOS option to declare it, so we define it
+  # ourselves and bring it up via a oneshot ordered after libvirtd.
+  defaultNetworkXml = pkgs.writeText "libvirt-default-network.xml" ''
+    <network>
+      <name>default</name>
+      <forward mode="nat">
+        <nat>
+          <port start="1024" end="65535"/>
+        </nat>
+      </forward>
+      <bridge name="virbr0" stp="on" delay="0"/>
+      <ip address="192.168.122.1" netmask="255.255.255.0">
+        <dhcp>
+          <range start="192.168.122.2" end="192.168.122.254"/>
+        </dhcp>
+      </ip>
+    </network>
+  '';
+in
+{
+  config = lib.mkIf cfg.enable {
+    # QEMU/KVM via libvirtd. KVM is an in-tree kernel module, so this does
+    # not pull in out-of-tree modules that rebuild on every kernel bump
+    # (unlike VirtualBox), and everything here is free software served from
+    # the binary cache.
+    virtualisation.libvirtd = {
+      enable = true;
+      qemu = {
+        package = pkgs.qemu_kvm;
+        swtpm.enable = cfg.enableTpm;
+      };
+    };
+
+    # SPICE USB redirection — native USB passthrough to guests, the
+    # open-source replacement for VirtualBox's unfree extension pack.
+    virtualisation.spiceUSBRedirection.enable = cfg.enableUsbRedirection;
+
+    programs.virt-manager.enable = cfg.enableVirtManager;
+
+    # Membership in the libvirtd group lets these users manage VMs without
+    # root and satisfies the polkit action 'org.libvirt.unix.manage', so
+    # virt-manager does not error out with "no polkit agent available".
+    users.groups.libvirtd.members = cfg.users;
+
+    # Make virt-manager auto-connect to the system QEMU instance on launch
+    # instead of opening a disconnected window. Applied per-user via dconf.
+    home-manager.users = lib.mkIf cfg.autoconnect (
+      lib.genAttrs cfg.users (_: {
+        dconf.settings."org/virt-manager/virt-manager/connections" = {
+          autoconnect = [ "qemu:///system" ];
+          uris = [ "qemu:///system" ];
+        };
+      })
+    );
+
+    # On recent nixpkgs the firewall blocks DHCP/DNS on virbr0, leaving
+    # guests without an IP or internet. Trusting the bridge restores NAT
+    # connectivity for the default network.
+    networking.firewall.trustedInterfaces = lib.mkIf cfg.defaultNetwork.enable [ "virbr0" ];
+
+    # Define and autostart the default NAT network declaratively so a fresh
+    # rebuild has working guest networking without any manual `virsh` steps.
+    systemd.services.libvirt-default-network = lib.mkIf cfg.defaultNetwork.enable {
+      description = "Define and autostart the libvirt default network";
+      after = [ "libvirtd.service" ];
+      requires = [ "libvirtd.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        virsh="${pkgs.libvirt}/bin/virsh -c qemu:///system"
+        if ! $virsh net-info default >/dev/null 2>&1; then
+          $virsh net-define ${defaultNetworkXml}
+        fi
+        $virsh net-autostart default
+        if ! $virsh net-info default | grep -q 'Active:.*yes'; then
+          $virsh net-start default
+        fi
+      '';
+    };
+  };
+}

--- a/hosts/linux/maranello/configuration.nix
+++ b/hosts/linux/maranello/configuration.nix
@@ -40,6 +40,8 @@ in
     enable_streaming = true;
   };
 
+  virtualization.libvirt.enable = true;
+
   boot = {
     kernelPackages = pkgs.linuxPackages_latest;
 


### PR DESCRIPTION
## Summary

Adds a `virtualization` feature module that enables libvirt/QEMU/KVM on **maranello only**.

- libvirtd + QEMU/KVM (`qemu_kvm`)
- virt-manager GUI
- SPICE USB redirection (native USB passthrough)
- swtpm (TPM emulation)
- libvirtd group membership for the host's users (fixes the polkit `org.libvirt.unix.manage` error)
- virt-manager auto-connect to `qemu:///system` via per-user dconf
- declaratively defined + autostarted default NAT network (virbr0) via a systemd oneshot, plus `networking.firewall.trustedInterfaces = [ "virbr0" ]` (otherwise the firewall blocks DHCP/DNS and guests get no IP on current nixpkgs)

## Why libvirt over VirtualBox

VirtualBox builds out-of-tree kernel modules that rebuild on every kernel bump — and maranello runs `linuxPackages_latest`, so that's nearly every flake update. Its USB-passthrough extension pack is also unfree and never cached, so it compiles locally each time. KVM is in-tree and everything here is cached free software, so no recurring local recompiles.

## Scope

- Module imported for desktops via `features/default.nix` (`isDesktop`-gated), enabled only in maranello's `configuration.nix`. All config is guarded by `cfg.enable`, so Daytona is unaffected.

## Verification

- `nixfmt` / `statix` / `deadnix` pass (pre-commit clean)
- `nix eval` of maranello `system.build.toplevel` and home-manager activation: clean
- Daytona toplevel eval: unchanged from baseline