### PR TITLE
chore(flake/nixpkgs-stable): `1f01958f` -> `80d591ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -813,11 +813,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1782691344,
-        "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
+        "lastModified": 1782999065,
+        "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1f01958ffb5b3545c96d9ef2f4e24c5e5e1eb846",
+        "rev": "80d591ed473cfc46329932c2aadac9b435342c7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`8170855e`](https://github.com/NixOS/nixpkgs/commit/8170855e2bd85a159a22f01afc6d2d7d5b2804f0) | `` doc/ci: use docPkgs from ci keeps local and ci render output the same ``   |
| [`0362e1f2`](https://github.com/NixOS/nixpkgs/commit/0362e1f2d1c3d2c6f336b6c8463b5c5f13143ac6) | `` lib.types: types.attrTag declaration info ``                               |
| [`0c728d45`](https://github.com/NixOS/nixpkgs/commit/0c728d45769c332c45b93af531342dca37d07c73) | `` Reapply "`postgresql`: fix overrides being forgotten on `withPackages`" `` |
| [`26830a86`](https://github.com/NixOS/nixpkgs/commit/26830a86ca63a39c8cbd73c7de45f3e0f7950c9c) | `` postgresql: return wrapper from `withoutJIT` passthru ``                   |
| [`8166a4ae`](https://github.com/NixOS/nixpkgs/commit/8166a4ae06c0ea57f2874a0ee329d503c9376889) | `` postgresql: refactor attributes ``                                         |
| [`e4c3e2d1`](https://github.com/NixOS/nixpkgs/commit/e4c3e2d185bdf1f858fb5526105e08cb5790a209) | `` sage: tweak cpu threshold to decrease test flakiness ``                    |
| [`c7045770`](https://github.com/NixOS/nixpkgs/commit/c7045770f6c5665ba3498d4ca0a70c3849cf98c7) | `` drawio: 30.2.4 -> 30.2.6 ``                                                |
| [`1ee5a808`](https://github.com/NixOS/nixpkgs/commit/1ee5a808260a5a8eb0a3e0ba34b7ae4b15838099) | `` firefox-beta-unwrapped: 151.0b9 -> 152.0b10 ``                             |
| [`53d017ab`](https://github.com/NixOS/nixpkgs/commit/53d017aba44716792bf3a3a130e7f271f3f28cf9) | `` xfr: 0.9.19 -> 0.9.20 ``                                                   |
| [`7c285f91`](https://github.com/NixOS/nixpkgs/commit/7c285f9111c44947e853cd0fb6f750576aa65da2) | `` mesa: 26.1.3 -> 26.1.4 ``                                                  |
| [`9365e41d`](https://github.com/NixOS/nixpkgs/commit/9365e41dd2c87c48f33bfcd8fe0e231f901fcfe4) | `` ioping: Fix cross compilation ``                                           |
| [`42c2b973`](https://github.com/NixOS/nixpkgs/commit/42c2b97332431823804d352e030c304e57452458) | `` acli: 1.3.20-stable -> 1.3.21-stable ``                                    |
| [`ea21df95`](https://github.com/NixOS/nixpkgs/commit/ea21df954a883a5fac5925cf692ae1e60175b599) | `` ci/eval: Allow disallowed attrs to depend on other disallowed attrs ``     |
| [`82fa6137`](https://github.com/NixOS/nixpkgs/commit/82fa6137cf0bbf86bb5e09ab6835f22a2086ed1f) | `` nixpkgs-review: 3.8.0 -> 3.9.0 ``                                          |
| [`82ef2f5c`](https://github.com/NixOS/nixpkgs/commit/82ef2f5c660d8326251bba8c9c2de5e05a191829) | `` google-chrome: 149.0.7827.200 -> 150.0.7871.46 ``                          |
| [`b85f3bd4`](https://github.com/NixOS/nixpkgs/commit/b85f3bd477a0ace16ea2d1f912e8ce0779206ec5) | `` kubernetes-helmPlugins.helm-unittest: fix per-arch exec error ``           |
| [`3d906ba7`](https://github.com/NixOS/nixpkgs/commit/3d906ba7c3715b4f902a83e385e0d56070343e07) | `` skypilot: patch CVE-2026-13482 ``                                          |
| [`554efaa7`](https://github.com/NixOS/nixpkgs/commit/554efaa77062bcb6d6a87161cda42b6fe93b2087) | `` skypilot: wrap websocket_proxy.py with wrapPythonProgramsIn ``             |
| [`0d013e5b`](https://github.com/NixOS/nixpkgs/commit/0d013e5b4e0f5691d3b4f98ff094f3f775030074) | `` skypilot: fix for incompat. w/ defaults handling in click >= 8.2 ``        |
| [`c8c6c98a`](https://github.com/NixOS/nixpkgs/commit/c8c6c98a4b10a0410567f73f3ef57f5ec1dab6d8) | `` checkstyle: 13.6.0 -> 13.7.0 ``                                            |
| [`8a1b3516`](https://github.com/NixOS/nixpkgs/commit/8a1b3516cfe4d0c63afb70d912ae035311ad6de0) | `` chromium,chromedriver: 149.0.7827.200 -> 150.0.7871.46 ``                  |
| [`88bdf353`](https://github.com/NixOS/nixpkgs/commit/88bdf353990e0e6ccf44de8e029164b24efaf8d7) | `` drawio: 30.0.4 -> 30.2.4 ``                                                |
| [`2dba4298`](https://github.com/NixOS/nixpkgs/commit/2dba4298f79c048e956d31c30475cdf12d66b96a) | `` librewolf-unwrapped: 152.0.2-1 -> 152.0.4-1 ``                             |
| [`77d22d9c`](https://github.com/NixOS/nixpkgs/commit/77d22d9c963b4201c73576edd2fe8a89c6e1edb1) | `` mdns-scanner: 0.27.2 -> 0.27.3 ``                                          |
| [`5090b88d`](https://github.com/NixOS/nixpkgs/commit/5090b88d5bee4d0f2df275ff658d0283f843323b) | `` ci: use nixos-render-docs from tree ``                                     |
| [`598fee4e`](https://github.com/NixOS/nixpkgs/commit/598fee4e1aad4e9277cb556cd1022716c9dc0b74) | `` lockbook-desktop: 26.6.16 -> 26.6.22 ``                                    |
| [`23addc14`](https://github.com/NixOS/nixpkgs/commit/23addc14c1687bd4c52e70e69e2de7f4e655858d) | `` ghostfolio: 3.13.0 -> 3.18.0 ``                                            |
| [`d17df067`](https://github.com/NixOS/nixpkgs/commit/d17df0679aefb2d84228fea096340a8e38c727d3) | `` acli: 1.3.19-stable -> 1.3.20-stable ``                                    |
| [`09500955`](https://github.com/NixOS/nixpkgs/commit/09500955a9d5fa3dd1c3e372c0aae2afdb90b1a9) | `` thunderbird-140-unwrapped: 140.12.0esr -> 140.12.1esr ``                   |
| [`2c2fce71`](https://github.com/NixOS/nixpkgs/commit/2c2fce71f9e383b52a9215436265c95c26a5848c) | `` pretix.plugins.payone: 1.4.2 -> 1.4.3 ``                                   |
| [`436e569e`](https://github.com/NixOS/nixpkgs/commit/436e569ef97c7542c9e1fc3441396849180ac48b) | `` pretix.plugins.mollie: 2.5.6 -> 2.5.7 ``                                   |
| [`4573a3a2`](https://github.com/NixOS/nixpkgs/commit/4573a3a2509302b2f935d1847abd33f3887bf5a9) | `` pretix: 2026.4.4 -> 2026.4.5 ``                                            |
| [`8170855e`](https://github.com/NixOS/nixpkgs/commit/8170855e2bd85a159a22f01afc6d2d7d5b2804f0) | `` doc/ci: use docPkgs from ci keeps local and ci render output the same ``   |
| [`0362e1f2`](https://github.com/NixOS/nixpkgs/commit/0362e1f2d1c3d2c6f336b6c8463b5c5f13143ac6) | `` lib.types: types.attrTag declaration info ``                               |
| [`0c728d45`](https://github.com/NixOS/nixpkgs/commit/0c728d45769c332c45b93af531342dca37d07c73) | `` Reapply "`postgresql`: fix overrides being forgotten on `withPackages`" `` |
| [`26830a86`](https://github.com/NixOS/nixpkgs/commit/26830a86ca63a39c8cbd73c7de45f3e0f7950c9c) | `` postgresql: return wrapper from `withoutJIT` passthru ``                   |
| [`8166a4ae`](https://github.com/NixOS/nixpkgs/commit/8166a4ae06c0ea57f2874a0ee329d503c9376889) | `` postgresql: refactor attributes ``                                         |
| [`e4c3e2d1`](https://github.com/NixOS/nixpkgs/commit/e4c3e2d185bdf1f858fb5526105e08cb5790a209) | `` sage: tweak cpu threshold to decrease test flakiness ``                    |
| [`c7045770`](https://github.com/NixOS/nixpkgs/commit/c7045770f6c5665ba3498d4ca0a70c3849cf98c7) | `` drawio: 30.2.4 -> 30.2.6 ``                                                |
| [`1ee5a808`](https://github.com/NixOS/nixpkgs/commit/1ee5a808260a5a8eb0a3e0ba34b7ae4b15838099) | `` firefox-beta-unwrapped: 151.0b9 -> 152.0b10 ``                             |
| [`53d017ab`](https://github.com/NixOS/nixpkgs/commit/53d017aba44716792bf3a3a130e7f271f3f28cf9) | `` xfr: 0.9.19 -> 0.9.20 ``                                                   |
| [`7c285f91`](https://github.com/NixOS/nixpkgs/commit/7c285f9111c44947e853cd0fb6f750576aa65da2) | `` mesa: 26.1.3 -> 26.1.4 ``                                                  |
| [`9365e41d`](https://github.com/NixOS/nixpkgs/commit/9365e41dd2c87c48f33bfcd8fe0e231f901fcfe4) | `` ioping: Fix cross compilation ``                                           |
| [`42c2b973`](https://github.com/NixOS/nixpkgs/commit/42c2b97332431823804d352e030c304e57452458) | `` acli: 1.3.20-stable -> 1.3.21-stable ``                                    |
| [`ea21df95`](https://github.com/NixOS/nixpkgs/commit/ea21df954a883a5fac5925cf692ae1e60175b599) | `` ci/eval: Allow disallowed attrs to depend on other disallowed attrs ``     |
| [`82fa6137`](https://github.com/NixOS/nixpkgs/commit/82fa6137cf0bbf86bb5e09ab6835f22a2086ed1f) | `` nixpkgs-review: 3.8.0 -> 3.9.0 ``                                          |
| [`82ef2f5c`](https://github.com/NixOS/nixpkgs/commit/82ef2f5c660d8326251bba8c9c2de5e05a191829) | `` google-chrome: 149.0.7827.200 -> 150.0.7871.46 ``                          |
| [`b85f3bd4`](https://github.com/NixOS/nixpkgs/commit/b85f3bd477a0ace16ea2d1f912e8ce0779206ec5) | `` kubernetes-helmPlugins.helm-unittest: fix per-arch exec error ``           |
| [`3d906ba7`](https://github.com/NixOS/nixpkgs/commit/3d906ba7c3715b4f902a83e385e0d56070343e07) | `` skypilot: patch CVE-2026-13482 ``                                          |
| [`554efaa7`](https://github.com/NixOS/nixpkgs/commit/554efaa77062bcb6d6a87161cda42b6fe93b2087) | `` skypilot: wrap websocket_proxy.py with wrapPythonProgramsIn ``             |
| [`0d013e5b`](https://github.com/NixOS/nixpkgs/commit/0d013e5b4e0f5691d3b4f98ff094f3f775030074) | `` skypilot: fix for incompat. w/ defaults handling in click >= 8.2 ``        |
| [`c8c6c98a`](https://github.com/NixOS/nixpkgs/commit/c8c6c98a4b10a0410567f73f3ef57f5ec1dab6d8) | `` checkstyle: 13.6.0 -> 13.7.0 ``                                            |
| [`8a1b3516`](https://github.com/NixOS/nixpkgs/commit/8a1b3516cfe4d0c63afb70d912ae035311ad6de0) | `` chromium,chromedriver: 149.0.7827.200 -> 150.0.7871.46 ``                  |
| [`88bdf353`](https://github.com/NixOS/nixpkgs/commit/88bdf353990e0e6ccf44de8e029164b24efaf8d7) | `` drawio: 30.0.4 -> 30.2.4 ``                                                |
| [`2dba4298`](https://github.com/NixOS/nixpkgs/commit/2dba4298f79c048e956d31c30475cdf12d66b96a) | `` librewolf-unwrapped: 152.0.2-1 -> 152.0.4-1 ``                             |
| [`77d22d9c`](https://github.com/NixOS/nixpkgs/commit/77d22d9c963b4201c73576edd2fe8a89c6e1edb1) | `` mdns-scanner: 0.27.2 -> 0.27.3 ``                                          |
| [`5090b88d`](https://github.com/NixOS/nixpkgs/commit/5090b88d5bee4d0f2df275ff658d0283f843323b) | `` ci: use nixos-render-docs from tree ``                                     |
| [`598fee4e`](https://github.com/NixOS/nixpkgs/commit/598fee4e1aad4e9277cb556cd1022716c9dc0b74) | `` lockbook-desktop: 26.6.16 -> 26.6.22 ``                                    |
| [`23addc14`](https://github.com/NixOS/nixpkgs/commit/23addc14c1687bd4c52e70e69e2de7f4e655858d) | `` ghostfolio: 3.13.0 -> 3.18.0 ``                                            |
| [`d17df067`](https://github.com/NixOS/nixpkgs/commit/d17df0679aefb2d84228fea096340a8e38c727d3) | `` acli: 1.3.19-stable -> 1.3.20-stable ``                                    |
| [`09500955`](https://github.com/NixOS/nixpkgs/commit/09500955a9d5fa3dd1c3e372c0aae2afdb90b1a9) | `` thunderbird-140-unwrapped: 140.12.0esr -> 140.12.1esr ``                   |
| [`2c2fce71`](https://github.com/NixOS/nixpkgs/commit/2c2fce71f9e383b52a9215436265c95c26a5848c) | `` pretix.plugins.payone: 1.4.2 -> 1.4.3 ``                                   |
| [`436e569e`](https://github.com/NixOS/nixpkgs/commit/436e569ef97c7542c9e1fc3441396849180ac48b) | `` pretix.plugins.mollie: 2.5.6 -> 2.5.7 ``                                   |
| [`4573a3a2`](https://github.com/NixOS/nixpkgs/commit/4573a3a2509302b2f935d1847abd33f3887bf5a9) | `` pretix: 2026.4.4 -> 2026.4.5 ``                                            |
| [`954ea237`](https://github.com/NixOS/nixpkgs/commit/954ea237fc342c8dc5c3d78999ad0791a7f9f014) | `` xaos: add support for darwin, aarch64-linux ``                             |
| [`77de5b33`](https://github.com/NixOS/nixpkgs/commit/77de5b3346dd2ad6217c6d77847aeed5a751fd50) | `` xaos: add coolcuber as maintainer ``                                       |
| [`1c7091f1`](https://github.com/NixOS/nixpkgs/commit/1c7091f1c195099b9c7ecedabb4193c706f2cfb8) | `` xaos: 4.3.4 -> 4.3.5 ``                                                    |
| [`f58c1e00`](https://github.com/NixOS/nixpkgs/commit/f58c1e0012d4d0d30f9f5ea44b15259e4143652e) | `` .github/labeler-no-sync: Remove `backport release-25.11` ``                |
| [`5e35bc8c`](https://github.com/NixOS/nixpkgs/commit/5e35bc8c1bab3d13d3dcc44a4587bbed93e13c3f) | `` .github/workflows: Remove 25.11 workflows ``                               |
| [`d6c3fed5`](https://github.com/NixOS/nixpkgs/commit/d6c3fed5f6c02ebeb29d4a21daca706d48148ddc) | `` zigbee2mqtt: 2.12.0 -> 2.12.1 ``                                           |
| [`516065fc`](https://github.com/NixOS/nixpkgs/commit/516065fc8804c084ca480dc88ba678678a6f0ab7) | `` sleuthkit: use finalAttrs.src.name instead of hardcoding `source` ``       |
| [`b525f224`](https://github.com/NixOS/nixpkgs/commit/b525f22445474297c0f2377617c5f74bd6c39df8) | `` dumpifs: use finalAttrs.src.name instead of hardcoding `source` ``         |
| [`5981c488`](https://github.com/NixOS/nixpkgs/commit/5981c4881c84074e3bc8b1f4659e88b707d164a1) | `` linux_testing: 7.1-rc7 -> 7.2-rc1 ``                                       |
| [`d3df9187`](https://github.com/NixOS/nixpkgs/commit/d3df9187159552c3aa1287e4fa017c2bf479855b) | `` linux/common-config: update for 7.2-rc1 ``                                 |
| [`ab0b3a22`](https://github.com/NixOS/nixpkgs/commit/ab0b3a22a78aa213ff36bf6471ee9b4f73a0fe99) | `` run0-sudo-shim: 1.3.1 -> 1.4.2 ``                                          |
| [`4ceb173a`](https://github.com/NixOS/nixpkgs/commit/4ceb173a6f67b8131bf271cc88212c0a5937a7df) | `` icinga2: 2.15.1 -> 2.15.5 ``                                               |
| [`d16743eb`](https://github.com/NixOS/nixpkgs/commit/d16743ebb257e422c1942ba2f1092c2a7434b45a) | `` mailpit: 1.30.2 -> 1.30.3 ``                                               |
| [`febe01ce`](https://github.com/NixOS/nixpkgs/commit/febe01ce53103b6b28b8ece6ede6b91431040ea2) | `` vivaldi: 8.0.4033.50 -> 8.0.4033.54 ``                                     |
| [`792ee117`](https://github.com/NixOS/nixpkgs/commit/792ee117f68a94377b97ae69ceb4524d27598e9c) | `` flarum: add passthru test ``                                               |
| [`7b383c07`](https://github.com/NixOS/nixpkgs/commit/7b383c071ec981b3c8dcdb1598af462170dde90c) | `` nixos/tests/flarum: init ``                                                |
| [`c91d1f72`](https://github.com/NixOS/nixpkgs/commit/c91d1f72d585529d1dad7b23290d245d43f0e205) | `` libfprint: Add patches to support more hardware ``                         |
| [`92979777`](https://github.com/NixOS/nixpkgs/commit/92979777d80a302eb77d6baddcae993b25dc0954) | `` batman-adv: 2026.1 -> 2026.2 ``                                            |
| [`75eb9eeb`](https://github.com/NixOS/nixpkgs/commit/75eb9eeb2181f9c86572920b8f2a1fa7d88b550b) | `` veloren: fix build with rust ≥ 1.95 ``                                     |
| [`04ce966a`](https://github.com/NixOS/nixpkgs/commit/04ce966ad0416e1a94d6a3f23eefdbfd94bbbc12) | `` openrgb: 1.0rc2 -> 1.0rc3 ``                                               |
| [`e2879236`](https://github.com/NixOS/nixpkgs/commit/e287923685f0d66a4119022e03c141258e090e2d) | `` radicle-ci-broker: 0.28.1 -> 0.29.0 ``                                     |
| [`f458e08e`](https://github.com/NixOS/nixpkgs/commit/f458e08ea26875f4e99f30cfe2ee0439805b8d72) | `` seaweedfs: 4.34 -> 4.36 ``                                                 |
| [`a9153b4e`](https://github.com/NixOS/nixpkgs/commit/a9153b4eb15a2e32ec0defe4a9006569c49fcb11) | `` seaweedfs: fix build on Darwin ``                                          |
| [`2918595b`](https://github.com/NixOS/nixpkgs/commit/2918595b88afb19f779eb3f26b5feeedc00861f4) | `` seaweedfs: 4.31 -> 4.34 ``                                                 |
| [`fc5e9f59`](https://github.com/NixOS/nixpkgs/commit/fc5e9f5938ffb433b6c00b31ba07bdb66af34465) | `` seaweedfs: mark broken on darwin ``                                        |
| [`c9698e34`](https://github.com/NixOS/nixpkgs/commit/c9698e34382bf6e749315da4029052d2a8569814) | `` seaweedfs: 4.24 -> 4.31 ``                                                 |
| [`22737c1f`](https://github.com/NixOS/nixpkgs/commit/22737c1f79d1840cf1c8da3d02fe922b1ca607a6) | `` seaweedfs: 4.19 -> 4.24 ``                                                 |
| [`e193635f`](https://github.com/NixOS/nixpkgs/commit/e193635f72d85c47544dc1c6b08de2f4a412c084) | `` matrix-tuwunel: build tests in debug profile ``                            |
| [`6f723ac9`](https://github.com/NixOS/nixpkgs/commit/6f723ac9f6cf26a0185b7baedcbe210eca03e9b4) | `` tor-browser: 15.0.16 -> 15.0.17 ``                                         |
| [`61a09b77`](https://github.com/NixOS/nixpkgs/commit/61a09b775c954a3a2e3673d38608472829e3269d) | `` faugus-launcher: 1.22.4 -> 1.22.6 ``                                       |
| [`e63ad51b`](https://github.com/NixOS/nixpkgs/commit/e63ad51bd6222ea1cde4695edec4a88b54d83184) | `` iperf2: fix cross compilation ``                                           |
| [`823b2de8`](https://github.com/NixOS/nixpkgs/commit/823b2de8ea16ecaf8c214bf8cedc0ef2cb26e35c) | `` ocamlPackages.js_of_ocaml: 6.3.2 → 6.4.0 ``                                |
| [`6a152828`](https://github.com/NixOS/nixpkgs/commit/6a152828e37a177ca524bd348cba98642618c1ca) | `` gnucash: 5.15 -> 5.16 ``                                                   |
| [`9a74acb1`](https://github.com/NixOS/nixpkgs/commit/9a74acb18f3b84b88c42c2411dd06ab8e3fa24ed) | `` electron-chromedriver_42: 42.4.0 -> 42.5.1 ``                              |
| [`a7a1b344`](https://github.com/NixOS/nixpkgs/commit/a7a1b3445f9216a946cede60cdd161fbbc14c5c7) | `` electron_42-bin: 42.4.0 -> 42.5.1 ``                                       |
| [`182f14bf`](https://github.com/NixOS/nixpkgs/commit/182f14bf4471c1b68493e46cdae4029814671e3f) | `` electron-chromedriver_41: 41.7.2 -> 41.9.1 ``                              |
| [`523149d5`](https://github.com/NixOS/nixpkgs/commit/523149d5de28ed0c9ea5d30ed6948861374a54e4) | `` electron_41-bin: 41.7.2 -> 41.9.1 ``                                       |
| [`8f0ff101`](https://github.com/NixOS/nixpkgs/commit/8f0ff10171ec5c67a15ee25c30e6475e677312b0) | `` electron-chromedriver_40: 40.10.3 -> 40.10.5 ``                            |
| [`f11cd960`](https://github.com/NixOS/nixpkgs/commit/f11cd960943a0d65b9aeeffe3f1ccef2f47e7f68) | `` electron_40-bin: 40.10.3 -> 40.10.5 ``                                     |
| [`8ccfe0c0`](https://github.com/NixOS/nixpkgs/commit/8ccfe0c0c99222dbb4e964099a3e6b285aabdbfc) | `` electron-source.electron_42: 42.4.0 -> 42.5.1 ``                           |
| [`fbc13d02`](https://github.com/NixOS/nixpkgs/commit/fbc13d021459486cbc8f19ba4a569011dff309d7) | `` electron-source.electron_41: 41.7.2 -> 41.9.1 ``                           |
| [`2f5116ae`](https://github.com/NixOS/nixpkgs/commit/2f5116ae730e5b793a3670713e0a34385ae7ca19) | `` electron-source.electron_40: 40.10.3 -> 40.10.5 ``                         |
| [`00c097e8`](https://github.com/NixOS/nixpkgs/commit/00c097e840602f219d40ae60404803eadcf5d8ae) | `` zipline: 4.6.2 -> 4.6.3 ``                                                 |
| [`3d698d7f`](https://github.com/NixOS/nixpkgs/commit/3d698d7f17b7fccce7d1ecc3c720cc3f5740ecb1) | `` pnpm: don't require knownVulnerabilities to be set ``                      |
| [`738de9c8`](https://github.com/NixOS/nixpkgs/commit/738de9c8cc1dcb958204abbec59ae2c3c922950d) | `` ocamlPackages.cohttp-server-lwt-unix: init at 6.2.1 ``                     |
| [`3e65f252`](https://github.com/NixOS/nixpkgs/commit/3e65f2524e55feaa90b684ff6707fc0bdc979854) | `` neard: 0.19-unstable-2024-07-02 -> 0.20 ``                                 |
| [`e6c77f1b`](https://github.com/NixOS/nixpkgs/commit/e6c77f1b010cabf5edbb1bd1511b7a59c52ceb44) | `` element-call: 0.20.2 -> 0.20.3 ``                                          |
| [`85c93693`](https://github.com/NixOS/nixpkgs/commit/85c93693f84a0d89d5913824c75e258fc7cca3fb) | `` rundeck: 5.20.1 -> 6.0.0 ``                                                |
| [`cec6beb1`](https://github.com/NixOS/nixpkgs/commit/cec6beb1d57b5a0bd0113c11d26d3b3c3b6abe6f) | `` trivy: 0.71.2 -> 0.72.0 ``                                                 |
| [`5c818f5a`](https://github.com/NixOS/nixpkgs/commit/5c818f5ac43cfaf8df508a0276d569d9c21e6fc4) | `` libtransmission_4: 4.1.2 -> 4.1.3 ``                                       |
| [`0536966b`](https://github.com/NixOS/nixpkgs/commit/0536966bb4ce4085011ac3d96c8308dadef7cf59) | `` pyright: 1.1.410 -> 1.1.411 ``                                             |
| [`6060ff93`](https://github.com/NixOS/nixpkgs/commit/6060ff93f5122aa4bd602d66a3ba739c0ee94afa) | `` kea: fixup python output ``                                                |
| [`56bb453f`](https://github.com/NixOS/nixpkgs/commit/56bb453fdb4b0bcccf3977d25237155d3504fada) | `` firefox-bin-unwrapped: 152.0.3 -> 152.0.4 ``                               |
| [`8a457358`](https://github.com/NixOS/nixpkgs/commit/8a457358447d2b53afbdaf358ac9f0a1b2f8950c) | `` firefox-unwrapped: 152.0.3 -> 152.0.4 ``                                   |
| [`d3ad7cb8`](https://github.com/NixOS/nixpkgs/commit/d3ad7cb894c354127b5e85e3339a4e530a9d6fbe) | `` servarr-ffmpeg: align config flags on upstream ``                          |
| [`64c2e5dc`](https://github.com/NixOS/nixpkgs/commit/64c2e5dcc201f72dd82da9eb3f19a3904f2af349) | `` ocamlPackages.grace: init at 0.3.0 ``                                      |
| [`2559a366`](https://github.com/NixOS/nixpkgs/commit/2559a3668cd82a38d77f20e10cae1cc144fd03b2) | `` tailwindcss_4: 4.3.0 -> 4.3.1 ``                                           |
| [`e1a03936`](https://github.com/NixOS/nixpkgs/commit/e1a03936a0bacdf2a35a127f1dfab120f1626074) | `` teamspeak6-client: fix libstdc++.so.6 not being found ``                   |
| [`a4da045b`](https://github.com/NixOS/nixpkgs/commit/a4da045b5d88ebb7d3a97aab5fe8cc9f696a43ec) | `` folo: modernize ``                                                         |
| [`8fe8b627`](https://github.com/NixOS/nixpkgs/commit/8fe8b62754627250740f95cc67c09ee6f0ae7c9a) | `` folo: add amadejkastelic to maintainers ``                                 |
| [`9421fae9`](https://github.com/NixOS/nixpkgs/commit/9421fae9fc9b57d973d73023daf173a22797e1ee) | `` folo: 0.7.0 -> 1.10.0 ``                                                   |
| [`f3dafc0a`](https://github.com/NixOS/nixpkgs/commit/f3dafc0ad9cc2797b6248e9a018a57afadc416bd) | `` folo: add nix-update-script ``                                             |
| [`3e281ca3`](https://github.com/NixOS/nixpkgs/commit/3e281ca3cc68418b2d8f631bca4e629bfe10e9a4) | `` jsonschema-cli: 0.46.5 -> 0.46.6 ``                                        |
| [`8b26bde9`](https://github.com/NixOS/nixpkgs/commit/8b26bde917b1e06e2f83b9ccc884ee13093fbec3) | `` beamPackages.hex: 2.4.2 -> 2.5.0 ``                                        |
| [`de81290d`](https://github.com/NixOS/nixpkgs/commit/de81290d48cf293a2ae634136f5d532b3f8e2b6e) | `` podman-desktop: derive .desktop entry from upstream .flatpak.desktop ``    |
| [`a8cce420`](https://github.com/NixOS/nixpkgs/commit/a8cce4204321f6667ed329ffc69a0bc457a99ff7) | `` podman-desktop: switch pnpm pin back to `pnpm_10` ``                       |
| [`5b57fdb7`](https://github.com/NixOS/nixpkgs/commit/5b57fdb76725fd1f4589a4dcf7099f7ff5fc8bbf) | `` komikku: 50.4.0 -> 50.8.0 ``                                               |
| [`77786c32`](https://github.com/NixOS/nixpkgs/commit/77786c323c033e23e8bcd5e6086aee3f7ae42a51) | `` slack: remove myself from maintainers ``                                   |
| [`e2f2cd81`](https://github.com/NixOS/nixpkgs/commit/e2f2cd810145220e2b4eb5455e511c37ba90746e) | `` open62541: 1.4.16 -> 1.4.17 ``                                             |
| [`e9ba6ae7`](https://github.com/NixOS/nixpkgs/commit/e9ba6ae7f22ce6bacb224deaa6bf33dae0e1c148) | `` metal-cli: remove myself from maintainers ``                               |
| [`6af9087a`](https://github.com/NixOS/nixpkgs/commit/6af9087ae5905b9688a924048b7e587a60c52225) | `` node-manta: remove myself from maintainers ``                              |
| [`05648073`](https://github.com/NixOS/nixpkgs/commit/05648073197b5a0b85354b37364eb956f2fddc06) | `` splayer: fix runtime packaging with pnpm 10 ``                             |
| [`f623c992`](https://github.com/NixOS/nixpkgs/commit/f623c9925aedfc9412184a434fe883829c32f6fb) | `` triton: remove myself from maintainers ``                                  |
| [`6ac6e6b9`](https://github.com/NixOS/nixpkgs/commit/6ac6e6b99c9952f4b5b64b8bbb3bc2c2a7055967) | `` sensu-go: remove myself from maintainers ``                                |
| [`a4412401`](https://github.com/NixOS/nixpkgs/commit/a441240177c77547f042ee56900008fdb48ea554) | `` maintainers/github-teams.json: Automated sync ``                           |
| [`51b845d6`](https://github.com/NixOS/nixpkgs/commit/51b845d6a047ba4553a7c547d21b50f3d58a65a2) | `` croaring: 4.7.1 -> 4.7.2 ``                                                |
| [`7325a81b`](https://github.com/NixOS/nixpkgs/commit/7325a81b9ccbe86305625246edda3b01ec88242d) | `` rapidraw: 1.5.6 -> 1.5.8 ``                                                |
| [`f9e460f5`](https://github.com/NixOS/nixpkgs/commit/f9e460f5e59ebb41d9ac18e83d4b9661d3eb85b0) | `` vikunja: unpin vulnerable pnpm 10.29.2 ``                                  |
| [`168e1a60`](https://github.com/NixOS/nixpkgs/commit/168e1a604ef8cf5ed95616cabb3f461d61249034) | `` miniflux: 2.3.1 -> 2.3.2 ``                                                |
| [`0ad1355c`](https://github.com/NixOS/nixpkgs/commit/0ad1355cd2b7bb03f66a0e5ef9d17d628e288461) | `` python3Packages.nltk: skip failing test on darwin ``                       |
| [`b3cdd9aa`](https://github.com/NixOS/nixpkgs/commit/b3cdd9aa6c8e31e13a221449da3e0c083c2c5c21) | `` python3Packages.nltk: skip failing test on darwin ``                       |
| [`a1d7ee01`](https://github.com/NixOS/nixpkgs/commit/a1d7ee0135883be777f4a483088e4402faa95596) | `` gelly: 1.6.2 -> 1.7.0 ``                                                   |
| [`a35469c1`](https://github.com/NixOS/nixpkgs/commit/a35469c19353aca97188ea5e4ca743c7d4c89d05) | `` lubelogger: 1.6.7 -> 1.6.8 ``                                              |
| [`54bae150`](https://github.com/NixOS/nixpkgs/commit/54bae150c7832456615d9c26de1df0603d63240f) | `` vesktop: switch to pnpm_10 ``                                              |
| [`524b6a52`](https://github.com/NixOS/nixpkgs/commit/524b6a52ca36343105a990e17b6a1833ef41bfc8) | `` lubelogger: add passthru.updateScript ``                                   |
| [`41c9ded2`](https://github.com/NixOS/nixpkgs/commit/41c9ded27e34b870bc188fc4f47cf20b7c83abd3) | `` lubelogger: 1.6.4 -> 1.6.7 ``                                              |
| [`124d964f`](https://github.com/NixOS/nixpkgs/commit/124d964fc737927587938f5153cc0d7cdc910091) | `` organicmaps: 2026.01.26-11 -> 2026.05.27-11, devendor dependencies ``      |
| [`7f44066d`](https://github.com/NixOS/nixpkgs/commit/7f44066d6432b5404bb42fa35954ed6d658cdd79) | `` grafana-loki: 3.7.2 -> 3.7.3 ``                                            |
| [`80b3ac7a`](https://github.com/NixOS/nixpkgs/commit/80b3ac7a2b1b49909175ceecb57e389464e5d924) | `` workflows/test: test release-supported-systems changes ``                  |
| [`0d8e5d0b`](https://github.com/NixOS/nixpkgs/commit/0d8e5d0b58ac545480c59217786335dc775839ba) | `` electron-fiddle: fix build with newer nodejs versions by bumping yauzl ``  |
| [`248458fa`](https://github.com/NixOS/nixpkgs/commit/248458fa246474eb10bcc2f200386f68ac5412d6) | `` cheating-daddy: fix build with newer nodejs versions by bumping yauzl ``   |
| [`3c902f43`](https://github.com/NixOS/nixpkgs/commit/3c902f43e58dde56a3731cefce1bc0fc07886706) | `` stoat-desktop: fix build with newer nodejs versions by bumping yauzl ``    |
| [`ab6cebb5`](https://github.com/NixOS/nixpkgs/commit/ab6cebb5fb877c4bbee77b68f792e816acd2cee9) | `` ytmdesktop: fix build with newer nodejs versions by bumping yauzl ``       |
| [`1498aaf6`](https://github.com/NixOS/nixpkgs/commit/1498aaf62c28076ff198827751e3b5371eca1739) | `` logseq: fix build with newer nodejs versions by bumping yauzl ``           |
| [`9e2fff49`](https://github.com/NixOS/nixpkgs/commit/9e2fff49e846d261ca407144ce6f9ac52c6f4835) | `` rstudio: fix build with newer nodejs versions by bumping yauzl ``          |
| [`1569734b`](https://github.com/NixOS/nixpkgs/commit/1569734bfc8774ec36d4da60ed9b5b6ac78971e7) | `` ride: fix build with newer nodejs versions by bumping yauzl ``             |
| [`a879b568`](https://github.com/NixOS/nixpkgs/commit/a879b568b949c43481f980ecef69eae653a09be3) | `` koodo-reader: fix darwin build ``                                          |
| [`44a48c9f`](https://github.com/NixOS/nixpkgs/commit/44a48c9f40faebda4bcd05fbd3c1926d87771ff5) | `` texlyre: 0.8.0 -> 0.9.0 ``                                                 |
| [`9fdbb7e8`](https://github.com/NixOS/nixpkgs/commit/9fdbb7e8073dce035b5a2f9763bb09ac2885b738) | `` texlyre: add updateScript ``                                               |