### PR TITLE
chore(flake/freminal): `2fa7791a` -> `0e4b0b34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1782620987,
-        "narHash": "sha256-IkZ7jeCB8cIP4HcRnP0x/vUUewuGyuRPkb4ttOHhPww=",
+        "lastModified": 1782754101,
+        "narHash": "sha256-lSGpgqwH15gGMslI+X4PdmMntUkiL5R0ibZjoAFun4c=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "2fa7791a25ac96d93b9ffcd70ab753c459d897fd",
+        "rev": "0e4b0b34d0ce27faf795473daf711dabe407d1ea",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781666412,
-        "narHash": "sha256-Tzgol+o9+V4lK99r4AERI4pyFoZwg6Si2xUd1wc/WQU=",
+        "lastModified": 1782703273,
+        "narHash": "sha256-WJPfr9EAWVIuTMyb/ilHKUYlg/RNa0xrNiWR+p1iHUg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d0e019d9543f0f1215a3d961fc4dca59aa29c638",
+        "rev": "5106a604b3d67cffe8eb51a8bd9f04e607f0d31d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`6d6d0b69`](https://github.com/fredsystems/freminal/commit/6d6d0b69f108531efdc4ea0040d3cc0481357ffe) | `` chore(deps): lock file maintenance ``                                              |
| [`4a334f6f`](https://github.com/fredsystems/freminal/commit/4a334f6fc23ed1e0c94fd970bb419efbb303fb65) | `` chore(deps): update actions/checkout action to v7 ``                               |
| [`344fec91`](https://github.com/fredsystems/freminal/commit/344fec91b0d354662e80e148acf0a43c78433941) | `` chore(deps): update actions/cache action to v6 ``                                  |
| [`0b5cb2df`](https://github.com/fredsystems/freminal/commit/0b5cb2dfd3bc38184cfe744ac6ff324045e3c057) | `` fix: declare GL/EGL runtime dependencies for the rpm ``                            |
| [`da3560ff`](https://github.com/fredsystems/freminal/commit/da3560ffebf67745535d89ba803171379bf49bcc) | `` chore: bump version to 0.10.2 ``                                                   |
| [`c06b271a`](https://github.com/fredsystems/freminal/commit/c06b271ac10066d1696f824f062dbdd495b57d2d) | `` chore(deps): update taiki-e/install-action action to v2.82.6 ``                    |
| [`bfe951d8`](https://github.com/fredsystems/freminal/commit/bfe951d8800c80fae1b5d51cf7a561750975806b) | `` chore(deps): update rust crate open to v5.3.6 ``                                   |
| [`72e3c0ec`](https://github.com/fredsystems/freminal/commit/72e3c0ec5a600c0e4c22b68f245a60ba578073da) | `` chore(deps): update rust crate arc-swap to v1.9.2 ``                               |
| [`6fdd474f`](https://github.com/fredsystems/freminal/commit/6fdd474f85df6674b3102b2b54f255ed9daba2b2) | `` chore(deps): update softprops/action-gh-release digest to 718ea10 ``               |
| [`5cd115ed`](https://github.com/fredsystems/freminal/commit/5cd115edba073a3b3a11cdf49a14ea4134ef35e7) | `` chore(deps): update dtolnay/rust-toolchain digest to 67ef31d ``                    |
| [`a3cac092`](https://github.com/fredsystems/freminal/commit/a3cac0926f1f5c7215e5d5bb83fe08e1ec9d6fc3) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 629b284 `` |
| [`0c92b270`](https://github.com/fredsystems/freminal/commit/0c92b2707e04a8fc047dfddd9178dc3b6705b1d4) | `` chore(deps): update actions/cache digest to caa2961 ``                             |
| [`44517c91`](https://github.com/fredsystems/freminal/commit/44517c91ea9427a96fad5c137acd2c71a11238b1) | `` feat: add `cargo xtask package-local` for portable local packages ``               |
| [`768e592f`](https://github.com/fredsystems/freminal/commit/768e592fdffd87fa82ba03e7819c4daf9e499837) | `` fix: declare correct deb runtime dependencies ``                                   |
| [`b0243911`](https://github.com/fredsystems/freminal/commit/b02439119ca950065aa3f74c918503b0ff5c8652) | `` fix: install full hicolor icon tree in deb/appimage bundles ``                     |
| [`e9d34977`](https://github.com/fredsystems/freminal/commit/e9d349777f5b0aa910764cb62970d85aa06a446d) | `` feat: refresh icon/logo and fix RPM icon installation ``                           |