### PR TITLE
chore(flake/nixpkgs-kernel): `26c310a5` -> `c9bfd86e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -781,11 +781,11 @@
     },
     "nixpkgs-kernel": {
       "locked": {
-        "lastModified": 1780318351,
-        "narHash": "sha256-hRWvF3ZlDl0NNV8XqoKQmupOiD9oNYs1lmCRwnz0tRs=",
+        "lastModified": 1782841183,
+        "narHash": "sha256-Ndt/5R7UN4rBdhFR1lxHZZZ42cD6vGlnuxC2VvvsKE4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26c310a50f1ded4113410eaec08dfe35e2f90031",
+        "rev": "c9bfd86ed684d27e63b0ff9ebb18699f84f27a3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`38badf81`](https://github.com/NixOS/nixpkgs/commit/38badf810e5b35e329cf7b314ca48fb551c158ed) | `` firefox-bin-unwrapped: 152.0.3 -> 152.0.4 ``                                                 |
| [`867a5bce`](https://github.com/NixOS/nixpkgs/commit/867a5bcea4a8d5f388ae99b8486286f13cd22d54) | `` firefox-unwrapped: 152.0.3 -> 152.0.4 ``                                                     |
| [`d406923d`](https://github.com/NixOS/nixpkgs/commit/d406923d8d0808ca39b84d114b82a3314f5b966b) | `` maintainers/github-teams.json: Automated sync ``                                             |
| [`789e7c25`](https://github.com/NixOS/nixpkgs/commit/789e7c25f9e4771551f507f4773ed78e5241f1e1) | `` workflows/test: test release-supported-systems changes ``                                    |
| [`d8bd5f37`](https://github.com/NixOS/nixpkgs/commit/d8bd5f376212ff36b6f6d513a129ba281256c0cf) | `` nextcloudPackages: update ``                                                                 |
| [`9f799582`](https://github.com/NixOS/nixpkgs/commit/9f7995828afe7f97871b07bbcbb201799dce125c) | `` llvmPackages_git: 23.0.0-unstable-2026-06-21 -> 23.0.0-unstable-2026-06-28 ``                |
| [`b27be05f`](https://github.com/NixOS/nixpkgs/commit/b27be05f2ba0bb6471b64b7c9cafa2d72fd061da) | `` linux_zen: 7.0.12 -> 7.1.2 ``                                                                |
| [`0abab76f`](https://github.com/NixOS/nixpkgs/commit/0abab76f14b9467a6694f783d9df0e090e22e25a) | `` google-chrome: 149.0.7827.196 -> 149.0.7827.200 ``                                           |
| [`2b9258c9`](https://github.com/NixOS/nixpkgs/commit/2b9258c91b186f39f1c7a4e0a1c63a405b0582ac) | `` brave: 1.91.175 -> 1.91.180 ``                                                               |
| [`2614abfa`](https://github.com/NixOS/nixpkgs/commit/2614abfa61c60802766996af2be48240129b69e9) | `` linux_xanmod_latest: 7.0.12 -> 7.0.14 ``                                                     |
| [`2b223989`](https://github.com/NixOS/nixpkgs/commit/2b223989918cb2b8699560fc2624c22a180bdf5f) | `` linux_xanmod: 6.18.35 -> 6.18.37 ``                                                          |
| [`f51e81f4`](https://github.com/NixOS/nixpkgs/commit/f51e81f48aa76bff00ba8ef23e542537a581f85b) | `` linux_6_18: 6.18.36 -> 6.18.37 ``                                                            |
| [`6b9f35bd`](https://github.com/NixOS/nixpkgs/commit/6b9f35bda4881e3462b50fb3b70c926ffedf13a1) | `` linux_7_0: 7.0.13 -> 7.0.14 ``                                                               |
| [`7189c0e7`](https://github.com/NixOS/nixpkgs/commit/7189c0e76735ecc59aecb0c8fe07bf238c301529) | `` linux_7_1: 7.1.1 -> 7.1.2 ``                                                                 |
| [`bb16f600`](https://github.com/NixOS/nixpkgs/commit/bb16f60021e0867b30bbe4ab4fbbed2f2ceca731) | `` thunderbird-esr-bin-unwrapped: 140.11.1esr -> 140.12.0esr ``                                 |
| [`5361550f`](https://github.com/NixOS/nixpkgs/commit/5361550f002f75096b3aae875e845a67b47e6a08) | `` ungoogled-chromium: 149.0.7827.196-1 -> 149.0.7827.200-1 ``                                  |
| [`eb0a771f`](https://github.com/NixOS/nixpkgs/commit/eb0a771fb55200b5b76387afcdc74c2854c04c43) | `` chromium,chromedriver: 149.0.7827.196 -> 149.0.7827.200 ``                                   |
| [`85c2858b`](https://github.com/NixOS/nixpkgs/commit/85c2858b9faa1c7b0417951ee0dca688b686527a) | `` incus: backport 7.2 security fixes ``                                                        |
| [`4eb94a32`](https://github.com/NixOS/nixpkgs/commit/4eb94a328f82589b434ce99d76cc9639df227d37) | `` zfs_2_4: apply patch for #18366 (dedup=on data corruption) ``                                |
| [`15098c02`](https://github.com/NixOS/nixpkgs/commit/15098c02037e19a67881eb747dfa1cddd779cd0a) | `` tor: 0.4.9.10 -> 0.4.9.11 ``                                                                 |
| [`02deb0c3`](https://github.com/NixOS/nixpkgs/commit/02deb0c3c787e32258be1fb7dbfcd219501ca0a7) | `` firefox-bin-unwrapped: 152.0.2 -> 152.0.3 ``                                                 |
| [`84e7a1de`](https://github.com/NixOS/nixpkgs/commit/84e7a1de91db5bc05912ce879739d656beb3d8f3) | `` firefox-unwrapped: 152.0.2 -> 152.0.3 ``                                                     |
| [`57805128`](https://github.com/NixOS/nixpkgs/commit/5780512817677926e9953738be44a130d5b58ee7) | `` mastodon: 4.5.11 -> 4.5.13 ``                                                                |
| [`9b5cdf83`](https://github.com/NixOS/nixpkgs/commit/9b5cdf8321e963f336f38f09f1be7f6585ba5159) | `` sonarr: 4.0.17.2952 -> 4.0.18.2971 ``                                                        |
| [`e8bcbc1e`](https://github.com/NixOS/nixpkgs/commit/e8bcbc1e18c09bb6e4e8b667571ce8d1742098e3) | `` servarr-ffmpeg: 5.1.4 -> 5.1.10 ``                                                           |
| [`f5bd1360`](https://github.com/NixOS/nixpkgs/commit/f5bd1360ce824e8c314615a214728ab9fa53f401) | `` ungoogled-chromium: 149.0.7827.155-1 -> 149.0.7827.196-1 ``                                  |
| [`236d19f2`](https://github.com/NixOS/nixpkgs/commit/236d19f2c42a0199c301007b20d839693b34a138) | `` servo: 0.2.0 -> 0.3.0 ``                                                                     |
| [`39d0f687`](https://github.com/NixOS/nixpkgs/commit/39d0f687facc991baf0d1d1e377232046df378a8) | `` maintainers/github-teams.json: Automated sync ``                                             |
| [`49edff43`](https://github.com/NixOS/nixpkgs/commit/49edff43c2d4517ed0a99cf02828edabb692f605) | `` ci/github-script/merge: share reviews fetch with bot.js, drop events ``                      |
| [`977e73ad`](https://github.com/NixOS/nixpkgs/commit/977e73ad9f9308f4890ebf83e1120e62f0c1d959) | `` ci/github-script/merge: clarify Auto Merge follow-up tip ``                                  |
| [`dee3291f`](https://github.com/NixOS/nixpkgs/commit/dee3291f6588419a2efbb73be6f10f67a96193a0) | `` ci/github-script/merge: refuse merge when a committer has requested changes ``               |
| [`9119d3e8`](https://github.com/NixOS/nixpkgs/commit/9119d3e8f543c2f59c24e2ef7e8022f1352d99fa) | `` ci/github-script/merge: skip auto-merge when CI has already failed ``                        |
| [`59448e2b`](https://github.com/NixOS/nixpkgs/commit/59448e2b79e055af3b19c4d1449d61265b7e6296) | `` docker: 29.5.3 -> 29.6.0 ``                                                                  |
| [`c55d6ab6`](https://github.com/NixOS/nixpkgs/commit/c55d6ab65010c5ddaba16324f208df6a38715b76) | `` nextcloud33: 33.0.5 -> 33.0.6 ``                                                             |
| [`8fdc9a73`](https://github.com/NixOS/nixpkgs/commit/8fdc9a7386469b5b8360102bb8fa12ba180f69c0) | `` nextcloud32: 32.0.11 -> 32.0.12 ``                                                           |
| [`697bbd74`](https://github.com/NixOS/nixpkgs/commit/697bbd747c38994d314a45eda65b82de048f1f9b) | `` nextcloudPackages: update ``                                                                 |
| [`73fe63f4`](https://github.com/NixOS/nixpkgs/commit/73fe63f4aaf6422c87c8f9416f04800bc2b449b0) | `` charls: 2.4.3 -> 2.4.4 ``                                                                    |
| [`3713b575`](https://github.com/NixOS/nixpkgs/commit/3713b57563116601aebfd1be1807499400a44306) | `` charls: 2.4.2 -> 2.4.3 ``                                                                    |
| [`97891aa3`](https://github.com/NixOS/nixpkgs/commit/97891aa3aecc7b3847197b4a95190c729f66a35c) | `` palemoon-bin: 34.3.0.1 -> 34.3.1 ``                                                          |
| [`9b47f000`](https://github.com/NixOS/nixpkgs/commit/9b47f00083ee75cafa461fcca3481e379416c1dc) | `` gitlab: 18.11.5 -> 18.11.6 ``                                                                |
| [`38d01d2d`](https://github.com/NixOS/nixpkgs/commit/38d01d2dbd248e825747ea0dda3cd16936f56c9c) | `` librewolf-unwrapped: 152.0.1-2 -> 152.0.2-1 ``                                               |
| [`1206d30d`](https://github.com/NixOS/nixpkgs/commit/1206d30df0352570d3a20aba61be46c37378a534) | `` thunderbird-latest-unwrapped: 151.0.1 -> 152.0 ``                                            |
| [`3333e218`](https://github.com/NixOS/nixpkgs/commit/3333e218675def0314e3c95b79d669bd77f0e4f9) | `` thunderbird-140-unwrapped: 140.11.1esr -> 140.12.0esr ``                                     |
| [`e8199b17`](https://github.com/NixOS/nixpkgs/commit/e8199b175f3ce2c92a646d14c74cf27f6604c899) | `` ci/treefmt: enable or-identifier rule ``                                                     |
| [`c8aa5c93`](https://github.com/NixOS/nixpkgs/commit/c8aa5c934cd4276b975329b47c98414e134c4120) | `` chromium,chromedriver: 149.0.7827.155 -> 149.0.7827.196 ``                                   |
| [`d3c31baa`](https://github.com/NixOS/nixpkgs/commit/d3c31baac1ac47a6304a4937b75b1af7e6b14291) | `` n8n: 1.123.40 -> 1.123.61 ``                                                                 |
| [`bf884b2d`](https://github.com/NixOS/nixpkgs/commit/bf884b2d69ff61a1bf4925d82d716658d29b25f6) | `` mysql84: add nixosTests.mysql.mysql84 to passthru.tests ``                                   |
| [`436e6804`](https://github.com/NixOS/nixpkgs/commit/436e6804138fb2518344bdcf25cefd021e0a8c22) | `` nixos/mysql: fix initalScript option after security fix ``                                   |
| [`08efb46e`](https://github.com/NixOS/nixpkgs/commit/08efb46ea64c48d27c415bfce6d685ecd5c6522c) | `` linuxPackages.openafs: Patch for Linux kernel 7.1 ``                                         |
| [`756a2873`](https://github.com/NixOS/nixpkgs/commit/756a2873f1db918ab4b106181ca847dbcc873c41) | `` openafs: 1.8.15 → 1.8.16 ``                                                                  |
| [`640073e4`](https://github.com/NixOS/nixpkgs/commit/640073e47c549ba6f0f117b240a751398b064ab2) | `` jackett: 0.24.2066 -> 0.24.2108 ``                                                           |
| [`049c9e75`](https://github.com/NixOS/nixpkgs/commit/049c9e75f331214528165913d7dc37c72646702f) | `` nodejs_24: 24.17.0 -> 24.18.0 ``                                                             |
| [`dc7c0beb`](https://github.com/NixOS/nixpkgs/commit/dc7c0beb309e4cae0789da8a50559ecb1a31ed9b) | `` google-chrome: 149.0.7827.155 -> 149.0.7827.196 ``                                           |
| [`44af5067`](https://github.com/NixOS/nixpkgs/commit/44af5067db1109b3c17315ea60cc888a43cd314b) | `` microsoft-edge: 149.0.4022.69 -> 149.0.4022.80 ``                                            |
| [`99b7856a`](https://github.com/NixOS/nixpkgs/commit/99b7856a71febab3efcffe0d1ceb110e71263ab4) | `` python3Packages.pypdf: 6.13.2 -> 6.14.2 ``                                                   |
| [`5611e17b`](https://github.com/NixOS/nixpkgs/commit/5611e17b736a5e02587680a4fb23def74b71db51) | `` vscode-langservers-extracted: extract directly from vscodium ``                              |
| [`55f5efcf`](https://github.com/NixOS/nixpkgs/commit/55f5efcfc14ddaf045353cefdc61200eab60810e) | `` actual-server: 25.5.2 -> 26.0.0 ``                                                           |
| [`6e1965b6`](https://github.com/NixOS/nixpkgs/commit/6e1965b6780621fcb5e6e7d5da9326880295953b) | `` actual-server: 26.4.0 -> 26.5.2 ``                                                           |
| [`8521bbeb`](https://github.com/NixOS/nixpkgs/commit/8521bbeb4d2d4ee90d7122b1a80126d2beab080d) | `` tor: 0.4.9.9 -> 0.4.9.10 ``                                                                  |
| [`8e1b1153`](https://github.com/NixOS/nixpkgs/commit/8e1b1153603704b32682a6eb19de47509682a128) | `` firefox-bin-unwrapped: 152.0.1 -> 152.0.2 ``                                                 |
| [`63672236`](https://github.com/NixOS/nixpkgs/commit/636722367a8c1efd8810e887a740e55b8e6a5598) | `` firefox-unwrapped: 152.0.1 -> 152.0.2 ``                                                     |
| [`f0baf4fd`](https://github.com/NixOS/nixpkgs/commit/f0baf4fd5fdc1dd2a253b83724acc7e180154db2) | `` heimdall-proxy: 0.17.13 -> 0.17.14 ``                                                        |
| [`80729133`](https://github.com/NixOS/nixpkgs/commit/80729133323ecfe99e8e41aafb99b85fe8c875de) | `` mobilizon: 5.2.2 -> 5.2.3 ``                                                                 |
| [`45be2423`](https://github.com/NixOS/nixpkgs/commit/45be2423b34b7bf664fd9d41db8aed7e577ced3d) | `` linux-firmware: 20260519 -> 20260622 ``                                                      |
| [`e7e2859f`](https://github.com/NixOS/nixpkgs/commit/e7e2859f6646ea43abdbf65843c6842dc1bb821c) | `` nixos/mysql: fix default MySQL/Percona Server insecure authentication ``                     |
| [`9a79baf1`](https://github.com/NixOS/nixpkgs/commit/9a79baf1af19d0c49c09c94108dfe21132098eb8) | `` kanidm_1_10: 1.10.3 -> 1.10.4 ``                                                             |
| [`166796b8`](https://github.com/NixOS/nixpkgs/commit/166796b810b5625a51e10f279ae1124fbc9e2907) | `` gitoxide: 0.54.0 -> 0.55.0 ``                                                                |
| [`51af8b6b`](https://github.com/NixOS/nixpkgs/commit/51af8b6b00ec6e875f208baf54324b95b8dda453) | `` ffmpeg_4: 4.4.7 -> 4.4.8 ``                                                                  |
| [`45abe5b2`](https://github.com/NixOS/nixpkgs/commit/45abe5b2d3192094b50e5d220611c78343b41ebd) | `` ffmpeg_4: 4.4.6 -> 4.4.7 ``                                                                  |
| [`450f5280`](https://github.com/NixOS/nixpkgs/commit/450f52805626b0a7edfb0336a554598237ffa722) | `` workflows/build: stop building for `x86_64-darwin` ``                                        |
| [`82818fd6`](https://github.com/NixOS/nixpkgs/commit/82818fd65a45633cd7171a0553077db35ec2b10e) | `` .github/PULL_REQUEST_TEMPLATE: drop `x86_64-darwin` checkbox ``                              |
| [`614a8502`](https://github.com/NixOS/nixpkgs/commit/614a8502406a77eeb7eb170da5a6bc7f298dd0df) | `` mailpit: 1.30.1 -> 1.30.2 ``                                                                 |
| [`06b14437`](https://github.com/NixOS/nixpkgs/commit/06b14437679b7f3a9c2fa356aa07bbbf267894eb) | `` mailpit: 1.30.0 -> 1.30.1 ``                                                                 |
| [`7417797e`](https://github.com/NixOS/nixpkgs/commit/7417797e58c0c5dd7f68b8e8d8c20751ce12942d) | `` llvmPackages_git: 23.0.0-unstable-2026-06-14 -> 23.0.0-unstable-2026-06-21 ``                |
| [`fa21df3f`](https://github.com/NixOS/nixpkgs/commit/fa21df3fb37c71f6fbf1d676e06d6d28d949ad3d) | `` nixosTests: remove deprecated config attribute access ``                                     |
| [`34fd6dd3`](https://github.com/NixOS/nixpkgs/commit/34fd6dd31739292f25d016c2ae19d4ca5a8d3ba1) | `` Revert "linux_6_12: 6.12.93 -> 6.12.94" ``                                                   |
| [`171486fb`](https://github.com/NixOS/nixpkgs/commit/171486fb241d4f3c4e925da4a90b052e27c50c0a) | `` bcachefs-tools: mark as working on kernel 7.1 ``                                             |
| [`2f9c3eeb`](https://github.com/NixOS/nixpkgs/commit/2f9c3eeb3b44823e8c730dc9411742815e24caaa) | `` thunderbird-latest-bin-unwrapped: 151.0.1 -> 152.0 ``                                        |
| [`cb32fade`](https://github.com/NixOS/nixpkgs/commit/cb32fadef5d0cbdc3e5d62d89bbb061667e49d06) | `` squid: 7.5 -> 7.6 ``                                                                         |
| [`1b164e42`](https://github.com/NixOS/nixpkgs/commit/1b164e42ec431dbc11c53b8be3660b1053d61c9f) | `` matrix-continuwuity: 0.5.9 -> 0.5.10 ``                                                      |
| [`7fbd2a1a`](https://github.com/NixOS/nixpkgs/commit/7fbd2a1a7c69046193766c477b99e6d5211b194c) | `` perlPackages.IOCompress: 2.206 -> 2.220 ``                                                   |
| [`075a74cd`](https://github.com/NixOS/nixpkgs/commit/075a74cdf470508361449ef6b97b2d4bdff317da) | `` perlPackages.CompressRawBzip2: 2.206 -> 2.222 ``                                             |
| [`fb69ad0b`](https://github.com/NixOS/nixpkgs/commit/fb69ad0b931660ab52536d319621e6efb41f4ac5) | `` perlPackages.CompressRawZlib: 2.206 -> 2.222 ``                                              |
| [`7853eaf4`](https://github.com/NixOS/nixpkgs/commit/7853eaf404d9347ac09401d85899012a06bd18be) | `` linuxPackages.bcachefs: fix vmlinux path ``                                                  |
| [`37d6da1d`](https://github.com/NixOS/nixpkgs/commit/37d6da1d55760008b5ca45cebae39d666aa52723) | `` simplex-chat-desktop: 6.5.4 -> 6.5.5 ``                                                      |
| [`a5c4073a`](https://github.com/NixOS/nixpkgs/commit/a5c4073a891dc850ebcece3f3c869641c75b08da) | `` bcachefs-tools: 1.38.5 -> 1.38.6 ``                                                          |
| [`b44f551a`](https://github.com/NixOS/nixpkgs/commit/b44f551a42fb0c072b7fc73fc8bc57f68046125c) | `` sqlpage: 0.44.0 -> 0.44.1 ``                                                                 |
| [`074e29d1`](https://github.com/NixOS/nixpkgs/commit/074e29d1fc665bdd625da53a6b06f77edb48199c) | `` sqlpage: add hythera as maintainer ``                                                        |
| [`ca8504e1`](https://github.com/NixOS/nixpkgs/commit/ca8504e185efb1f1b3bbed4b5c67002d68cf032e) | `` sqlpage: modernize ``                                                                        |
| [`229315ee`](https://github.com/NixOS/nixpkgs/commit/229315ee76290beae41398aa62b756742f2de7dc) | `` sqlpage: 0.41.0 -> 0.44.0 ``                                                                 |
| [`dada6a14`](https://github.com/NixOS/nixpkgs/commit/dada6a14b39cb34689ca6f3935087383dc46e2e9) | `` rust_1_95: init ``                                                                           |
| [`1204df9e`](https://github.com/NixOS/nixpkgs/commit/1204df9e26e21f6071d4513ced56a576fd07c500) | `` bcachefs-tools: 1.38.4 -> 1.38.5 ``                                                          |
| [`9fc47cd2`](https://github.com/NixOS/nixpkgs/commit/9fc47cd2551a86d63df246588d84e7445c871f45) | `` bcachefs-tools: 1.38.3 -> 1.38.4 ``                                                          |
| [`db64a96c`](https://github.com/NixOS/nixpkgs/commit/db64a96c998d6cd3e75515ad46a825a4eeff16c3) | `` sqlpage: 0.40.0 -> 0.41.0 ``                                                                 |
| [`cb2f88d2`](https://github.com/NixOS/nixpkgs/commit/cb2f88d2287df8561f8c41ac4cf8bdde0b2afdef) | `` coturn: 4.9.0 -> 4.13.1 ``                                                                   |
| [`67d08a27`](https://github.com/NixOS/nixpkgs/commit/67d08a270d8340efb61d427f993dcc37aa7fea51) | `` sqlpage: 0.39.1 -> 0.40.0 ``                                                                 |
| [`dc8899be`](https://github.com/NixOS/nixpkgs/commit/dc8899be4ba1bf98ebdf96150abc537de77271fa) | `` sqlpage: 0.39.0 -> 0.39.1 ``                                                                 |
| [`fc19cff9`](https://github.com/NixOS/nixpkgs/commit/fc19cff9f9eb7fc6272c29cb4bf4d5bb9df6f52f) | `` mozillavpn: 2.37.0 -> 2.38.0 ``                                                              |
| [`481bbd1b`](https://github.com/NixOS/nixpkgs/commit/481bbd1b52d86e5aa7f21061e1eac27cbba22e33) | `` ci/treefmt: sort formatters alphabetically ``                                                |
| [`6e2b7750`](https://github.com/NixOS/nixpkgs/commit/6e2b7750512bb9612282d02ef98cbdd51d430c09) | `` ci/treefmt: use pkgs.treefmt.withConfig ``                                                   |
| [`8cef94a5`](https://github.com/NixOS/nixpkgs/commit/8cef94a5f5bb4afea3efc735aa386cad429cabd4) | `` shell: use nixpkgs-reviewFull ``                                                             |
| [`a09c8da9`](https://github.com/NixOS/nixpkgs/commit/a09c8da9515cf10aa7c42ff277ed42abc5369079) | `` desync: add matshch to maintainers ``                                                        |
| [`6dc17148`](https://github.com/NixOS/nixpkgs/commit/6dc17148739a9e8d73bf1750784fde91a62f5a3f) | `` maintainers: add matshch ``                                                                  |
| [`24377bca`](https://github.com/NixOS/nixpkgs/commit/24377bca369d1ab8f6dfd68d5bddc163c4205d48) | `` maintainers/github-teams.json: Automated sync ``                                             |
| [`336c63b4`](https://github.com/NixOS/nixpkgs/commit/336c63b414bbd7a616fac5170060291304fd6d23) | `` oggvideotools: unbreak on Darwin, add patches ``                                             |
| [`edc2e803`](https://github.com/NixOS/nixpkgs/commit/edc2e8030d1e8c67f3547f8c594d31532abe0a1a) | `` diffoscope: fix hdf5 tools on Darwin ``                                                      |
| [`8cfa5a97`](https://github.com/NixOS/nixpkgs/commit/8cfa5a97c7eca95409dbd2c0897792defcbd6b32) | `` waywall: 0.2026.02.06 -> 0.2026.06.13 ``                                                     |
| [`fb16e1d1`](https://github.com/NixOS/nixpkgs/commit/fb16e1d1951f4649b2c74db58ca39f35bc492e44) | `` tests.replaceVars: fix group mismatches ``                                                   |
| [`437c14ed`](https://github.com/NixOS/nixpkgs/commit/437c14ede59f360eee0607c6898e90a2197166d2) | `` tests.trivial-builders.symlinkJoin: fix group mismatches ``                                  |
| [`861e3956`](https://github.com/NixOS/nixpkgs/commit/861e3956379cd51a03fcfad857c8ed5e8426fa70) | `` diffoscope: fix aarch64-linux eval ``                                                        |
| [`7a5f534c`](https://github.com/NixOS/nixpkgs/commit/7a5f534ceee694d7efc2272c177e4918a1ad13bd) | `` aapt: set for x86_64-linux ``                                                                |
| [`96aa66b0`](https://github.com/NixOS/nixpkgs/commit/96aa66b07534532db845909883d41fd8c629f0bb) | `` nixos/sniffnet: install package when enabled ``                                              |
| [`1e6199af`](https://github.com/NixOS/nixpkgs/commit/1e6199af297ba2047d8b9c766dbc75f98e5e17ba) | `` matrix-synapse-unwrapped: 1.154.0 -> 1.155.0 ``                                              |
| [`ef4fea54`](https://github.com/NixOS/nixpkgs/commit/ef4fea547421a16aea494605f8105c907016a74c) | `` nextcloudPackages: update ``                                                                 |
| [`e4db0946`](https://github.com/NixOS/nixpkgs/commit/e4db09467645e7072a67174d855a3da726b4cf00) | `` linux_5_10: 5.10.258 -> 5.10.259 ``                                                          |
| [`3e19add4`](https://github.com/NixOS/nixpkgs/commit/3e19add47dbccb04058d1bb5b81d2240c7899402) | `` linux_5_15: 5.15.209 -> 5.15.210 ``                                                          |
| [`aa667359`](https://github.com/NixOS/nixpkgs/commit/aa667359a9a941d39157b893542ff84e44009928) | `` linux_6_1: 6.1.175 -> 6.1.176 ``                                                             |
| [`a1546787`](https://github.com/NixOS/nixpkgs/commit/a15467874b863b637a476940a87bade1992bba55) | `` linux_6_6: 6.6.142 -> 6.6.143 ``                                                             |
| [`2fe2a701`](https://github.com/NixOS/nixpkgs/commit/2fe2a70111d704638186ee46f2ca71e0bc1f2974) | `` linux_6_12: 6.12.93 -> 6.12.94 ``                                                            |
| [`6a177ecf`](https://github.com/NixOS/nixpkgs/commit/6a177ecf5dec019d24f91d425edd3d448054640a) | `` linux_6_18: 6.18.35 -> 6.18.36 ``                                                            |
| [`932e02d0`](https://github.com/NixOS/nixpkgs/commit/932e02d03e6585c3c09064a0816892c27d396610) | `` linux_7_0: 7.0.12 -> 7.0.13 ``                                                               |
| [`d76be7ad`](https://github.com/NixOS/nixpkgs/commit/d76be7add405dfe335f41831e34359c1ff7d4330) | `` linux_7_1: 7.1 -> 7.1.1 ``                                                                   |
| [`fd163f8f`](https://github.com/NixOS/nixpkgs/commit/fd163f8f065012ba1f82711799fb8efdb573ecc9) | `` github-runner: 2.334.0 -> 2.335.1 ``                                                         |
| [`6dbd813e`](https://github.com/NixOS/nixpkgs/commit/6dbd813ed6c8d3d4cfc5cbda95775da59defb190) | `` librewolf-unwrapped: 152.0-1 -> 152.0.1-2 ``                                                 |
| [`58dfdd41`](https://github.com/NixOS/nixpkgs/commit/58dfdd41784064f7ef9dbe7b594313c6577821d1) | `` hedgedoc: 1.10.8 -> 1.11.0 ``                                                                |
| [`15d6a801`](https://github.com/NixOS/nixpkgs/commit/15d6a80115be4512d26a3c2e88cdbc5719447493) | `` firefox-bin-unwrapped: 152.0 -> 152.0.1 ``                                                   |
| [`9dd2cf8d`](https://github.com/NixOS/nixpkgs/commit/9dd2cf8db4e39b04734e898cf634aee689f6716a) | `` firefox-unwrapped: 152.0 -> 152.0.1 ``                                                       |
| [`4e98cd48`](https://github.com/NixOS/nixpkgs/commit/4e98cd485872f22965cf5baac04b97ed2da96e3e) | `` brave: 1.91.171 -> 1.91.175 ``                                                               |
| [`c54be963`](https://github.com/NixOS/nixpkgs/commit/c54be96397fbc4b091bb90683ea11cf23b99ece4) | `` librewolf-bin-unwrapped: 151.0.1-2 -> 152.0-1 ``                                             |
| [`73f23ab9`](https://github.com/NixOS/nixpkgs/commit/73f23ab9f113f337bc635c4d17cd593eb6d36c30) | `` librewolf-unwrapped: 151.0.2-1 -> 152.0-1 ``                                                 |
| [`21f8d64d`](https://github.com/NixOS/nixpkgs/commit/21f8d64d70bdd0b1244875b32c0f4e6c8411e9d3) | `` nodejs_24: 24.16.0 -> 24.17.0 ``                                                             |
| [`42124fe6`](https://github.com/NixOS/nixpkgs/commit/42124fe6f6527b57ea68213c296ccf7090bd73a4) | `` mullvad-browser: 15.0.14 -> 15.0.16 ``                                                       |
| [`685b2f85`](https://github.com/NixOS/nixpkgs/commit/685b2f859568ec1cc081616934b7d7e0a7873e8f) | `` tor-browser: 15.0.15 -> 15.0.16 ``                                                           |
| [`5db9883b`](https://github.com/NixOS/nixpkgs/commit/5db9883ba55e73c4180400d971faaaf77bad062a) | `` openbao: 2.5.4 -> 2.5.5 ``                                                                   |
| [`7f02cb4b`](https://github.com/NixOS/nixpkgs/commit/7f02cb4b35b5c1e99631b12200e87c84cc4474c8) | `` ungoogled-chromium: 149.0.7827.114-1 -> 149.0.7827.155-1 ``                                  |
| [`804a08c3`](https://github.com/NixOS/nixpkgs/commit/804a08c32dcd3fd494736b1fe6cda43701181c12) | `` chromium,chromedriver: 149.0.7827.114 -> 149.0.7827.155 ``                                   |
| [`990f3e4b`](https://github.com/NixOS/nixpkgs/commit/990f3e4b97756bc6941c8d36f6387c33d2bf10c8) | `` ci/eval: name the base branch in the performance comparison summary ``                       |
| [`04db3cac`](https://github.com/NixOS/nixpkgs/commit/04db3caceea4fa740bd9afec0b05ccf9606fe69a) | `` clamav: 1.4.3 -> 1.4.4 ``                                                                    |
| [`f1aa38b1`](https://github.com/NixOS/nixpkgs/commit/f1aa38b1c52c4c7b7e092749888d0362274fc558) | `` envoy-bin: 1.36.5 -> 1.36.8 ``                                                               |
| [`6ed7b3f2`](https://github.com/NixOS/nixpkgs/commit/6ed7b3f2d60815b5b849892390f0c7f8cf44e6e3) | `` google-chrome: 149.0.7827.114 -> 149.0.7827.155 ``                                           |
| [`640cfa6d`](https://github.com/NixOS/nixpkgs/commit/640cfa6d331131d5a82db78a3cb985865351829e) | `` {palemoon-bin,palemoon-gtk2-bin}: 34.3.0 -> 34.3.0.1 ``                                      |
| [`0901b182`](https://github.com/NixOS/nixpkgs/commit/0901b1826e85a40884c1923454f653601afc06b8) | `` maintainers/github-teams.json: Automated sync ``                                             |
| [`36e6a416`](https://github.com/NixOS/nixpkgs/commit/36e6a4169de4ee344bd40ec474c622d74ae7cebd) | `` radarr: 6.1.1.10360 -> 6.2.1.10461 ``                                                        |
| [`3d57a5f9`](https://github.com/NixOS/nixpkgs/commit/3d57a5f9f96df3ad082e15d3c1f0a28149e4bccd) | `` unofficial-homestuck-collection: upgrade Electron requirement to 14 ``                       |
| [`6fac6e4a`](https://github.com/NixOS/nixpkgs/commit/6fac6e4a9f55f5c8e5de55c2c655d0cd277ed027) | `` llvmPackages_git: 23.0.0-unstable-2026-06-07 -> 23.0.0-unstable-2026-06-14 ``                |
| [`e03e533b`](https://github.com/NixOS/nixpkgs/commit/e03e533b51a4836364df8fa058f54167b782ad11) | `` firefox-esr-140-unwrapped: 141.11.0esr -> 140.12.0esr ``                                     |
| [`9e8bae5f`](https://github.com/NixOS/nixpkgs/commit/9e8bae5f87b8d865adf644a12d5a3205f3b03ec5) | `` firefox-bin-unwrapped: 151.0.4 -> 152.0 ``                                                   |
| [`0884974f`](https://github.com/NixOS/nixpkgs/commit/0884974f058b4bdf2755109cadce5d2df72daf76) | `` firefox-unwrapped: 151.0.4 -> 152.0 ``                                                       |
| [`03cf7038`](https://github.com/NixOS/nixpkgs/commit/03cf7038dbe17889b3348f9f2be4f11fa77f43e1) | `` buildMozillaMach: fix 152+ build with apple-sdk_26==26.0 ``                                  |
| [`8f657f00`](https://github.com/NixOS/nixpkgs/commit/8f657f009081509a2e20b68f87294ed3b024fc0c) | `` perlPackages.CatalystPluginAuthentication: 0.10023 -> 0.10_027 ``                            |
| [`71ca19c3`](https://github.com/NixOS/nixpkgs/commit/71ca19c33783b992a4ff57c4a874e4edff0a38d3) | `` mattermost: buildGoModule -> buildGo126Module ``                                             |
| [`a2d42e2f`](https://github.com/NixOS/nixpkgs/commit/a2d42e2feb6fefd98f0b549dc1a21aa1a27048b1) | `` mattermost: 10.11.18 -> 10.11.20 ``                                                          |
| [`caa619f0`](https://github.com/NixOS/nixpkgs/commit/caa619f0515b8a816fcf226c8a90cbf0c31b9474) | `` mattermostLatest: 11.7.0 -> 11.8.1 ``                                                        |
| [`7c51834f`](https://github.com/NixOS/nixpkgs/commit/7c51834ff1e0874496e0c7d116ffe85a1c8a72b2) | `` dotnetCorePackages.sdk_11_0: 11.0.100-preview.4.26230.115 -> 11.0.100-preview.5.26302.115 `` |
| [`b4841d67`](https://github.com/NixOS/nixpkgs/commit/b4841d676eac75132e8cf3e3f209eb6d3b7a86d6) | `` dotnetCorePackages.sdk_10_0: 10.0.300 -> 10.0.301 ``                                         |
| [`f19e17e5`](https://github.com/NixOS/nixpkgs/commit/f19e17e54954a2cc3f92a90935e554aabddae404) | `` dotnetCorePackages.sdk_9_0: 9.0.314 -> 9.0.315 ``                                            |
| [`da24bdae`](https://github.com/NixOS/nixpkgs/commit/da24bdae6d9dc74d811862c6e04282652de92a57) | `` dotnetCorePackages.sdk_8_0: 8.0.421 -> 8.0.422 ``                                            |
| [`fc160d22`](https://github.com/NixOS/nixpkgs/commit/fc160d22ee16d482cf8d8e26e5ef003b57f50d0e) | `` nss_latest: 3.124 -> 3.125 ``                                                                |
| [`60239cc6`](https://github.com/NixOS/nixpkgs/commit/60239cc6f55980bab28114194fd058900bf774f5) | `` p2pool: 4.14 -> 4.16 ``                                                                      |
| [`bdadde8c`](https://github.com/NixOS/nixpkgs/commit/bdadde8cb9149b6bb92d08cd532f977f3c4bf6ad) | `` jackett: 0.24.2021 -> 0.24.2066 ``                                                           |
| [`9022a93e`](https://github.com/NixOS/nixpkgs/commit/9022a93e6b67fcefeff984f945266b205c69f3d2) | `` knot-dns: 3.5.4 -> 3.5.5 ``                                                                  |
| [`bdf063de`](https://github.com/NixOS/nixpkgs/commit/bdf063de85ca31fb2c5651663366df5d8054f382) | `` openssl_4_0: 4.0.0 -> 4.0.1 ``                                                               |
| [`d1930b75`](https://github.com/NixOS/nixpkgs/commit/d1930b75bbc8c233baf15996dcdfcbdac6a9bcb8) | `` openssl_3: 3.0.20 -> 3.0.21 ``                                                               |
| [`00355855`](https://github.com/NixOS/nixpkgs/commit/0035585502a60f08ea236a59eee5dce34358293c) | `` linux_7_1: init at 7.1 ``                                                                    |
| [`5fe92de2`](https://github.com/NixOS/nixpkgs/commit/5fe92de209a8e950b87daf7af50fcb09a1d74ae4) | `` plausible: 3.0.1 -> 3.2.1 ``                                                                 |
| [`4b9a9ba5`](https://github.com/NixOS/nixpkgs/commit/4b9a9ba5f0a80cec9016adda8b01baff4eb9621e) | `` microsoft-edge: 149.0.4022.52 -> 149.0.4022.69 ``                                            |
| [`4f9991a1`](https://github.com/NixOS/nixpkgs/commit/4f9991a171621f52150c57afc5381a4f21ae0614) | `` linux/common-config: adjust preempt settings to avoid conflicts ``                           |
| [`9a2b6c9e`](https://github.com/NixOS/nixpkgs/commit/9a2b6c9e86de696fe9cc8d545cd63c60bfff18eb) | `` linux/generate-config: disallow conflicting answers on choice questions ``                   |
| [`9c075d05`](https://github.com/NixOS/nixpkgs/commit/9c075d051f88b213e1e7d22b19053f3447699752) | `` librewolf: mark with knownVulnerabilities ``                                                 |
| [`4433373c`](https://github.com/NixOS/nixpkgs/commit/4433373c60e900fc01021f8ea9afddf1f8ec16f5) | `` prowlarr: 2.3.5.5327 -> 2.4.0.5397 ``                                                        |
| [`6ecc1a10`](https://github.com/NixOS/nixpkgs/commit/6ecc1a1005c7691799891d2394e3fc0ada7e0958) | `` brave: 1.91.168 -> 1.91.171 ``                                                               |
| [`db153f5b`](https://github.com/NixOS/nixpkgs/commit/db153f5baf633b749d4f52ce952cc43275c98271) | `` forgejo-runner: 12.10.2 -> 12.11.1 ``                                                        |
| [`36546b7c`](https://github.com/NixOS/nixpkgs/commit/36546b7cd3bf9c2324ef9766993ff16562c9529d) | `` filebrowser: 2.63.5 -> 2.63.14 ``                                                            |
| [`12af1c03`](https://github.com/NixOS/nixpkgs/commit/12af1c035d4706518d2fe5388060cec32b1fcf8f) | `` veracrypt: 1.26.24 -> 1.26.29 ``                                                             |
| [`84be1279`](https://github.com/NixOS/nixpkgs/commit/84be12799c12b9e12622d636e4220e8d1b2a4738) | `` nixos/bcachefs: add upstream Systemd units to initrd ``                                      |
| [`9ee31d03`](https://github.com/NixOS/nixpkgs/commit/9ee31d038afe893fdee2807a1b12a116daa16586) | `` nixos/bcachefs: add sbin/bcachefs to the Systemd initrd's storePaths ``                      |
| [`01339908`](https://github.com/NixOS/nixpkgs/commit/013399082d75df93f9369679a45d9c06c9d8bf95) | `` bcachefs-tools: 1.38.2 -> 1.38.3 ``                                                          |
| [`4a5ddc13`](https://github.com/NixOS/nixpkgs/commit/4a5ddc13dc6d00af6c2831ed0fcc33e431c45408) | `` nixos/bcachefs: fix scrub command ``                                                         |
| [`77c559f0`](https://github.com/NixOS/nixpkgs/commit/77c559f039da586bade3f90dbff2ecc84811e6dc) | `` plocate: Fix the package license ``                                                          |
| [`ebeb43b1`](https://github.com/NixOS/nixpkgs/commit/ebeb43b122cc70478f067bb4217bb6091d9b7e94) | `` ungoogled-chromium: 149.0.7827.102-1 -> 149.0.7827.114-1 ``                                  |
| [`c97b4597`](https://github.com/NixOS/nixpkgs/commit/c97b4597f6753eb5306c266816e664f5aaea2c18) | `` chromium,chromedriver: 149.0.7827.102 -> 149.0.7827.114 ``                                   |
| [`410392ba`](https://github.com/NixOS/nixpkgs/commit/410392ba22029eb46dbfa5ce2f3b332ab2b60591) | `` ci: update pinned ``                                                                         |
| [`427b192b`](https://github.com/NixOS/nixpkgs/commit/427b192becafc58ad339ef74aee1c0d7a7ed74be) | `` redis: 8.6.3 -> 8.6.4 ``                                                                     |
| [`7fd0bfb8`](https://github.com/NixOS/nixpkgs/commit/7fd0bfb815757b32938e445dbcd485bf400023dd) | `` ungoogled-chromium: 149.0.7827.53-1 -> 149.0.7827.102-1 ``                                   |
| [`6ca41dd8`](https://github.com/NixOS/nixpkgs/commit/6ca41dd80e4445549b568f5f806e1e3232ac21f2) | `` electron-chromedriver_42: 42.3.0 -> 42.4.0 ``                                                |
| [`cbd3901a`](https://github.com/NixOS/nixpkgs/commit/cbd3901a29133158d300d024416d9f8e57b59b1a) | `` electron_42-bin: 42.3.0 -> 42.4.0 ``                                                         |
| [`dd3a694b`](https://github.com/NixOS/nixpkgs/commit/dd3a694b0c5a5c1b21bae97c0503be20565fd637) | `` electron-chromedriver_41: 41.7.1 -> 41.7.2 ``                                                |
| [`cac1eb83`](https://github.com/NixOS/nixpkgs/commit/cac1eb83adf377cce168a3e47d9f184e7c325c4e) | `` electron_41-bin: 41.7.1 -> 41.7.2 ``                                                         |
| [`7a2dae25`](https://github.com/NixOS/nixpkgs/commit/7a2dae256d2f8961d802c15bc84ab3d3d02aef31) | `` electron-chromedriver_40: 40.10.2 -> 40.10.3 ``                                              |
| [`0445e529`](https://github.com/NixOS/nixpkgs/commit/0445e5294fc7db40365df246d02898e6bf38eb10) | `` electron_40-bin: 40.10.2 -> 40.10.3 ``                                                       |
| [`72e48235`](https://github.com/NixOS/nixpkgs/commit/72e4823504a6ab6f85ec17759cbf07a90f991bc0) | `` electron-source.electron_41: 41.7.1 -> 41.7.2 ``                                             |
| [`b4721ec4`](https://github.com/NixOS/nixpkgs/commit/b4721ec4b200d66fa413ffc13a6b533951e4a289) | `` electron-source.electron_40: 40.10.2 -> 40.10.3 ``                                           |
| [`30afd15f`](https://github.com/NixOS/nixpkgs/commit/30afd15fdd037942cf6607379239a8bf4a31b39f) | `` electron-source.electron_42: 42.3.0 -> 42.4.0 ``                                             |
| [`2da8a53b`](https://github.com/NixOS/nixpkgs/commit/2da8a53bcdcb951f602d769a2916aec6e273539c) | `` gitlab: 18.11.4 -> 18.11.5 ``                                                                |
| [`830d3d7d`](https://github.com/NixOS/nixpkgs/commit/830d3d7dd1d762395dde013dd289d6aac82e2422) | `` google-chrome: 149.0.7827.102 -> 149.0.7827.114 ``                                           |
| [`3e63427a`](https://github.com/NixOS/nixpkgs/commit/3e63427a335db2a1b15cbf0eb8d1d6b37c56ef75) | `` simplex-chat-desktop: 6.5.2 -> 6.5.4 ``                                                      |
| [`39c980a4`](https://github.com/NixOS/nixpkgs/commit/39c980a42ba2c7937b57de3b5396afd3a04d5f89) | `` ci: move Treefmt settings into a separate file ``                                            |
| [`711e5025`](https://github.com/NixOS/nixpkgs/commit/711e502522ee11d319bc070a923ab04fd4a7b824) | `` linux_zen: 7.0.11 -> 7.0.12 ``                                                               |
| [`964cd5cd`](https://github.com/NixOS/nixpkgs/commit/964cd5cdbd66af1afa2039b207554daad729c252) | `` transmission_4: 4.1.1 -> 4.1.2 ``                                                            |
| [`63442961`](https://github.com/NixOS/nixpkgs/commit/634429611f4fa12eaf1d6c2cfec53d3c13e1c359) | `` jenkins: 2.555.2 -> 2.555.3 ``                                                               |
| [`c9ded191`](https://github.com/NixOS/nixpkgs/commit/c9ded191e92a552d598e512ee930d40c52d8a442) | `` jasterix: fix tests ``                                                                       |
| [`e7f162e0`](https://github.com/NixOS/nixpkgs/commit/e7f162e062ba6692063ff5049b2f8b9ac3076d3f) | `` beam.interpreters.erlang_26: 26.2.5.20 -> 26.2.5.21 ``                                       |
| [`b794074e`](https://github.com/NixOS/nixpkgs/commit/b794074e5edc8de9de9b45ee90ff31d57e217190) | `` beam.interpreters.erlang_28: 28.5.0.1 -> 28.5.0.2 ``                                         |
| [`557e9d6a`](https://github.com/NixOS/nixpkgs/commit/557e9d6a87a238a4c1d620279b20f5759fd7abc7) | `` beam28Packages.erlang: 28.5 -> 28.5.0.1 ``                                                   |
| [`68fd2afb`](https://github.com/NixOS/nixpkgs/commit/68fd2afb27f0dc76aa0f3538df022401faea40b1) | `` beam.interpreters.erlang_27: 27.3.4.12 -> 27.3.4.13 ``                                       |
| [`c34f8cb3`](https://github.com/NixOS/nixpkgs/commit/c34f8cb386abf63a1142a6c4d004952ad0cf144a) | `` beam27Packages.erlang: 27.3.4.11 -> 27.3.4.12 ``                                             |
| [`f1d863e6`](https://github.com/NixOS/nixpkgs/commit/f1d863e6e34a3a2de747073bbf5d3a1f8b50bb90) | `` oauth2-proxy: 7.15.2 -> 7.15.3 ``                                                            |
| [`4b8fa655`](https://github.com/NixOS/nixpkgs/commit/4b8fa6555f66ca452a32afe2d238a461632cabaa) | `` percona-xtrabackup_8_0: 8.0.35-34 -> 8.0.35-36 ``                                            |
| [`1d0cc382`](https://github.com/NixOS/nixpkgs/commit/1d0cc382d9a5aa62e4ac2df4bdc0b59078d9c9be) | `` percona-server_8_0: 8.0.45-36 -> 8.0.46-37 ``                                                |
| [`8c9472aa`](https://github.com/NixOS/nixpkgs/commit/8c9472aafc2afbc6f34f78964ea01c8ab339ce62) | `` python3Packages.pypdf: 6.12.2 -> 6.13.2 ``                                                   |
| [`61734f7a`](https://github.com/NixOS/nixpkgs/commit/61734f7ad5f5bdcb97c453ebd2eb29e23737f9a5) | `` xen: patch with XSA-494 ``                                                                   |
| [`4c9edbd8`](https://github.com/NixOS/nixpkgs/commit/4c9edbd88396c65df64e92d3a8d0a0781f2d9587) | `` xen: patch with XSA-493 ``                                                                   |
| [`5a2dcb2c`](https://github.com/NixOS/nixpkgs/commit/5a2dcb2c23e0604c05ea4af280c0a774f90337ae) | `` xen: patch with XSA-492 ``                                                                   |
| [`9b27e958`](https://github.com/NixOS/nixpkgs/commit/9b27e9583cafd666814593dcb662920226bc3129) | `` xen: patch with XSA-491 ``                                                                   |
| [`a15b5ac8`](https://github.com/NixOS/nixpkgs/commit/a15b5ac85ec91f63d7817fd029c1d1c74c847e13) | `` xen: patch with XSA-490 ``                                                                   |
| [`b08e8833`](https://github.com/NixOS/nixpkgs/commit/b08e883325fef5c55b5754b443e03b7b7314ee58) | `` yt-dlp: 2026.03.17 -> 2026.06.09 ``                                                          |
| [`81bd3986`](https://github.com/NixOS/nixpkgs/commit/81bd3986b21b14f43dec5161e796a0e0b673de0a) | `` teleport_17: 17.7.23 -> 17.7.24 ``                                                           |
| [`8589051d`](https://github.com/NixOS/nixpkgs/commit/8589051d529764556df8330989816f54b4f9bfe8) | `` forgejo: 15.0.2 -> 15.0.3 ``                                                                 |
| [`faf8b37a`](https://github.com/NixOS/nixpkgs/commit/faf8b37a59e03f01bb24347868848182fb91e5c0) | `` matrix-synapse-unwrapped: drop outdated postPatch ``                                         |
| [`ce933fc0`](https://github.com/NixOS/nixpkgs/commit/ce933fc06e3b6ac205c1822c38253436508db3d3) | `` llvmPackages_git: 23.0.0-unstable-2026-05-31 -> 23.0.0-unstable-2026-06-07 ``                |
| [`0946da0e`](https://github.com/NixOS/nixpkgs/commit/0946da0e4214a7a04ff10d429c93d5bcfd1f3e99) | `` victoriametrics: 1.144.0 -> 1.145.0 ``                                                       |
| [`37d0bb02`](https://github.com/NixOS/nixpkgs/commit/37d0bb023f4ca9549cb5536db8cb3da37d39ab1b) | `` forgejo-lts: 11.0.14 -> 11.0.15 ``                                                           |
| [`8f1f1651`](https://github.com/NixOS/nixpkgs/commit/8f1f165114e126ccf0869aa401b7136e516ad160) | `` linuxKernel.kernels.linux_zen: 7.0.10 -> 7.0.11 ``                                           |
| [`cfae47c2`](https://github.com/NixOS/nixpkgs/commit/cfae47c2ea575548749b25a5aa641ef815f69bdb) | `` linux_xanmod_latest: 7.0.11 -> 7.0.12 ``                                                     |
| [`1008374b`](https://github.com/NixOS/nixpkgs/commit/1008374b69c4e2c034d51bab0512a06db0e5e8ce) | `` linux_xanmod: 6.18.34 -> 6.18.35 ``                                                          |
| [`4218da06`](https://github.com/NixOS/nixpkgs/commit/4218da065ad1c2c9e1ed70e4270ddc9441e476f8) | `` ci: update pinned ``                                                                         |
| [`1e8fd8b5`](https://github.com/NixOS/nixpkgs/commit/1e8fd8b5152076c574b51ebeffd6556af6d3457a) | `` ci/update-pinned.sh: use nixpkgs from current dir, run npins upgrade too ``                  |
| [`848a553e`](https://github.com/NixOS/nixpkgs/commit/848a553e9dfae9318b51ef4f18a5f915e14a6311) | `` google-chrome: 149.0.7827.53 -> 149.0.7827.102 ``                                            |
| [`b9c27e79`](https://github.com/NixOS/nixpkgs/commit/b9c27e793dd4caf0a0429b1183e617a8ef3abf7d) | `` bird3: 3.3.0 -> 3.3.1 ``                                                                     |
| [`10685bfb`](https://github.com/NixOS/nixpkgs/commit/10685bfbb1227b233c09ba0c6f6f9a8beb53ae63) | `` bird2: 2.19.0 -> 2.19.1 ``                                                                   |
| [`e20c1ad4`](https://github.com/NixOS/nixpkgs/commit/e20c1ad427c75eefaef95ea20df4496c0d417cf8) | `` jasterix: init at 0.1.4 ``                                                                   |
| [`4cafc3ba`](https://github.com/NixOS/nixpkgs/commit/4cafc3ba9b56b3a1e7d6032cb988370f44438715) | `` docker: 29.5.2 -> 29.5.3 ``                                                                  |
| [`389f9e49`](https://github.com/NixOS/nixpkgs/commit/389f9e499c096cc50fcac5b9f3181329eb792b38) | `` usbmuxd: 1.1.1+date=2023-05-05 -> 1.1.1+date=2025-12-06 ``                                   |
| [`fc66b8dc`](https://github.com/NixOS/nixpkgs/commit/fc66b8dc68bade639caaeb731d7b7c6d39cda541) | `` usbmuxd: add ProxyVT as maintainer ``                                                        |
| [`c8b3b1bd`](https://github.com/NixOS/nixpkgs/commit/c8b3b1bdc36fb0ebe70cc17f6fc367b4fef40576) | `` usbmuxd: switch to finalAttrs ``                                                             |
| [`2cca7222`](https://github.com/NixOS/nixpkgs/commit/2cca7222d54a7a77b5e0fa51f2d4802186c0dfc2) | `` firefox-bin-unwrapped: 151.0.3 -> 151.0.4 ``                                                 |
| [`a81122d5`](https://github.com/NixOS/nixpkgs/commit/a81122d5bf93c5839cd4a92f5c3daa09ee04175e) | `` firefox-unwrapped: 151.0.3 -> 151.0.4 ``                                                     |
| [`1ceed498`](https://github.com/NixOS/nixpkgs/commit/1ceed498ef308a9b436e81d84f9526e218f5b17c) | `` chromium,chromedriver: 149.0.7827.53 -> 149.0.7827.102 ``                                    |
| [`7ed8ad22`](https://github.com/NixOS/nixpkgs/commit/7ed8ad2222b0e918edd51e4cb9672e7146046e8b) | `` linux_6_12: 6.12.92 -> 6.12.93 ``                                                            |
| [`e71b7e57`](https://github.com/NixOS/nixpkgs/commit/e71b7e57302a3678bc004c10e34c33810624715f) | `` linux_6_18: 6.18.34 -> 6.18.35 ``                                                            |
| [`a7121bb4`](https://github.com/NixOS/nixpkgs/commit/a7121bb43882e70f03166f995ba7ee8b6e8e30e6) | `` linux_7_0: 7.0.11 -> 7.0.12 ``                                                               |
| [`a29f10c7`](https://github.com/NixOS/nixpkgs/commit/a29f10c7ef84cbc9677307c7bc5c34bc00f8d0cc) | `` linux_testing: 7.1-rc6 -> 7.1-rc7 ``                                                         |
| [`aeed3d35`](https://github.com/NixOS/nixpkgs/commit/aeed3d350314701c919cc1e37a3aca476aff6536) | `` flake-checker: 0.2.11 -> 0.2.13 ``                                                           |
| [`260c5459`](https://github.com/NixOS/nixpkgs/commit/260c54597228cdce329e517827300b6f69b47869) | `` python3Packages.gradio: update the vulnerability message ``                                  |
| [`3e78f573`](https://github.com/NixOS/nixpkgs/commit/3e78f573f9c333445cb94c504123339be4eb1b1f) | `` freetube: 0.24.0 -> 0.24.1 ``                                                                |
| [`b85d509e`](https://github.com/NixOS/nixpkgs/commit/b85d509ebda862610ed5464051bcb3d2ef5364b8) | `` cinny{-unwrapped,-desktop}: 4.12.1 -> 4.12.2 ``                                              |
| [`e0cd8531`](https://github.com/NixOS/nixpkgs/commit/e0cd853103d647720fd9049223052a434fb9cacd) | `` workflows/teams: fix execution day of comment ``                                             |
| [`fd268aca`](https://github.com/NixOS/nixpkgs/commit/fd268acafba523c5bb6b4fd1961341a77203aa5b) | `` maintainers/github-teams.json: Automated sync ``                                             |
| [`fbf9cd94`](https://github.com/NixOS/nixpkgs/commit/fbf9cd9417ee91bf2e57f2c56fbd2c36e4f11fdb) | `` etcd_3_6: 3.6.11 -> 3.6.12 ``                                                                |
| [`bb81b0e5`](https://github.com/NixOS/nixpkgs/commit/bb81b0e57f943c78d0c48a5a184a53cb7fb8c2c6) | `` etcd_3_5: 3.5.30 -> 3.5.31 ``                                                                |
| [`366a0a98`](https://github.com/NixOS/nixpkgs/commit/366a0a98ab7fcd9a3895f0ab996f91d0899d94eb) | `` etcd_3_4: 3.4.44 -> 3.4.45 ``                                                                |
| [`3c910ad8`](https://github.com/NixOS/nixpkgs/commit/3c910ad8e08492eed5a52b91330f07fb2fec888d) | `` etcd_3_6: 3.6.10 -> 3.6.11 ``                                                                |
| [`965e6842`](https://github.com/NixOS/nixpkgs/commit/965e684249082964c9a68538469b971b064b5401) | `` etcd_3_5: 3.5.29 -> 3.5.30 ``                                                                |
| [`48aede6b`](https://github.com/NixOS/nixpkgs/commit/48aede6b4f6a3b49929ffa00a3b7127a233509b5) | `` etcd_3_4: 3.4.42 -> 3.4.44 ``                                                                |
| [`fc62f9af`](https://github.com/NixOS/nixpkgs/commit/fc62f9afd87ae4b86c75b1438a4000ab6af2cab6) | `` etcd*: cleanup ``                                                                            |
| [`c185b1ed`](https://github.com/NixOS/nixpkgs/commit/c185b1ed1b02ced2b7cb7ae8cbf2445e39d8a039) | `` etcd: 3.6.9 -> 3.6.10 ``                                                                     |
| [`1baad7c0`](https://github.com/NixOS/nixpkgs/commit/1baad7c0d790785c5771a358023a7a626d05107f) | `` etcd_3_5: 3.5.28 -> 3.5.29 ``                                                                |
| [`46e7d9da`](https://github.com/NixOS/nixpkgs/commit/46e7d9da43c42df9013b572273f84651fb26f8be) | `` olivetin-3k: 3000.13.0 -> 3000.14.0 ``                                                       |
| [`a963213b`](https://github.com/NixOS/nixpkgs/commit/a963213bd98b09d7c631abc4d46bea95980b464a) | `` haveged: 1.9.20 -> 1.9.21 ``                                                                 |
| [`55d5a7ae`](https://github.com/NixOS/nixpkgs/commit/55d5a7ae9fd3b1f3017f7d7f7d6ef8491120b6ab) | `` haveged: 1.9.19 -> 1.9.20 ``                                                                 |
| [`fd41abbf`](https://github.com/NixOS/nixpkgs/commit/fd41abbf87a4e736f6e013477d24a6ee335fa403) | `` llvmPackages_git: 23.0.0-unstable-2026-05-24 -> 23.0.0-unstable-2026-05-31 ``                |
| [`795c2b2e`](https://github.com/NixOS/nixpkgs/commit/795c2b2efb8d32beab78d0b8d0cf4cb0f1e046e8) | `` ci/eval/compare: show performance comparison even when package sets differ ``                |
| [`4aead5aa`](https://github.com/NixOS/nixpkgs/commit/4aead5aa52ce38dda5170bd750f8bb9225c7ff25) | `` microsoft-edge: 148.0.3967.83 -> 149.0.4022.52 ``                                            |
| [`007baa37`](https://github.com/NixOS/nixpkgs/commit/007baa379ec1da9745c80d679edf5ff28ec122e9) | `` brave: 1.90.128 -> 1.91.168 ``                                                               |
| [`186fef9d`](https://github.com/NixOS/nixpkgs/commit/186fef9d5e74330ccb5a3338583c777c51c34785) | `` ci/github-script/merge: ignore case when checking for merge bot comment ``                   |
| [`dbb8a1a6`](https://github.com/NixOS/nixpkgs/commit/dbb8a1a68efbb0033aa6325ee73c7bec9ce125ab) | `` librewolf: only do LTO on linux ``                                                           |
| [`e9434ec9`](https://github.com/NixOS/nixpkgs/commit/e9434ec9bbd1cd24799fa8087ea2b191ab7519ad) | `` matrix-synapse-unwrapped: 1.153.0 -> 1.154.0 ``                                              |
| [`5f581f7b`](https://github.com/NixOS/nixpkgs/commit/5f581f7bf71ff61f38f474e4e576947d8367b7f4) | `` perlPackages.DBI: 1.644 -> 1.648 ``                                                          |
| [`d165db78`](https://github.com/NixOS/nixpkgs/commit/d165db786cbeece21655bb1f17eb696c1ef63794) | `` inspircd: apply patches for missing escaping in LDAP modules ``                              |
| [`516983d3`](https://github.com/NixOS/nixpkgs/commit/516983d3c3f5f5253b0c46af06c96108317af5e2) | `` {palemoon-bin,palemoon-gtk2-bin}: 34.2.2 -> 34.3.0 ``                                        |
| [`d0226faa`](https://github.com/NixOS/nixpkgs/commit/d0226faa083d795e06f7b70415c3e8817d1c7d80) | `` php85: 8.5.6 -> 8.5.7 ``                                                                     |
| [`f8b87638`](https://github.com/NixOS/nixpkgs/commit/f8b87638a6a833fbbe5e0e6d9fda5d82b1227148) | `` php84: 8.4.21 -> 8.4.22 ``                                                                   |
| [`2600144a`](https://github.com/NixOS/nixpkgs/commit/2600144a9cc5b38f345fa1148488d8abd4dc99c3) | `` threadcat: init at 0.1.2 ``                                                                  |
| [`58e4ca0c`](https://github.com/NixOS/nixpkgs/commit/58e4ca0c42ba769c1c44a98486581c3b72003868) | `` tor-browser: 15.0.14 -> 15.0.15 ``                                                           |
| [`f1a45fdb`](https://github.com/NixOS/nixpkgs/commit/f1a45fdb7c248088e75add78306e8a2d9ef6fa9d) | `` nextcloud33Packages: update ``                                                               |
| [`ee80139f`](https://github.com/NixOS/nixpkgs/commit/ee80139fbfb76c0c0cb08d383a8a8eddcfd587b7) | `` nextcloud32: 33.0.4 -> 33.0.5 ``                                                             |
| [`ece94c30`](https://github.com/NixOS/nixpkgs/commit/ece94c30a78909e5b482f7daea45b85c5f6a57a2) | `` nextcloud32Packages: update ``                                                               |
| [`9fab8a8c`](https://github.com/NixOS/nixpkgs/commit/9fab8a8cf41a6b96aaadce1f53efdfd43edc49f4) | `` nextcloud32: 32.0.10 -> 32.0.11 ``                                                           |
| [`6dd85f6a`](https://github.com/NixOS/nixpkgs/commit/6dd85f6a6c4b349a2297890c0d3632c97bbe4675) | `` .github: Bump actions/checkout from 6.0.2 to 6.0.3 ``                                        |
| [`c3710b56`](https://github.com/NixOS/nixpkgs/commit/c3710b5625cc4d0f1661f3d31d82f7092846609c) | `` jackett: 0.24.1954 -> 0.24.2021 ``                                                           |
| [`431fce39`](https://github.com/NixOS/nixpkgs/commit/431fce390b56f94fdd3fbaea4baccaa3e9459567) | `` python3Packages.pypdf: 6.10.2 -> 6.12.2 ``                                                   |
| [`13c3e687`](https://github.com/NixOS/nixpkgs/commit/13c3e68726304e895cc3da44ed74af0088558269) | `` scaleway-cli: disable time-dependent test ``                                                 |
| [`66bcf362`](https://github.com/NixOS/nixpkgs/commit/66bcf362b06db06c2225902b940df9f2f89247e3) | `` ungoogled-chromium: 148.0.7778.215-1 -> 149.0.7827.53-1 ``                                   |
| [`2b5a3a0d`](https://github.com/NixOS/nixpkgs/commit/2b5a3a0d503040a26f382d4f8997b696874f2bad) | `` keycloak: 26.6.2 -> 26.6.3 ``                                                                |
| [`25b54e4c`](https://github.com/NixOS/nixpkgs/commit/25b54e4c9e26b21a864ab858c84d97ba60bcff0d) | `` keycloak: 26.6.1 -> 26.6.2 ``                                                                |
| [`7268b21c`](https://github.com/NixOS/nixpkgs/commit/7268b21c992b044634185e00792b7364d9dcd66c) | `` keycloak: 26.5.7 -> 26.6.1 ``                                                                |
| [`c69b0187`](https://github.com/NixOS/nixpkgs/commit/c69b0187b17ef0b5d95770d3c8a056ab0e3c816b) | `` zipline: 4.6.1 -> 4.6.2 ``                                                                   |
| [`0cc683be`](https://github.com/NixOS/nixpkgs/commit/0cc683be40e4475a104edb225a3135cfa8888b8c) | `` webkitgtk_6_0: fix build with system malloc ``                                               |
| [`415d0f4c`](https://github.com/NixOS/nixpkgs/commit/415d0f4cdca49b2ddbe69ccf7e567965053d7894) | `` polyml: Fix polyc linking script ``                                                          |
| [`7799f064`](https://github.com/NixOS/nixpkgs/commit/7799f06413a8bfb9b8d402a3f5ae6f08f15b60c3) | `` polyml: replace kovirobi with sempiternal-aurora as maintainer ``                            |
| [`2480ca84`](https://github.com/NixOS/nixpkgs/commit/2480ca84edb49362c87c27d7e70caeef89967b73) | `` polyml: cleanup and mark cross broken ``                                                     |
| [`3a0225ab`](https://github.com/NixOS/nixpkgs/commit/3a0225ab5097d38dc4dfbaef1ae67d1a9eb0e6e2) | `` polyml: migrate to by-name ``                                                                |
| [`27259aeb`](https://github.com/NixOS/nixpkgs/commit/27259aeb2271c8301a741c7c0aeaff6ab15aff1a) | `` caddy: 2.11.3 -> 2.11.4 ``                                                                   |
| [`bf60430f`](https://github.com/NixOS/nixpkgs/commit/bf60430f6af5481a033f2e8b75bd187d1ccbbbbb) | `` mastodon: 4.5.10 -> 4.5.11 ``                                                                |
| [`9d4c30e1`](https://github.com/NixOS/nixpkgs/commit/9d4c30e1c50d10a12095f108d51f8f344d588cb5) | `` gsasl: 2.2.2 -> 2.2.3 ``                                                                     |
| [`70becd4a`](https://github.com/NixOS/nixpkgs/commit/70becd4ad8b7d24e8da20b492103659858660ddb) | `` webkitgtk_6_0: 2.52.3 → 2.52.4 ``                                                            |
| [`ac844dee`](https://github.com/NixOS/nixpkgs/commit/ac844dee3dcf84c57e31ee6458720a122296dee8) | `` nextcloud33Packages: update ``                                                               |
| [`822abaeb`](https://github.com/NixOS/nixpkgs/commit/822abaebdc6c9b93564d6e94d3f3836c1dae8eac) | `` nextcloud33: 33.0.3 -> 33.0.4 ``                                                             |
| [`4213d10b`](https://github.com/NixOS/nixpkgs/commit/4213d10b972018ca286d1e09759fba81046ec612) | `` nextcloud32Packages: update ``                                                               |
| [`11532394`](https://github.com/NixOS/nixpkgs/commit/1153239470f763085e1f02da8b3a1d739245a21d) | `` nextcloud32: 32.0.9 -> 32.0.10 ``                                                            |
| [`5dbbfa03`](https://github.com/NixOS/nixpkgs/commit/5dbbfa03ab107416e19bedea471e67bf8320adf5) | `` nextcloudPackages: update ``                                                                 |
| [`f796bb21`](https://github.com/NixOS/nixpkgs/commit/f796bb2132b29d71bfbf0496f3f7d4234e1331fd) | `` nextcloudPackages: update ``                                                                 |
| [`1be12275`](https://github.com/NixOS/nixpkgs/commit/1be122754cf7403847b5a698464692b565ec8bca) | `` nextcloud{32,33}Apps: add oidc, update all ``                                                |
| [`778be54e`](https://github.com/NixOS/nixpkgs/commit/778be54e6d8fa0a46a18be85f36a83cb8149fc6f) | `` opensc: fix CVE-2026-10275 ``                                                                |
| [`94632614`](https://github.com/NixOS/nixpkgs/commit/946326142c8d8dc8e4ac2dc8028c029606b99d02) | `` Revert "[Backport release-25.11] tyrolienne: 1.2.0 -> 1.2.2" ``                              |
| [`ee88a54b`](https://github.com/NixOS/nixpkgs/commit/ee88a54b33eb0e67d5fa5e0f94562c9113077c43) | `` boringssl: 0.20260508.0 -> 0.20260526.0 ``                                                   |
| [`f8a3a373`](https://github.com/NixOS/nixpkgs/commit/f8a3a373b48f3f74c69e0053461cf7d4b892e0de) | `` linux/common-config: drop X86_AMD_PSTATE_DYNAMIC_EPP ``                                      |
| [`3935611d`](https://github.com/NixOS/nixpkgs/commit/3935611d08751b59d1645089cdbf3267d9333fd3) | `` chromium,chromedriver: 148.0.7778.215 -> 149.0.7827.53 ``                                    |
| [`38badf81`](https://github.com/NixOS/nixpkgs/commit/38badf810e5b35e329cf7b314ca48fb551c158ed) | `` firefox-bin-unwrapped: 152.0.3 -> 152.0.4 ``                                                 |
| [`867a5bce`](https://github.com/NixOS/nixpkgs/commit/867a5bcea4a8d5f388ae99b8486286f13cd22d54) | `` firefox-unwrapped: 152.0.3 -> 152.0.4 ``                                                     |
| [`d406923d`](https://github.com/NixOS/nixpkgs/commit/d406923d8d0808ca39b84d114b82a3314f5b966b) | `` maintainers/github-teams.json: Automated sync ``                                             |
| [`789e7c25`](https://github.com/NixOS/nixpkgs/commit/789e7c25f9e4771551f507f4773ed78e5241f1e1) | `` workflows/test: test release-supported-systems changes ``                                    |
| [`d8bd5f37`](https://github.com/NixOS/nixpkgs/commit/d8bd5f376212ff36b6f6d513a129ba281256c0cf) | `` nextcloudPackages: update ``                                                                 |
| [`9f799582`](https://github.com/NixOS/nixpkgs/commit/9f7995828afe7f97871b07bbcbb201799dce125c) | `` llvmPackages_git: 23.0.0-unstable-2026-06-21 -> 23.0.0-unstable-2026-06-28 ``                |
| [`b27be05f`](https://github.com/NixOS/nixpkgs/commit/b27be05f2ba0bb6471b64b7c9cafa2d72fd061da) | `` linux_zen: 7.0.12 -> 7.1.2 ``                                                                |
| [`0abab76f`](https://github.com/NixOS/nixpkgs/commit/0abab76f14b9467a6694f783d9df0e090e22e25a) | `` google-chrome: 149.0.7827.196 -> 149.0.7827.200 ``                                           |
| [`2b9258c9`](https://github.com/NixOS/nixpkgs/commit/2b9258c91b186f39f1c7a4e0a1c63a405b0582ac) | `` brave: 1.91.175 -> 1.91.180 ``                                                               |
| [`2614abfa`](https://github.com/NixOS/nixpkgs/commit/2614abfa61c60802766996af2be48240129b69e9) | `` linux_xanmod_latest: 7.0.12 -> 7.0.14 ``                                                     |
| [`2b223989`](https://github.com/NixOS/nixpkgs/commit/2b223989918cb2b8699560fc2624c22a180bdf5f) | `` linux_xanmod: 6.18.35 -> 6.18.37 ``                                                          |
| [`f51e81f4`](https://github.com/NixOS/nixpkgs/commit/f51e81f48aa76bff00ba8ef23e542537a581f85b) | `` linux_6_18: 6.18.36 -> 6.18.37 ``                                                            |
| [`6b9f35bd`](https://github.com/NixOS/nixpkgs/commit/6b9f35bda4881e3462b50fb3b70c926ffedf13a1) | `` linux_7_0: 7.0.13 -> 7.0.14 ``                                                               |
| [`7189c0e7`](https://github.com/NixOS/nixpkgs/commit/7189c0e76735ecc59aecb0c8fe07bf238c301529) | `` linux_7_1: 7.1.1 -> 7.1.2 ``                                                                 |
| [`bb16f600`](https://github.com/NixOS/nixpkgs/commit/bb16f60021e0867b30bbe4ab4fbbed2f2ceca731) | `` thunderbird-esr-bin-unwrapped: 140.11.1esr -> 140.12.0esr ``                                 |
| [`5361550f`](https://github.com/NixOS/nixpkgs/commit/5361550f002f75096b3aae875e845a67b47e6a08) | `` ungoogled-chromium: 149.0.7827.196-1 -> 149.0.7827.200-1 ``                                  |
| [`eb0a771f`](https://github.com/NixOS/nixpkgs/commit/eb0a771fb55200b5b76387afcdc74c2854c04c43) | `` chromium,chromedriver: 149.0.7827.196 -> 149.0.7827.200 ``                                   |
| [`85c2858b`](https://github.com/NixOS/nixpkgs/commit/85c2858b9faa1c7b0417951ee0dca688b686527a) | `` incus: backport 7.2 security fixes ``                                                        |
| [`4eb94a32`](https://github.com/NixOS/nixpkgs/commit/4eb94a328f82589b434ce99d76cc9639df227d37) | `` zfs_2_4: apply patch for #18366 (dedup=on data corruption) ``                                |
| [`15098c02`](https://github.com/NixOS/nixpkgs/commit/15098c02037e19a67881eb747dfa1cddd779cd0a) | `` tor: 0.4.9.10 -> 0.4.9.11 ``                                                                 |
| [`02deb0c3`](https://github.com/NixOS/nixpkgs/commit/02deb0c3c787e32258be1fb7dbfcd219501ca0a7) | `` firefox-bin-unwrapped: 152.0.2 -> 152.0.3 ``                                                 |
| [`84e7a1de`](https://github.com/NixOS/nixpkgs/commit/84e7a1de91db5bc05912ce879739d656beb3d8f3) | `` firefox-unwrapped: 152.0.2 -> 152.0.3 ``                                                     |

*... and 115 more commits (truncated)*