### PR TITLE
chore(flake/frext): `21420458` -> `a15187aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1782652482,
-        "narHash": "sha256-dQY7P9sQCd+eiB96BVZ9FmlUek7vofTIfKloKuwvddk=",
+        "lastModified": 1782763860,
+        "narHash": "sha256-GCmvkrn9CyMrvnd085BVZaAaB6oRN27i0lY0Z+hGhq4=",
         "owner": "FredSystems",
         "repo": "frext",
-        "rev": "214204585168c478cb1a3bb08f222a2c3a73cc29",
+        "rev": "a15187aa6b25bb16ad4ecd84946de51428f769ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`a15187aa`](https://github.com/fredsystems/frext/commit/a15187aa6b25bb16ad4ecd84946de51428f769ca) | `` feat: render emoji via a discovered system emoji font ``            |
| [`14c4a9fb`](https://github.com/fredsystems/frext/commit/14c4a9fba4268790ec7d6d1713696565ecf2e821) | `` fix: lint action ``                                                 |
| [`5ffef0ad`](https://github.com/fredsystems/frext/commit/5ffef0ada27afe64c081ac28be7092ec17a47020) | `` feat: confirm before closing a tab with unsaved changes ``          |
| [`c5acf0ee`](https://github.com/fredsystems/frext/commit/c5acf0eec424a5881be3d43225f01d6acc207da6) | `` fix: align the line-number gutter with soft-wrapped editor rows ``  |
| [`8e6ca1ff`](https://github.com/fredsystems/frext/commit/8e6ca1ff11d11d83b9a93e21b9c84b2ab2089f90) | `` feat: bundle CaskaydiaCove for editor ligatures ``                  |
| [`d62eae33`](https://github.com/fredsystems/frext/commit/d62eae33752f532f9d58adfef44f0cd3e1e1e35f) | `` feat: find and replace for the active buffer ``                     |
| [`5bfd8859`](https://github.com/fredsystems/frext/commit/5bfd8859ae2e80574dc8bf25a4da1ae2a5a48264) | `` feat: set the application icon for the window and desktop entry ``  |
| [`f2a6f4cf`](https://github.com/fredsystems/frext/commit/f2a6f4cfe715f09e14c080e2eba81890b4b323dd) | `` feat: let the file-tree sidebar be closed ``                        |
| [`2a07888b`](https://github.com/fredsystems/frext/commit/2a07888bad0a19596641867b4c455d987c388354) | `` feat: show the file-tree root as a resolved, home-collapsed path `` |
| [`ba35edb6`](https://github.com/fredsystems/frext/commit/ba35edb62cc1fb22df6360fc22cebd0a7682ccb8) | `` fix: remove the coloured focus ring around the editor ``            |
| [`adaf405c`](https://github.com/fredsystems/frext/commit/adaf405c54adcaf899a9a64bbebbc4e1107cc685) | `` fix: provide dbus and zenity for the rfd file dialog at runtime ``  |