### PR TITLE
chore(flake/niri): `350668ec` -> `bd0092c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1782813347,
-        "narHash": "sha256-oqk6IR36aoeRUjU0Tb9vK4shHfI8QyoabMugMM2QW7s=",
+        "lastModified": 1783169304,
+        "narHash": "sha256-5OMhGL9EAeDKdc8H+zSCHol2R+8HWE4FbzuidFb3SmY=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "350668eca0bbc657bc5721e0a90f3707e269f021",
+        "rev": "bd0092c694e7c5fc305638115e621b218523d6d7",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1782691344,
-        "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
+        "lastModified": 1782999065,
+        "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f01958ffb5b3545c96d9ef2f4e24c5e5e1eb846",
+        "rev": "80d591ed473cfc46329932c2aadac9b435342c7c",
         "type": "github"
       },
       "original": {
@@ -1002,11 +1002,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                              |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`bd0092c6`](https://github.com/epireyn/niri-flake/commit/bd0092c694e7c5fc305638115e621b218523d6d7) | `` fix link to sodiboo's repo in README ``                           |
| [`954fba65`](https://github.com/epireyn/niri-flake/commit/954fba65c21f6399566516e9a6c7e9d5ed3ed70b) | `` Update refs ``                                                    |
| [`20d74806`](https://github.com/epireyn/niri-flake/commit/20d7480642779c9306caf7b899fefcca3c762866) | `` exit with error if reference could not be built in post-commit `` |
| [`11c6fa4e`](https://github.com/epireyn/niri-flake/commit/11c6fa4e92ded659d43121cd972762c0b2b99654) | `` Update flake.lock ``                                              |
| [`ef1d1db5`](https://github.com/epireyn/niri-flake/commit/ef1d1db5dbc9a329825cd6eedc8387dc0cfbeeb1) | `` Update flake.lock ``                                              |
| [`7007897a`](https://github.com/epireyn/niri-flake/commit/7007897a299091d74c283b38e1d63213511fa5f0) | `` Update flake.lock ``                                              |