### PR TITLE
chore(flake/freminal): `0e4b0b34` -> `c82fe8e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1782754101,
-        "narHash": "sha256-lSGpgqwH15gGMslI+X4PdmMntUkiL5R0ibZjoAFun4c=",
+        "lastModified": 1782915266,
+        "narHash": "sha256-BKHY5H2pFtApomJnzxYFqBlqoHnw7FO5Frc9TXQIwtU=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "0e4b0b34d0ce27faf795473daf711dabe407d1ea",
+        "rev": "c82fe8e64f93ad160f01e1a252dc8f5793e6c789",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`aac44651`](https://github.com/fredsystems/freminal/commit/aac4465100a93c1e4d7abf14a316aec24dad6832) | `` chore(deps): update taiki-e/install-action action to v2.82.7 `` |
| [`7e21c7da`](https://github.com/fredsystems/freminal/commit/7e21c7da2736aadcbd7a9ef674472c8ba9c9d9d8) | `` chore(deps): update dtolnay/rust-toolchain digest ``            |