### PR TITLE
chore(flake/sops-nix-stable): `1ebd4171` -> `f1406619`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1359,11 +1359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783104586,
-        "narHash": "sha256-vSLKc7m34/g5xH4dwmNZSqxc5OcHeE3qiG3EIz6bJKs=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1ebd41717762d837d5115f7108522c29cdb00fbb",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                      |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`c7447821`](https://github.com/Mic92/sops-nix/commit/c7447821f3bf526d8bee82701c10f649366a40de) | `` [create-pull-request] automated change `` |