### PR TITLE
feat: use upstream caches for colmena/catppuccin/niri + push dev shell to Attic

### DIFF
--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -339,17 +339,93 @@ jobs:
           fi
 
   # =====================================================================
+  # Decide whether the dev shell / dev packages need rebuilding (Darwin)
+  #
+  # Same detection as ci-linux.yaml's find-devshell: the dev shell is fed
+  # by flake/dev/*.nix and the inputs nixpkgs, precommit-base, colmena, and
+  # walls-*. Unrelated PRs skip the dev-shell build entirely.
+  find-devshell:
+    name: Detect dev-shell changes
+    runs-on: ubuntu-latest
+    needs: [skip-if-clean]
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect dev-shell-affecting changes
+        id: detect
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          else
+            base_sha="${{ github.event.merge_group.base_sha }}"
+          fi
+
+          changed_files=$(git diff --name-only "$base_sha" HEAD)
+          echo "Changed files:"
+          echo "$changed_files"
+
+          changed=false
+          flake_lock_changed=false
+
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              flake/dev/*.nix)
+                changed=true ;;
+              .github/workflows/ci-linux.yaml|.github/workflows/ci-darwin.yaml)
+                changed=true ;;
+              flake.lock)
+                flake_lock_changed=true ;;
+            esac
+          done <<< "$changed_files"
+
+          devshell_inputs="nixpkgs precommit-base colmena walls-catppuccin walls-zhichaoh walls-cozypixels"
+
+          if [ "$changed" = "false" ] && [ "$flake_lock_changed" = "true" ]; then
+            old_lock=$(git show "${base_sha}:flake.lock" 2>/dev/null || echo '{}')
+            new_lock=$(cat flake.lock)
+            for input in $devshell_inputs; do
+              node_name=$(echo "$new_lock" | jq -r ".nodes.root.inputs.\"$input\" // empty")
+              [ -z "$node_name" ] && continue
+              old_rev=$(echo "$old_lock" | jq -r ".nodes.\"$node_name\".locked.rev // .nodes.\"$node_name\".locked.narHash // empty" 2>/dev/null)
+              new_rev=$(echo "$new_lock" | jq -r ".nodes.\"$node_name\".locked.rev // .nodes.\"$node_name\".locked.narHash // empty")
+              if [ "$old_rev" != "$new_rev" ]; then
+                echo "  dev-shell input changed: $input"
+                changed=true
+                break
+              fi
+            done
+          fi
+
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "dev-shell rebuild needed: $changed"
+
+  # =====================================================================
   # Build + push the dev shell and dev packages (Darwin)
   #
   # Mirrors the dev-shell job in ci-linux.yaml so the Mac fetches the dev
   # shell (`nix develop`) and per-system packages from Attic instead of
-  # rebuilding them locally. `--accept-flake-config` honors the flake's
-  # nixConfig extra-substituters (colmena/catppuccin/niri caches).
+  # rebuilding them locally. Gated on find-devshell so unrelated PRs skip.
+  # `--accept-flake-config` honors the flake's nixConfig extra-substituters
+  # (colmena/catppuccin/niri caches).
   dev-shell-darwin:
     name: Build & push dev shell + packages (Darwin)
     runs-on: [self-hosted, macOS]
-    needs: [skip-if-clean]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    needs: [skip-if-clean, find-devshell]
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-devshell.outputs.changed == 'true' }}
     permissions:
       id-token: "write"
       contents: "read"
@@ -383,13 +459,16 @@ jobs:
 
           echo "Building dev packages..."
           # Enumerate every packages.<system>.* attr; tolerate an empty set.
-          pkg_attrs=$(nix eval --json ".#packages.${system}" --apply builtins.attrNames)
-          echo "$pkg_attrs" | jq -r '.[]' | while read -r attr; do
+          # Emit newline-separated names via Nix itself so this step has no
+          # dependency on jq (not present on the self-hosted runner).
+          pkg_attrs=$(nix eval --raw ".#packages.${system}" \
+            --apply 'ps: builtins.concatStringsSep "\n" (builtins.attrNames ps)')
+          while read -r attr; do
             [ -z "$attr" ] && continue
             echo "  building packages.${system}.${attr}"
             nix build --accept-flake-config --no-link --print-out-paths \
               ".#packages.${system}.${attr}" >> devshell.paths
-          done
+          done <<< "$pkg_attrs"
 
           echo "Pushing built dev outputs to Attic..."
           # Push the realised store paths (and their closures) directly.

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -339,12 +339,70 @@ jobs:
           fi
 
   # =====================================================================
+  # Build + push the dev shell and dev packages (Darwin)
+  #
+  # Mirrors the dev-shell job in ci-linux.yaml so the Mac fetches the dev
+  # shell (`nix develop`) and per-system packages from Attic instead of
+  # rebuilding them locally. `--accept-flake-config` honors the flake's
+  # nixConfig extra-substituters (colmena/catppuccin/niri caches).
+  dev-shell-darwin:
+    name: Build & push dev shell + packages (Darwin)
+    runs-on: [self-hosted, macOS]
+    needs: [skip-if-clean]
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    permissions:
+      id-token: "write"
+      contents: "read"
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          trust-runner-user: true
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+            substituters = http://192.168.31.14/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
+
+      - name: Build & push dev shell + packages
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          system=$(nix eval --raw --impure --expr builtins.currentSystem)
+          echo "Building dev outputs for system: $system"
+
+          echo "Logging in to Attic..."
+          nix shell --inputs-from . nixpkgs#attic-client --command attic login fred http://192.168.31.14:8080 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIxNDgyMzMyODksIm5iZiI6MTc2OTU0MjA4OSwic3ViIjoiZnJlZCIsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJmcmVkIjp7InIiOjEsInciOjEsImNjIjoxfX19fQ.WhR5ixdW0j-wV77Tl8VubJPEyEvgQ8nQWYbgJxI8pPiLJN6v4DVaqKPu15mcY0N0B0zKnq9-njG5EOn2Z2-4dMgfx9ttTA-lltxrvPf5nKR9zAXg6hgPYsnGQuRFBvAFzlfPCpcIU2rgEVzMajzjipQgfUnVPDuto9uPU1VG25fncVRYz5dUhOXTfvN_WWpzcgQ7HDHQufbui5IoG-nmFMFWcNkxTCw7XVNs1PYFpadMGn6zAeh9Hi6epYYllr1aTcmTCx6ut3-fbFdQaxGG_HsCyxFiIf9r6GNSQvZOeHbeLcE21RQ6qNrkKZuQiVoOAcQr7ngpQ2jjcWnajw_hCPi6rqByZxdZy8IAbPQ83nm9o5UlfKg99sr6YSV-6ZTBvsOm-ioUX9hSktWm3O7cdH74ygmbUC_QL-os6aYNhbyQjSEMgiOpS65VnFURG58gnnvVHncMvohyDKwZqcWVtiaQApNeL3_LEATtX_zdqlaWdCVXO3t3QlD0ebYVhb4rn2KEg0GOZHGpWPqJnszRSMwXgWM1fG37OF117Qz6O9280BoEMdjLvITr5Cq0kQqS0PzapLdI5maU6ZluyqvAvgqdHzwjey4hDDq3FjITA_JMUStRlH7sMwtaSGTiTTOHQPe7WT9PImqfm4G8Q3urOsHMBE_Au1dqnUz4Lq-yU4M
+
+          echo "Building dev shell..."
+          nix build --accept-flake-config --no-link --print-out-paths \
+            ".#devShells.${system}.default" > devshell.paths
+
+          echo "Building dev packages..."
+          # Enumerate every packages.<system>.* attr; tolerate an empty set.
+          pkg_attrs=$(nix eval --json ".#packages.${system}" --apply builtins.attrNames)
+          echo "$pkg_attrs" | jq -r '.[]' | while read -r attr; do
+            [ -z "$attr" ] && continue
+            echo "  building packages.${system}.${attr}"
+            nix build --accept-flake-config --no-link --print-out-paths \
+              ".#packages.${system}.${attr}" >> devshell.paths
+          done
+
+          echo "Pushing built dev outputs to Attic..."
+          # Push the realised store paths (and their closures) directly.
+          xargs -r nix shell --inputs-from . nixpkgs#attic-client --command \
+            attic push fred --ignore-upstream-cache-filter -j 2 < devshell.paths
+
+  # =====================================================================
   # Required Check Summary
   # =====================================================================
   build-darwin-summary:
     name: Build Darwin Systems Summary
     runs-on: ubuntu-latest
-    needs: [skip-if-clean, build-darwin]
+    needs: [skip-if-clean, build-darwin, dev-shell-darwin]
     if: ${{ always() }}
 
     steps:
@@ -358,14 +416,16 @@ jobs:
 
           # Case 2: enforce matrix results
           STATUS="${{ needs.build-darwin.result }}"
-          echo "build-darwin result: $STATUS"
+          DEVSHELL="${{ needs.dev-shell-darwin.result }}"
+          echo "build-darwin result:     $STATUS"
+          echo "dev-shell-darwin result: $DEVSHELL"
 
-          if [ "$STATUS" = "failure" ]; then
+          if [ "$STATUS" = "failure" ] || [ "$DEVSHELL" = "failure" ]; then
             echo "❌ One or more Darwin builds failed."
             exit 1
           fi
 
-          if [ "$STATUS" = "cancelled" ]; then
+          if [ "$STATUS" = "cancelled" ] || [ "$DEVSHELL" = "cancelled" ]; then
             echo "❌ Darwin build was cancelled — treating as failure."
             exit 1
           fi

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -495,12 +495,75 @@ jobs:
           fi
 
   # =====================================================================
+  # Build + push the dev shell and dev packages
+  #
+  # The host build jobs only cache system.build.toplevel and the
+  # home-manager activation package. The dev shell (`nix develop`) and the
+  # per-system `packages` outputs (colmena CLI, lint tooling, wallpapers)
+  # are never part of a host closure, so without this job every machine
+  # rebuilds them on first `nix develop`. Build and push them to Attic so
+  # all machines (and this Mac) fetch instead of build.
+  #
+  # `--accept-flake-config` is required so the flake's nixConfig
+  # extra-substituters (colmena/catppuccin/niri caches) are honored.
+  dev-shell:
+    name: Build & push dev shell + packages
+    runs-on: [self-hosted, Linux]
+    needs: [skip-if-clean]
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    permissions:
+      id-token: "write"
+      contents: "read"
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          trust-runner-user: true
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+            substituters = http://192.168.31.14/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
+
+      - name: Build & push dev shell + packages
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          system=$(nix eval --raw --impure --expr builtins.currentSystem)
+          echo "Building dev outputs for system: $system"
+
+          echo "Logging in to Attic..."
+          nix shell --inputs-from . nixpkgs#attic-client --command attic login fred http://192.168.31.14:8080 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIxNDgyMzMyODksIm5iZiI6MTc2OTU0MjA4OSwic3ViIjoiZnJlZCIsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJmcmVkIjp7InIiOjEsInciOjEsImNjIjoxfX19fQ.WhR5ixdW0j-wV77Tl8VubJPEyEvgQ8nQWYbgJxI8pPiLJN6v4DVaqKPu15mcY0N0B0zKnq9-njG5EOn2Z2-4dMgfx9ttTA-lltxrvPf5nKR9zAXg6hgPYsnGQuRFBvAFzlfPCpcIU2rgEVzMajzjipQgfUnVPDuto9uPU1VG25fncVRYz5dUhOXTfvN_WWpzcgQ7HDHQufbui5IoG-nmFMFWcNkxTCw7XVNs1PYFpadMGn6zAeh9Hi6epYYllr1aTcmTCx6ut3-fbFdQaxGG_HsCyxFiIf9r6GNSQvZOeHbeLcE21RQ6qNrkKZuQiVoOAcQr7ngpQ2jjcWnajw_hCPi6rqByZxdZy8IAbPQ83nm9o5UlfKg99sr6YSV-6ZTBvsOm-ioUX9hSktWm3O7cdH74ygmbUC_QL-os6aYNhbyQjSEMgiOpS65VnFURG58gnnvVHncMvohyDKwZqcWVtiaQApNeL3_LEATtX_zdqlaWdCVXO3t3QlD0ebYVhb4rn2KEg0GOZHGpWPqJnszRSMwXgWM1fG37OF117Qz6O9280BoEMdjLvITr5Cq0kQqS0PzapLdI5maU6ZluyqvAvgqdHzwjey4hDDq3FjITA_JMUStRlH7sMwtaSGTiTTOHQPe7WT9PImqfm4G8Q3urOsHMBE_Au1dqnUz4Lq-yU4M
+
+          echo "Building dev shell..."
+          nix build --accept-flake-config --no-link --print-out-paths \
+            ".#devShells.${system}.default" > devshell.paths
+
+          echo "Building dev packages..."
+          # Enumerate every packages.<system>.* attr; tolerate an empty set.
+          pkg_attrs=$(nix eval --json ".#packages.${system}" --apply builtins.attrNames)
+          echo "$pkg_attrs" | jq -r '.[]' | while read -r attr; do
+            [ -z "$attr" ] && continue
+            echo "  building packages.${system}.${attr}"
+            nix build --accept-flake-config --no-link --print-out-paths \
+              ".#packages.${system}.${attr}" >> devshell.paths
+          done
+
+          echo "Pushing built dev outputs to Attic..."
+          # Push the realised store paths (and their closures) directly.
+          xargs -r nix shell --inputs-from . nixpkgs#attic-client --command \
+            attic push fred --ignore-upstream-cache-filter -j 2 < devshell.paths
+
+  # =====================================================================
   # Required summary check
   # =====================================================================
   build-linux-summary:
     name: Build Linux Summary
     runs-on: ubuntu-latest
-    needs: [skip-if-clean, build-servers, build-desktops]
+    needs: [skip-if-clean, build-servers, build-desktops, dev-shell]
     if: ${{ always() }}
 
     steps:
@@ -514,18 +577,20 @@ jobs:
 
           SERVERS="${{ needs.build-servers.result }}"
           DESKTOPS="${{ needs.build-desktops.result }}"
+          DEVSHELL="${{ needs.dev-shell.result }}"
 
           echo "Servers result:   $SERVERS"
           echo "Desktops result:  $DESKTOPS"
+          echo "Dev shell result: $DEVSHELL"
 
           # A result of "skipped" means the matrix was empty (no systems in
           # scope for this PR) — that is a valid outcome, not a failure.
-          if [ "$SERVERS" = "failure" ] || [ "$DESKTOPS" = "failure" ]; then
+          if [ "$SERVERS" = "failure" ] || [ "$DESKTOPS" = "failure" ] || [ "$DEVSHELL" = "failure" ]; then
             echo "❌ One or more Linux builds failed."
             exit 1
           fi
 
-          if [ "$SERVERS" = "cancelled" ] || [ "$DESKTOPS" = "cancelled" ]; then
+          if [ "$SERVERS" = "cancelled" ] || [ "$DESKTOPS" = "cancelled" ] || [ "$DEVSHELL" = "cancelled" ]; then
             echo "❌ Build job was cancelled — treating as failure."
             exit 1
           fi

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -495,6 +495,88 @@ jobs:
           fi
 
   # =====================================================================
+  # Decide whether the dev shell / dev packages need rebuilding
+  #
+  # The dev shell does NOT share the host input set, so the host filter
+  # would both over- and under-build it. It is fed by:
+  #   - flake/dev/*.nix              (the shell / checks / packages defs)
+  #   - input: nixpkgs               (nodejs, typescript, wallpaper pkgs)
+  #   - input: precommit-base        (statix/nixfmt/deadnix/... hooks)
+  #   - input: colmena               (the colmena CLI in the shell)
+  #   - input: walls-{catppuccin,zhichaoh,cozypixels} (wallpaper sources)
+  # Anything else (host dirs, server modules, docs) leaves it untouched.
+  find-devshell:
+    name: Detect dev-shell changes
+    runs-on: ubuntu-latest
+    needs: [skip-if-clean]
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect dev-shell-affecting changes
+        id: detect
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          # workflow_dispatch has no diff context — always rebuild.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          else
+            base_sha="${{ github.event.merge_group.base_sha }}"
+          fi
+
+          changed_files=$(git diff --name-only "$base_sha" HEAD)
+          echo "Changed files:"
+          echo "$changed_files"
+
+          changed=false
+          flake_lock_changed=false
+
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              flake/dev/*.nix)
+                changed=true ;;
+              .github/workflows/ci-linux.yaml|.github/workflows/ci-darwin.yaml)
+                changed=true ;;
+              flake.lock)
+                flake_lock_changed=true ;;
+            esac
+          done <<< "$changed_files"
+
+          # Inputs that actually feed the dev shell / dev packages.
+          devshell_inputs="nixpkgs precommit-base colmena walls-catppuccin walls-zhichaoh walls-cozypixels"
+
+          if [ "$changed" = "false" ] && [ "$flake_lock_changed" = "true" ]; then
+            old_lock=$(git show "${base_sha}:flake.lock" 2>/dev/null || echo '{}')
+            new_lock=$(cat flake.lock)
+            for input in $devshell_inputs; do
+              node_name=$(echo "$new_lock" | jq -r ".nodes.root.inputs.\"$input\" // empty")
+              [ -z "$node_name" ] && continue
+              old_rev=$(echo "$old_lock" | jq -r ".nodes.\"$node_name\".locked.rev // .nodes.\"$node_name\".locked.narHash // empty" 2>/dev/null)
+              new_rev=$(echo "$new_lock" | jq -r ".nodes.\"$node_name\".locked.rev // .nodes.\"$node_name\".locked.narHash // empty")
+              if [ "$old_rev" != "$new_rev" ]; then
+                echo "  dev-shell input changed: $input"
+                changed=true
+                break
+              fi
+            done
+          fi
+
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "dev-shell rebuild needed: $changed"
+
+  # =====================================================================
   # Build + push the dev shell and dev packages
   #
   # The host build jobs only cache system.build.toplevel and the
@@ -504,13 +586,15 @@ jobs:
   # rebuilds them on first `nix develop`. Build and push them to Attic so
   # all machines (and this Mac) fetch instead of build.
   #
+  # Gated on find-devshell so unrelated PRs skip it entirely.
+  #
   # `--accept-flake-config` is required so the flake's nixConfig
   # extra-substituters (colmena/catppuccin/niri caches) are honored.
   dev-shell:
     name: Build & push dev shell + packages
     runs-on: [self-hosted, Linux]
-    needs: [skip-if-clean]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    needs: [skip-if-clean, find-devshell]
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-devshell.outputs.changed == 'true' }}
     permissions:
       id-token: "write"
       contents: "read"
@@ -544,13 +628,16 @@ jobs:
 
           echo "Building dev packages..."
           # Enumerate every packages.<system>.* attr; tolerate an empty set.
-          pkg_attrs=$(nix eval --json ".#packages.${system}" --apply builtins.attrNames)
-          echo "$pkg_attrs" | jq -r '.[]' | while read -r attr; do
+          # Emit newline-separated names via Nix itself so this step has no
+          # dependency on jq (not present on the self-hosted runner).
+          pkg_attrs=$(nix eval --raw ".#packages.${system}" \
+            --apply 'ps: builtins.concatStringsSep "\n" (builtins.attrNames ps)')
+          while read -r attr; do
             [ -z "$attr" ] && continue
             echo "  building packages.${system}.${attr}"
             nix build --accept-flake-config --no-link --print-out-paths \
               ".#packages.${system}.${attr}" >> devshell.paths
-          done
+          done <<< "$pkg_attrs"
 
           echo "Pushing built dev outputs to Attic..."
           # Push the realised store paths (and their closures) directly.

--- a/agents.md
+++ b/agents.md
@@ -150,6 +150,31 @@ The full input-to-category mapping (the source of truth shared between
 script) is in the `nixos-input-category-sync` skill. When changing it,
 load that skill.
 
+Both `ci-linux.yaml` and `ci-darwin.yaml` also carry a `dev-shell`
+build-and-push job (one per OS, on the self-hosted runners). The host
+matrix only caches `toplevel` + home-manager activation, so the dev
+shell (`nix develop`) and the per-system `packages.*` outputs (colmena
+CLI, lint tooling, wallpapers) would otherwise be rebuilt locally on
+every machine. The job builds `.#devShells.<system>.default` and every
+`.#packages.<system>.*` and pushes them to Attic. It is **gated by its
+own `find-devshell` detection job**, which is independent of the host
+filter because the dev shell has a different input set: it rebuilds only
+when `flake/dev/*.nix`, a CI workflow file, or one of the inputs that
+actually feed the shell changes -- `nixpkgs`, `precommit-base`,
+`colmena`, or the `walls-*` wallpaper inputs. Note that `precommit-base`
+and `colmena` are `skip` for the host filter but **do** trigger the dev
+shell. Keep that `devshell_inputs` list in sync (in both workflows) when
+the dev shell's dependencies change.
+
+Three inputs deliberately do **not** follow our `nixpkgs` so their
+prebuilt outputs can be substituted from the projects' own caches:
+`colmena` (colmena.cachix.org), `catppuccin` (catppuccin.cachix.org),
+and `niri` (niri.cachix.org / niri-epireyn.cachix.org). Those caches are
+wired both into `flake.nix`'s `nixConfig` (for ad-hoc builds) and into
+`modules/base/system.nix` (so every host's `/etc/nix/nix.conf` uses them
+during normal `nixos-rebuild` / `nix develop`). Following our `nixpkgs`
+would change their derivation hashes and force local source builds.
+
 ## Update workflows
 
 - **`update-flakes.yaml`** runs weekly, opens one PR per input via

--- a/flake.lock
+++ b/flake.lock
@@ -71,9 +71,7 @@
     },
     "catppuccin": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1782648384,
@@ -137,17 +135,15 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_3",
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1782828582,
-        "narHash": "sha256-nw21SYqCfWfHZH2UMG/DeN5BKv2BJWz9IVKrCTViZ74=",
+        "lastModified": 1782840621,
+        "narHash": "sha256-I9i2GvAmrC3IqH0pqNevrF5nNocPiZBeHGWxBXDDmJI=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "e052f9b322aa4406d35c1f88892acea34c8d3e33",
+        "rev": "5107501000dc834c846a8d316d787019aabe72b1",
         "type": "github"
       },
       "original": {
@@ -500,7 +496,7 @@
       "inputs": {
         "flake-compat": "flake-compat_4",
         "gitignore": "gitignore_3",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1763988335,
@@ -674,9 +670,7 @@
       "inputs": {
         "niri-stable": "niri-stable",
         "niri-unstable": "niri-unstable",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-stable": "nixpkgs-stable",
         "xwayland-satellite-stable": "xwayland-satellite-stable",
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
@@ -753,7 +747,7 @@
       "inputs": {
         "flake-utils": "flake-utils_5",
         "git-hooks": "git-hooks_3",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "lastModified": 1764529576,
@@ -835,6 +829,22 @@
     },
     "nixpkgs_10": {
       "locked": {
+        "lastModified": 1764406085,
+        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "nixos",
@@ -849,7 +859,39 @@
         "type": "github"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -867,32 +909,29 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
-        "type": "github"
+        "lastModified": 1782175435,
+        "narHash": "sha256-8d2wCNWKnd86GzKZvbuqqlS+HqMrheXkvRf0qGJ/oA0=",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1020805.89570f24e97e/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -931,6 +970,54 @@
     },
     "nixpkgs_6": {
       "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
         "lastModified": 1759417375,
         "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "NixOS",
@@ -945,58 +1032,10 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1764406085,
-        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_12",
         "systems": "systems_6"
       },
       "locked": {
@@ -1029,7 +1068,7 @@
       "inputs": {
         "flake-utils": "flake-utils_3",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_4",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
@@ -1050,7 +1089,7 @@
       "inputs": {
         "flake-utils": "flake-utils_6",
         "git-hooks": "git-hooks_4",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_13",
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
@@ -1071,7 +1110,7 @@
       "inputs": {
         "flake-utils": "flake-utils_4",
         "git-hooks": "git-hooks_2",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_6",
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
@@ -1102,7 +1141,7 @@
         "home-manager-stable": "home-manager-stable",
         "niri": "niri",
         "nixos-needsreboot": "nixos-needsreboot",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_11",
         "nixpkgs-kernel": "nixpkgs-kernel",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixvim": "nixvim",
@@ -1117,7 +1156,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1780456895,
@@ -1156,7 +1195,7 @@
     },
     "rust-overlay_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1780456895,
@@ -1195,7 +1234,7 @@
     },
     "rust-overlay_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": "nixpkgs_14"
       },
       "locked": {
         "lastModified": 1782789458,

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,26 @@
 {
   description = "Fred's NixOS config flake";
 
+  # Extra binary caches for inputs that are deliberately NOT following our
+  # nixpkgs (colmena, catppuccin, niri). Their upstream CI publishes prebuilt
+  # outputs to these caches built against each project's own pinned nixpkgs,
+  # so substitution only works when we keep those inputs' nixpkgs unchanged.
+  # `extra-*` appends to (does not replace) the system / CI substituters.
+  nixConfig = {
+    extra-substituters = [
+      "https://colmena.cachix.org"
+      "https://catppuccin.cachix.org"
+      "https://niri.cachix.org"
+      "https://niri-epireyn.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg="
+      "catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU="
+      "niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964="
+      "niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA="
+    ];
+  };
+
   inputs = {
     ##########################################################################
     ## CI categories  (see agents.md for the full mapping)                  ##
@@ -50,9 +70,13 @@
     };
 
     # CI: desktop
+    # NOTE: deliberately NOT following our nixpkgs. catppuccin publishes
+    # prebuilt outputs (whiskers, ports) to catppuccin.cachix.org built
+    # against its own pinned nixpkgs. Following our nixpkgs would change
+    # every derivation hash and force local rebuilds (cache miss). Keeping
+    # catppuccin's own nixpkgs lets us substitute from its cache.
     catppuccin = {
       url = "github:catppuccin/nix";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # CI: server
@@ -84,11 +108,14 @@
     };
 
     # CI: desktop
+    # NOTE: deliberately NOT following our nixpkgs so niri's prebuilt
+    # outputs can be substituted from niri.cachix.org / niri-epireyn.cachix.org
+    # (built against niri's own pinned nixpkgs). Following our nixpkgs would
+    # change the derivation hashes and force a local source build.
     niri = {
       # TODO: Watch both of these url's. sodiboo is the OG, but hasn't been updated in a while
       #url = "github:sodiboo/niri-flake";
       url = "github:epireyn/niri-flake";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # CI: skip (macOS only)
@@ -126,9 +153,12 @@
     };
 
     # CI: skip (deployment tool, no effect on builds)
+    # NOTE: deliberately NOT following our nixpkgs so the colmena CLI binary
+    # can be substituted from colmena.cachix.org (built against colmena's own
+    # pinned nixpkgs). Following our nixpkgs would change its derivation hash
+    # and force a local source build of the whole Rust closure.
     colmena = {
       url = "github:zhaofengli/colmena";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # CI: desktop

--- a/flake/dev/shell.nix
+++ b/flake/dev/shell.nix
@@ -5,6 +5,11 @@
 #   - nodejs + typescript (for any JS tooling in the repo)
 #   - colmena CLI (matched to the colmenaHive evaluator version)
 #
+# CI builds and pushes this shell to Attic via the `dev-shell` job in
+# ci-linux.yaml / ci-darwin.yaml, gated by `find-devshell`. If you add a
+# tool here that comes from a new flake input, add that input to the
+# `devshell_inputs` list in both workflows so the cache stays warm.
+#
 # Arguments are the flake-level bindings passed in from flake.nix.
 {
   inputs,

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -29,6 +29,8 @@ in
     settings = {
       substituters = [
         "http://192.168.31.14:8080/fred"
+        "https://colmena.cachix.org"
+        "https://catppuccin.cachix.org"
         "https://niri.cachix.org"
         "https://niri-epireyn.cachix.org"
         "https://cache.nixos.org"
@@ -36,6 +38,8 @@ in
 
       trusted-public-keys = [
         "fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0="
+        "colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg="
+        "catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU="
         "niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964="
         "niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA="
       ];


### PR DESCRIPTION
## What

Stops local machines from rebuilding dev tooling (colmena, whiskers/catppuccin, niri) and the dev shell on every `nix develop` / `nixos-rebuild`.

### 1. Use upstream binary caches (commit 1)
- Drop `inputs.nixpkgs.follows = "nixpkgs"` on **colmena**, **catppuccin**, **niri**. Following our nixpkgs changed every derivation hash, so their public cachix builds never matched -> cache miss -> local source build. Each input now uses its **own** pinned nixpkgs (the rev its cache was built against).
- Add the caches as substituters in **both**:
  - flake-level `nixConfig` (ad-hoc `nix build`/`nix develop` against this flake), and
  - `modules/base/system.nix` -> every host's `/etc/nix/nix.conf` (all 9 Linux hosts + both Macs), so normal `nixos-rebuild` / `nix develop` use them.

### 2. Push the dev shell + dev packages (commit 2)
- New `dev-shell` (self-hosted Linux) and `dev-shell-darwin` (self-hosted macOS) jobs build `.#devShells.<system>` and every `.#packages.<system>.*` and push them to Attic. Host build jobs only cached `toplevel` + HM activation, never the dev shell.

## Verification
- colmena CLI and catppuccin **whiskers** are cache hits (HTTP 200) on aarch64-darwin **and** x86_64-linux.
- `colmena/nixpkgs` adopts `a799d3e3` (its own pin) rather than nixos-unstable HEAD, which is what makes the cache match.
- Daytona, maranello, fredhub eval cleanly; substituter list verified on a Linux host and on Freds-Mac-Studio.
- nixfmt + statix + deadnix clean; all pre-commit hooks pass.

## Notes
- `modules/base/*` is `global`, so CI will rebuild all hosts (correct -- every host's nix.conf changed).
- The inline Attic JWT in the workflows is reused as-is (out of scope; flagged separately for rotation).