### PR TITLE
chore(flake/niri): `9378abae` -> `350668ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -679,11 +679,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1782663639,
-        "narHash": "sha256-ACD9fV8NItTLSx6Zk85+cFN11CjZ0BhyG2ocCuzAd70=",
+        "lastModified": 1782813347,
+        "narHash": "sha256-oqk6IR36aoeRUjU0Tb9vK4shHfI8QyoabMugMM2QW7s=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "9378abaebb8db044ef4bbb2df05972e4a92eac07",
+        "rev": "350668eca0bbc657bc5721e0a90f3707e269f021",
         "type": "github"
       },
       "original": {
@@ -800,11 +800,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1782535326,
-        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
+        "lastModified": 1782691344,
+        "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
+        "rev": "1f01958ffb5b3545c96d9ef2f4e24c5e5e1eb846",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`350668ec`](https://github.com/epireyn/niri-flake/commit/350668eca0bbc657bc5721e0a90f3707e269f021) | `` Update flake.lock `` |
| [`6bfe7ef5`](https://github.com/epireyn/niri-flake/commit/6bfe7ef5b84f7109c5264193a951a78eea23b06a) | `` Update flake.lock `` |