### PR TITLE
fix: route Hyprland portal FileChooser to gtk backend

### DIFF
--- a/features/desktop/environments/hyprland/default.nix
+++ b/features/desktop/environments/hyprland/default.nix
@@ -35,6 +35,22 @@ in
     # exit completes.
     environment.systemPackages = [ pkgs.hyprshutdown ];
 
+    # xdg-desktop-portal-hyprland does not implement the FileChooser interface,
+    # and the implicit hyprland;gtk fallback chain does not reliably fall
+    # through to the gtk backend for it — leaving rfd/Firefox/Flatpak native
+    # file dialogs broken ("No such interface org.freedesktop.portal.
+    # FileChooser"). Route FileChooser explicitly to the gtk backend (which is
+    # always present via xdg.portal.extraPortals in common.nix) while keeping
+    # screencast/screenshot on the hyprland backend. The `hyprland` config key
+    # matches XDG_CURRENT_DESKTOP under this compositor.
+    xdg.portal.config.hyprland = {
+      default = [
+        "hyprland"
+        "gtk"
+      ];
+      "org.freedesktop.impl.portal.FileChooser" = [ "gtk" ];
+    };
+
     # xdg-desktop-portal-hyprland segfaults when Hyprland exits (a bug in xdph
     # itself), then restarts 6 times in rapid succession against a dead
     # compositor and hits the burst limit — leaving it permanently dead for the
@@ -54,6 +70,22 @@ in
     };
 
     home-manager.users = lib.genAttrs allUsers (_: {
+
+      # The xdg-desktop-portal daemon discovers portal *definition* files
+      # (`*.portal`) by scanning `xdg-desktop-portal/portals` under each
+      # XDG_DATA_DIRS entry, and the per-user profile
+      # (`/etc/profiles/per-user/<user>/share`) is on that path. home-manager's
+      # `wayland.windowManager.hyprland` integration installs only
+      # `xdg-desktop-portal-hyprland` into that profile, so the gtk backend's
+      # `gtk.portal` definition is absent from the user profile. The
+      # system-level `FileChooser=gtk` routing (above) then resolves to a
+      # backend the daemon reports as "Requested gtk.portal is unrecognized",
+      # and rfd/Firefox/Flatpak get "No such interface
+      # org.freedesktop.portal.FileChooser". Installing the gtk portal here
+      # places `gtk.portal` next to `hyprland.portal` in the user profile so
+      # the routing resolves. The system-level `xdg.portal.extraPortals` entry
+      # in common.nix keeps the backend's D-Bus/systemd activation wired up.
+      home.packages = [ pkgs.xdg-desktop-portal-gtk ];
 
       # wayland.windowManager.hyprland generates a broken stub unit at
       # ~/.config/systemd/user/xdg-desktop-portal-hyprland.service that only

--- a/features/desktop/environments/modules/wayle/default.nix
+++ b/features/desktop/environments/modules/wayle/default.nix
@@ -403,6 +403,7 @@ in
               label-max-length = 20;
               icon-mappings = {
                 "freminal" = "freminal";
+                "frext" = "frext";
               };
             };
 


### PR DESCRIPTION
## Problem

On the Hyprland desktops (maranello, Daytona), GUI apps that open a native file dialog via the XDG desktop portal fail:

```
ERROR rfd::backend::xdg_desktop_portal::portal] OpenFile failed:
  org.freedesktop.DBus.Error.UnknownMethod:
  No such interface "org.freedesktop.portal.FileChooser"
  on object at path /org/freedesktop/portal/desktop
```

## Root cause (two layers)

1. `xdg-desktop-portal-hyprland` does not implement the `FileChooser` interface, and the implicit `default=hyprland;gtk` chain in the generated `hyprland-portals.conf` does not reliably fall through to gtk for it.
2. Even with explicit routing, the gtk backend's `gtk.portal` *definition* file is absent from the per-user home-manager profile that the portal daemon scans — home-manager's `wayland.windowManager.hyprland` integration installs only `xdg-desktop-portal-hyprland` there. The daemon then reports `Requested gtk.portal is unrecognized` and never provides the FileChooser interface.

## Fix

In `features/desktop/environments/hyprland/default.nix`:

- **System level**: `xdg.portal.config.hyprland` routes `org.freedesktop.impl.portal.FileChooser` to `gtk` while keeping `default = [ "hyprland" "gtk" ]` so screencast/screenshot stay on the hyprland backend.
- **home-manager level**: `home.packages = [ pkgs.xdg-desktop-portal-gtk ]` so `gtk.portal` lands next to `hyprland.portal` in the per-user portals directory the daemon reads.

`xdg-desktop-portal-gtk` was already in `xdg.portal.extraPortals` (common.nix) for D-Bus/systemd activation; this PR makes the definition reachable by the daemon. The hyprland backend is not disabled and screencast/screenshot are untouched.

## Verification

- nixfmt + statix + deadnix pass (pre-commit clean).
- Built `home-manager.users.fred.home.path` for both **maranello** and **Daytona**; the resulting `share/xdg-desktop-portal/portals/` now contains **both** `gtk.portal` and `hyprland.portal` (previously only `hyprland.portal`).
- Confirmed the generated `hyprland-portals.conf` contains `org.freedesktop.impl.portal.FileChooser=gtk`.
- Ran the actual `xdg-desktop-portal` daemon (verbose) in the live environment: it now logs `Using gtk.portal for org.freedesktop.impl.portal.FileChooser (config)` -> `providing portal org.freedesktop.portal.FileChooser`, and `busctl --user introspect org.freedesktop.portal.Desktop /org/freedesktop/portal/desktop` shows the `org.freedesktop.portal.FileChooser` interface present.

## Note for deploy

`nixos-rebuild switch` does not restart the running `xdg-desktop-portal` user service, which caches its backend set at startup. After activating, restart it (or re-login):

```sh
systemctl --user restart xdg-desktop-portal.service
```

## Impacted hosts

maranello, Daytona (Hyprland desktops). Change lives in a `features/desktop/*` module → CI classifies as desktop-global.

---

## Additional change

`feat: map frext to its icon in the wayle window-title bar` — adds `frext` to the wayle bar `window-title.icon-mappings` alongside `freminal` so frext windows show the correct icon. Separate atomic commit on the same branch.