### PR TITLE
fix(tracked-fixes): gate dateutils-darwin revert on pin containing the real fix

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -82,11 +82,16 @@
       "done": false,
       "summary": "staging-next autoconf update forced Clang to -std=gnu23, breaking dateutils 0.4.11 (dgrep.c) on aarch64-darwin.",
       "repo": "NixOS/nixpkgs",
-      "check": "issue-closed",
-      "issue": 511329,
-      "tracking": ["https://github.com/NixOS/nixpkgs/issues/511329"],
+      "check": "nixpkgs-pin-contains-commit",
+      "fix_commit": "670c46f746ea46f6a3acab704abff3869a5bcb38",
+      "pin_node": "nixpkgs",
+      "tracking": [
+        "https://github.com/NixOS/nixpkgs/issues/511329",
+        "https://github.com/NixOS/nixpkgs/pull/526257",
+        "https://github.com/hroptatyr/dateutils/commit/b30902c2f46288b570c7fa8de06e17cc7dfd6a37"
+      ],
       "workaround": "overlays/default.nix -- `dateutils` overlay pins `CFLAGS=-std=gnu17` on darwin only.",
-      "revert_action": "#511329 is already closed/completed upstream. Confirm our pinned nixpkgs builds dateutils on aarch64-darwin without the gnu17 pin, then drop the darwin branch of the `dateutils` overlay and set `done: true`. (This entry will flag immediately on first run, which is the intended prompt to test the revert.)"
+      "revert_action": "The real fix is the upstream dateutils patch (hroptatyr commit b30902c) packaged in nixpkgs PR #526257 (merge commit 670c46f, merged to master 2026-06-09; backported to release-26.05 via #530052). It adds flex/bison and substitutes the yyparse declaration -- it does NOT use the gnu17 CFLAGS hack. The umbrella issue #511329 was closed only because the breakage was reduced enough for staging-next to merge, not because dateutils was fixed, so `issue-closed` was a false signal. This entry is now gated on our pinned `nixpkgs` (unstable, the channel the darwin host follows) actually containing 670c46f. Once it does, drop the darwin branch of the `dateutils` overlay and set `done: true`. IMPORTANT verification: a green darwin CI build is NOT sufficient on its own -- dateutils-0.4.11 is substitutable from cache.nixos.org, so confirm CI actually built it from source (or build with `--rebuild`) before trusting the revert."
     },
     {
       "id": "nixpkgs-526476-fwupd-polkit",


### PR DESCRIPTION
## Problem

Issue #1913 flagged `nixpkgs-511329-dateutils-darwin` as ready to revert. That was a **false positive on two levels**:

1. **Wrong upstream signal.** The entry used `check: issue-closed` against umbrella issue [NixOS/nixpkgs#511329](https://github.com/NixOS/nixpkgs/issues/511329). That issue was closed only because the staging-next breakage was reduced *enough to merge* (maintainer: "Closing this now since the breakage was reduced enough for staging-next to be merged, but please do keep fixing broken packages!"). `dateutils` is still listed unresolved in that issue. `issue-closed` is the weakest signal per the manifest's own docs.

2. **Cache-masked CI.** When I test-reverted the overlay, the Darwin CI went green — but the build log showed `dateutils-0.4.11` was **substituted from `cache.nixos.org`**, not built from source. Only `dateutils-0.4.11-fish-completions` built locally, which does not exercise the C23 `dgrep.c`/`yyparse` compile. (That test-revert PR #1914 has been closed.)

## The real fix

[nixpkgs#526257](https://github.com/NixOS/nixpkgs/pull/526257) ("dateutils: fix build errors", merge commit `670c46f`, merged 2026-06-09, backported to `release-26.05` via #530052) applies the upstream dateutils patch ([hroptatyr b30902c](https://github.com/hroptatyr/dateutils/commit/b30902c2f46288b570c7fa8de06e17cc7dfd6a37)) and adds flex/bison. It does **not** use the gnu17 CFLAGS hack. `nixpkgs-review` confirmed it builds on aarch64-darwin and x86_64-darwin.

## Why we can't revert yet

Our pinned `nixpkgs` (unstable, rev `2fc6539b`, the channel the darwin host follows) does **not** contain `670c46f`. Verified via the GitHub compare API: the fix is ahead, `behind_by: 0`. Reverting the overlay now would build the old, unpatched source.

## Change

Switch the entry from `issue-closed` to the channel-aware `nixpkgs-pin-contains-commit`, gated on `670c46f` against `pin_node: nixpkgs`. The checker now correctly reports BLOCKED:

```text
checking nixpkgs-511329-dateutils-darwin (nixpkgs-pin-contains-commit on NixOS/nixpkgs)
  pinned nixpkgs (2fc6539b481e) does NOT yet contain 670c46f746ea
```

The overlay workaround is left in place. The entry will re-flag for revert only once our pin actually carries the fix — and the revert_action now warns that a green darwin CI build alone is insufficient (verify a from-source build, not a cache substitution).

Refs #1913