### PR TITLE
ci: fix issue-body output in track-upstream-fixes workflow

### DIFF
--- a/.github/workflows/track-upstream-fixes.yaml
+++ b/.github/workflows/track-upstream-fixes.yaml
@@ -59,12 +59,13 @@ jobs:
 
       - name: Build issue body
         if: steps.check.outputs.count != '0'
-        id: body
         env:
           RESOLVED: ${{ steps.check.outputs.resolved }}
         run: |
+          # Build the markdown body into a file. We pass it to the next step
+          # via a file (gh --body-file) rather than a step output, which avoids
+          # GITHUB_OUTPUT heredoc-delimiter fragility entirely.
           {
-            echo "body<<'EOF_BODY'"
             echo "One or more upstream fixes we were waiting on have landed."
             echo "Each item below is ready to have its local workaround reverted."
             echo
@@ -81,17 +82,16 @@ jobs:
               <<<"$RESOLVED"
             echo
             echo "<!-- track-upstream-fixes:sticky -->"
-            echo "EOF_BODY"
-          } >> "$GITHUB_OUTPUT"
+          } > "$RUNNER_TEMP/issue-body.md"
 
       - name: Open or update tracking issue
         if: steps.check.outputs.count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          BODY: ${{ steps.body.outputs.body }}
         run: |
           title="Upstream fix(es) landed - revert local workaround(s)"
+          body_file="$RUNNER_TEMP/issue-body.md"
           # Find an existing open sticky issue (idempotent: update rather than
           # spam a new one each run).
           existing="$(gh issue list \
@@ -104,9 +104,9 @@ jobs:
           if [[ -n "$existing" && "$existing" != "null" ]]; then
             echo "Updating existing tracking issue #$existing" >&2
             gh issue edit "$existing" --repo "$REPO" \
-              --title "$title" --body "$BODY"
+              --title "$title" --body-file "$body_file"
           else
             echo "Opening new tracking issue" >&2
             gh issue create --repo "$REPO" \
-              --title "$title" --body "$BODY"
+              --title "$title" --body-file "$body_file"
           fi


### PR DESCRIPTION
## Summary

Follow-up to #1911. The `track-upstream-fixes` workflow's **Build issue
body** step wrote a quoted heredoc delimiter (`body<<'EOF_BODY'`) to
`$GITHUB_OUTPUT`. GitHub's output parser matches the literal delimiter line,
so it looked for a closing `'EOF_BODY'` (quoted) but the step emitted
`EOF_BODY` (unquoted) — failing with `Matching delimiter not found ''EOF_BODY''`.

Seen in the first post-merge run:
https://github.com/fredsystems/nixos/actions/runs/28468719240

Note the checker itself worked correctly (it resolved the dateutils #511329
entry); only the issue-body formatting failed.

## Fix

Build the markdown into `$RUNNER_TEMP/issue-body.md` and pass it to
`gh issue create/edit --body-file` instead of routing multiline content
through a step output. This removes the `$GITHUB_OUTPUT` delimiter fragility
entirely.

## Verification

- `actionlint`: clean
- `shellcheck` (via pre-commit): clean
- Local simulation of the body build produces correct markdown.

## Expected behavior once merged

On the next run, the workflow will open a tracking issue for
`nixpkgs-511329-dateutils-darwin` (dateutils #511329 is confirmed fixed
upstream), prompting a test of dropping that darwin overlay branch. That's
the system working as intended.