### PR TITLE
revert: drop dateutils darwin gnu17 pin (nixpkgs#511329 fixed)

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -79,7 +79,7 @@
     },
     {
       "id": "nixpkgs-511329-dateutils-darwin",
-      "done": false,
+      "done": true,
       "summary": "staging-next autoconf update forced Clang to -std=gnu23, breaking dateutils 0.4.11 (dgrep.c) on aarch64-darwin.",
       "repo": "NixOS/nixpkgs",
       "check": "issue-closed",

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -30,20 +30,6 @@ final: prev: {
     }
   );
 
-  # Workaround for the staging-next autoconf update that forces Clang to
-  # `-std=gnu23`, breaking C code that isn't C23-compliant.  See upstream
-  # tracking issue: https://github.com/NixOS/nixpkgs/issues/511329.
-  # `dateutils` 0.4.11 fails to compile `dgrep.c` under C23 on aarch64-darwin
-  # (Clang is the default C compiler on macOS, so this only affects darwin).
-  # Pin CFLAGS back to the previous default of gnu17 via configureFlags.
-  dateutils =
-    if prev.stdenv.isDarwin then
-      prev.dateutils.overrideAttrs (old: {
-        configureFlags = (old.configureFlags or [ ]) ++ [ "CFLAGS=-std=gnu17" ];
-      })
-    else
-      prev.dateutils;
-
   # `direnv`'s checkPhase runs `make test-go test-bash test-fish test-zsh`.
   # On darwin, the fish test suite hangs indefinitely (CI hits the 6h max
   # execution time with no output).  Tracked upstream:


### PR DESCRIPTION
## What

Reverts the darwin-only `CFLAGS=-std=gnu17` pin on the `dateutils` overlay and marks the tracked upstream fix `nixpkgs-511329-dateutils-darwin` as `done: true`.

## Why

The staging-next autoconf update that forced Clang to `-std=gnu23` and broke `dateutils` 0.4.11 (`dgrep.c`) on aarch64-darwin is resolved upstream: [NixOS/nixpkgs#511329](https://github.com/NixOS/nixpkgs/issues/511329) is closed (2026-05-03).

## Verification

This is a darwin-only revert and cannot be eval'd locally on this Linux machine. `dateutils` is in `profiles/darwin.nix` system packages, so the darwin CI workflow will build it and confirm it compiles on aarch64-darwin without the gnu17 pin. Linux eval (Daytona toplevel) confirmed the overlay file still parses/evaluates cleanly.

Closes #1913