### PR TITLE
chore(flake/home-manager): `5d72a29f` -> `b885baad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -632,11 +632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782749631,
-        "narHash": "sha256-slFTUgDy0KTPA4LBAmC/9SngDq8GCPdX+ZR0yQHHN1E=",
+        "lastModified": 1783134515,
+        "narHash": "sha256-qMoZazubXlXUD9k/syJ/aiWC4X4g73mwVmZ7Z4+rdpM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d72a29fc36ac21adae6ae35568fe5ee6700850f",
+        "rev": "b885baad531fa3d3beae2ba9a0712d22974d8016",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b885baad`](https://github.com/nix-community/home-manager/commit/b885baad531fa3d3beae2ba9a0712d22974d8016) | `` syncthing: add option for ignore patterns ``                 |
| [`b2e4390f`](https://github.com/nix-community/home-manager/commit/b2e4390ff35319c52935d6a700b615da4c0f204d) | `` kanshi: Add test to check service when settings are unset `` |
| [`1c9ddc70`](https://github.com/nix-community/home-manager/commit/1c9ddc707ce6398abf1b410797d172b0f9373344) | `` kanshi: fix check for empty settings ``                      |
| [`3a60d513`](https://github.com/nix-community/home-manager/commit/3a60d513d0b667b299694b0da7ea7e36ece8f173) | `` clipse: use rfc 042 style settings ``                        |
| [`a4d410db`](https://github.com/nix-community/home-manager/commit/a4d410db95a6416d1008049330bd86b85b5db45a) | `` fzf: group related module attributes ``                      |
| [`0396024e`](https://github.com/nix-community/home-manager/commit/0396024ea5c0e52d698b475612e00ae4a2834bd4) | `` fzf: warn on conflicting ctrl-r bindings ``                  |
| [`f15a4bf0`](https://github.com/nix-community/home-manager/commit/f15a4bf0657f3bdbb66ccd1c768a6cbfa25f6b7a) | `` fzf: add per-shell widget overrides ``                       |
| [`2d92f539`](https://github.com/nix-community/home-manager/commit/2d92f5398d7c6489fd45cef39ee3c5f948e50742) | `` fzf: export environment variables to nushell ``              |
| [`fe3ce0a5`](https://github.com/nix-community/home-manager/commit/fe3ce0a527367cb3302981137ca890155166cef0) | `` fzf: add historyWidget.command option ``                     |
| [`cde77509`](https://github.com/nix-community/home-manager/commit/cde77509b6c13108ec58b18681b0bf2440b0e4ad) | `` fzf: restructure widget options ``                           |
| [`31ca071a`](https://github.com/nix-community/home-manager/commit/31ca071a7d2b4d7ee98f93d1795c6ad740b3e871) | `` fzf: remove legacy shell integration fallback ``             |
| [`2fca6a73`](https://github.com/nix-community/home-manager/commit/2fca6a73722945e3558d89e43d261c147df5805b) | `` atuin: order nushell integration after fzf ``                |
| [`f469c79b`](https://github.com/nix-community/home-manager/commit/f469c79b955609d6a8fdd9e689be76a93b1621d7) | `` home: document defaults inherited from NixOS/nix-darwin ``   |
| [`7b64c06f`](https://github.com/nix-community/home-manager/commit/7b64c06f1d37654e02c8dc79c0d5345f9c451f5c) | `` home: use `lib.literalMD` ``                                 |
| [`937e85df`](https://github.com/nix-community/home-manager/commit/937e85df03e2cf8bc2c0daafc68b2b2782ddbcec) | `` home: check `username` being non-empty through its type ``   |
| [`c0b7cadd`](https://github.com/nix-community/home-manager/commit/c0b7cadd8194e937f49818d9caf9fbc9084b117f) | `` home: remove redundant non-emptiness assertion ``            |
| [`ebc87daa`](https://github.com/nix-community/home-manager/commit/ebc87daabc8d3f595e9a8b67107eaaa8115ad582) | `` launchd: only use --wait on macOS 26 and later ``            |
| [`74b38179`](https://github.com/nix-community/home-manager/commit/74b38179ac0820af3ea4a240ff12668fb2b8c72e) | `` kanshi: Reload on config change ``                           |
| [`d3253798`](https://github.com/nix-community/home-manager/commit/d32537981c036473cf6990ae03176a5d84c43b29) | `` lib: escape backslash in `lib.hm.generators.toKDL` ``        |
| [`2f3da3d4`](https://github.com/nix-community/home-manager/commit/2f3da3d45fbf503f874bd7db7aa2c298e87ab9ea) | `` launchd: fix user domain agents ``                           |
| [`2a37d71b`](https://github.com/nix-community/home-manager/commit/2a37d71bbe69e1522ddabf03a4cea0374958bdbe) | `` herdr: add module ``                                         |