### PR TITLE
chore(flake/solaar): `7229b334` -> `1870d5bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1342,11 +1342,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1781721497,
-        "narHash": "sha256-Qt4bx0zxdZBPWrDJV0RB2CwqYKlSzQRIpdSi0i2Nq0I=",
+        "lastModified": 1783018147,
+        "narHash": "sha256-mqQiBqpTYNFxA/LyOdTIpvV+B1/cNOB38aYyXj3iXvY=",
         "owner": "Svenum",
         "repo": "Solaar-Flake",
-        "rev": "7229b334cad772a5fef7326e7086ec63a6ba421e",
+        "rev": "1870d5bd8c5ddb54b64eb67c6c32fead1aab9276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`1870d5bd`](https://github.com/Svenum/Solaar-Flake/commit/1870d5bd8c5ddb54b64eb67c6c32fead1aab9276) | `` update to 1.1.20 (#28) `` |