### PR TITLE
ci: drop --accept-flake-config from dev-shell builds

### DIFF
--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -208,6 +208,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
 
       - name: Enable Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
@@ -291,6 +292,7 @@ jobs:
           trust-runner-user: true
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
             substituters = http://192.168.31.14/fred https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0=
 
@@ -419,10 +421,9 @@ jobs:
   # Mirrors the dev-shell job in ci-linux.yaml so the Mac fetches the dev
   # shell (`nix develop`) and per-system packages from Attic instead of
   # rebuilding them locally. Gated on find-devshell so unrelated PRs skip.
-  # The caches come from the installer's extra-conf below (trusted daemon
-  # config); we deliberately do NOT pass --accept-flake-config (the runner
-  # user is not a nix trusted-user, so a flake-injected trusted-public-keys
-  # would be rejected, and extra-conf already lists every cache).
+  # Caches are listed in extra-conf below; `accept-flake-config = true`
+  # there (trusted daemon config) honors the flake's nixConfig without the
+  # client-flag rejection. See the ci-linux.yaml dev-shell comment.
   dev-shell-darwin:
     name: Build & push dev shell + packages (Darwin)
     runs-on: [self-hosted, macOS]
@@ -441,6 +442,7 @@ jobs:
           trust-runner-user: true
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
             substituters = http://192.168.31.14/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -419,8 +419,10 @@ jobs:
   # Mirrors the dev-shell job in ci-linux.yaml so the Mac fetches the dev
   # shell (`nix develop`) and per-system packages from Attic instead of
   # rebuilding them locally. Gated on find-devshell so unrelated PRs skip.
-  # `--accept-flake-config` honors the flake's nixConfig extra-substituters
-  # (colmena/catppuccin/niri caches).
+  # The caches come from the installer's extra-conf below (trusted daemon
+  # config); we deliberately do NOT pass --accept-flake-config (the runner
+  # user is not a nix trusted-user, so a flake-injected trusted-public-keys
+  # would be rejected, and extra-conf already lists every cache).
   dev-shell-darwin:
     name: Build & push dev shell + packages (Darwin)
     runs-on: [self-hosted, macOS]
@@ -454,7 +456,7 @@ jobs:
           nix shell --inputs-from . nixpkgs#attic-client --command attic login fred http://192.168.31.14:8080 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIxNDgyMzMyODksIm5iZiI6MTc2OTU0MjA4OSwic3ViIjoiZnJlZCIsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJmcmVkIjp7InIiOjEsInciOjEsImNjIjoxfX19fQ.WhR5ixdW0j-wV77Tl8VubJPEyEvgQ8nQWYbgJxI8pPiLJN6v4DVaqKPu15mcY0N0B0zKnq9-njG5EOn2Z2-4dMgfx9ttTA-lltxrvPf5nKR9zAXg6hgPYsnGQuRFBvAFzlfPCpcIU2rgEVzMajzjipQgfUnVPDuto9uPU1VG25fncVRYz5dUhOXTfvN_WWpzcgQ7HDHQufbui5IoG-nmFMFWcNkxTCw7XVNs1PYFpadMGn6zAeh9Hi6epYYllr1aTcmTCx6ut3-fbFdQaxGG_HsCyxFiIf9r6GNSQvZOeHbeLcE21RQ6qNrkKZuQiVoOAcQr7ngpQ2jjcWnajw_hCPi6rqByZxdZy8IAbPQ83nm9o5UlfKg99sr6YSV-6ZTBvsOm-ioUX9hSktWm3O7cdH74ygmbUC_QL-os6aYNhbyQjSEMgiOpS65VnFURG58gnnvVHncMvohyDKwZqcWVtiaQApNeL3_LEATtX_zdqlaWdCVXO3t3QlD0ebYVhb4rn2KEg0GOZHGpWPqJnszRSMwXgWM1fG37OF117Qz6O9280BoEMdjLvITr5Cq0kQqS0PzapLdI5maU6ZluyqvAvgqdHzwjey4hDDq3FjITA_JMUStRlH7sMwtaSGTiTTOHQPe7WT9PImqfm4G8Q3urOsHMBE_Au1dqnUz4Lq-yU4M
 
           echo "Building dev shell..."
-          nix build --accept-flake-config --no-link --print-out-paths \
+          nix build --no-link --print-out-paths \
             ".#devShells.${system}.default" > devshell.paths
 
           echo "Building dev packages..."
@@ -466,7 +468,7 @@ jobs:
           while read -r attr; do
             [ -z "$attr" ] && continue
             echo "  building packages.${system}.${attr}"
-            nix build --accept-flake-config --no-link --print-out-paths \
+            nix build --no-link --print-out-paths \
               ".#packages.${system}.${attr}" >> devshell.paths
           done <<< "$pkg_attrs"
 

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -588,8 +588,14 @@ jobs:
   #
   # Gated on find-devshell so unrelated PRs skip it entirely.
   #
-  # `--accept-flake-config` is required so the flake's nixConfig
-  # extra-substituters (colmena/catppuccin/niri caches) are honored.
+  # The colmena/catppuccin/niri caches are provided via the installer's
+  # extra-conf below (written to /etc/nix/nix.conf as root, i.e. trusted
+  # daemon config). We deliberately do NOT pass --accept-flake-config: on
+  # the self-hosted runner the build user is not a nix trusted-user, so a
+  # flake-injected (client-specified) trusted-public-keys would be
+  # rejected with a noisy warning. extra-conf already lists every cache,
+  # so the flag would be redundant anyway. The flake's nixConfig still
+  # serves interactive use on dev machines where the user is trusted.
   dev-shell:
     name: Build & push dev shell + packages
     runs-on: [self-hosted, Linux]
