### PR TITLE
chore(flake/nixpkgs): `b5aa0fbd` -> `65179426`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -845,11 +845,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`1f361d71`](https://github.com/NixOS/nixpkgs/commit/1f361d71e42402a5fb63708fc8925ca8899c3c2a) | `` terraform-providers.oracle_oci: 8.19.0 -> 8.20.0 ``                                              |
| [`ccdaa14e`](https://github.com/NixOS/nixpkgs/commit/ccdaa14e41d119c84ce023683e8270d5bbd9d10e) | `` plakar: 1.1.3 -> 1.1.4 ``                                                                        |
| [`840882f7`](https://github.com/NixOS/nixpkgs/commit/840882f722280f053950a359ba5e1a2e2a4fe5ca) | `` ocrmypdf: 17.7.1 -> 17.8.0 ``                                                                    |
| [`be7ff532`](https://github.com/NixOS/nixpkgs/commit/be7ff532045690baa3514aa2779ce05750ed7113) | `` pretix.plugins.fontpack-free: init at 1.11.1 ``                                                  |
| [`5ade122e`](https://github.com/NixOS/nixpkgs/commit/5ade122efad02e6efc1af449f2bfbe54650a1b62) | `` pretix: 2026.5.3 -> 2026.6.0 ``                                                                  |
| [`774f85f0`](https://github.com/NixOS/nixpkgs/commit/774f85f0091f260ef05a2c2c05a67a5f55d4134f) | `` yscan: init at 0.1.0 ``                                                                          |
| [`fe86804f`](https://github.com/NixOS/nixpkgs/commit/fe86804fdbac7a86b9fdbcfb1bad983aaf2e8699) | `` python3Packages.slack-bolt: 1.28.0 -> 1.29.0 ``                                                  |
| [`6c2d6b21`](https://github.com/NixOS/nixpkgs/commit/6c2d6b218e481a8470ffb44439f3c848a7644e16) | `` python3Packages.ngff-zarr: 0.36.0 -> 0.37.0 ``                                                   |
| [`e4bb7470`](https://github.com/NixOS/nixpkgs/commit/e4bb7470aa36247a240428e6f56246067aeb9dbb) | `` cfripper: 1.20.1 -> 1.21.0 ``                                                                    |
| [`3803eeb7`](https://github.com/NixOS/nixpkgs/commit/3803eeb718e0b1cf2a0b804002d376d4fa13c84b) | `` python3Packages.pycfmodel: migrate to finalAttrs ``                                              |
| [`f8dda7d7`](https://github.com/NixOS/nixpkgs/commit/f8dda7d7c0ce1e901921d4d3ac5c02d57f198c95) | `` python3Packages.pycfmodel: 1.2.0 -> 2.1.1 ``                                                     |
| [`49951091`](https://github.com/NixOS/nixpkgs/commit/49951091aad9219dcc6bfc422eb554114efd98e8) | `` nixos/paperless: use package.passthru.dependencies for PYTHONPATH ``                             |
| [`5a9cb67b`](https://github.com/NixOS/nixpkgs/commit/5a9cb67b6e53a26e2b2dd937769e5573ce89712d) | `` paperless-ngx: factor frontend into separate file ``                                             |
| [`8b266eba`](https://github.com/NixOS/nixpkgs/commit/8b266eba3a0771c00461183d9b4ca4a59bdd9be2) | `` google-chrome: 149.0.7827.200 -> 150.0.7871.46 ``                                                |
| [`d7e9b59c`](https://github.com/NixOS/nixpkgs/commit/d7e9b59c620ba521f06f2dfad700314e31bbe1e3) | `` python3Packages.boto3-stubs: 1.43.38 -> 1.43.39 ``                                               |
| [`c8d6f44c`](https://github.com/NixOS/nixpkgs/commit/c8d6f44c22e38fc7452c5e6ff44da4e30e827dfa) | `` python3Packages.mypy-boto3-quicksight: 1.43.35 -> 1.43.39 ``                                     |
| [`fc40bec0`](https://github.com/NixOS/nixpkgs/commit/fc40bec0ba08ba2bb2b7365b05750edcaec1c84b) | `` python3Packages.mypy-boto3-opensearch: 1.43.34 -> 1.43.39 ``                                     |
| [`e8dd0e80`](https://github.com/NixOS/nixpkgs/commit/e8dd0e8038c73f820617fdc76a079dac5f671001) | `` python3Packages.mypy-boto3-meteringmarketplace: 1.43.0 -> 1.43.39 ``                             |
| [`bf0b3432`](https://github.com/NixOS/nixpkgs/commit/bf0b3432665c0002dc53c47319bd9cae778a1029) | `` python3Packages.mypy-boto3-mediaconvert: 1.43.24 -> 1.43.39 ``                                   |
| [`15a9b07a`](https://github.com/NixOS/nixpkgs/commit/15a9b07a489b8535d4b5fe49cc7f56324530f157) | `` python3Packages.mypy-boto3-ec2: 1.43.38 -> 1.43.39 ``                                            |
| [`7f31af96`](https://github.com/NixOS/nixpkgs/commit/7f31af9631117cdc2d5fcfc379f86be77ac9e383) | `` python3Packages.mypy-boto3-connect: 1.43.38 -> 1.43.39 ``                                        |
| [`67c4b2ed`](https://github.com/NixOS/nixpkgs/commit/67c4b2ed5c0a748a616a486da887da9ff718e858) | `` python3Packages.mypy-boto3-cloud9: 1.43.0 -> 1.43.39 ``                                          |
| [`8962fff4`](https://github.com/NixOS/nixpkgs/commit/8962fff412e7f71904a195715fa8bab892a3a245) | `` python3Packages.yaswfp: modernize ``                                                             |
| [`1e68b909`](https://github.com/NixOS/nixpkgs/commit/1e68b909e4ac21c4338fd10824b9646f646ee490) | `` python3Packages.slack-sdk: 3.42.0 -> 3.43.0 ``                                                   |
| [`9d97fa5c`](https://github.com/NixOS/nixpkgs/commit/9d97fa5c04df86cd4ebf5d78be0f99396549f7fa) | `` python3Packages.iocx: 0.7.4.1 -> 0.7.5 ``                                                        |
| [`cc4ee642`](https://github.com/NixOS/nixpkgs/commit/cc4ee642cdefba7ef586b9c575cce4a4f59344fd) | `` python3Packages.env-canada: 0.15.0 -> 0.16.0 ``                                                  |
| [`e00ecf96`](https://github.com/NixOS/nixpkgs/commit/e00ecf96431f6934d6ee275e60f1980ddf2954f5) | `` qovery-cli: 1.166.0 -> 1.166.2 ``                                                                |
| [`9b468164`](https://github.com/NixOS/nixpkgs/commit/9b468164daec3b894fa83fbda2ef65b8fbe64854) | `` python3Packages.alibabacloud-ecs20140526: 7.8.7 -> 7.9.0 ``                                      |
| [`46a6171b`](https://github.com/NixOS/nixpkgs/commit/46a6171bb72db4547c8ad252178d23264ae39d77) | `` greenmask: 0.2.21 -> 0.2.22 ``                                                                   |
| [`6c55bac9`](https://github.com/NixOS/nixpkgs/commit/6c55bac908fc5972a6c45a208def52e5eb85a68b) | `` cnspec: 13.25.0 -> 13.27.0 ``                                                                    |
| [`fce51411`](https://github.com/NixOS/nixpkgs/commit/fce514111b1606e510bda6a02561b498dfdb1ffd) | `` betterleaks: 1.5.0 -> 1.6.1 ``                                                                   |
| [`b39e765a`](https://github.com/NixOS/nixpkgs/commit/b39e765aca948ddc74df0f81872e44e8d22c92f9) | `` nerva: 1.30.0 -> 1.36.0 ``                                                                       |
| [`30488602`](https://github.com/NixOS/nixpkgs/commit/30488602e99d4aefb3f29a4c3668eb0cd40c29e7) | `` python3Packages.faraday-agent-parameters-types: clean-up ``                                      |
| [`d26c9962`](https://github.com/NixOS/nixpkgs/commit/d26c99622b72808b1a773fc0354c21b6b62c9181) | `` python3Packages.torchdata: enable __strcturedAttrs ``                                            |
| [`31aa4e10`](https://github.com/NixOS/nixpkgs/commit/31aa4e108dc867944f0ea0b72b336681f5baf106) | `` python3Packages.torchdata: add missing test dependency ``                                        |
| [`e637509a`](https://github.com/NixOS/nixpkgs/commit/e637509aa21a028df0df6d741a53a717768aed34) | `` faraday-agent-dispatcher: relax pytenable ``                                                     |
| [`c20d90de`](https://github.com/NixOS/nixpkgs/commit/c20d90de3a2442f7590589e361e9316ec9180bd5) | `` audiness: relax pytenable ``                                                                     |
| [`891b3c13`](https://github.com/NixOS/nixpkgs/commit/891b3c13a49a57795904cf910ba04a35c314196f) | `` python3Packages.torchsnapshot: skip failing test on aarch64-linux ``                             |
| [`34b8c9eb`](https://github.com/NixOS/nixpkgs/commit/34b8c9eb3320273925c5d5ae57dd5f6ec43fa7ce) | `` python3Packages.torchtune: 0.6.2-unstable-2026-02-19 -> 0.6.1-unstable-2026-04-23 ``             |
| [`d454b8b9`](https://github.com/NixOS/nixpkgs/commit/d454b8b972e51720607c102bd17ff631ae4117f2) | `` python3Packages.torchsnapshot: enable __structuredAttrs ``                                       |
| [`59170b89`](https://github.com/NixOS/nixpkgs/commit/59170b8937b60ff2baf1b00208fff3e5e8f4960b) | `` python3Packages.torchsnapshot: cleanup, add missing dependency ``                                |
| [`11c76393`](https://github.com/NixOS/nixpkgs/commit/11c76393b7a4cec2f7f535604d558418229b1837) | `` python3Packages.torchsnapshot: use finalAttrs ``                                                 |
| [`f339648a`](https://github.com/NixOS/nixpkgs/commit/f339648a1d9fa28176ae16ce9b9456025a690fec) | `` bitcomet: 2.19.2 -> 2.21.2 ``                                                                    |
| [`9800cfc0`](https://github.com/NixOS/nixpkgs/commit/9800cfc08b24d54beab6b987de7905c671699c89) | `` Revert "ctranslate2: don't set default nvcc arch flags" ``                                       |
| [`73f14bdd`](https://github.com/NixOS/nixpkgs/commit/73f14bddfff4a5ad01fcc76042a06be08a2cc21a) | `` tofu-ls: 0.5.0 -> 0.5.1 ``                                                                       |
| [`1acf7f6f`](https://github.com/NixOS/nixpkgs/commit/1acf7f6f3eb8bc96351c239d3863083690ba90fd) | `` sage: tweak cpu threshold to decrease test flakiness ``                                          |
| [`31876af5`](https://github.com/NixOS/nixpkgs/commit/31876af59c9cc71384dcd74571e047de96094171) | `` python3Packages.pyhomee: 1.4.0 -> 1.4.1 ``                                                       |
| [`df54a0c2`](https://github.com/NixOS/nixpkgs/commit/df54a0c2970d677c359f61a2e719caa322392e08) | `` aaa: 1.1.1 -> 2.1.0 ``                                                                           |
| [`2ed1be53`](https://github.com/NixOS/nixpkgs/commit/2ed1be538e3b18b8c924cbe0b1900ba104b4a66f) | `` nixos/tinc: chown the network state directory itself ``                                          |
| [`37bc7834`](https://github.com/NixOS/nixpkgs/commit/37bc783497a811bae3f6cd524a76adff0735ed8d) | `` wasilibc: re-enable hardening options ``                                                         |
| [`c2cb8bc9`](https://github.com/NixOS/nixpkgs/commit/c2cb8bc9e35be81620ac308cbdc0f5829ee2e39e) | `` wasilibc: 27 -> 32, clean up, modernise ``                                                       |
| [`cdbe58fd`](https://github.com/NixOS/nixpkgs/commit/cdbe58fd8b72df37c4692204a8cc870ff5d3738d) | `` kdePackages.plasma-bigscreen: missing cec dep ``                                                 |
| [`86d3e446`](https://github.com/NixOS/nixpkgs/commit/86d3e4465e9df8e5bbc94d84b312e1dd2f77d41c) | `` zennotes-desktop: 2.3.0 -> 2.8.0 ``                                                              |
| [`ac9e8e63`](https://github.com/NixOS/nixpkgs/commit/ac9e8e635ab96615086ccfb8d398b493446ea33e) | `` google-cloud-sql-proxy: 2.22.1 -> 2.23.0 ``                                                      |
| [`db055ea3`](https://github.com/NixOS/nixpkgs/commit/db055ea31360242007d159e19421754838159de7) | `` gamemac: init at 0.8.328 ``                                                                      |
| [`8fe742d2`](https://github.com/NixOS/nixpkgs/commit/8fe742d247a60b44ba4c7b1ea7951bcac8d00bf7) | `` frotz and sfrotz: fix changelog link ``                                                          |
| [`e244aaf7`](https://github.com/NixOS/nixpkgs/commit/e244aaf7aac7f24259b3f7b816bb65529359434f) | `` python3Packages.deebot-client: update disabled ``                                                |
| [`558d49ff`](https://github.com/NixOS/nixpkgs/commit/558d49ffef55c3616eae88e72c77fc438286adb9) | `` mcporter: 0.11.3 -> 0.12.3 ``                                                                    |
| [`e1ca3e5f`](https://github.com/NixOS/nixpkgs/commit/e1ca3e5f96caa461627ad3c675b4f5a7b2a024c2) | `` multica-cli: 0.3.27 -> 0.3.34 ``                                                                 |
| [`a14a77f0`](https://github.com/NixOS/nixpkgs/commit/a14a77f04913f752939806a031480a1c12d69fcd) | `` itgmaniaPackages.digital-dance: 1.1.3-unstable-2026-06-22 -> 1.1.4-unstable-2026-06-30 ``        |
| [`f861d868`](https://github.com/NixOS/nixpkgs/commit/f861d868b40af34abd08db09539953be3ba45e55) | `` itgmaniaPackages.itg3encore: 0-unstable-2026-06-22 -> 0-unstable-2026-06-28 ``                   |
| [`ceedd293`](https://github.com/NixOS/nixpkgs/commit/ceedd293cac800dd69c2a325fe1224ef546dcdcd) | `` itgmaniaPackages.itgmania-unwrapped: 1.2.1 -> 1.3.0 ``                                           |
| [`8a2f6974`](https://github.com/NixOS/nixpkgs/commit/8a2f69744c6cf67793393ef7c1798ac7d72c2579) | `` doc/python: state benefit of fixed point arguments ``                                            |
| [`ef767014`](https://github.com/NixOS/nixpkgs/commit/ef767014902d2c7e9386f99dc5084d381124f71b) | `` code2prompt: 1.1.0 -> 4.2.0; switch to cargoHash, delete old Cargo.lock ``                       |
| [`576a40e0`](https://github.com/NixOS/nixpkgs/commit/576a40e0be905cc8151fef3fdc44d2388dd057f2) | `` maintainers: fix githubId for fraioveio ``                                                       |
| [`132fd885`](https://github.com/NixOS/nixpkgs/commit/132fd8858a0b10de54a8b7f31eab7260fb0cb7ad) | `` wxmaxima: 26.06.2 -> 26.07.0 ``                                                                  |
| [`e156c29e`](https://github.com/NixOS/nixpkgs/commit/e156c29e8db08f52f63a320dac1c451a4da0fb65) | `` runme: 3.16.15 -> 3.16.17 ``                                                                     |
| [`d8dbd33a`](https://github.com/NixOS/nixpkgs/commit/d8dbd33a5ef038dc051f675634d0fa6192ba165f) | `` docker-sbx: init at 0.34.0 ``                                                                    |
| [`8a2621bf`](https://github.com/NixOS/nixpkgs/commit/8a2621bf52fae65966e68b28c01b59a24d6008af) | `` paperless-ngx: add nix-update-script ``                                                          |
| [`e97a92dc`](https://github.com/NixOS/nixpkgs/commit/e97a92dc4a3a2a48aafa9338ba7772b087c8ba76) | `` paperless-ngx: make python overrides injectable ``                                               |
| [`05c11f7e`](https://github.com/NixOS/nixpkgs/commit/05c11f7e28c950f8dba447dfcf2d28381c008e86) | `` paperless-ngx: rec → finalAttrs ``                                                               |
| [`10dc7618`](https://github.com/NixOS/nixpkgs/commit/10dc7618029b025c67fb9f75d61f8e87d0fdf231) | `` maintainers: add erics118 ``                                                                     |
| [`1b42ae48`](https://github.com/NixOS/nixpkgs/commit/1b42ae4853d39d21c330be9cfd701add226e85e7) | `` electron-mail: 5.3.7 -> 5.3.8 ``                                                                 |
| [`4ff1f6b4`](https://github.com/NixOS/nixpkgs/commit/4ff1f6b4e4464f44697d1e38a2979056c67cc933) | `` pear-desktop: fix darwin build ``                                                                |
| [`7e309d0c`](https://github.com/NixOS/nixpkgs/commit/7e309d0c94643f93b905e1332216b5caad519cf5) | `` ldash: init at 1.3.1 ``                                                                          |
| [`912907b3`](https://github.com/NixOS/nixpkgs/commit/912907b3fea99ff4474128c41d83fdac6f0096fb) | `` jfrog-cli: 2.109.0 -> 2.112.0 ``                                                                 |
| [`981023a7`](https://github.com/NixOS/nixpkgs/commit/981023a7355f841c0cac5d3d04f9ff74c6b6255f) | `` home-assistant-custom-components.frigidaire: 0.1.21 -> 0.1.22 ``                                 |
| [`371f9754`](https://github.com/NixOS/nixpkgs/commit/371f9754a576f1e882b01aaa82c9c60a59a19062) | `` slint-viewer: 1.16.1 -> 1.17.0 ``                                                                |
| [`abf0a8b2`](https://github.com/NixOS/nixpkgs/commit/abf0a8b2ea73bb6b4fbfcf9a9a8fb4c024d68d3e) | `` wasmer: harden the update script ``                                                              |
| [`0afeb08e`](https://github.com/NixOS/nixpkgs/commit/0afeb08e7581748f3f1bff046c42679c68b7156f) | `` wasmer: 7.1.0 -> 7.2.0 ``                                                                        |
| [`7c103644`](https://github.com/NixOS/nixpkgs/commit/7c103644dc00a6fa7ae18e9046a1926524cb6ae7) | `` allure: 2.43.0 -> 2.44.0 ``                                                                      |
| [`7cbda565`](https://github.com/NixOS/nixpkgs/commit/7cbda565f86eb363f71768a874962fe94731b2bc) | `` chromium,chromedriver: 149.0.7827.200 -> 150.0.7871.46 ``                                        |
| [`39d0de2e`](https://github.com/NixOS/nixpkgs/commit/39d0de2e78db52f0377578f9383b115eff0ac007) | `` abtop: init at 0.5.1 ``                                                                          |
| [`e7282731`](https://github.com/NixOS/nixpkgs/commit/e72827317e16193c5d9d255a40b99971809256d8) | `` coroot: 1.22.0 -> 1.23.2 ``                                                                      |
| [`77ea5f7e`](https://github.com/NixOS/nixpkgs/commit/77ea5f7ed3d3ec1480f57a7f10a10bfc2a0a6308) | `` ci: use nixos-render-docs from tree ``                                                           |
| [`e33da78d`](https://github.com/NixOS/nixpkgs/commit/e33da78d58d221d54809ea02369b6d652a48a04e) | `` kopuz: 0.6.0 -> 0.8.2 ``                                                                         |
| [`b92ab834`](https://github.com/NixOS/nixpkgs/commit/b92ab834b4fee01c351b02750a869a6676944820) | `` flyctl: 0.4.60 -> 0.4.63 ``                                                                      |
| [`b6ad4210`](https://github.com/NixOS/nixpkgs/commit/b6ad42103ade945e2eaec387cd7a731d87fcb0a1) | `` steam-lancache-prefill: 3.4.2 -> 3.5.1 ``                                                        |
| [`cadbfc35`](https://github.com/NixOS/nixpkgs/commit/cadbfc35a5633630c2db87de8c63873fe62d42d1) | `` breseq: init at 0.39.0 ``                                                                        |
| [`ddcda767`](https://github.com/NixOS/nixpkgs/commit/ddcda767a17acec0e9d3c16dc1eb341dd314da4b) | `` pretix.plugins.payone: 1.4.2 -> 1.4.3 ``                                                         |
| [`c87a47c8`](https://github.com/NixOS/nixpkgs/commit/c87a47c86b0733e59e50d15cce4a09f277ee07c1) | `` pretix.plugins.mollie: 2.5.6 -> 2.5.7 ``                                                         |
| [`f9595d61`](https://github.com/NixOS/nixpkgs/commit/f9595d61c87575539b2431b91e68112ed9796f1d) | `` lockbook-desktop: 26.6.16 -> 26.6.22 ``                                                          |
| [`64e10ccd`](https://github.com/NixOS/nixpkgs/commit/64e10ccdad8e06e3db24d2d117db5ce4e0310484) | `` pretix: 2026.5.2 -> 2026.5.3 ``                                                                  |
| [`95a51138`](https://github.com/NixOS/nixpkgs/commit/95a51138838af73aa3bab6bd16aaf75f59df53d8) | `` maintainers: add croots ``                                                                       |
| [`6c24debe`](https://github.com/NixOS/nixpkgs/commit/6c24debe912ba114971984a882960edf82ac35d5) | `` nodejs: update keyring used to verify the signatures ``                                          |
| [`c4c4df13`](https://github.com/NixOS/nixpkgs/commit/c4c4df133851c78434be4cbd7ba508258a05cc8a) | `` python3Packages.cvxpy: 1.9.1 -> 1.9.2 ``                                                         |
| [`89f275a2`](https://github.com/NixOS/nixpkgs/commit/89f275a25385953c755aabc67d3cfe90e07fc8a7) | `` mdns-scanner: 0.27.2 -> 0.27.3 ``                                                                |
| [`b8bba632`](https://github.com/NixOS/nixpkgs/commit/b8bba632b8eda9afdd248c49c3cda379b267e3dd) | `` jackett: 0.24.2108 -> 0.24.2151 ``                                                               |
| [`532d67b4`](https://github.com/NixOS/nixpkgs/commit/532d67b42f5225fc01b1f447bf0ae29ea7605d38) | `` squix: 0.4.0-beta -> 0.5.0-beta ``                                                               |
| [`c654747e`](https://github.com/NixOS/nixpkgs/commit/c654747ed7f4cde61749c6314875334a01333337) | `` gitlab-ci-validate: init at 0.6.0 ``                                                             |
| [`a5aa47bb`](https://github.com/NixOS/nixpkgs/commit/a5aa47bb60eac0352d9479f154fa18202f3e82ef) | `` oelint-adv: 9.9.0 -> 9.9.1 ``                                                                    |
| [`8f4a585e`](https://github.com/NixOS/nixpkgs/commit/8f4a585ef78fec392aa9b33b73f595e7b3d660ba) | `` rdfind: autoreconf to fix build with gcc 16 ``                                                   |
| [`52d63c04`](https://github.com/NixOS/nixpkgs/commit/52d63c04a3cb1f9068e6bac63a712c0380cdccd8) | `` deck: 1.63.0 -> 1.64.0 ``                                                                        |
| [`9ee6bef3`](https://github.com/NixOS/nixpkgs/commit/9ee6bef3f336aa69fb2623ad91593157dce2d1f2) | `` python3Packages.deebot-client: 18.3.0 -> 18.4.0 ``                                               |
| [`6c4e3761`](https://github.com/NixOS/nixpkgs/commit/6c4e3761f5bc5a947243f7a79127533ad85d0c76) | `` ledger-live-desktop: 4.8.0 -> 4.10.0 ``                                                          |
| [`73621d05`](https://github.com/NixOS/nixpkgs/commit/73621d05a922735e15f9bacd154b56d3001e6dbe) | `` survex: 1.4.21 -> 1.4.22 ``                                                                      |
| [`5b576c13`](https://github.com/NixOS/nixpkgs/commit/5b576c13f529388e86d30b06aad3e846f5e13f62) | `` butane: 0.28.0 -> 0.29.0 ``                                                                      |
| [`a8de31c6`](https://github.com/NixOS/nixpkgs/commit/a8de31c649a8e57eeebfa3e37590251945ddbe1a) | `` smux: init at 0.3.1 ``                                                                           |
| [`0e5c6e5e`](https://github.com/NixOS/nixpkgs/commit/0e5c6e5e7f19e54a95f66d51235c95f614dbdf41) | `` python3Packages.swh-shard: 2.2.0 -> 2.2.1 ``                                                     |
| [`53cd6f26`](https://github.com/NixOS/nixpkgs/commit/53cd6f263c9a90ae02fdcabceb7db10c60e3d3cd) | `` lib/trivial: Bump oldestSupportedRelease to 2605 ``                                              |
| [`fd782901`](https://github.com/NixOS/nixpkgs/commit/fd782901e5c4c00431c8cb423c411784fcebea77) | `` .github/labeler-no-sync: Remove `backport release-25.11` ``                                      |
| [`816da78b`](https://github.com/NixOS/nixpkgs/commit/816da78bbc385445b7092546a107ecf02452b593) | `` reqable: 3.1.3 -> 3.2.3 ``                                                                       |
| [`976c1f00`](https://github.com/NixOS/nixpkgs/commit/976c1f007e4589f4850994a00d04a0f706a1d416) | `` .github/workflows: Remove 25.11 workflows ``                                                     |
| [`607f990c`](https://github.com/NixOS/nixpkgs/commit/607f990c9276847c3e04a517982e416d5b498694) | `` grimblast: 0.1-unstable-2026-05-29 -> 0.1-unstable-2026-06-30 ``                                 |
| [`6b1e2459`](https://github.com/NixOS/nixpkgs/commit/6b1e245992ccc541c720965418eec727f703fa6b) | `` zigbee2mqtt: 2.12.0 -> 2.12.1 ``                                                                 |
| [`dce31222`](https://github.com/NixOS/nixpkgs/commit/dce31222ecd72eb999ad074b09d9a2f2522945c1) | `` thunderbird-140-unwrapped: 140.12.0esr -> 140.12.1esr ``                                         |
| [`ebf6b493`](https://github.com/NixOS/nixpkgs/commit/ebf6b493d68f492ce7805ba818bc7dd6e9fff443) | `` fetchtastic: 0.10.10 -> 0.10.11 ``                                                               |
| [`e11d2dec`](https://github.com/NixOS/nixpkgs/commit/e11d2dec4b89dc7d44922e59ea56433c3f59fb8e) | `` ankiAddons.advanced-browser: init at 4.5 ``                                                      |
| [`28b39eb6`](https://github.com/NixOS/nixpkgs/commit/28b39eb67289dbe245b8b52d0653c953d544b9ad) | `` checkstyle: 13.6.0 -> 13.7.0 ``                                                                  |
| [`96a28d91`](https://github.com/NixOS/nixpkgs/commit/96a28d910c3962782abcc76ebb999b536df68350) | `` plezy: 2.7.1 -> 2.8.0 ``                                                                         |
| [`cc5d8b54`](https://github.com/NixOS/nixpkgs/commit/cc5d8b5414cb8f443f80ca171b6be07d55819f33) | `` python3Packages.tt-perf-report: init at 1.2.4 ``                                                 |
| [`51f1beff`](https://github.com/NixOS/nixpkgs/commit/51f1befff29d45f19555664b3a6dbf20c349d067) | `` maintainers: add mert-kurttutan ``                                                               |
| [`bb258c2d`](https://github.com/NixOS/nixpkgs/commit/bb258c2dbedde8601dd9981c069b06fe7ae34c78) | `` nixos/systemd-boot: update via Varlink instead of parsing bootctl status ``                      |
| [`42f6c68c`](https://github.com/NixOS/nixpkgs/commit/42f6c68c40f54ec06d208f9344c5e29c6efcab18) | `` icinga2: 2.16.2 -> 2.16.3 ``                                                                     |
| [`5ea624f0`](https://github.com/NixOS/nixpkgs/commit/5ea624f05cfe6ff48c9bae544a6b60eb5453ea38) | `` qidi-studio: 2.06.00.51 -> 2.07.01.57 ``                                                         |
| [`a0d77af5`](https://github.com/NixOS/nixpkgs/commit/a0d77af5818cdbf54d5f0c2093d9ca3f3c1ddbbe) | `` jwx: 4.0.2 -> 4.1.0 ``                                                                           |
| [`b256ed53`](https://github.com/NixOS/nixpkgs/commit/b256ed53f19368cb58b96c8952da3af3054eeddf) | `` fishPlugins.forgit: 26.05.0 -> 26.07.0 ``                                                        |
| [`68fe8fab`](https://github.com/NixOS/nixpkgs/commit/68fe8fabedcc1c0f0332d8ff71afa79f0069a493) | `` enzyme: 0.0.271 -> 0.0.277 ``                                                                    |
| [`26c67f7e`](https://github.com/NixOS/nixpkgs/commit/26c67f7ed3d69fd462d62d0316f231f10f07548c) | `` python3Packages.openinference-instrumentation: 0.1.53 -> 0.1.54 ``                               |
| [`33683c38`](https://github.com/NixOS/nixpkgs/commit/33683c385ac9b95d137344370d33dc7431d3c093) | `` python3Packages.selenium-wire-roadtx: 0-unstable-2026-05-20 -> 5.2.4-unstable-2026-05-20 ``      |
| [`a35476c0`](https://github.com/NixOS/nixpkgs/commit/a35476c08b1b083a1778ab662accb651d9c5bc44) | `` pdk-ciel: 2.5.1 -> 2.6.0 ``                                                                      |
| [`780013d4`](https://github.com/NixOS/nixpkgs/commit/780013d45ea1264f011e331efc8c2ecff23af4fe) | `` skaffold: 2.21.0 -> 2.23.0 ``                                                                    |
| [`c13a8937`](https://github.com/NixOS/nixpkgs/commit/c13a8937ce5af28eb04041d7efd17af40f33f661) | `` usage: 3.5.0 -> 3.5.3 ``                                                                         |
| [`46c4e578`](https://github.com/NixOS/nixpkgs/commit/46c4e5782f86dfb4f18e2f543b004e7cf7668273) | `` python3Packages.microsoft-kiota-serialization-text: 1.11.6 -> 1.11.7 ``                          |
| [`66285e6c`](https://github.com/NixOS/nixpkgs/commit/66285e6c825b8e8e4063b935dea352d89bc2c964) | `` python3Packages.microsoft-kiota-serialization-multipart: 1.11.6 -> 1.11.7 ``                     |
| [`6269a2ad`](https://github.com/NixOS/nixpkgs/commit/6269a2ad7c00d20aaee9bcb6b1a57560c3673fff) | `` python3Packages.microsoft-kiota-serialization-json: 1.11.6 -> 1.11.7 ``                          |
| [`cfa37693`](https://github.com/NixOS/nixpkgs/commit/cfa376931ad193eea232a88d015258b5eb98a427) | `` python3Packages.microsoft-kiota-serialization-form: 1.11.6 -> 1.11.7 ``                          |
| [`07b4e183`](https://github.com/NixOS/nixpkgs/commit/07b4e18301a3670af5eb1e812e8b5b47faebe1b6) | `` python3Packages.microsoft-kiota-http: 1.11.6 -> 1.11.7 ``                                        |
| [`703370a6`](https://github.com/NixOS/nixpkgs/commit/703370a67c20a328a8df58f09de57daf422ae8be) | `` python3Packages.microsoft-kiota-authentication-azure: 1.11.6 -> 1.11.7 ``                        |
| [`3290f005`](https://github.com/NixOS/nixpkgs/commit/3290f005f198465197e15b6e04807ebffc8c53f3) | `` python3Packages.microsoft-kiota-abstractions: 1.11.6 -> 1.11.7 ``                                |
| [`8816ce5b`](https://github.com/NixOS/nixpkgs/commit/8816ce5bdbe18665069e993c5451c74606334934) | `` ghostfolio: 3.13.0 -> 3.18.0 ``                                                                  |
| [`02934505`](https://github.com/NixOS/nixpkgs/commit/02934505cea8a7e416c7b810965f14f7e7065ac0) | `` python3Packages.boto3-stubs: 1.43.37 -> 1.43.38 ``                                               |
| [`e3cce69c`](https://github.com/NixOS/nixpkgs/commit/e3cce69c41a21635ed2140a068f3a1c7eebfebcb) | `` python3Packages.mypy-boto3-sso-admin: 1.43.1 -> 1.43.38 ``                                       |
| [`effe6126`](https://github.com/NixOS/nixpkgs/commit/effe6126d4b57b51b3c1500c7beb6f310811d361) | `` python3Packages.mypy-boto3-network-firewall: 1.43.0 -> 1.43.38 ``                                |
| [`3eca4604`](https://github.com/NixOS/nixpkgs/commit/3eca460482f3693f7e29cdf9653219e30f578762) | `` python3Packages.mypy-boto3-eks: 1.43.33 -> 1.43.38 ``                                            |
| [`80218113`](https://github.com/NixOS/nixpkgs/commit/80218113589a07b569232357d76a9a370dc920c5) | `` python3Packages.mypy-boto3-ecs: 1.43.37 -> 1.43.38 ``                                            |
| [`225c4265`](https://github.com/NixOS/nixpkgs/commit/225c426593241c0cb64ccb2f3a007c5d00693a9b) | `` python3Packages.mypy-boto3-ec2: 1.43.37 -> 1.43.38 ``                                            |
| [`26c21b69`](https://github.com/NixOS/nixpkgs/commit/26c21b6995ad2963fe7dc78eb4ddd118e136999c) | `` python3Packages.mypy-boto3-connect: 1.43.34 -> 1.43.38 ``                                        |
| [`e6c8bfae`](https://github.com/NixOS/nixpkgs/commit/e6c8bfaeeb15217584995cffb09cc0d6aa31a905) | `` python3Packages.mypy-boto3-codebuild: 1.43.0 -> 1.43.38 ``                                       |
| [`a85894db`](https://github.com/NixOS/nixpkgs/commit/a85894db83cb0a8ea7a1bb6f0f6e48026b008432) | `` python3Packages.mypy-boto3-cloudwatch: 1.43.37 -> 1.43.38 ``                                     |
| [`6b343469`](https://github.com/NixOS/nixpkgs/commit/6b3434699f3191bd9f003a121198780c52c60a94) | `` python3Packages.mypy-boto3-cloudformation: 1.43.23 -> 1.43.38 ``                                 |
| [`08b0fc8c`](https://github.com/NixOS/nixpkgs/commit/08b0fc8c01479a4b61df6de8ebbf59fa2299ffe5) | `` python3Packages.mypy-boto3-cleanrooms: 1.43.13 -> 1.43.38 ``                                     |
| [`76fb6400`](https://github.com/NixOS/nixpkgs/commit/76fb640091d73f748e07362a7b0bfb1af845b380) | `` python3Packages.mypy-boto3-autoscaling: 1.43.0 -> 1.43.38 ``                                     |
| [`20c81b96`](https://github.com/NixOS/nixpkgs/commit/20c81b96fbbec8af3e977a4e96f516ab90a3147b) | `` python3Packages.mypy-boto3-acm: 1.43.29 -> 1.43.38 ``                                            |
| [`a028392a`](https://github.com/NixOS/nixpkgs/commit/a028392a35f2b6d1af51fd804f04f4c46f94a26c) | `` dalfox: modernize ``                                                                             |
| [`ec51ed14`](https://github.com/NixOS/nixpkgs/commit/ec51ed1449cca66ba6cec05d5aab57c4f8cc1829) | `` nixos/pam/u2f: add settings.{,cue_}prompt option ``                                              |
| [`10936493`](https://github.com/NixOS/nixpkgs/commit/10936493b31258f7b24fab2a7b1be46774aef72a) | `` python3Packages.tencentcloud-sdk-python: 3.1.123 -> 3.1.125 ``                                   |
| [`fffd6bc6`](https://github.com/NixOS/nixpkgs/commit/fffd6bc64699c3b94d051203c74b8b6c5a1f2781) | `` run0-sudo-shim: 1.3.1 -> 1.4.2 ``                                                                |
| [`034b8a07`](https://github.com/NixOS/nixpkgs/commit/034b8a07c38925d16f5a541aacfaaaff19b49a56) | `` unityhub: 3.18.3 -> 3.19.1 ``                                                                    |
| [`0ff03353`](https://github.com/NixOS/nixpkgs/commit/0ff033531c74652b6760e9efa2bee1f824093c00) | `` otel-desktop-viewer: 0.3.0 -> 0.3.2 ``                                                           |
| [`0e8889de`](https://github.com/NixOS/nixpkgs/commit/0e8889de25fafc1e376be3787e4d1b67e9ae3263) | `` matrix-authentication-service: add matrix team to maintainers ``                                 |
| [`a27c48ff`](https://github.com/NixOS/nixpkgs/commit/a27c48ff6b6e1c6c51084b09d0816a05d1414dd8) | `` python3Packages.llama-cloud: 2.9.0 -> 2.10.0 ``                                                  |
| [`dcb83169`](https://github.com/NixOS/nixpkgs/commit/dcb8316955ec9530b67ff9fa87c3d4bf4ec4433a) | `` checkov: 3.3.0 -> 3.3.6 ``                                                                       |
| [`24f5ec9a`](https://github.com/NixOS/nixpkgs/commit/24f5ec9a8333432333f235f2b125c26cb850d375) | `` python3Packages.iamdata: 0.1.202606301 -> 0.1.202607011 ``                                       |
| [`90bfc388`](https://github.com/NixOS/nixpkgs/commit/90bfc388f67a58f90282a4ac9f51af857b7ceb24) | `` python3Packages.reolink-aio: 0.21.1 -> 0.21.3 ``                                                 |
| [`b41a4a8d`](https://github.com/NixOS/nixpkgs/commit/b41a4a8de3096e6525a4f7e31bd31283b06a472c) | `` python3Packages.hstspreload: 2026.6.1 -> 2026.7.1 ``                                             |
| [`84b18004`](https://github.com/NixOS/nixpkgs/commit/84b180042ce809ee5651dad026c77d9965c25860) | `` github-mcp-server: 1.4.0 -> 1.5.0 ``                                                             |
| [`988618b2`](https://github.com/NixOS/nixpkgs/commit/988618b2be679c95e47ee5f404534a200a8e5b3c) | `` gitify: pnpm_10_29_2 -> pnpm_10 ``                                                               |
| [`5e1a9069`](https://github.com/NixOS/nixpkgs/commit/5e1a90699646d73fc5988324b1e2625c3d4c68ca) | `` git-machete: 3.41.0 -> 3.44.0 ``                                                                 |
| [`9041124d`](https://github.com/NixOS/nixpkgs/commit/9041124d9954e8fd7b9008c6d9263d54d0a10639) | `` lnd: 0.21.0-beta -> 0.21.1-beta ``                                                               |
| [`c7d40d39`](https://github.com/NixOS/nixpkgs/commit/c7d40d39db98d15348374c3bb3c7a89ca9308e2d) | `` skypilot: patch CVE-2026-13482 ``                                                                |
| [`979881ab`](https://github.com/NixOS/nixpkgs/commit/979881abc50ecc69e53854be9b88c636ba817fe3) | `` terraform-providers.dopplerhq_doppler: 1.21.3 -> 1.21.4 ``                                       |
| [`a396c3dd`](https://github.com/NixOS/nixpkgs/commit/a396c3dd2b39014d23ccd80e3edb0e6253341837) | `` kitty-themes: 0-unstable-2026-06-08 -> 0-unstable-2026-06-29 ``                                  |
| [`384606f2`](https://github.com/NixOS/nixpkgs/commit/384606f24ec41e6fe8fb3c767707952e98e13aa2) | `` xaos: remove man output, add strictDeps and __structuredAttrs ``                                 |
| [`edb5548f`](https://github.com/NixOS/nixpkgs/commit/edb5548f797e9c6dec5fffc973e4da90ba218175) | `` xaos: add support for darwin, aarch64-linux ``                                                   |
| [`9509c415`](https://github.com/NixOS/nixpkgs/commit/9509c4155b1640e79a4b4a8820d8244e3e2053eb) | `` vacuum-tube: 1.7.3 -> 1.8.0 ``                                                                   |
| [`acaf38af`](https://github.com/NixOS/nixpkgs/commit/acaf38af9430780124226dfe00710b5e52df77c9) | `` mailpit: 1.30.2 -> 1.30.3 ``                                                                     |
| [`909b1ee6`](https://github.com/NixOS/nixpkgs/commit/909b1ee676347e06cde9a0776fcd4acbbbc45b4c) | `` git-mit: 6.4.3 -> 6.5.2 ``                                                                       |
| [`d8595015`](https://github.com/NixOS/nixpkgs/commit/d8595015131f1386dcddbfe7ada8827cfcdd9009) | `` phpstan: 2.2.2 -> 2.2.3 ``                                                                       |
| [`4d6608a2`](https://github.com/NixOS/nixpkgs/commit/4d6608a25a1e9be3f4c423ca2373f43c493acb53) | `` prusa-slicer: 2.9.5 -> 2.9.6 ``                                                                  |
| [`2ff8d5c2`](https://github.com/NixOS/nixpkgs/commit/2ff8d5c2e03a45257204d8c7a35c69158cc8ff10) | `` terraform-providers.newrelic_newrelic: 3.93.2 -> 3.94.0 ``                                       |
| [`ed29e1b0`](https://github.com/NixOS/nixpkgs/commit/ed29e1b0310185f1417daec8910e46aacfca687d) | `` lib.strings: remove throwIfNot usage ``                                                          |
| [`bb50241c`](https://github.com/NixOS/nixpkgs/commit/bb50241c6057c3996e469ea5049fa33a790336ed) | `` lib.modules: remove throwIfNot usage ``                                                          |
| [`e1ae8a81`](https://github.com/NixOS/nixpkgs/commit/e1ae8a8194f6aa153286aee24fb1d3ddd25662f5) | `` lib.gvariant.mkArray: refactor ``                                                                |
| [`feb74fca`](https://github.com/NixOS/nixpkgs/commit/feb74fca3771f93fabdc86b6f682cbe276e487ad) | `` lib.gvariant: remove throwIfNot usage ``                                                         |
| [`079b1a7d`](https://github.com/NixOS/nixpkgs/commit/079b1a7d07b26f8f81261cce068f6d5221ac7542) | `` lib.derivations: remove throwIfNot usage ``                                                      |
| [`44eafb29`](https://github.com/NixOS/nixpkgs/commit/44eafb29537d5c3d786915a17f0c05dddec17afb) | `` lib.types: remove throwIf usage ``                                                               |
| [`dd6f1736`](https://github.com/NixOS/nixpkgs/commit/dd6f1736b78c83593544cf9959750973f2efc93a) | `` lib.gvariant: remove throwIf usage ``                                                            |
| [`c81b12b6`](https://github.com/NixOS/nixpkgs/commit/c81b12b698ab6726abff151979d0589855cbd3d3) | `` lib.fetchers: remove throwIf usage ``                                                            |
| [`ce99cfa1`](https://github.com/NixOS/nixpkgs/commit/ce99cfa1039d81a377f044f4a079b5b3e2b781bb) | `` lib.types: remove assertMsg usage ``                                                             |
| [`855f2d04`](https://github.com/NixOS/nixpkgs/commit/855f2d04358991a8cd10d4f7b5ff9e0b0ea53901) | `` lib.strings: remove assertMsg usage ``                                                           |
| [`4ff26455`](https://github.com/NixOS/nixpkgs/commit/4ff2645579deb793e8307077b4f8cb2b04b4167a) | `` lib.path: remove assertMsg usage ``                                                              |
| [`a017ab10`](https://github.com/NixOS/nixpkgs/commit/a017ab10eb0ecdd676280bc4c89c0e94850eee16) | `` lib.network: remove assertMsg usage ``                                                           |
| [`1e47a49c`](https://github.com/NixOS/nixpkgs/commit/1e47a49c79c34040957c0f701ddd236148d05c64) | `` lib.meta: remove assertMsg usage ``                                                              |
| [`2221cbb4`](https://github.com/NixOS/nixpkgs/commit/2221cbb4aaea3ecbda2d4497d2121ed28a4f0bf5) | `` lib.lists: remove assertMsg usage ``                                                             |
| [`370135bd`](https://github.com/NixOS/nixpkgs/commit/370135bdc880092a7ef0c7a4ce14befba1abe5b8) | `` lib.generators: remove assertMsg usage ``                                                        |
| [`d2b0c3ce`](https://github.com/NixOS/nixpkgs/commit/d2b0c3cecfff1f7676abe673808efb7ad3989661) | `` python3Packages.pyanglianwater: 3.2.2 -> 3.2.3 ``                                                |
| [`37168520`](https://github.com/NixOS/nixpkgs/commit/371685205eb10d2cba897243fc1548afdfdd21ba) | `` python3Packages.pyglossary: 5.4.1 -> 5.4.2 ``                                                    |
| [`0198c91e`](https://github.com/NixOS/nixpkgs/commit/0198c91e1c8cfcdbf1d712d6e63d00c25c7c9960) | `` incus-ui-canonical: 0.21.2 -> 0.21.3 ``                                                          |
| [`af1ab66a`](https://github.com/NixOS/nixpkgs/commit/af1ab66a5b69e6cf7ae76b989936ff85ed8b3f9d) | `` terraform-providers.opentelekomcloud_opentelekomcloud: 1.36.69 -> 1.36.70 ``                     |
| [`336550bc`](https://github.com/NixOS/nixpkgs/commit/336550bce50527b170b3a0d6fd0a319fe11bc4a3) | `` home-assistant-custom-components.blueprints-updater: 2.9.0 -> 2.9.1 ``                           |
| [`298e2f06`](https://github.com/NixOS/nixpkgs/commit/298e2f0683df22018b31fe1312134c34313d896d) | `` pana: 0.23.12 -> 0.23.13 ``                                                                      |
| [`998dc0f0`](https://github.com/NixOS/nixpkgs/commit/998dc0f0648e42d4b96ba0d09f0e7a0d5f945054) | `` musescore-evolution: 3.7.0-unstable-2026-06-10 -> 3.7.0-unstable-2026-06-30 ``                   |
| [`b2a8dd2e`](https://github.com/NixOS/nixpkgs/commit/b2a8dd2e5543c2dab0a8f20742eb93ebf94a2759) | `` vivaldi: 8.0.4033.50 -> 8.0.4033.54 ``                                                           |
| [`d74b61a1`](https://github.com/NixOS/nixpkgs/commit/d74b61a16f931fb26f1b7487a72a5d3815c81df6) | `` avml: 0.18.0 -> 0.19.0 ``                                                                        |
| [`f874f44b`](https://github.com/NixOS/nixpkgs/commit/f874f44bd1f273eac349a66e74b6f8b96a29a295) | `` python3Packages.free-proxy: 1.1.3 -> 1.2.1 ``                                                    |
| [`4a121cc2`](https://github.com/NixOS/nixpkgs/commit/4a121cc25a66c3b9c11bd830f71be98367404829) | `` glitchtip: 6.1.8 -> 6.2.0 ``                                                                     |
| [`2606a235`](https://github.com/NixOS/nixpkgs/commit/2606a235af555f170d1564b67a6b7354318a81ba) | `` python3Packages.django-vtasks: 2.1.1 -> 2.1.2 ``                                                 |
| [`eb9d0efb`](https://github.com/NixOS/nixpkgs/commit/eb9d0efb6ed3e67ff1fc8e8284fb8cbeb9e00aeb) | `` batman-adv: 2026.1 -> 2026.2 ``                                                                  |
| [`a20680fd`](https://github.com/NixOS/nixpkgs/commit/a20680fd418fe0e5e2df58c13f398fd60800d482) | `` amp-cli: 0.0.1782120930-g64087b -> 0.0.1782851652-gfd0e56 ``                                     |
| [`78c7213f`](https://github.com/NixOS/nixpkgs/commit/78c7213fe44b1db49ea2d772b80b3f8cddf42edf) | `` radicle-ci-broker: 0.28.1 -> 0.29.0 ``                                                           |
| [`a4b490dc`](https://github.com/NixOS/nixpkgs/commit/a4b490dcf52b7087feb8cddb5815d2b597ddac8a) | `` home-assistant-custom-lovelace-modules.weather-radar-card: 3.7.0 -> 3.7.1 ``                     |
| [`d361ab53`](https://github.com/NixOS/nixpkgs/commit/d361ab53b7af4c95d52ed7ad858dbdf450080872) | `` libretro.snes9x2010: 0-unstable-2026-06-15 -> 0-unstable-2026-06-29 ``                           |
| [`317071b5`](https://github.com/NixOS/nixpkgs/commit/317071b55326320d38859db8ee8fa25f2e9c5d68) | `` diffoscope: 322 -> 323 ``                                                                        |
| [`3b962d6c`](https://github.com/NixOS/nixpkgs/commit/3b962d6ca741648c6dc43b0de6f374d5fed907c7) | `` librewolf-unwrapped: 152.0.2-1 -> 152.0.4-1 ``                                                   |
| [`fb0d1a7c`](https://github.com/NixOS/nixpkgs/commit/fb0d1a7cd306c43ab7edb0b9cd51e5fbcce412ed) | `` treewide: follow some GitHub redirects for `fetchFromGitHub` ``                                  |
| [`6b5822b1`](https://github.com/NixOS/nixpkgs/commit/6b5822b1d9f4cecf8c50d62578663deae836b524) | `` wp-scanner: init at 2.0.1-unstable-2026-03-17 ``                                                 |
| [`29627956`](https://github.com/NixOS/nixpkgs/commit/296279566a60c62020c29c5e5e2bae9a1d58b455) | `` libdict: 1.0.5 -> 1.0.6 ``                                                                       |
| [`2344c176`](https://github.com/NixOS/nixpkgs/commit/2344c1760ce4c1c6975e3ba0c1fa1146142a798f) | `` python3Packages.muon-optimizer: init at 0.1.0 ``                                                 |
| [`09181d54`](https://github.com/NixOS/nixpkgs/commit/09181d5479c6a9791d8a318f053fdad32e603ff6) | `` forgejo-mcp: 2.30.0 -> 2.30.1 ``                                                                 |
| [`f3d7d953`](https://github.com/NixOS/nixpkgs/commit/f3d7d953c32c19300f1d384fd7defc1f358bba6c) | `` pythpn3Packages.simplisafe-python: modernize ``                                                  |
| [`7e6427f6`](https://github.com/NixOS/nixpkgs/commit/7e6427f6ad1efa145d9c50ecaca44a2e0a768c46) | `` rar: 7.21 -> 7.23 ``                                                                             |
| [`823c46ee`](https://github.com/NixOS/nixpkgs/commit/823c46ee6fd319b71d953d8d466bf19cfdc34fbf) | `` jan: 0.8.2 -> 0.8.3 ``                                                                           |
| [`a8b1a80a`](https://github.com/NixOS/nixpkgs/commit/a8b1a80a6af6a775db6e00423749b510904040d1) | `` jan: refactor ``                                                                                 |
| [`83891d70`](https://github.com/NixOS/nixpkgs/commit/83891d702c23085f35b15c93de8bb36453c12a17) | `` jan: add update script ``                                                                        |
| [`1574c734`](https://github.com/NixOS/nixpkgs/commit/1574c73498b2de56a96d729d53dedec883361ded) | `` nextvi: 5.3 -> 6.0 ``                                                                            |
| [`b42b7c89`](https://github.com/NixOS/nixpkgs/commit/b42b7c89d063b3932e29e6e5ed71a22d25917a2e) | `` hyper8: init at 1.0.1 ``                                                                         |
| [`801431c6`](https://github.com/NixOS/nixpkgs/commit/801431c6deea492dd608d5b28522add2d13fe14f) | `` protozero: 1.8.1 -> 1.8.2 ``                                                                     |
| [`a7473371`](https://github.com/NixOS/nixpkgs/commit/a747337182437f4d05b31a0fc75991cbd44f808d) | `` wasm-component-ld: init at 0.5.25 ``                                                             |
| [`21cb8f1c`](https://github.com/NixOS/nixpkgs/commit/21cb8f1c0ca9df6811093e06096eff4c3a04824a) | `` vscode-extensions.anthropic.claude-code: 2.1.196 -> 2.1.197 ``                                   |
| [`148870a5`](https://github.com/NixOS/nixpkgs/commit/148870a5b354296aa8e921372fa508d9a50982b4) | `` claude-code: 2.1.196 -> 2.1.197 ``                                                               |
| [`1cafcf67`](https://github.com/NixOS/nixpkgs/commit/1cafcf671b2deea52bfe7aa61843c86cf6dbf8b3) | `` postgrest: 14.13 -> 14.14 ``                                                                     |
| [`4efde464`](https://github.com/NixOS/nixpkgs/commit/4efde464e76bf62686bc88d7a1a76667ef3eff3d) | `` libretro.snes9x2002: 0-unstable-2026-04-20 -> 0-unstable-2026-06-25 ``                           |
| [`25a20fae`](https://github.com/NixOS/nixpkgs/commit/25a20faea6964fb13d35974ae64f3f1cd293bf6b) | `` steam-art-manager: 3.16.0 -> 3.16.1 ``                                                           |
| [`e935bea8`](https://github.com/NixOS/nixpkgs/commit/e935bea81aadc598d97a6f74010288181b3edbcf) | `` terraform-providers.auth0_auth0: 1.50.0 -> 1.51.0 ``                                             |
| [`ef0eaf6c`](https://github.com/NixOS/nixpkgs/commit/ef0eaf6c3f9b8bfc68a8ea626153534122e82f69) | `` python3Packages.datadog: 0.52.1 -> 0.52.2 ``                                                     |
| [`c78f5f41`](https://github.com/NixOS/nixpkgs/commit/c78f5f413fd0f8e0a682b3a1e8a93966e0cfb26b) | `` onnxruntime: fix CUDAExecutionProvider loading error ``                                          |
| [`dd41f01a`](https://github.com/NixOS/nixpkgs/commit/dd41f01aecfd10aa49e26c7709fbcd577717eb89) | `` python3Packages.granian: 2.7.5 -> 2.7.8 ``                                                       |
| [`0b0e89c6`](https://github.com/NixOS/nixpkgs/commit/0b0e89c6e591f7c7266ff5a98427ec35899e5e1b) | `` rime-wanxiang: 15.14.2 -> 15.16.0 ``                                                             |
| [`a35081b4`](https://github.com/NixOS/nixpkgs/commit/a35081b427c807824f6aacb1035907f7bb6b5406) | `` maintainers: add n0pl4c3 ``                                                                      |
| [`d64ac8a6`](https://github.com/NixOS/nixpkgs/commit/d64ac8a6428534095354814aa88c446bfcd80cb6) | `` tree-sitter: Update org and org-nvim grammars to new source ``                                   |
| [`eaabaa04`](https://github.com/NixOS/nixpkgs/commit/eaabaa04db0b5030fc343a27aaa27fc2dadc3114) | `` maintainers: add sorooris ``                                                                     |
| [`f881aba1`](https://github.com/NixOS/nixpkgs/commit/f881aba1629bfc44b1bd73ce7988529412cfe3bb) | `` veila: 0.4.2 -> 0.4.3 ``                                                                         |
| [`fd68039f`](https://github.com/NixOS/nixpkgs/commit/fd68039fdcc2a2ebe08c6a0e1ea46c5f07065f52) | `` lumen: add `fzf` and `mdcat` to `PATH` ``                                                        |
| [`f1a714ef`](https://github.com/NixOS/nixpkgs/commit/f1a714efde086cc7f9ab07dd7e648442831a54e2) | `` firebase-tools: 15.22.0 -> 15.22.3 ``                                                            |
| [`330b51cf`](https://github.com/NixOS/nixpkgs/commit/330b51cfeeaa48ba8c28f0504c32f56a222e86d4) | `` kdePackages: Plasma 6.7.1 -> 6.7.2 ``                                                            |
| [`fa0c4ce8`](https://github.com/NixOS/nixpkgs/commit/fa0c4ce8335a4f649b904d1bbe4ec3c1193b44bb) | `` tailscale: 1.98.5 -> 1.98.8 ``                                                                   |
| [`043f26c4`](https://github.com/NixOS/nixpkgs/commit/043f26c4dd93b1af7ea1d10599db3d18daddbc74) | `` _1password-gui: 8.12.24 -> 8.12.26 ``                                                            |
| [`a2903322`](https://github.com/NixOS/nixpkgs/commit/a2903322cce6fe51f3cd1640b3fc539cbcfbc4ef) | `` dashy-ui: 4.3.3 -> 4.3.11 ``                                                                     |
| [`0fa8a110`](https://github.com/NixOS/nixpkgs/commit/0fa8a1100a659e873e87420663bc257357540fef) | `` iperf2: fix cross compilation ``                                                                 |
| [`35cec3ed`](https://github.com/NixOS/nixpkgs/commit/35cec3ed737cb499650c3038a0ce94d4baf01ae1) | `` python3Packages.langchain-anthropic: 1.4.6 -> 1.4.8 ``                                           |
| [`8925d23e`](https://github.com/NixOS/nixpkgs/commit/8925d23eb1298e5e48f97e09e3adb22324393151) | `` starship: 1.25.1 -> 1.26.0 ``                                                                    |
| [`1948ddd6`](https://github.com/NixOS/nixpkgs/commit/1948ddd6be8be8cfed7c63af66fe5c9b93cd8659) | `` vacuum-go: 0.29.4 -> 0.29.7 ``                                                                   |
| [`d6b5e31e`](https://github.com/NixOS/nixpkgs/commit/d6b5e31e99d37a752addbda3da06f945660f9ece) | `` python3Packages.rich-rst: 2.0.1 -> 2.0.2 ``                                                      |
| [`dd37af7c`](https://github.com/NixOS/nixpkgs/commit/dd37af7c57d5fc72c3b242c2ccbb4582369dbc46) | `` python3Packages.nexia: 2.12.0 -> 2.13.0 ``                                                       |
| [`7ef8f38f`](https://github.com/NixOS/nixpkgs/commit/7ef8f38fb08f413878649fc9225c1e51361911d8) | `` mdbook-linkcheck2: add stepbrobd to maintainers ``                                               |
| [`1bcb03cf`](https://github.com/NixOS/nixpkgs/commit/1bcb03cfb250e443c7fb6a874b4a167d6c96b9d4) | `` mdbook-linkcheck2: cleanup, enable tests, and propagate cacert ``                                |
| [`3a40b52c`](https://github.com/NixOS/nixpkgs/commit/3a40b52cc7bf2a32e3523e09731bca8055477a82) | `` aerospace: 0.20.3-Beta -> 0.21.0-Beta ``                                                         |
| [`1c188b98`](https://github.com/NixOS/nixpkgs/commit/1c188b986c2ecb96348fdc541805e86de1def6ae) | `` terraform-providers.grafana_grafana: 4.38.0 -> 4.39.0 ``                                         |
| [`458b6277`](https://github.com/NixOS/nixpkgs/commit/458b6277ab9907c06536cc94b0dbc64913f00d60) | `` libretro.gpsp: 0-unstable-2026-06-04 -> 0-unstable-2026-06-29 ``                                 |
| [`047a8b83`](https://github.com/NixOS/nixpkgs/commit/047a8b839cecac9e5da95a027f3fa7dca25bf3b9) | `` vg: 1.75.0 -> 1.75.1 ``                                                                          |
| [`69cc069e`](https://github.com/NixOS/nixpkgs/commit/69cc069e56bd06c09de8a7f8cedecd663f8be743) | `` ggml: 0.15.2 -> 0.15.3 ``                                                                        |
| [`ba3ba11b`](https://github.com/NixOS/nixpkgs/commit/ba3ba11ba4b39ae58463a99ae88efbf42d7c7f02) | `` sail: 0.6.3 -> 0.6.5 ``                                                                          |
| [`739447ed`](https://github.com/NixOS/nixpkgs/commit/739447ed421a02ad6ad12d6ff6cd7b4f0a36e76f) | `` python3Packages.aioghost: 0.4.17 -> 0.4.18 ``                                                    |
| [`e98bd51f`](https://github.com/NixOS/nixpkgs/commit/e98bd51f8c2139e41ddb9c3ea36fbeeb0fb5ec7b) | `` bencher-cli: init at 0.6.8 ``                                                                    |
| [`7bd8e5f6`](https://github.com/NixOS/nixpkgs/commit/7bd8e5f602d7aebbb8d1927674452daf2c935f1b) | `` maintainers: add sepointon ``                                                                    |
| [`d98f4a92`](https://github.com/NixOS/nixpkgs/commit/d98f4a92b895cdef2fd58fdb6f1b029bd287e6ce) | `` tree-sitter-grammars.tree-sitter-scala: 0.25.0 -> 0.26.0 ``                                      |
| [`a6363b53`](https://github.com/NixOS/nixpkgs/commit/a6363b5363ee3659a0ba7967563d913e3c8f20af) | `` tree-sitter-grammars.tree-sitter-llvm: 0-unstable-2025-08-22 -> 1.1.0-unstable-2025-08-22 ``     |
| [`dbb38eaf`](https://github.com/NixOS/nixpkgs/commit/dbb38eafef804202f4ad03a5627bd54cf5405ea2) | `` tree-sitter-grammars.tree-sitter-julia: 0.23.1 -> 0.25.0 ``                                      |
| [`c6a8e57c`](https://github.com/NixOS/nixpkgs/commit/c6a8e57ce8496689af4dcb2fd39502bc67952e13) | `` tree-sitter-grammars.tree-sitter-gren: 2.0.0-unstable-2025-05-03 -> 2.0.0-unstable-2026-03-31 `` |
| [`e3067d9e`](https://github.com/NixOS/nixpkgs/commit/e3067d9eebde04ac1a936b2de8c1136131e7afd1) | `` tree-sitter-grammars.tree-sitter-gdscript: 6.0.0 -> 6.1.0 ``                                     |
| [`a0f08e7f`](https://github.com/NixOS/nixpkgs/commit/a0f08e7fa01b7853a6ef583b568b1c49933b13f0) | `` tree-sitter-grammars.tree-sitter-devicetree: 0.11.1 -> 0.15.0 ``                                 |
| [`f53be317`](https://github.com/NixOS/nixpkgs/commit/f53be3175a3f2ed093425cb4723a445e10030fdf) | `` tree-sitter-grammars.tree-sitter-c-sharp: 0.23.1 -> 0.23.5 ``                                    |
| [`e3018fe1`](https://github.com/NixOS/nixpkgs/commit/e3018fe1ee10af1d86dbec9035277bb84573652d) | `` tree-sitter-grammars.tree-sitter-c: 0.24.1 -> 0.24.2 ``                                          |
| [`fe0e0239`](https://github.com/NixOS/nixpkgs/commit/fe0e023943cb02a94e4a0aa887e484fbe464608a) | `` fotowall: 1.1.0 -> 1.1.1 ``                                                                      |
| [`e17e0879`](https://github.com/NixOS/nixpkgs/commit/e17e0879e1a2b59179a5296498b5311b594ac09a) | `` harbor-cli: 0.0.22 -> 0.0.23 ``                                                                  |
| [`8618042e`](https://github.com/NixOS/nixpkgs/commit/8618042eafd9aa7bce51d6c80eec3c7fc6aed10d) | `` goose: 3.27.1 -> 3.27.2 ``                                                                       |
| [`a16604ca`](https://github.com/NixOS/nixpkgs/commit/a16604caff590a0cfabce4e385142e3cfbed6d63) | `` highlight-pointer: 1.2 -> 1.3 ``                                                                 |
| [`e243d0c0`](https://github.com/NixOS/nixpkgs/commit/e243d0c0a67edbb97c5ac9af17d096dd9b59868e) | `` spotube: 5.1.1 -> 5.1.2 ``                                                                       |
| [`f286327a`](https://github.com/NixOS/nixpkgs/commit/f286327a1aa469e8404b2c187bc3d56a1de9794b) | `` dalfox: build with rustPlatform ``                                                               |
| [`38a04026`](https://github.com/NixOS/nixpkgs/commit/38a040264ef1833811576b104485c42175b69dd3) | `` acli: 1.3.20-stable -> 1.3.21-stable ``                                                          |
| [`7e4bea4e`](https://github.com/NixOS/nixpkgs/commit/7e4bea4e72b10f4e6e024985310a3da6c1f59fee) | `` terraform-providers.ciscodevnet_aci: 2.19.0 -> 2.20.0 ``                                         |
| [`eed3ecfe`](https://github.com/NixOS/nixpkgs/commit/eed3ecfef560b9762afa8e70f60411de94c69cf9) | `` zipline: 4.6.2 -> 4.6.3 ``                                                                       |
| [`bf80cf0f`](https://github.com/NixOS/nixpkgs/commit/bf80cf0f2e8d5e3809931011d4c8c949d2b196d2) | `` ci/eval: Allow disallowed attrs to depend on other disallowed attrs ``                           |
| [`bde45f4b`](https://github.com/NixOS/nixpkgs/commit/bde45f4b4979dbbc7270a835020cadfe84e2e4f7) | `` fosrl-pangolin: 1.18.4 -> 1.19.4 ``                                                              |
| [`5bef5d0b`](https://github.com/NixOS/nixpkgs/commit/5bef5d0b1d459f1ea0f4d14bd9e210c8d0642f78) | `` terraform-providers.hashicorp_awscc: 1.89.0 -> 1.90.0 ``                                         |
| [`02ccfd5b`](https://github.com/NixOS/nixpkgs/commit/02ccfd5b658f703cdfb23145ca804586c4d618fb) | `` stalwart_0_16: limit cargo build to server package ``                                            |
| [`4694d1c2`](https://github.com/NixOS/nixpkgs/commit/4694d1c24a6561c40175dabd68f990ce1f5dcfa5) | `` nuclei: 3.9.0 -> 3.10.0 ``                                                                       |
| [`bb1b5eec`](https://github.com/NixOS/nixpkgs/commit/bb1b5eec30645e3796d837f7ba97980997f6c9c3) | `` ocamlPackages.kdf: 1.0.0 -> 1.1.0 ``                                                             |
| [`1ffdcbbe`](https://github.com/NixOS/nixpkgs/commit/1ffdcbbe20c8d1b8eb2d9fb09053fca0486f098e) | `` nixos/gocron: Add to release notes ``                                                            |
| [`1cf8b35f`](https://github.com/NixOS/nixpkgs/commit/1cf8b35fa470a98d7fa8108e4e4851390c500472) | `` nixos/gocron: Add nixos test ``                                                                  |
| [`190aab7c`](https://github.com/NixOS/nixpkgs/commit/190aab7c576c2ce7d49039f22150d19fb6a42c1c) | `` nixos/gocron: init ``                                                                            |
| [`9d38d336`](https://github.com/NixOS/nixpkgs/commit/9d38d3367ad7596b16f585794aca34e54dd837e3) | `` gocron: init at 0.9.14 ``                                                                        |
| [`c0baf706`](https://github.com/NixOS/nixpkgs/commit/c0baf70601ae9de91ff7433d69ccff209587a504) | `` sleuthkit: use finalAttrs.src.name instead of hardcoding `source` ``                             |
| [`5b082362`](https://github.com/NixOS/nixpkgs/commit/5b082362503e7ce9c1b123e0ea0e8c2ab6f324df) | `` dumpifs: use finalAttrs.src.name instead of hardcoding `source` ``                               |
| [`0220d8af`](https://github.com/NixOS/nixpkgs/commit/0220d8af58153f4c8a8782b7d6f5b65bc67f6982) | `` icestudio: 0.12-unstable-2026-05-28 -> 0.12-unstable-2026-06-29 ``                               |
| [`4e7b8cb5`](https://github.com/NixOS/nixpkgs/commit/4e7b8cb589e2780802e36a0613b0b1ce0cd75f38) | `` matrix-alertmanager-receiver: 2026.6.17 -> 2026.6.24 ``                                          |
| [`1493c0a9`](https://github.com/NixOS/nixpkgs/commit/1493c0a95f01099467769264d86cc058786c26bf) | `` kubernetes-helmPlugins.helm-unittest: fix per-arch exec error ``                                 |
| [`f15a2c0d`](https://github.com/NixOS/nixpkgs/commit/f15a2c0d65bf3760390ca07ebe0e3a9e1fa09a2e) | `` pict-rs: 0.5.23 -> 0.5.24 ``                                                                     |
| [`1696763a`](https://github.com/NixOS/nixpkgs/commit/1696763ab4014290a7272b247476a9c033898fed) | `` just: 1.54.0 -> 1.55.1 ``                                                                        |
| [`83bad8ec`](https://github.com/NixOS/nixpkgs/commit/83bad8ec410a188d6f1d4ad849cc58dc3ce770ad) | `` croc: 10.4.4 -> 10.4.5 ``                                                                        |
| [`a8b9f480`](https://github.com/NixOS/nixpkgs/commit/a8b9f4802b0d20842612f48614bb074fdc7c66b6) | `` clever-tools: 4.10.0 -> 4.11.0 ``                                                                |
| [`af79c4d4`](https://github.com/NixOS/nixpkgs/commit/af79c4d45fd898c7ea013f4a0f29509952411b3f) | `` panoply: 5.9.2 -> 5.10.0 ``                                                                      |
| [`8d4b4019`](https://github.com/NixOS/nixpkgs/commit/8d4b4019a3164974f8001f5fec37d0c1f3ee31c7) | `` xarchiver: 0.5.4.26 -> 0.5.4.27 ``                                                               |
| [`9beb65db`](https://github.com/NixOS/nixpkgs/commit/9beb65dbfa6adf87a204ef482f0ce09a4ff1755d) | `` mdterm: do version check ``                                                                      |
| [`488d294a`](https://github.com/NixOS/nixpkgs/commit/488d294af1e102f953595ab3337ba62cdacd4b98) | `` ocamlPackages.cohttp-server-lwt-unix: init at 6.2.1 ``                                           |
| [`ebb6df49`](https://github.com/NixOS/nixpkgs/commit/ebb6df49c46e5efeb3fa9d3b5017a3ef786697df) | `` mdterm: add passthru.updateScript ``                                                             |
| [`82bd6b02`](https://github.com/NixOS/nixpkgs/commit/82bd6b023698863e489c7fe1f7897ec1037abe20) | `` qman: use patchShebangs ``                                                                       |
| [`4901ce73`](https://github.com/NixOS/nixpkgs/commit/4901ce733e324265d65a6eb875fb6d789e0cac13) | `` high-tide: 1.3.1 -> 1.5.0 ``                                                                     |
| [`4e3b9ed8`](https://github.com/NixOS/nixpkgs/commit/4e3b9ed8ccbaffd23db2d72cf7642a82b452ce0d) | `` qman: do version check ``                                                                        |
| [`0ed577e3`](https://github.com/NixOS/nixpkgs/commit/0ed577e3c99a1797a7e75e04e09ce8427dbf1735) | `` prometheus-nvidia-gpu-exporter: 1.4.1 -> 1.6.0 ``                                                |
| [`84377154`](https://github.com/NixOS/nixpkgs/commit/8437715471342a41ec4bee2a8c95e78efdc0a2c3) | `` changie: 1.24.2 -> 1.25.0 ``                                                                     |
| [`978ebe0f`](https://github.com/NixOS/nixpkgs/commit/978ebe0ff8f85312f9f02c37a14e3143a8070cb7) | `` neard: 0.19-unstable-2024-07-02 -> 0.20 ``                                                       |
| [`8f469e6f`](https://github.com/NixOS/nixpkgs/commit/8f469e6f7c4e45dbaaf106c26f6a519d081779a9) | `` python3Packages.particle: 0.26.2 -> 1.0.0 ``                                                     |
| [`04cbd125`](https://github.com/NixOS/nixpkgs/commit/04cbd125326bad5943f8fbb4ef8ae5cb0a1e8811) | `` netavark: revert 1.17.2 -> 2.0.0" ``                                                             |
| [`f7576c97`](https://github.com/NixOS/nixpkgs/commit/f7576c972f0fabc422386139d01041dd51fd40dc) | `` fotowall: init at 1.1.0 ``                                                                       |
| [`7c6364dc`](https://github.com/NixOS/nixpkgs/commit/7c6364dc7d70a16c98c07b62d4789d38d43b67ca) | `` terraform-providers.mongodb_mongodbatlas: 2.12.0 -> 2.13.0 ``                                    |
| [`3e38e4bc`](https://github.com/NixOS/nixpkgs/commit/3e38e4bc4d36ba54b895a451f35973dea48c5e9d) | `` pixi: 0.70.2 -> 0.71.2 ``                                                                        |
| [`41df2c56`](https://github.com/NixOS/nixpkgs/commit/41df2c56c0b5acb7f6ae62a0ea7affe5c046015c) | `` maintainers: add dshatz ``                                                                       |
| [`2b35ffed`](https://github.com/NixOS/nixpkgs/commit/2b35ffed0abc52ed38c8f8296b238dca2f242d4a) | `` kotlin-cli: init at 0.11.1 ``                                                                    |
| [`9c412077`](https://github.com/NixOS/nixpkgs/commit/9c412077b0bb230f129fbcd89ed929e99c63a4f1) | `` comigo: 1.2.31 -> 1.3.0 ``                                                                       |
| [`81aeff18`](https://github.com/NixOS/nixpkgs/commit/81aeff18da566fc26f1720ce38570143343a8ee1) | `` pinact: 4.0.0 -> 4.1.0 ``                                                                        |
| [`7de49dea`](https://github.com/NixOS/nixpkgs/commit/7de49dea15ed7b902e929f139d83f5b034907fa0) | `` libretro.smsplus-gx: 0-unstable-2026-04-20 -> 0-unstable-2026-06-25 ``                           |

*... and 643 more commits (truncated)*