### PR TITLE
revert: drop dateutils darwin gnu17 pin (nixpkgs#526257 fix in our pin)

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -79,14 +79,18 @@
     },
     {
       "id": "nixpkgs-511329-dateutils-darwin",
-      "done": false,
+      "done": true,
       "summary": "staging-next autoconf update forced Clang to -std=gnu23, breaking dateutils 0.4.11 (dgrep.c) on aarch64-darwin.",
       "repo": "NixOS/nixpkgs",
       "check": "issue-closed",
       "issue": 511329,
-      "tracking": ["https://github.com/NixOS/nixpkgs/issues/511329"],
+      "tracking": [
+        "https://github.com/NixOS/nixpkgs/issues/511329",
+        "https://github.com/NixOS/nixpkgs/pull/526257",
+        "https://github.com/hroptatyr/dateutils/commit/b30902c2f46288b570c7fa8de06e17cc7dfd6a37"
+      ],
       "workaround": "overlays/default.nix -- `dateutils` overlay pins `CFLAGS=-std=gnu17` on darwin only.",
-      "revert_action": "#511329 is already closed/completed upstream. Confirm our pinned nixpkgs builds dateutils on aarch64-darwin without the gnu17 pin, then drop the darwin branch of the `dateutils` overlay and set `done: true`. (This entry will flag immediately on first run, which is the intended prompt to test the revert.)"
+      "revert_action": "DONE. The umbrella issue #511329 closing was not itself the signal -- it closed once staging-next breakage was reduced enough to merge, not because dateutils was fixed. The actual fix is nixpkgs PR #526257 (merge commit 670c46f, backported to release-26.05 via #530052), which applies the upstream dateutils patch (hroptatyr b30902c) and adds flex/bison instead of the gnu17 CFLAGS hack. Verified our pinned nixpkgs (rev b5aa0fbd, which the darwin host evaluates via the nixpkgs_8 node) contains 670c46f and that pkgs.dateutils on the darwin host carries the b30902c patch + flex/bison. The patched, no-gnu17 dateutils for aarch64-darwin is already built on cache.nixos.org by upstream Hydra (store path ir1k1nb...-dateutils-0.4.11), so the from-source build is confirmed good. Overlay darwin branch removed."
     },
     {
       "id": "nixpkgs-526476-fwupd-polkit",

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -30,20 +30,6 @@ final: prev: {
     }
   );
 
-  # Workaround for the staging-next autoconf update that forces Clang to
-  # `-std=gnu23`, breaking C code that isn't C23-compliant.  See upstream
-  # tracking issue: https://github.com/NixOS/nixpkgs/issues/511329.
-  # `dateutils` 0.4.11 fails to compile `dgrep.c` under C23 on aarch64-darwin
-  # (Clang is the default C compiler on macOS, so this only affects darwin).
-  # Pin CFLAGS back to the previous default of gnu17 via configureFlags.
-  dateutils =
-    if prev.stdenv.isDarwin then
-      prev.dateutils.overrideAttrs (old: {
-        configureFlags = (old.configureFlags or [ ]) ++ [ "CFLAGS=-std=gnu17" ];
-      })
-    else
-      prev.dateutils;
-
   # `direnv`'s checkPhase runs `make test-go test-bash test-fish test-zsh`.
   # On darwin, the fish test suite hangs indefinitely (CI hits the 6h max
   # execution time with no output).  Tracked upstream:


### PR DESCRIPTION
## What

Removes the darwin-only `CFLAGS=-std=gnu17` pin from the `dateutils` overlay and marks the tracked upstream fix `nixpkgs-511329-dateutils-darwin` `done: true`.

## Why this is genuinely fixed (not just a closed issue)

The umbrella issue [NixOS/nixpkgs#511329](https://github.com/NixOS/nixpkgs/issues/511329) closing was *not* the real signal — it closed once staging-next breakage dropped enough to merge, while dateutils was still listed unresolved there.

The actual fix is [nixpkgs#526257](https://github.com/NixOS/nixpkgs/pull/526257) (`dateutils: fix build errors`, merge commit `670c46f`, backported to `release-26.05` via #530052). It applies the upstream dateutils patch ([hroptatyr b30902c](https://github.com/hroptatyr/dateutils/commit/b30902c2f46288b570c7fa8de06e17cc7dfd6a37)) and adds flex/bison instead of forcing gnu17. `nixpkgs-review` confirmed it builds on aarch64-darwin / x86_64-darwin.

## Verification (done locally despite no darwin builder)

- Our pinned nixpkgs rev the **darwin host actually evaluates** is `b5aa0fbd` (the `nixpkgs_8` lock node, updated 2026-06-29 by #1910), not the stale top-level `nixpkgs` node. Confirmed via `nix eval .#darwinConfigurations.Freds-MacBook-Pro.pkgs.path`.
- `b5aa0fbd` **contains** the fix commit `670c46f` (GitHub compare: `ahead_by: 0, behind_by: 10459`).
- The darwin host's `pkgs.dateutils` carries the `b30902c` patch and `flex`/`bison` in nativeBuildInputs.
- After this revert, the darwin `dateutils` resolves to `ir1k1nb...-dateutils-0.4.11` with `configureFlags = []` — the bare patched build, which **already exists on cache.nixos.org** from upstream Hydra (so the from-source aarch64-darwin build is confirmed good, not a stale artifact).
- Linux (Daytona) toplevel still evals cleanly.

The darwin CI build will reuse that upstream cache path; that is expected and is positive evidence, not a false positive.

Closes #1913