### PR TITLE
chore(flake/niri): `b66e20b3` -> `9378abae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -679,11 +679,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1782515860,
-        "narHash": "sha256-7vtZ/hzih/wwFGWS4G9SLKGNWBMyOE2qBkVO0NRcWdU=",
+        "lastModified": 1782663639,
+        "narHash": "sha256-ACD9fV8NItTLSx6Zk85+cFN11CjZ0BhyG2ocCuzAd70=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "b66e20b38c3dca6f1f3d950ece62cb8a6fcad354",
+        "rev": "9378abaebb8db044ef4bbb2df05972e4a92eac07",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1782375420,
-        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`9378abae`](https://github.com/epireyn/niri-flake/commit/9378abaebb8db044ef4bbb2df05972e4a92eac07) | `` Update flake.lock `` |