### PR TITLE
chore(flake/frext): `a15187aa` -> `ab07112a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1782763860,
-        "narHash": "sha256-GCmvkrn9CyMrvnd085BVZaAaB6oRN27i0lY0Z+hGhq4=",
+        "lastModified": 1782831014,
+        "narHash": "sha256-5feyrCZmIz/cDDJtRlrq5CyKYHqUExi41k9WlmC+pv8=",
         "owner": "FredSystems",
         "repo": "frext",
-        "rev": "a15187aa6b25bb16ad4ecd84946de51428f769ca",
+        "rev": "ab07112a7e9b6e628068eb8918ab8e05f0db0a71",
         "type": "github"
       },
       "original": {
@@ -1163,11 +1163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782616745,
-        "narHash": "sha256-NN5B1cKBXF6h1Ec681gMGZ2o/99d7vKXAAfFNEvyOKA=",
+        "lastModified": 1782703273,
+        "narHash": "sha256-WJPfr9EAWVIuTMyb/ilHKUYlg/RNa0xrNiWR+p1iHUg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b916d014dc57eb555f84e51172a82f7f6fb560d7",
+        "rev": "5106a604b3d67cffe8eb51a8bd9f04e607f0d31d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                               |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`016b4c31`](https://github.com/fredsystems/frext/commit/016b4c31d1eb10251c1910c5a3dbc06b313c9d71) | `` chore: bump harfrust to 0.11.0 and fix shape() API drift ``                        |
| [`f03002a9`](https://github.com/fredsystems/frext/commit/f03002a9e5fc7c973cb5d200cc2b6c4c9f2de2dd) | `` feat: right-click context menu in the editor ``                                    |
| [`e3b04be0`](https://github.com/fredsystems/frext/commit/e3b04be00e1226201336117697628b2cdc17d0aa) | `` feat: right-click context menus in the file-tree sidebar ``                        |
| [`923a5c0c`](https://github.com/fredsystems/frext/commit/923a5c0c728aca1d5e27d669390b34d075b71551) | `` chore(deps): lock file maintenance (#5) ``                                         |
| [`678f6167`](https://github.com/fredsystems/frext/commit/678f6167b7268838182f637aa3f79fccd9130f18) | `` chore(deps): update actions/checkout action to v7 (#4) ``                          |
| [`1f964f47`](https://github.com/fredsystems/frext/commit/1f964f479e441f171cd31e7909a5a78d9ac7d075) | `` feat: show file-type icons in the sidebar file tree ``                             |
| [`1d389dc2`](https://github.com/fredsystems/frext/commit/1d389dc262685c2d5785c148b33eb764b5826d12) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 629b284 `` |