### PR TITLE
chore(flake/nixvim): `dbf9550d` -> `c6a99bb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -981,11 +981,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1782254890,
-        "narHash": "sha256-kjsEECqhpPnJWqhooXp6tWh2qGQftCPAo2G1GvZtKdw=",
+        "lastModified": 1782706849,
+        "narHash": "sha256-b2ODGxKD3hgrwuesLtDomp2DKF3UiOn3+EBTDXpcqGo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "dbf9550dba8448b03e11d58e5695d6c44a464554",
+        "rev": "c6a99bb41fb0f37e03ca38b1d81b006e98e3bf1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`c6a99bb4`](https://github.com/nix-community/nixvim/commit/c6a99bb41fb0f37e03ca38b1d81b006e98e3bf1a) | `` modules/nixpkgs: warn about platform specs `` |
| [`adfa139f`](https://github.com/nix-community/nixvim/commit/adfa139f94e2249afa3acdc2e360749b727cf752) | `` wrappers: inherit platform config tuples ``   |