### PR TITLE
chore(flake/nixvim): `a26ceb58` -> `a402fdf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1783170258,
-        "narHash": "sha256-QC8jqauRSMAZK0uQTqhfD9R4leNET9AOBFbvdU6eu2o=",
+        "lastModified": 1783173302,
+        "narHash": "sha256-nlnOw/zsD2H2NHSZ5oNWwcjuM17vipyAapfXsO78GjY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a26ceb58b0e56b5af6c8f414a3f4fa05eba404a6",
+        "rev": "a402fdf2a1ef297d8ea7c95b90d6af0dbe90ab11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`a402fdf2`](https://github.com/nix-community/nixvim/commit/a402fdf2a1ef297d8ea7c95b90d6af0dbe90ab11) | `` docs/modules: move page rendering orchestration to Python `` |
| [`d3ba58e0`](https://github.com/nix-community/nixvim/commit/d3ba58e0bdd5a4f579047b6cf72ab056b0041269) | `` docs/modules: move rendering logic ``                        |
| [`79df3b16`](https://github.com/nix-community/nixvim/commit/79df3b165ca454f611624dbf1d98102fa796a1b6) | `` docs/modules: propagate collections of page nodes ``         |
| [`2ab9e79e`](https://github.com/nix-community/nixvim/commit/2ab9e79e9209d76c3523ff092e4f04d75b1cad1f) | `` docs/modules: add main entrypoint ``                         |