### PR TITLE
chore(flake/sops-nix-stable): `56b24064` -> `1ebd4171`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1382,11 +1382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782165805,
-        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
+        "lastModified": 1783104586,
+        "narHash": "sha256-vSLKc7m34/g5xH4dwmNZSqxc5OcHeE3qiG3EIz6bJKs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
+        "rev": "1ebd41717762d837d5115f7108522c29cdb00fbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`b1b7b183`](https://github.com/Mic92/sops-nix/commit/b1b7b1839d9a0a91aa116ce99cf9846eb7de86c4) | `` update vendorHash ``                           |
| [`9d042d6b`](https://github.com/Mic92/sops-nix/commit/9d042d6b22771b1a7a6fa75eeda32bb4191c32d5) | `` Bump golang.org/x/net from 0.52.0 to 0.55.0 `` |