### PR TITLE
chore(flake/nixpkgs-stable): `4062d36e` -> `714a5f8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -816,11 +816,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1782375420,
-        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`d5d2b8a6`](https://github.com/NixOS/nixpkgs/commit/d5d2b8a6ef08c1a043884e5364bcfee2f492a5c1) | `` glances: 4.5.4 -> 4.5.5 ``                                                          |
| [`5db1641a`](https://github.com/NixOS/nixpkgs/commit/5db1641a3ddfb8a5788879dbc2698dbc1535f8da) | `` pnpm_10_29_2: mark insecure ``                                                      |
| [`4b6aed1d`](https://github.com/NixOS/nixpkgs/commit/4b6aed1d9a530d59b214791dcab27b0e851a3e58) | `` authelia: mark web build broken on darwin ``                                        |
| [`ccfb602b`](https://github.com/NixOS/nixpkgs/commit/ccfb602b885b3c752f81338dcabeae0e2eece464) | `` discord: recreate module symlinks on every launch ``                                |
| [`8a8a20ef`](https://github.com/NixOS/nixpkgs/commit/8a8a20ef2e737f56738bf12053c64e7bf066094a) | `` release-checks: Prevent meta.problem warnings ``                                    |
| [`168b18f6`](https://github.com/NixOS/nixpkgs/commit/168b18f6e3e8357d19b190bc3f7b5738c74ad500) | `` ci/eval: Allow preventing internal Nixpkgs use of certain problem kinds ``          |
| [`caeedbd7`](https://github.com/NixOS/nixpkgs/commit/caeedbd700498339b387bdf7e49071ca0245cfab) | `` ci/eval: Refactor attrpaths.nix to a more generic pre-eval.nix ``                   |
| [`3c4f976c`](https://github.com/NixOS/nixpkgs/commit/3c4f976c69ef38d87fccac361121d1399aff64ef) | `` config: Introduce attrPathsDisallowedForInternalUse ``                              |
| [`45a743c9`](https://github.com/NixOS/nixpkgs/commit/45a743c9f3d6d1f10611c882ddbb240fe81e6787) | `` meta.problems: Fill out output meta with final list of problems ``                  |
| [`ff79595a`](https://github.com/NixOS/nixpkgs/commit/ff79595a294f25ccb7777154a66ce5ef952280a0) | `` meta.problems: Internal refactoring ``                                              |
| [`c63637a6`](https://github.com/NixOS/nixpkgs/commit/c63637a6607e56568f01ab5e9fda64f3b9816313) | `` stdenv/problems: don't create pname variable ``                                     |
| [`5b0477b2`](https://github.com/NixOS/nixpkgs/commit/5b0477b28d30e609de4371de37e9067f78eda54d) | `` stdenv/problems: make handlerForProblem more performant with partial application `` |
| [`dc025af0`](https://github.com/NixOS/nixpkgs/commit/dc025af01930f739dbef0a65496e0b7ec4c384b9) | `` stdenv/problems: reverse parameter order for handlerForProblem ``                   |
| [`3358486a`](https://github.com/NixOS/nixpkgs/commit/3358486adb1c45e4a9318b978387bff61ccd6bf9) | `` stdenv/problems: avoid a lookup for meta.broken ``                                  |
| [`bd8250ab`](https://github.com/NixOS/nixpkgs/commit/bd8250ab9611e14e669d32f0dda2215957f000fd) | `` stdenv/problems: use early knowledge of allowBroken and allowBrokenPredicate ``     |
| [`2fef7770`](https://github.com/NixOS/nixpkgs/commit/2fef77700c3d197bd9d5f3cdc387b1470e972f3e) | `` stdenv/problems: avoid creating manual problems attrset ``                          |
| [`2199f6dc`](https://github.com/NixOS/nixpkgs/commit/2199f6dce9e73bb4d5e9f81c38591e7cbd1749a2) | `` stdenv/problems: only run problem if it's not ignored ``                            |
| [`fe447ad9`](https://github.com/NixOS/nixpkgs/commit/fe447ad91fe2f4fd6fd7bfb4fce089e2746969dc) | `` teleport_18: 18.8.3 -> 18.9.1 ``                                                    |
| [`4aa1553f`](https://github.com/NixOS/nixpkgs/commit/4aa1553fe586c8800134da476d8b3e811e593316) | `` teleport_17: 17.7.24 -> 17.7.25 ``                                                  |
| [`eb197cfe`](https://github.com/NixOS/nixpkgs/commit/eb197cfed7927b14ee6cc88d51f3fddd68e03a3e) | `` ungoogled-chromium: 149.0.7827.196-1 -> 149.0.7827.200-1 ``                         |
| [`ce83b7ee`](https://github.com/NixOS/nixpkgs/commit/ce83b7ee8a937cab5bd4c29d8d0e5c3c4a9d0239) | `` chromium,chromedriver: 149.0.7827.196 -> 149.0.7827.200 ``                          |
| [`4f622148`](https://github.com/NixOS/nixpkgs/commit/4f622148f95610a8c76ed7df0eb275d8958369b3) | `` python3Packages.itables: 2.8.0 -> 2.8.1 ``                                          |
| [`e803789c`](https://github.com/NixOS/nixpkgs/commit/e803789c69d0dcb78e65cf5ca44d5d262da10f7e) | `` redmine: 6.1.2 -> 6.1.3 ``                                                          |
| [`e3451ba3`](https://github.com/NixOS/nixpkgs/commit/e3451ba38c99baced976160035cdffac8fa95b92) | `` vencord: 1.14.13 -> 1.14.15 ``                                                      |
| [`cf002d5b`](https://github.com/NixOS/nixpkgs/commit/cf002d5b5c93647314466717b53750c1ee3a2a77) | `` proton-ge-bin: GE-Proton10-34 -> GE-Proton11-1 ``                                   |
| [`b517e5b3`](https://github.com/NixOS/nixpkgs/commit/b517e5b3bf7cbff9f882488ed3f72632306f819d) | `` pnpm_11: 11.8.0 -> 11.9.0 ``                                                        |
| [`b6ac7849`](https://github.com/NixOS/nixpkgs/commit/b6ac784981077b0cad256a738ef0e60319d63428) | `` asahi-audio: 3.4 -> 4.0 ``                                                          |
| [`fd7cd539`](https://github.com/NixOS/nixpkgs/commit/fd7cd5390f2b9232fae7244157a0bcee639ad864) | `` zfs_2_4: apply patch for #18366 (dedup=on data corruption) ``                       |
| [`e76dda2b`](https://github.com/NixOS/nixpkgs/commit/e76dda2b0c74e8a28691d4b6452d198c6917f6ef) | `` ocamlPackages.landmarks: 1.5 → 1.7 ``                                               |
| [`b4a0f1f2`](https://github.com/NixOS/nixpkgs/commit/b4a0f1f20169290fba9e62918158358bc6a90158) | `` ocamlPackages.ocsipersist: 2.0.0 → 2.1.0 ``                                         |
| [`8724e288`](https://github.com/NixOS/nixpkgs/commit/8724e2885dcca76639aeeffd14c563b75bafb34e) | `` m1n1: remove broken font generation ``                                              |
| [`bf7fa321`](https://github.com/NixOS/nixpkgs/commit/bf7fa32121714847299b4dcc16c6bee623b4f022) | `` m1n1: 1.5.2 -> 1.6.0 ``                                                             |
| [`8667d923`](https://github.com/NixOS/nixpkgs/commit/8667d923077236464362cb8d1e77d6e762be5a61) | `` mastodon: 4.6.1 -> 4.6.2 ``                                                         |
| [`f1b3c363`](https://github.com/NixOS/nixpkgs/commit/f1b3c3631f2f4d2d9b49c3920893bcf93f320d3f) | `` sonarr: add nyanloutre to maintainers ``                                            |
| [`e6a9555f`](https://github.com/NixOS/nixpkgs/commit/e6a9555f254e6c978d72f83e0a558d8d10cdab6f) | `` tor: 0.4.9.10 -> 0.4.9.11 ``                                                        |
| [`5bc2e030`](https://github.com/NixOS/nixpkgs/commit/5bc2e0305670a2becd3451e59d186f8c933a5652) | `` firefox-bin-unwrapped: 152.0.2 -> 152.0.3 ``                                        |
| [`cfdb94bc`](https://github.com/NixOS/nixpkgs/commit/cfdb94bc05a729d81a06da6128e552598f897b9c) | `` firefox-unwrapped: 152.0.2 -> 152.0.3 ``                                            |
| [`ad3613ec`](https://github.com/NixOS/nixpkgs/commit/ad3613ec6415a573b9d1bfc8a10a5ea97db08ca1) | `` speakersafetyd: 2.0.0 -> 2.0.1 ``                                                   |
| [`be9c0e7e`](https://github.com/NixOS/nixpkgs/commit/be9c0e7ec5997700d32f5e32fba2ee12066d7045) | `` forge-mtg: 2.0.12 -> 2.0.13 ``                                                      |
| [`26a9d492`](https://github.com/NixOS/nixpkgs/commit/26a9d492701377cf2aa81996e1b46fafd128591d) | `` buf: 1.70.0 -> 1.71.0 ``                                                            |
| [`d0f17a62`](https://github.com/NixOS/nixpkgs/commit/d0f17a62506c32e733ea96940a55f2a42dc61cf3) | `` temporal_capi: 0.2.3 -> 0.2.4 ``                                                    |
| [`e28f2207`](https://github.com/NixOS/nixpkgs/commit/e28f220794c92f99421649b8549224349fbd7d57) | `` nixosTests/cosmic: add test for polkit authentication ``                            |
| [`eed1c06c`](https://github.com/NixOS/nixpkgs/commit/eed1c06cabe98ac7dd9052c492c81d92cad984d7) | `` nixosTests/cosmic: move core testing logic into a dedicated script ``               |
| [`62d5c922`](https://github.com/NixOS/nixpkgs/commit/62d5c922e3a49e401899c54fb60fd57ad7141397) | `` empty-pdf: init ``                                                                  |
| [`52fdecf3`](https://github.com/NixOS/nixpkgs/commit/52fdecf30ef96b9562ecf35bf7501715d7fe2bcf) | `` nixosTests/cosmic: move test into a dedicated directory ``                          |
| [`c47eb3a5`](https://github.com/NixOS/nixpkgs/commit/c47eb3a51e0894e1c4288dd7a8717e80fc2efdaf) | `` servarr-ffmpeg: 5.1.4 -> 5.1.10 ``                                                  |
| [`ee8879c8`](https://github.com/NixOS/nixpkgs/commit/ee8879c853a4bbbc18a732791483b145e5e2e27c) | `` kikit: fix version ``                                                               |
| [`cae468b6`](https://github.com/NixOS/nixpkgs/commit/cae468b6e989d195e4bfe40be210b4ba5bd7501e) | `` olivetin-3k: 3000.14.0 -> 3000.15.0 ``                                              |
| [`75f9d5f1`](https://github.com/NixOS/nixpkgs/commit/75f9d5f174680d84df8b6153710ecceb5e41c257) | `` sonarr: 4.0.17.2952 -> 4.0.18.2971 ``                                               |
| [`3453d061`](https://github.com/NixOS/nixpkgs/commit/3453d0610741c7fb4b8244f4f9b6035258c96f0b) | `` osu-lazer: 2026.620.0 -> 2026.624.0 ``                                              |
| [`c1c6356f`](https://github.com/NixOS/nixpkgs/commit/c1c6356f7f9ddb970142b2e265c66b3ab10e017a) | `` osu-lazer-bin: 2026.620.0 -> 2026.624.0 ``                                          |
| [`71fbf0f6`](https://github.com/NixOS/nixpkgs/commit/71fbf0f65ab46bc4a2a7a581c394ad1c6e98114d) | `` ffmpeg_6: drop superfluous patch ``                                                 |
| [`ffce6c17`](https://github.com/NixOS/nixpkgs/commit/ffce6c17a19a395890ca75f55a86780ae40a0562) | `` nginx: 1.30.2 -> 1.30.3; nginxMainline: 1.31.1 -> 1.31.2 ``                         |
| [`04cb280f`](https://github.com/NixOS/nixpkgs/commit/04cb280fa32cf8c47938f5e0a59a3144760be8e5) | `` hmcl: 3.15.1 -> 3.15.2 ``                                                           |
| [`dec0814c`](https://github.com/NixOS/nixpkgs/commit/dec0814cd6a20e46a4891632e1413c94e9cc1568) | `` element-call: 0.20.1 -> 0.20.2 ``                                                   |
| [`c05170b7`](https://github.com/NixOS/nixpkgs/commit/c05170b772659afed9f539bff38e4539a7ed3d7f) | `` element-call: add bartoostveen as a maintainer ``                                   |
| [`fa8cae66`](https://github.com/NixOS/nixpkgs/commit/fa8cae660cf4d0e1ae451f9e2a2e620eebf58fa8) | `` element-call: 0.18.0 -> 0.20.1 ``                                                   |
| [`ba4f4947`](https://github.com/NixOS/nixpkgs/commit/ba4f4947add6a565c4d57cb821b37fbec8d9228c) | `` ungoogled-chromium: 149.0.7827.155-1 -> 149.0.7827.196-1 ``                         |
| [`5d61e317`](https://github.com/NixOS/nixpkgs/commit/5d61e31707153dca09beaa190f184a9bdc7a0c74) | `` servo: 0.2.0 -> 0.3.0 ``                                                            |
| [`f335fa85`](https://github.com/NixOS/nixpkgs/commit/f335fa851967aeed5b952a6dbb73073ac2fd1dff) | `` sing-box: 1.13.13 -> 1.13.14 ``                                                     |
| [`c5644dea`](https://github.com/NixOS/nixpkgs/commit/c5644dead4f8b042f2572caace0dd61dcb99edf8) | `` maintainers/github-teams.json: Automated sync ``                                    |
| [`93c339f7`](https://github.com/NixOS/nixpkgs/commit/93c339f75d22606f83ac451553999c01ea328201) | `` gotosocial: 0.21.2 -> 0.21.3 ``                                                     |
| [`7e6880fb`](https://github.com/NixOS/nixpkgs/commit/7e6880fb6d0ce254d0972c74ca67bcd0d1f3a483) | `` pretix.plugins.mollie: 2.5.5 -> 2.5.6 ``                                            |
| [`464f8459`](https://github.com/NixOS/nixpkgs/commit/464f845902cb1726d70f6fb502596be5c59c59a8) | `` pretix.plugins.mollie: 2.5.4 -> 2.5.5 ``                                            |
| [`0b4240de`](https://github.com/NixOS/nixpkgs/commit/0b4240de33e04bfd7dc32ab770e2575f14c0175e) | `` pretix.plugins.pages: 1.6.3 -> 1.6.4 ``                                             |
| [`71dfe187`](https://github.com/NixOS/nixpkgs/commit/71dfe187906e8f1b529ce51ccf61fbdc0198fe27) | `` pretix: 2026.4.3 -> 2026.4.4 ``                                                     |
| [`a51b6aa9`](https://github.com/NixOS/nixpkgs/commit/a51b6aa9aebaee56d9c178e9588039b8ce572c19) | `` grafana: 13.0.2 -> 13.0.3 ``                                                        |
| [`1e057b48`](https://github.com/NixOS/nixpkgs/commit/1e057b483cf3f36c3ec3a5765e909c794c453059) | `` lasuite-docs{,-frontend,-collaboration-server}: 5.2.1 -> 5.3.0 ``                   |
| [`5f745f50`](https://github.com/NixOS/nixpkgs/commit/5f745f50a062795f789e40e58f64554775b29265) | `` lasuite-docs{,-frontend,-collaboration-server}: 5.2.0 -> 5.2.1 ``                   |
| [`8443ab06`](https://github.com/NixOS/nixpkgs/commit/8443ab0607fd1176c7d21d36c45aeade74d01707) | `` lasuite-docs{,-frontend,-collaboration-server}: 5.1.0 -> 5.2.0 ``                   |
| [`926237f6`](https://github.com/NixOS/nixpkgs/commit/926237f642380c1aefcc2cf2aa414ca16456da8a) | `` ci/github-script/merge: share reviews fetch with bot.js, drop events ``             |
| [`e934e8a3`](https://github.com/NixOS/nixpkgs/commit/e934e8a36434a63ff1e516a5bff9447574aed2fb) | `` ci/github-script/merge: clarify Auto Merge follow-up tip ``                         |
| [`86980620`](https://github.com/NixOS/nixpkgs/commit/86980620a28c4c63ebb598ceecadceea71aa50a4) | `` ci/github-script/merge: refuse merge when a committer has requested changes ``      |
| [`139a66fe`](https://github.com/NixOS/nixpkgs/commit/139a66fe7e6fe027ed9ecaaf536cc0c9a322602b) | `` ci/github-script/merge: skip auto-merge when CI has already failed ``               |
| [`f893dec7`](https://github.com/NixOS/nixpkgs/commit/f893dec7853aa976efc4de8e437c8933a180995b) | `` element-{desktop,web}: 1.12.21 -> 1.12.22 ``                                        |
| [`1d2e376b`](https://github.com/NixOS/nixpkgs/commit/1d2e376b84d882fe637412364682424561b3b551) | `` openjdk11{, -headless}: fix UB in markOop ``                                        |
| [`f4f26e32`](https://github.com/NixOS/nixpkgs/commit/f4f26e3293807306db5bffdfb0e71bfbdf306fc2) | `` alcom: add me as maintainer ``                                                      |
| [`e60a48c2`](https://github.com/NixOS/nixpkgs/commit/e60a48c2ea6819368d5425ccffc856952d009370) | `` alcom: add name to npmDeps derivation ``                                            |
| [`bc04f024`](https://github.com/NixOS/nixpkgs/commit/bc04f02413de2400eb123847fdf7f7b8495c1cbb) | `` alcom: migrate to finalAttrs ``                                                     |
| [`98218b19`](https://github.com/NixOS/nixpkgs/commit/98218b19249325b85b8d870ce901127616dacf29) | `` alcom: 1.1.5 -> 1.1.6 ``                                                            |
| [`4606549b`](https://github.com/NixOS/nixpkgs/commit/4606549b65475c8f85b21bd94f2e25fe2a15e1e6) | `` linux: forward features into passthru ``                                            |
| [`18b44fd7`](https://github.com/NixOS/nixpkgs/commit/18b44fd7d24bae2b92c91b8fc6b7b07dce27fa41) | `` pnpmConfigHook: allow opt-out ``                                                    |
| [`cb10a073`](https://github.com/NixOS/nixpkgs/commit/cb10a073bf791f2f1efc6317b3f09a823e76fb0e) | `` nextcloud33: 33.0.5 -> 33.0.6 ``                                                    |
| [`023d63fc`](https://github.com/NixOS/nixpkgs/commit/023d63fc7319883937728c32bb4ecd7014ded12d) | `` nextcloud32: 32.0.11 -> 32.0.12 ``                                                  |
| [`8db1da77`](https://github.com/NixOS/nixpkgs/commit/8db1da774a506f992d6eb7fbf969baed50f4e309) | `` nixos/zigbee2mqtt: add RestartSec ``                                                |
| [`ee0e84e3`](https://github.com/NixOS/nixpkgs/commit/ee0e84e3853485d05220a22896463200d7f340c3) | `` nextcloudPackages: update ``                                                        |
| [`2e1d87b2`](https://github.com/NixOS/nixpkgs/commit/2e1d87b279e1cec79b8fa8b1de1ff94cabe6fb29) | `` tmc-cli: 1.1.2 -> 1.1.3 ``                                                          |
| [`92939309`](https://github.com/NixOS/nixpkgs/commit/92939309b115c93100902222361dcec5d435c5f4) | `` cargo-zigbuild: 0.22.3 -> 0.23.0 ``                                                 |
| [`309f2fbd`](https://github.com/NixOS/nixpkgs/commit/309f2fbd824f38e5a02dc266358f8cbf92bcae57) | `` cargo-tarpaulin: 0.35.4 -> 0.35.5 ``                                                |
| [`1a14fbac`](https://github.com/NixOS/nixpkgs/commit/1a14fbacadbafd238e790a27aed2aa5a72dcc0d2) | `` makemkv: 1.18.3 -> 1.18.4 ``                                                        |
| [`09f25b2a`](https://github.com/NixOS/nixpkgs/commit/09f25b2a53b80a12beee9f7d948fe4c0a49a88b6) | `` palemoon-bin: 34.3.0.1 -> 34.3.1 ``                                                 |
| [`b3de9289`](https://github.com/NixOS/nixpkgs/commit/b3de928932ff9ba872ef0f3d9a2483fe594203c5) | `` nodejs_26: 26.3.1 -> 26.4.0 ``                                                      |
| [`90cfb3f8`](https://github.com/NixOS/nixpkgs/commit/90cfb3f838b585869baa8cfee5053e7ceed4ffdf) | `` gitlab: 18.11.5 -> 18.11.6 ``                                                       |
| [`41b423f0`](https://github.com/NixOS/nixpkgs/commit/41b423f0611c08c4ed5ebee5992a37ef417a48e3) | `` rocqPackages.hierarchy-builder: 1.10.2 -> 1.10.3 ``                                 |
| [`5c56c1af`](https://github.com/NixOS/nixpkgs/commit/5c56c1afa2d1d5dad89777bce58c1a75fa93e4f6) | `` vscode-extensions.anthropic.claude-code: 2.1.186 -> 2.1.187 ``                      |
| [`8ff7cbcd`](https://github.com/NixOS/nixpkgs/commit/8ff7cbcdbad978ee5e4a9a5192d5b548f095bfd6) | `` claude-code: 2.1.186 -> 2.1.187 ``                                                  |
| [`abebc076`](https://github.com/NixOS/nixpkgs/commit/abebc07636ac06722e1a2b3efdc67d014e91141f) | `` vscode-extensions.anthropic.claude-code: 2.1.183 -> 2.1.186 ``                      |
| [`07cd7835`](https://github.com/NixOS/nixpkgs/commit/07cd7835077fd0a921cb831c82b080a02b8e97dc) | `` claude-code: 2.1.183 -> 2.1.186 ``                                                  |
| [`6b8ac763`](https://github.com/NixOS/nixpkgs/commit/6b8ac763612b12f568ae235ddb0069e0b79bb05e) | `` vscode-extensions.anthropic.claude-code: 2.1.183 -> 2.1.185 ``                      |
| [`c1620d9b`](https://github.com/NixOS/nixpkgs/commit/c1620d9bc3d939d90d8cdd880ff6a0c1507963b0) | `` claude-code: 2.1.183 -> 2.1.185 ``                                                  |
| [`3026efc5`](https://github.com/NixOS/nixpkgs/commit/3026efc585551e17bf72cbf0fca049c30495a4b1) | `` vscode-extensions.anthropic.claude-code: 2.1.179 -> 2.1.183 ``                      |
| [`097270cd`](https://github.com/NixOS/nixpkgs/commit/097270cdf8cf2f32da0a74bd3c9eb879d3a6f962) | `` claude-code: 2.1.179 -> 2.1.183 ``                                                  |
| [`81d270f9`](https://github.com/NixOS/nixpkgs/commit/81d270f9573f7f79cc59ebe76a168f83e5090cf8) | `` vscode-extensions.anthropic.claude-code: 2.1.175 -> 2.1.179 ``                      |
| [`16494e91`](https://github.com/NixOS/nixpkgs/commit/16494e91ee931784ddf9dde4c69b18364a3f2464) | `` claude-code: 2.1.177 -> 2.1.179 ``                                                  |
| [`6f69f9e0`](https://github.com/NixOS/nixpkgs/commit/6f69f9e0dd44fa341603bf939262b57828e299ad) | `` claude-code: 2.1.175 -> 2.1.177 ``                                                  |
| [`032fa9d6`](https://github.com/NixOS/nixpkgs/commit/032fa9d66050cf0d82ffcd4dda14518d183d5051) | `` vscode-extensions.anthropic.claude-code: 2.1.172 -> 2.1.175 ``                      |
| [`fe856802`](https://github.com/NixOS/nixpkgs/commit/fe85680268afcbe0592ee62abe059d9da0ad8e69) | `` claude-code: 2.1.172 -> 2.1.175 ``                                                  |
| [`71f7797d`](https://github.com/NixOS/nixpkgs/commit/71f7797da670f5a48543fbbc4912de449b1549b1) | `` claude-code: 2.1.170 -> 2.1.172 ``                                                  |
| [`6b08db38`](https://github.com/NixOS/nixpkgs/commit/6b08db382930d6410bd2e42dce569cd8c758f4d1) | `` claude-code: 2.1.161 -> 2.1.170 ``                                                  |
| [`152f8b3d`](https://github.com/NixOS/nixpkgs/commit/152f8b3d5347db3d6742bd3ff5a9285f1750e4bf) | `` vscode-extensions.anthropic.claude-code: 2.1.158 -> 2.1.161 ``                      |
| [`ffcf7a91`](https://github.com/NixOS/nixpkgs/commit/ffcf7a91401331d63b1678f4a57193209256fa63) | `` claude-code: 2.1.158 -> 2.1.161 ``                                                  |
| [`2149b916`](https://github.com/NixOS/nixpkgs/commit/2149b9169a4f50ec17285d8e583471b4fa1cb53a) | `` claude-code: use baseUrl from official install script ``                            |
| [`83f7e130`](https://github.com/NixOS/nixpkgs/commit/83f7e130870d6bc09a26cb5a7fd0c6618ac451ca) | `` vscode-extensions.anthropic.claude-code: 2.1.156 -> 2.1.158 ``                      |
| [`b7838f75`](https://github.com/NixOS/nixpkgs/commit/b7838f7593cebf7b04e708be6c6e2b3f0dd27c21) | `` claude-code: 2.1.156 -> 2.1.158 ``                                                  |
| [`d7f50277`](https://github.com/NixOS/nixpkgs/commit/d7f50277f57de05fa3b537cb3137b28c13265c47) | `` vscode-extensions.anthropic.claude-code: 2.1.154 -> 2.1.156 ``                      |
| [`de9ae842`](https://github.com/NixOS/nixpkgs/commit/de9ae84216ba3c468e09c61dd83900f903c7dfdc) | `` claude-code: 2.1.154 -> 2.1.156 ``                                                  |
| [`4a59da71`](https://github.com/NixOS/nixpkgs/commit/4a59da71eb9c5f24329d1a813b0974ed22efcfc1) | `` vscode-extensions.anthropic.claude-code: 2.1.153 -> 2.1.154 ``                      |
| [`b4f7eec0`](https://github.com/NixOS/nixpkgs/commit/b4f7eec08e976792ae48cbbc8c997759c284c571) | `` claude-code: 2.1.153 -> 2.1.154 ``                                                  |
| [`b2d1ea1d`](https://github.com/NixOS/nixpkgs/commit/b2d1ea1d1a75bbb4a9cc39f58e3c1e5ba9c932d7) | `` vscode-extensions.anthropic.claude-code: 2.1.152 -> 2.1.153 ``                      |
| [`9fb22582`](https://github.com/NixOS/nixpkgs/commit/9fb22582c2babda0ea93836fa7da67e38aaecf7c) | `` claude-code: 2.1.152 -> 2.1.153 ``                                                  |
| [`1e30976d`](https://github.com/NixOS/nixpkgs/commit/1e30976d4bdef6adc980ee2c6655fa1fdc9358f4) | `` vscode-extensions.anthropic.claude-code: 2.1.148 -> 2.1.152 ``                      |
| [`b2267700`](https://github.com/NixOS/nixpkgs/commit/b2267700e44e234d21c7bbee9f94ef7a0585f9ec) | `` claude-code: 2.1.148 -> 2.1.152 ``                                                  |
| [`21d9ffbe`](https://github.com/NixOS/nixpkgs/commit/21d9ffbe5517c5a2258ae9b6282e863ad97e9162) | `` linuxPackages.nvidiaPackages.legacy_470: support up to linux 7.1 ``                 |
| [`0562da53`](https://github.com/NixOS/nixpkgs/commit/0562da53597fb8c4f9e55d9627a84854ce024bdf) | `` mattermost: 11.7.3 -> 11.7.4 ``                                                     |
| [`5b86e518`](https://github.com/NixOS/nixpkgs/commit/5b86e51850c976818140345a7c9bb38616415e44) | `` mastodon: 4.6.0 -> 4.6.1 ``                                                         |
| [`5a818d9a`](https://github.com/NixOS/nixpkgs/commit/5a818d9adf589aa0d51fafb843f21e33ebfa294d) | `` godot_4_7: init at 4.7-stable ``                                                    |
| [`1ae521d9`](https://github.com/NixOS/nixpkgs/commit/1ae521d958f100c3ffe557b6392a84c2e15389e8) | `` godot: set __structuredAttrs and strictDeps to true ``                              |
| [`ee8e35d0`](https://github.com/NixOS/nixpkgs/commit/ee8e35d073a3e2b52c4bb8feb2d584b36c32568f) | `` python315: 3.15.0b2 -> 3.15.0b3 ``                                                  |
| [`9f05bc57`](https://github.com/NixOS/nixpkgs/commit/9f05bc5734159fe0310b544b8adb1088e9272e44) | `` linuxPackages.openafs: Patch for Linux kernel 7.1 ``                                |
| [`e24a6edb`](https://github.com/NixOS/nixpkgs/commit/e24a6edb6f65fa8c41fee6ab17dab221d42d6af9) | `` openafs: 1.8.15 → 1.8.16 ``                                                         |
| [`2a0c78cf`](https://github.com/NixOS/nixpkgs/commit/2a0c78cf3ec616f7bec88ad0bf4f8c765e24dcbf) | `` eddie: fix path mismatch error ``                                                   |
| [`f0eda30a`](https://github.com/NixOS/nixpkgs/commit/f0eda30aa68031f089dd15533dbda4525bd65973) | `` ffmpeg_6: 6.1.5 -> 6.1.6 ``                                                         |
| [`4cc98234`](https://github.com/NixOS/nixpkgs/commit/4cc982344ca61ff547be850c32a6253a252d2ca1) | `` ffmpeg_7: 7.1.4 -> 7.1.5 ``                                                         |
| [`641b2a70`](https://github.com/NixOS/nixpkgs/commit/641b2a70a2dd8089ec634a17bc7e0475d0fb3554) | `` ffmpeg_4: 4.4.7 -> 4.4.8 ``                                                         |
| [`ef475440`](https://github.com/NixOS/nixpkgs/commit/ef475440c846d88cb72a7b2e458871aed03b9723) | `` archon-lite: init at 9.3.85 ``                                                      |
| [`364ab857`](https://github.com/NixOS/nixpkgs/commit/364ab857806ccb4e5986d12e1542b38d7c06a63c) | `` maintainers: add sophiebsw ``                                                       |
| [`c8dd4d49`](https://github.com/NixOS/nixpkgs/commit/c8dd4d49647b84d21f77cb5fe27fb7286a93f998) | `` image-analyzer: 3.3.0 -> 3.3.1 ``                                                   |
| [`f5a81181`](https://github.com/NixOS/nixpkgs/commit/f5a811819fc3c46797b30f6a00d831e3a10daa8d) | `` cdemu-daemon: 3.3.0 -> 3.3.1 ``                                                     |
| [`4fcf16f9`](https://github.com/NixOS/nixpkgs/commit/4fcf16f9b26b88a2d7278f968edddbb582ac0e22) | `` filebrowser: 2.63.14 -> 2.63.15 ``                                                  |
| [`9d71efa1`](https://github.com/NixOS/nixpkgs/commit/9d71efa1c821e7888cfa8944373654a86561a6e4) | `` github-runner: 2.334.0 -> 2.335.1 ``                                                |
| [`c91b561e`](https://github.com/NixOS/nixpkgs/commit/c91b561e0a0ec620773588c78fc140eb4014dfa7) | `` gatus: 5.35.0 -> 5.36.0 ``                                                          |
| [`c39d8ac0`](https://github.com/NixOS/nixpkgs/commit/c39d8ac0c571fa2fd7cc17a2c104bed4a4fbf6e8) | `` mutter: 50.1 → 50.2 ``                                                              |
| [`35e2a361`](https://github.com/NixOS/nixpkgs/commit/35e2a36161bf94ad7d40472b20140c4b94e2f9a4) | `` yelp: 49.0 → 49.1 ``                                                                |
| [`1583fa56`](https://github.com/NixOS/nixpkgs/commit/1583fa5634c28129ab58164b9dda906d9e3b0817) | `` sushi: 50.rc.1 → 50.0 ``                                                            |
| [`c3d7311d`](https://github.com/NixOS/nixpkgs/commit/c3d7311dd923760e591f17528710ab4775a320de) | `` rygel: 45.1 → 45.2 ``                                                               |
| [`d97283b0`](https://github.com/NixOS/nixpkgs/commit/d97283b0ed032e2334b1da79b726071b2d8a52c9) | `` papers: 50.0 → 50.2 ``                                                              |
| [`5c5d5d0e`](https://github.com/NixOS/nixpkgs/commit/5c5d5d0e60d3a70d2ad994a322bf1552ad721ef2) | `` orca: 50.1.2 → 50.2 ``                                                              |
| [`daab3ecb`](https://github.com/NixOS/nixpkgs/commit/daab3ecb00ba400a797c28b51581ce890c3f27f6) | `` nautilus: 50.1 → 50.2.2 ``                                                          |
| [`90cb46c1`](https://github.com/NixOS/nixpkgs/commit/90cb46c1d3a10295542eafc28ad0c2f5e35ee57a) | `` gupnp-av: 0.14.4 → 0.14.5 ``                                                        |
| [`07598f9f`](https://github.com/NixOS/nixpkgs/commit/07598f9f5b4c80c23976e35eb3162d7f4ec7eb6f) | `` gnome-user-share: 48.2 → 48.3 ``                                                    |
| [`2f25627e`](https://github.com/NixOS/nixpkgs/commit/2f25627e98341b60f9aac14383105979b7a27559) | `` gnome-user-docs: 50.0 → 50.2 ``                                                     |
| [`68101792`](https://github.com/NixOS/nixpkgs/commit/681017927c66ac7677d675c8e873c61902b656dd) | `` gnome-text-editor: 50.0 → 50.1 ``                                                   |
| [`3c2aa51e`](https://github.com/NixOS/nixpkgs/commit/3c2aa51e43a21f75ce9edc4f3d42f2f628cb987e) | `` gnome-software: 50.1 → 50.2 ``                                                      |
| [`ead9cf9d`](https://github.com/NixOS/nixpkgs/commit/ead9cf9d5317f01e3db091c8bba533ca5c3fd732) | `` gnome-shell: 50.1 → 50.2 ``                                                         |
| [`5a438929`](https://github.com/NixOS/nixpkgs/commit/5a438929e5dc8effaa5b8c93c6eaad5f08908cd8) | `` gnome-session: 50.0 → 50.1 ``                                                       |
| [`e45a1582`](https://github.com/NixOS/nixpkgs/commit/e45a15826051f85b3511ddb6757c855e0892e121) | `` gnome-control-center: 50.1 → 50.2 ``                                                |
| [`fd824771`](https://github.com/NixOS/nixpkgs/commit/fd82477190dbec446f3ae038b117c38b884c7859) | `` gdm: 50.0 → 50.1 ``                                                                 |
| [`c9f9061f`](https://github.com/NixOS/nixpkgs/commit/c9f9061fded4f55c6bfc2999336e03d15e0f580b) | `` evolution-data-server: 3.60.1 → 3.60.2 ``                                           |
| [`11098067`](https://github.com/NixOS/nixpkgs/commit/110980672254c0583ce9f749e4331b768663b9a0) | `` teleport_18: 18.7.6 -> 18.8.3 ``                                                    |
| [`e313aca5`](https://github.com/NixOS/nixpkgs/commit/e313aca58d7d69d7b017962baca1ecdea28c6e11) | `` teleport_17: 17.7.23 -> 17.7.24 ``                                                  |
| [`d46fd9cd`](https://github.com/NixOS/nixpkgs/commit/d46fd9cd08eaa1d1bd0c2fcdd4f9339e1bc10216) | `` pnpm_10: 10.33.4 -> 10.34.0 ``                                                      |
| [`42d6d779`](https://github.com/NixOS/nixpkgs/commit/42d6d7792b7303b762697d04a61f04601cc5610d) | `` prismlauncher: add wrapGAppsHook3 ``                                                |