### PR TITLE
chore(flake/home-manager): `8d8a6cc5` -> `5d72a29f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782522538,
-        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
+        "lastModified": 1782749631,
+        "narHash": "sha256-slFTUgDy0KTPA4LBAmC/9SngDq8GCPdX+ZR0yQHHN1E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
+        "rev": "5d72a29fc36ac21adae6ae35568fe5ee6700850f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`5d72a29f`](https://github.com/nix-community/home-manager/commit/5d72a29fc36ac21adae6ae35568fe5ee6700850f) | `` hyprpaper: add system target option ``                             |
| [`8f096963`](https://github.com/nix-community/home-manager/commit/8f096963ae8f4ddae0f887545ac601657ac3e474) | `` maintainers: regenerate all-maintainers ``                         |
| [`7042d2b3`](https://github.com/nix-community/home-manager/commit/7042d2b31b5cdca1454555332dd19e8f759e6678) | `` lib/nix: use locked nixpkgs for maintainer extraction ``           |
| [`9eec3ef0`](https://github.com/nix-community/home-manager/commit/9eec3ef087f544c443e0be79e112f31103db8289) | `` maintainers: remove quoted names in set ``                         |
| [`789a35fb`](https://github.com/nix-community/home-manager/commit/789a35fbdeb3c46b260096daa0b321c11be527ea) | `` maintainers: remove duplicate maintainers ``                       |
| [`2c661cc9`](https://github.com/nix-community/home-manager/commit/2c661cc960846ee4c36db592bc0354ab019a8e5a) | `` flake: bump nixpkgs from `3e41b24` to `89570f2` ``                 |
| [`1cba40f9`](https://github.com/nix-community/home-manager/commit/1cba40f9317c8aef79b02de7f84d729236d162fc) | `` vscode: refactor profile paths to use unified profileDir helper `` |
| [`abeeea12`](https://github.com/nix-community/home-manager/commit/abeeea1221a356158bc81b1ff285bf3b9c19991a) | `` vscode: fix userMcp option example syntax ``                       |
| [`4ad9aaae`](https://github.com/nix-community/home-manager/commit/4ad9aaae70c9aaab504127f926c0fa9cfbc2b365) | `` generic-linux-gpu: add EGL support for Nvidia ``                   |