### PR TITLE
chore(flake/home-manager-stable): `7bfff44b` -> `868d0a69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -653,11 +653,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781981105,
-        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
+        "lastModified": 1782704057,
+        "narHash": "sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
+        "rev": "868d0a692de703c2de98fab61968e4e310b7c28e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`868d0a69`](https://github.com/nix-community/home-manager/commit/868d0a692de703c2de98fab61968e4e310b7c28e) | `` generic-linux-gpu: add EGL support for Nvidia `` |