### PR TITLE
chore(flake/nixvim): `c6a99bb4` -> `a26ceb58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -861,11 +861,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1782948114,
+        "narHash": "sha256-AXmz9ho4Lud5CsbrZsuSVwpQZ4o5FgZ1chxBn5cJ8+0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "9e92285f211dad236540fd617d7e30e0b99bc0e1",
         "type": "github"
       },
       "original": {
@@ -1039,11 +1039,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1782706849,
-        "narHash": "sha256-b2ODGxKD3hgrwuesLtDomp2DKF3UiOn3+EBTDXpcqGo=",
+        "lastModified": 1783170258,
+        "narHash": "sha256-QC8jqauRSMAZK0uQTqhfD9R4leNET9AOBFbvdU6eu2o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c6a99bb41fb0f37e03ca38b1d81b006e98e3bf1a",
+        "rev": "a26ceb58b0e56b5af6c8f414a3f4fa05eba404a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`a26ceb58`](https://github.com/nix-community/nixvim/commit/a26ceb58b0e56b5af6c8f414a3f4fa05eba404a6) | `` flake: Update ``                                             |
| [`f138b5b7`](https://github.com/nix-community/nixvim/commit/f138b5b7271936845e8d99d66dbe914ca911b876) | `` flake: Update ``                                             |
| [`e52f93e1`](https://github.com/nix-community/nixvim/commit/e52f93e175e63e4b9bfefd53b051a18f12217bed) | `` treewide: elixir -> beamPackages.elixir ``                   |
| [`23ad0398`](https://github.com/nix-community/nixvim/commit/23ad03985a01f42e75bbcfe2cc1c90bd48244169) | `` tests: skip packages which depend on insecure pnpm-9.15.9 `` |
| [`24538354`](https://github.com/nix-community/nixvim/commit/24538354b3bd48a929bfb44bae65406fbeee4921) | `` generated: Updated lint-linters.json ``                      |
| [`fd188924`](https://github.com/nix-community/nixvim/commit/fd18892463de840100d96c4a42942ea974c32d03) | `` flake: Update ``                                             |
| [`97f048f6`](https://github.com/nix-community/nixvim/commit/97f048f640c779a70c4d2fdc5f86bc238546e108) | `` ci: buildbot-nix → nixbot ``                                 |
| [`702008d2`](https://github.com/nix-community/nixvim/commit/702008d2b3dd1d032a953e3bdd2532531aac0639) | `` ci/backport: specify `workflows` permission ``               |
| [`be307b6b`](https://github.com/nix-community/nixvim/commit/be307b6b8fe5745095b2de8587bed94a46b06c5f) | `` ci/pr-merged: explicitly checkout base_ref ``                |
| [`266d5c31`](https://github.com/nix-community/nixvim/commit/266d5c31d54dd1224ebd8170ae9979a4e083a4af) | `` ci/backport: explicitly define persist-credentials ``        |
| [`aeb34e84`](https://github.com/nix-community/nixvim/commit/aeb34e84f6c2326e7a0adf6a31271e4008a3017e) | `` ci/backport: update for checkout v7 ``                       |
| [`78acb50d`](https://github.com/nix-community/nixvim/commit/78acb50d9aa9cbb5d8e0ac1518d0842a29d70553) | `` modules/nixpkgs: import `libForPkgs` correctly ``            |
| [`cc3b773a`](https://github.com/nix-community/nixvim/commit/cc3b773a7a4f76b9c6c03e3547b059e976159bdf) | `` modules/nixpkgs: use `libForPkgs` for `elaborate` ``         |