### PR TITLE
chore(flake/colmena): `51075010` -> `1ebe1b55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1782840621,
-        "narHash": "sha256-I9i2GvAmrC3IqH0pqNevrF5nNocPiZBeHGWxBXDDmJI=",
+        "lastModified": 1782904768,
+        "narHash": "sha256-tu/otndlmVoSxoQVkNL5cvMFAMyekO2mCVYTl0DRlfs=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "5107501000dc834c846a8d316d787019aabe72b1",
+        "rev": "1ebe1b5526099a3b108a599c59ce0e6422a1a663",
         "type": "github"
       },
       "original": {
@@ -922,11 +922,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -1397,11 +1397,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1781208879,
-        "narHash": "sha256-XPKU44t3oYCfFg96CAB1I89xehfBkvDb2epk715L8VM=",
+        "lastModified": 1782851755,
+        "narHash": "sha256-91ODtG9bUk4AMsgPfGlHzHxh+3r64DClTRxaiTHevIQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3d063f711fae8a1ec4950248798f8d439d5d668",
+        "rev": "f3fb8f32d52b627190abb82438bdcc75a9c77b4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`f2f7e5ce`](https://github.com/nix-community/colmena/commit/f2f7e5cef4cebbc93a0bcf1b5852c68d543f5da2) | `` .git-blame-ignore-revs: init ``                   |
| [`40561e67`](https://github.com/nix-community/colmena/commit/40561e67d5046571a61ff24cef2db6e94d734cb8) | `` flake: bump the inputs group with 2 updates ``    |
| [`328fcf0f`](https://github.com/nix-community/colmena/commit/328fcf0fa8931a313ce989d489069119cbed6251) | `` cargo: bump the cargo group with 4 updates ``     |
| [`f3a17e74`](https://github.com/nix-community/colmena/commit/f3a17e741e294dd8024c3fa19e39e8201f0ac21e) | `` ci: bump the actions group with 4 updates ``      |
| [`e57452fc`](https://github.com/nix-community/colmena/commit/e57452fcb8af78880c766eb551575a5cb53c8b18) | `` ci: use dependabot groups to prevent prs spams `` |