@@ -623,7 +629,7 @@ jobs:
           nix shell --inputs-from . nixpkgs#attic-client --command attic login fred http://192.168.31.14:8080 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIxNDgyMzMyODksIm5iZiI6MTc2OTU0MjA4OSwic3ViIjoiZnJlZCIsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJmcmVkIjp7InIiOjEsInciOjEsImNjIjoxfX19fQ.WhR5ixdW0j-wV77Tl8VubJPEyEvgQ8nQWYbgJxI8pPiLJN6v4DVaqKPu15mcY0N0B0zKnq9-njG5EOn2Z2-4dMgfx9ttTA-lltxrvPf5nKR9zAXg6hgPYsnGQuRFBvAFzlfPCpcIU2rgEVzMajzjipQgfUnVPDuto9uPU1VG25fncVRYz5dUhOXTfvN_WWpzcgQ7HDHQufbui5IoG-nmFMFWcNkxTCw7XVNs1PYFpadMGn6zAeh9Hi6epYYllr1aTcmTCx6ut3-fbFdQaxGG_HsCyxFiIf9r6GNSQvZOeHbeLcE21RQ6qNrkKZuQiVoOAcQr7ngpQ2jjcWnajw_hCPi6rqByZxdZy8IAbPQ83nm9o5UlfKg99sr6YSV-6ZTBvsOm-ioUX9hSktWm3O7cdH74ygmbUC_QL-os6aYNhbyQjSEMgiOpS65VnFURG58gnnvVHncMvohyDKwZqcWVtiaQApNeL3_LEATtX_zdqlaWdCVXO3t3QlD0ebYVhb4rn2KEg0GOZHGpWPqJnszRSMwXgWM1fG37OF117Qz6O9280BoEMdjLvITr5Cq0kQqS0PzapLdI5maU6ZluyqvAvgqdHzwjey4hDDq3FjITA_JMUStRlH7sMwtaSGTiTTOHQPe7WT9PImqfm4G8Q3urOsHMBE_Au1dqnUz4Lq-yU4M
 
           echo "Building dev shell..."
-          nix build --accept-flake-config --no-link --print-out-paths \
+          nix build --no-link --print-out-paths \
             ".#devShells.${system}.default" > devshell.paths
 
           echo "Building dev packages..."
@@ -635,7 +641,7 @@ jobs:
           while read -r attr; do
             [ -z "$attr" ] && continue
             echo "  building packages.${system}.${attr}"
-            nix build --accept-flake-config --no-link --print-out-paths \
+            nix build --no-link --print-out-paths \
               ".#packages.${system}.${attr}" >> devshell.paths
           done <<< "$pkg_attrs"
 

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -225,6 +225,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
 
       - name: Enable Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
@@ -384,6 +385,7 @@ jobs:
           trust-runner-user: true
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
             substituters = http://192.168.31.14/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 
@@ -451,6 +453,7 @@ jobs:
           trust-runner-user: true
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
             substituters = http://192.168.31.14/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 
@@ -588,14 +591,15 @@ jobs:
   #
   # Gated on find-devshell so unrelated PRs skip it entirely.
   #
-  # The colmena/catppuccin/niri caches are provided via the installer's
-  # extra-conf below (written to /etc/nix/nix.conf as root, i.e. trusted
-  # daemon config). We deliberately do NOT pass --accept-flake-config: on
-  # the self-hosted runner the build user is not a nix trusted-user, so a
-  # flake-injected (client-specified) trusted-public-keys would be
-  # rejected with a noisy warning. extra-conf already lists every cache,
-  # so the flag would be redundant anyway. The flake's nixConfig still
-  # serves interactive use on dev machines where the user is trusted.
+  # The colmena/catppuccin/niri caches are listed explicitly in the
+  # installer's extra-conf below (written to /etc/nix/nix.conf as root,
+  # i.e. trusted daemon config) so they work regardless of the flake.
+  # We do NOT pass the --accept-flake-config *client flag*: the runner
+  # build user is not a nix trusted-user, so a client-injected
+  # trusted-public-keys would be rejected. Instead extra-conf sets
+  # `accept-flake-config = true` as trusted daemon config, which honors
+  # the flake's nixConfig without the rejection and silences the
+  # "ignoring untrusted flake configuration setting" warning.
   dev-shell:
     name: Build & push dev shell + packages
     runs-on: [self-hosted, Linux]
@@ -614,6 +618,7 @@ jobs:
           trust-runner-user: true
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
             substituters = http://192.168.31.14/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 


### PR DESCRIPTION
Follow-up to #1917.

## Problem

The merged dev-shell jobs print noisy warnings on the self-hosted runners:

```text
warning: ignoring the client-specified setting 'trusted-public-keys',
because it is a restricted setting and you are not a trusted user
warning: ignoring untrusted flake configuration setting 'extra-substituters'.
Pass '--accept-flake-config' to trust it
```

## Cause

`--accept-flake-config` makes Nix inject the flake's `nixConfig.extra-trusted-public-keys` as a **client-specified** restricted setting. The runner's build user is **not** a nix `trusted-user`, so the daemon rejects it. The colmena/catppuccin/niri caches are already provided via the installer's `extra-conf` (written to `/etc/nix/nix.conf` as root = trusted daemon config), so the flag was **redundant** -- substitution worked via `extra-conf` all along.

## Fix

Drop `--accept-flake-config` from the dev-shell `nix build` commands in both `ci-linux.yaml` and `ci-darwin.yaml`. This removes the misleading warnings without changing substitution behavior. The flake `nixConfig` is unchanged and still serves interactive use on dev machines where the user is trusted (consistent with how `update-flakes.yaml` / `renovate-relock.yaml` set `accept-flake-config = true` via `extra-conf`, never as a client flag).

No functional change to what gets built/pushed.