### PR TITLE
chore(flake/nixpkgs-stable): `714a5f8c` -> `1f01958f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -816,11 +816,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1782535326,
-        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
+        "lastModified": 1782691344,
+        "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
+        "rev": "1f01958ffb5b3545c96d9ef2f4e24c5e5e1eb846",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`32b1a373`](https://github.com/NixOS/nixpkgs/commit/32b1a373732e2560eb6d1fed01cf7c57be9edb46) | `` invidious: enable __structuredAttrs ``                                                               |
| [`2f9fc83a`](https://github.com/NixOS/nixpkgs/commit/2f9fc83ad6e840ad0786432aeb1be70131cd6aea) | `` invidious: 2.20260207.0 -> 2.20260626.0 ``                                                           |
| [`0068b1d2`](https://github.com/NixOS/nixpkgs/commit/0068b1d232048ccfed572a6063946ecdf1fd08c7) | `` invidious: fix update script ``                                                                      |
| [`289e6957`](https://github.com/NixOS/nixpkgs/commit/289e6957b5b8f93b5dd40b388eb072a83b0e8876) | `` gtree: 1.14.2 -> 1.14.5 ``                                                                           |
| [`b1a3bd7c`](https://github.com/NixOS/nixpkgs/commit/b1a3bd7caa5c5fd0fdee9a40b258c3e5d0ac928d) | `` pgdog: 0.1.45 -> 0.1.46 ``                                                                           |
| [`10aea2ec`](https://github.com/NixOS/nixpkgs/commit/10aea2ec974da8cf513bc197e640da4a1b886934) | `` grav: 1.7.52 -> 1.7.53 ``                                                                            |
| [`bb72c90c`](https://github.com/NixOS/nixpkgs/commit/bb72c90cc7f43175676c4784f1a3a0bd7972c46f) | `` linux_zen: 7.0.12 -> 7.1.2 ``                                                                        |
| [`dba32b31`](https://github.com/NixOS/nixpkgs/commit/dba32b31b54df952900e51f1de947f60ea57f005) | `` deskflow: 1.25.0 -> 1.26.0 ``                                                                        |
| [`c5af0af8`](https://github.com/NixOS/nixpkgs/commit/c5af0af803442ded49b6a6fb8f8a2f0ce911c28e) | `` aurulent-sans: add pancaek as maintainer ``                                                          |
| [`fe012629`](https://github.com/NixOS/nixpkgs/commit/fe012629bc5a8bf2e4f82de8a9512046f911b3a1) | `` maintainers: remove deepfire ``                                                                      |
| [`2fdb2e1f`](https://github.com/NixOS/nixpkgs/commit/2fdb2e1f6f39cb7486fb013a6abb57edd791b7c7) | `` maintainers: remove f4814n ``                                                                        |
| [`faf3cd7a`](https://github.com/NixOS/nixpkgs/commit/faf3cd7aebaa8081e6607586463c38e3e014d731) | `` maintainers: remove afldcr ``                                                                        |
| [`b6efa95b`](https://github.com/NixOS/nixpkgs/commit/b6efa95b923e8bda6c021ebd07fc5dd6acb2e1ad) | `` maintainers: remove vbmithr ``                                                                       |
| [`0e637648`](https://github.com/NixOS/nixpkgs/commit/0e6376485550ed7e698eac88f7e8d3fd8e822689) | `` lemon-graph: add hzeller as maintainer ``                                                            |
| [`0a94a243`](https://github.com/NixOS/nixpkgs/commit/0a94a243e3e41a09aeb36cb92bf4698c9ee23438) | `` maintaines: remove trepetti ``                                                                       |
| [`59dfd1a4`](https://github.com/NixOS/nixpkgs/commit/59dfd1a4bb349371a1c74e30847d847c78bb41e6) | `` pdns: add meta.changelog ``                                                                          |
| [`0eb1794e`](https://github.com/NixOS/nixpkgs/commit/0eb1794e1ce16e09e9998abc4ab8de29f68ced7c) | `` pdns-recursor: 5.4.1 -> 5.4.3 ``                                                                     |
| [`727c939d`](https://github.com/NixOS/nixpkgs/commit/727c939d2c0f36355d277d0169010b0cbaf8d1fb) | `` google-chrome: 149.0.7827.196 -> 149.0.7827.200 ``                                                   |
| [`807d0962`](https://github.com/NixOS/nixpkgs/commit/807d0962b7ee7e2adca7eb1ab5f5d7e6036029a9) | `` losslesscut: build against electron_42 ``                                                            |
| [`009e6986`](https://github.com/NixOS/nixpkgs/commit/009e6986c83cfa1f3b22f2bb3708d57e36d4c6ed) | `` cargo-shear: 1.12.4 -> 1.13.1 ``                                                                     |
| [`6c056fe8`](https://github.com/NixOS/nixpkgs/commit/6c056fe813bbbc9d0752567b12399eb72defad27) | `` ndg: 2.8.0 -> 2.9.0 ``                                                                               |
| [`a48d5816`](https://github.com/NixOS/nixpkgs/commit/a48d5816de643915978c47d573dc78a884bb86c4) | `` r2modman: rip out update banner component from build ``                                              |
| [`7256bf9d`](https://github.com/NixOS/nixpkgs/commit/7256bf9d6c15d0cbf0c80f509733a15328de05f4) | `` voicevox: pnpm_10_29_2 -> pnpm_10 ``                                                                 |
| [`65d3e9b7`](https://github.com/NixOS/nixpkgs/commit/65d3e9b7fa1c986f45929431807a38d49ab4b811) | `` qwt: fix generated pkg-config file ``                                                                |
| [`113909a6`](https://github.com/NixOS/nixpkgs/commit/113909a6ba73b78706f8c38e626a2678846ffad8) | `` tailwindcss-language-server: 0.14.28 -> 0.14.29 ``                                                   |
| [`b2af5f2d`](https://github.com/NixOS/nixpkgs/commit/b2af5f2df701943a7f265aac4c0cff5235bddd37) | `` signal-desktop: pnpm_10_29_2 -> pnpm_10 ``                                                           |
| [`38c93258`](https://github.com/NixOS/nixpkgs/commit/38c93258e37ae65555f13375025f61d5c07b3bfc) | `` signal-desktop: fix darwin build ``                                                                  |
| [`fffb5733`](https://github.com/NixOS/nixpkgs/commit/fffb57337d7bcb0dd32585ee261563c2e3b7ef46) | `` signal-desktop: 8.14.0 -> 8.15.0 ``                                                                  |
| [`7444887a`](https://github.com/NixOS/nixpkgs/commit/7444887ac5b465c8eaeb178222019c5cf9f3f992) | `` signal-desktop: 8.13.0 -> 8.14.0 ``                                                                  |
| [`1907cd65`](https://github.com/NixOS/nixpkgs/commit/1907cd65400089e6023d4801ee07c838f5987eb0) | `` brave: 1.91.175 -> 1.91.180 ``                                                                       |
| [`49d0d809`](https://github.com/NixOS/nixpkgs/commit/49d0d80993135ab122459acf9c369c014c558dfa) | `` opengist: 1.12.2 -> 1.13.1 ``                                                                        |
| [`a727ba75`](https://github.com/NixOS/nixpkgs/commit/a727ba755a5b5c729131e9d5579d8c5e91cdedf3) | `` linux_xanmod_latest: 7.0.12 -> 7.0.14 ``                                                             |
| [`4b48548f`](https://github.com/NixOS/nixpkgs/commit/4b48548ffd01bec917e86fda7fe299f15bb1c9d1) | `` linux_xanmod: 6.18.35 -> 6.18.37 ``                                                                  |
| [`e4431417`](https://github.com/NixOS/nixpkgs/commit/e4431417d416d5482a714660cfd7aee405b2b5bb) | `` github-mcp-server: 1.0.5 -> 1.1.2 ``                                                                 |
| [`91d2b666`](https://github.com/NixOS/nixpkgs/commit/91d2b66698f3b4f21b0f740831e89cfbea4b5c77) | `` github-mcp-server: 1.0.4 -> 1.0.5 ``                                                                 |
| [`4dd449d2`](https://github.com/NixOS/nixpkgs/commit/4dd449d232439498293fe62ae355f87c5338fb20) | `` freecad: require big-parallel system feature ``                                                      |
| [`1faac95b`](https://github.com/NixOS/nixpkgs/commit/1faac95b497cadb14c8e5ffcc0ef221c8afa9559) | `` dnsdist: inherit both NixOS tests ``                                                                 |
| [`04a6e45d`](https://github.com/NixOS/nixpkgs/commit/04a6e45df21521c7a8d0e5862ddf95b720819855) | `` dnsdist: 2.0.5 -> 2.0.7 ``                                                                           |
| [`0939631e`](https://github.com/NixOS/nixpkgs/commit/0939631e1362c0c7acd024b81c023b9c757be904) | `` openresty: fix lib.optional misuse in configureFlags ``                                              |
| [`f0065a37`](https://github.com/NixOS/nixpkgs/commit/f0065a37c9fbd3d86bdc767e30989fb14101e395) | `` woodpecker-{agent,cli,server}: 3.14.1 -> 3.16.0 ``                                                   |
| [`06798c37`](https://github.com/NixOS/nixpkgs/commit/06798c3775238fdd56b88fae05179705a1d17101) | `` unityhub: 3.18.2 -> 3.18.3 ``                                                                        |
| [`88491d66`](https://github.com/NixOS/nixpkgs/commit/88491d663de349742aeb527b698ace6ea5814095) | `` unityhub: 3.18.0 -> 3.18.2 ``                                                                        |
| [`5a51a8d5`](https://github.com/NixOS/nixpkgs/commit/5a51a8d58c9f65ab8352a6248c160c0bb150d50a) | `` sdl_gamecontrollerdb: 0-unstable-2026-06-12 -> 0-unstable-2026-06-26 ``                              |
| [`8e12631d`](https://github.com/NixOS/nixpkgs/commit/8e12631d6a5429307e9664317c21c5cc02eb9b0e) | `` shaperglot-cli: 1.2.0 -> 1.2.1 ``                                                                    |
| [`0e951b58`](https://github.com/NixOS/nixpkgs/commit/0e951b589f89d4b4260adc148f5b382e4e814b0f) | `` nixos/tabbyapi: add writable HOME and cache ``                                                       |
| [`69dabba8`](https://github.com/NixOS/nixpkgs/commit/69dabba80d79adce0a3945fc6f20a34bf0a2aa11) | `` tabbyapi: unstable-2026-06-13 -> unstable-2026-06-27 ``                                              |
| [`bc937b84`](https://github.com/NixOS/nixpkgs/commit/bc937b84a74bf72de8e1d8de8970002d5ae2bf26) | `` python3Packages.flash-linear-attention: 0.5.0 -> 0.5.1 ``                                            |
| [`98143898`](https://github.com/NixOS/nixpkgs/commit/98143898b6a630bd7433afabfb6386523f08e054) | `` perlPackages.BytesRandomSecure: add patch for CVE-2026-11625 ``                                      |
| [`66bd9c06`](https://github.com/NixOS/nixpkgs/commit/66bd9c06f8c94ca8a1d02bfbdeed219da265a5c7) | `` linux_6_18: 6.18.36 -> 6.18.37 ``                                                                    |
| [`cb55ab04`](https://github.com/NixOS/nixpkgs/commit/cb55ab04b93b145d4a579d447ea9be43b244a9f9) | `` linux_7_0: 7.0.13 -> 7.0.14 ``                                                                       |
| [`7e265987`](https://github.com/NixOS/nixpkgs/commit/7e265987666ae4e936ceb338705303bd11f4fce2) | `` linux_7_1: 7.1.1 -> 7.1.2 ``                                                                         |
| [`2e542f01`](https://github.com/NixOS/nixpkgs/commit/2e542f016565ab8013e1f4a3193940fcc8fb3501) | `` perlPackages.BytesRandomSecureTiny: add patch for CVE-2026-11702 ``                                  |
| [`17fd66ce`](https://github.com/NixOS/nixpkgs/commit/17fd66ced4bcd7e0f8f202b5af208c4221e3ad9f) | `` protoc-gen-grpc-java: 1.81.0 -> 1.82.1 ``                                                            |
| [`6976546d`](https://github.com/NixOS/nixpkgs/commit/6976546df106b80faefc2311fa01fe5cad7ef252) | `` n8n: 2.25.7 -> 2.27.4 ``                                                                             |
| [`f7b833a5`](https://github.com/NixOS/nixpkgs/commit/f7b833a5ccc89af37bbc6cf9425748b98d2126b4) | `` memos: set version in go code ``                                                                     |
| [`113d57e6`](https://github.com/NixOS/nixpkgs/commit/113d57e664c407cbd24ec7e54571aea97943f504) | `` memos: finalAttrs ``                                                                                 |
| [`baa5a220`](https://github.com/NixOS/nixpkgs/commit/baa5a220fe0cef8c495eed0e69a5e8b4e7b1e317) | `` ddhx: 0.9.3 -> 0.10.0 ``                                                                             |
| [`6438b08f`](https://github.com/NixOS/nixpkgs/commit/6438b08f33575458f12b4ccb23a74705d9a3e242) | `` nixos/dovecot: order non-attrs values first in rendered config ``                                    |
| [`ca7ea526`](https://github.com/NixOS/nixpkgs/commit/ca7ea526c7ba7fc7a346f680a694979f9ac80627) | `` feishin: pnpm_10_29_2 -> pnpm_10 ``                                                                  |
| [`9f665e65`](https://github.com/NixOS/nixpkgs/commit/9f665e65b581428f44cf2847737a4d8650704b72) | `` pear-desktop: unpinn pnpm to stop depending on marked insecure package and bring it back to cache `` |
| [`ff710dde`](https://github.com/NixOS/nixpkgs/commit/ff710ddefb8ed080effd887ee367fb2f30780787) | `` kicad-small: 10.0.3 -> 10.0.4 ``                                                                     |
| [`1e0a658f`](https://github.com/NixOS/nixpkgs/commit/1e0a658f390363496f0d9c4baa37d96a294865cc) | `` deadbeef: 1.10.2 -> 1.10.3 ``                                                                        |
| [`fb60282e`](https://github.com/NixOS/nixpkgs/commit/fb60282eec1a262419e28a6070f6d2d1d1ea13aa) | `` gren: 0.6.5 -> 0.6.6 ``                                                                              |
| [`973fdacd`](https://github.com/NixOS/nixpkgs/commit/973fdacdd67c3defb1e6d56c715cc5f4e6fdd02a) | `` calibre: 9.9.0 -> 9.10.0 ``                                                                          |
| [`15eea121`](https://github.com/NixOS/nixpkgs/commit/15eea12188ccbbdf05a0fa3e51efd7940386dc1b) | `` trivy: 0.71.1 -> 0.71.2 ``                                                                           |
| [`70476cc8`](https://github.com/NixOS/nixpkgs/commit/70476cc8176b2c787a147b8ffb22925087b7f276) | `` trivy: clean-up ``                                                                                   |
| [`9ed4f41b`](https://github.com/NixOS/nixpkgs/commit/9ed4f41b617d90b521a41298ee8549d644da1f3e) | `` trivy: 0.71.0 -> 0.71.1 ``                                                                           |
| [`6f6e5498`](https://github.com/NixOS/nixpkgs/commit/6f6e5498f33c3fd10e1d13e59d418e7d9bad8bc7) | `` thunderbird-esr-bin-unwrapped: 140.11.1esr -> 140.12.0esr ``                                         |
| [`3c6c560b`](https://github.com/NixOS/nixpkgs/commit/3c6c560ba3d42e8483479699ac6534f9f1aab57d) | `` zammad: 7.1.0 -> 7.1.1 ``                                                                            |
| [`b1a789fa`](https://github.com/NixOS/nixpkgs/commit/b1a789fa1fe4e45a773eb218326781acc4e0addd) | `` Revert "[Backport staging-nixos-26.05] cargo-auditable: 0.7.2 -> 0.7.5" ``                           |
| [`7feb3143`](https://github.com/NixOS/nixpkgs/commit/7feb3143a6df8f0f54eb26594618bda4fc2db511) | `` efitools: Fix cross-compilation ``                                                                   |
| [`54e0bdd9`](https://github.com/NixOS/nixpkgs/commit/54e0bdd99d86ad96f3fdb901280d0be8db028cd7) | `` sbsigntool: Fix cross-compilation ``                                                                 |
| [`10736c2c`](https://github.com/NixOS/nixpkgs/commit/10736c2cd31375237cf0e531d1f06b3fcf497741) | `` ocamlPackages.batteries: 3.10.0 → 3.11.0 ``                                                          |
| [`5a3bc0d9`](https://github.com/NixOS/nixpkgs/commit/5a3bc0d928a221ea18e5c1e557dd1043985e4461) | `` pnpmBuildHook: init ``                                                                               |
| [`81a0274d`](https://github.com/NixOS/nixpkgs/commit/81a0274d02ae06ef986ad60093977450f5b7222d) | `` makeSetupHook: support structuredAttrs to unbreak adding to by-name ``                               |
| [`ae8998ae`](https://github.com/NixOS/nixpkgs/commit/ae8998ae019dc03532b22183aa34592a54235042) | `` incus-lts: backport 7.2 security fixes ``                                                            |
| [`c4363c36`](https://github.com/NixOS/nixpkgs/commit/c4363c36c5c28878d3c741f640332c5d4c805bd4) | `` incus: 7.1.0 -> 7.2.0 ``                                                                             |
| [`41d769b3`](https://github.com/NixOS/nixpkgs/commit/41d769b35cfc60ab72a1a671c965490e17b2dd2d) | `` nano: remove pname substitution anti-pattern ``                                                      |
| [`31bb29fa`](https://github.com/NixOS/nixpkgs/commit/31bb29fabc8ee0e109b507eede0271b4c6e4f852) | `` nano: 9.0 -> 9.1 ``                                                                                  |
| [`4cf19166`](https://github.com/NixOS/nixpkgs/commit/4cf191665b0b92406a67d9024c7f9c7c786f68df) | `` cosmic-applets: deduplicate cosmic-settings-daemon sources ``                                        |
| [`ee6ad27d`](https://github.com/NixOS/nixpkgs/commit/ee6ad27d22a687b9ecc29bcfbe949a7dc24dfc5d) | `` cosmic-monitor: init at 1.1.0 ``                                                                     |
| [`991d07d6`](https://github.com/NixOS/nixpkgs/commit/991d07d6ba63f5b6b1dbc89f04bdcc77c4aa6e82) | `` cosmic-settings: deduplicate multiple libcosmic sources ``                                           |
| [`cdc0c563`](https://github.com/NixOS/nixpkgs/commit/cdc0c56367fe2791b4544071bbec83711219bb75) | `` cosmic-settings: 1.0.16 -> 1.1.0 ``                                                                  |
| [`a8258406`](https://github.com/NixOS/nixpkgs/commit/a825840621df4d465e0f87484c5468ef70e1c347) | `` cosmic-osd: 1.0.16 -> 1.1.0 ``                                                                       |
| [`dd922a6c`](https://github.com/NixOS/nixpkgs/commit/dd922a6cd7e6580298ee9890ff086b4f1bcbc477) | `` Revert "cosmic-osd: deduplicate the dual sources for the cosmic-settings crate" ``                   |
| [`d296a338`](https://github.com/NixOS/nixpkgs/commit/d296a3384a3117e2befd604b618fdff5888e795c) | `` xdg-desktop-portal-cosmic: 1.0.16 -> 1.1.0 ``                                                        |
| [`797aa9b2`](https://github.com/NixOS/nixpkgs/commit/797aa9b25fd4fa543881476acad639661c1d36c0) | `` cosmic-edit: 1.0.16 -> 1.1.0 ``                                                                      |
| [`35cd91e8`](https://github.com/NixOS/nixpkgs/commit/35cd91e83456e6b2ee15c5dbfad1606c90c43ac6) | `` cosmic-applets: 1.0.16 -> 1.1.0 ``                                                                   |
| [`568f8945`](https://github.com/NixOS/nixpkgs/commit/568f8945a47d6a79290e74bd3ef3e1ddfc1310eb) | `` cosmic-player: 1.0.16 -> 1.1.0 ``                                                                    |
| [`5de7e852`](https://github.com/NixOS/nixpkgs/commit/5de7e852e444272037056b9ca65bc76be15d02bb) | `` cosmic-launcher: 1.0.16 -> 1.1.0 ``                                                                  |
| [`0077ea81`](https://github.com/NixOS/nixpkgs/commit/0077ea81480fe7751fc02ec6ba1273d5b6d89868) | `` cosmic-greeter: 1.0.16 -> 1.1.0 ``                                                                   |
| [`08a4e89b`](https://github.com/NixOS/nixpkgs/commit/08a4e89bc34788949ed1ece2562bcd4ec5b8c329) | `` cosmic-files: 1.0.16 -> 1.1.0 ``                                                                     |
| [`05db3e22`](https://github.com/NixOS/nixpkgs/commit/05db3e22ac8134ca86abff7093cc58eb77a38e28) | `` cosmic-store: 1.0.16 -> 1.1.0 ``                                                                     |
| [`1dafc828`](https://github.com/NixOS/nixpkgs/commit/1dafc828e80de215078a30862f2e0e330760fcba) | `` cosmic-notifications: 1.0.16 -> 1.1.0 ``                                                             |
| [`33118a19`](https://github.com/NixOS/nixpkgs/commit/33118a19826fba855f06a76473e50ddc4cece1ff) | `` cosmic-applibrary: 1.0.16 -> 1.1.0 ``                                                                |
| [`96107275`](https://github.com/NixOS/nixpkgs/commit/9610727572350141b59fd7653e7b7a2192882c45) | `` cosmic-comp: 1.0.16 -> 1.1.0 ``                                                                      |
| [`2b799e67`](https://github.com/NixOS/nixpkgs/commit/2b799e676a8a9fbc544259f6e987073d87291493) | `` cosmic-bg: 1.0.16 -> 1.1.0 ``                                                                        |
| [`fe74e6fa`](https://github.com/NixOS/nixpkgs/commit/fe74e6fada86d3197bd3f5561591fdc99cb58fed) | `` cosmic-term: 1.0.16 -> 1.1.0 ``                                                                      |
| [`80a5c207`](https://github.com/NixOS/nixpkgs/commit/80a5c207f1fe74a54a98cc67a337477f15260821) | `` cosmic-idle: 1.0.16 -> 1.1.0 ``                                                                      |
| [`48c7c706`](https://github.com/NixOS/nixpkgs/commit/48c7c706c9d199ffda583639c44b5a1613544df5) | `` cosmic-initial-setup: 1.0.16 -> 1.1.0 ``                                                             |
| [`cae5de3e`](https://github.com/NixOS/nixpkgs/commit/cae5de3ea19b9b1e48796f5f3549c64c2a19cae7) | `` cosmic-workspaces-epoch: 1.0.16 -> 1.1.0 ``                                                          |
| [`6b12da5c`](https://github.com/NixOS/nixpkgs/commit/6b12da5cde0708ecf22bf3d441f9712af4274187) | `` cosmic-panel: 1.0.16 -> 1.1.0 ``                                                                     |
| [`9f40eba4`](https://github.com/NixOS/nixpkgs/commit/9f40eba48a5c0ba09ec6d52a974a4e6c562e1ffd) | `` cosmic-screenshot: 1.0.16 -> 1.1.0 ``                                                                |
| [`c87a7443`](https://github.com/NixOS/nixpkgs/commit/c87a744341212a2705f9c9513c84fdc7502b58ba) | `` cosmic-settings-daemon: 1.0.16 -> 1.1.0 ``                                                           |
| [`38804ba2`](https://github.com/NixOS/nixpkgs/commit/38804ba2f68da2aa8492165764f8df4f33ff3335) | `` cosmic-session: 1.0.16 -> 1.1.0 ``                                                                   |
| [`4b0181eb`](https://github.com/NixOS/nixpkgs/commit/4b0181eb5808638b1090ec55ce3382b069ec5328) | `` cosmic-randr: 1.0.16 -> 1.1.0 ``                                                                     |
| [`cd8bbcde`](https://github.com/NixOS/nixpkgs/commit/cd8bbcde5c2066449102336f0c89352acc515272) | `` cosmic-icons: 1.0.16 -> 1.1.0 ``                                                                     |
| [`518eeff3`](https://github.com/NixOS/nixpkgs/commit/518eeff3f186ec79ae2b3b53532d1eb4965a0afd) | `` cosmic-wallpapers: 1.0.16 -> 1.1.0 ``                                                                |
| [`5724e9a6`](https://github.com/NixOS/nixpkgs/commit/5724e9a69d65e1fbd0a6eee33816858ba0902fe6) | `` nixos/apparmor: load bpf last unconditionally ``                                                     |
| [`4d2781bb`](https://github.com/NixOS/nixpkgs/commit/4d2781bbbe185c43f23e7bcc31a266e1041b86f7) | `` nixos/incus: remove named profile ``                                                                 |
| [`870c204a`](https://github.com/NixOS/nixpkgs/commit/870c204a601a8d78020e62007af031992fc69837) | `` phpPackages.composer: 2.10.0 -> 2.10.1 ``                                                            |
| [`3a5e533a`](https://github.com/NixOS/nixpkgs/commit/3a5e533ae3bafd5266cc9185f1e3b4e385c1ed70) | `` phpPackages.composer: 2.9.8 -> 2.10.0 ``                                                             |
| [`54720e04`](https://github.com/NixOS/nixpkgs/commit/54720e047e563207f5a3124499832f3dea242d43) | `` cargo-auditable: add nix-update-script ``                                                            |
| [`612b911b`](https://github.com/NixOS/nixpkgs/commit/612b911b331b4766e08aad9e8e58a3adadb806b9) | `` cargo-auditable: 0.7.2 -> 0.7.5 ``                                                                   |
| [`9145bb74`](https://github.com/NixOS/nixpkgs/commit/9145bb741c43ae15a2611a27c08b1dbfdbb9607f) | `` gram: 2.1.2 -> 2.2.0 ``                                                                              |
| [`6df0ff29`](https://github.com/NixOS/nixpkgs/commit/6df0ff292cea6f899cb8a1da05e0e7945dac58d8) | `` libgit2: add withExperimentalSha256 argument ``                                                      |
| [`e8ce05aa`](https://github.com/NixOS/nixpkgs/commit/e8ce05aafc63e91ba4ccecbd59fa367218da0829) | `` nixos/tests: Load root profile in nspawn tests ``                                                    |
| [`1dbeae0e`](https://github.com/NixOS/nixpkgs/commit/1dbeae0ebc7f4ab77f48bfd6893e257b45b063b2) | `` python3Packages.marimo: 0.23.6 -> 0.23.10 ``                                                         |
| [`ca8d2bce`](https://github.com/NixOS/nixpkgs/commit/ca8d2bce2be37074287da086349b6bbe4682f5a2) | `` firewalld-gui: fix firewall-{applet,config} ``                                                       |
| [`0860761c`](https://github.com/NixOS/nixpkgs/commit/0860761caaa44fcaee860072ccf8696c0da5bf26) | `` nixos/test-driver: properly tokenize udev rule ``                                                    |
| [`32d1a2d6`](https://github.com/NixOS/nixpkgs/commit/32d1a2d63f24fa10f42f0376fc53eb8fe3c64bae) | `` nixos/systemd: ship time-set.target ``                                                               |
| [`f87d7f7a`](https://github.com/NixOS/nixpkgs/commit/f87d7f7a4da5bcb17891555750f0a7857ae5b1dc) | `` bottom: 0.12.3 -> 0.13.0 ``                                                                          |
| [`00582f8d`](https://github.com/NixOS/nixpkgs/commit/00582f8dcf125c23a2b21cf3fd06e1ea14fd8c71) | `` nixos/systemd-initrd: add systemd.*.services.path to initrd store ``                                 |
| [`605115a6`](https://github.com/NixOS/nixpkgs/commit/605115a6413dee75ee2e06bbaac23c4d6c068503) | `` pocket-id: 2.8.0 -> 2.9.0 ``                                                                         |
| [`13da4a1a`](https://github.com/NixOS/nixpkgs/commit/13da4a1a52cd6ce707e031cc2a26eec99b71329d) | `` perlPackages.DBDCSV: 0.60 -> 0.62 ``                                                                 |
| [`18277e3e`](https://github.com/NixOS/nixpkgs/commit/18277e3eed1c0653d5467bcb3130f3b4df88f24d) | `` perlPackages.DBDCSV: backport fix for build on latest DBI ``                                         |
| [`0df0908d`](https://github.com/NixOS/nixpkgs/commit/0df0908ddc283f537d6608d43b9694c068ad765a) | `` trivy: 0.69.3 -> 0.71.0 ``                                                                           |
| [`eb7d5c28`](https://github.com/NixOS/nixpkgs/commit/eb7d5c28f485147ce5bb24755777c503f7ef9387) | `` libslirp: add meta.changelog ``                                                                      |
| [`28bc10fe`](https://github.com/NixOS/nixpkgs/commit/28bc10fe11278e26bfda49a78cfb09513c49a331) | `` libslirp: 4.9.1 -> 4.9.3 ``                                                                          |