### PR TITLE
chore(flake/home-manager): `b885baad` -> `a1645f40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783134515,
-        "narHash": "sha256-qMoZazubXlXUD9k/syJ/aiWC4X4g73mwVmZ7Z4+rdpM=",
+        "lastModified": 1783222121,
+        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b885baad531fa3d3beae2ba9a0712d22974d8016",
+        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a1645f40`](https://github.com/nix-community/home-manager/commit/a1645f40777620c4bd2b6d854b290c2fc354a266) | `` maintainers: regenerate all-maintainers ``           |
| [`cf0c5c3e`](https://github.com/nix-community/home-manager/commit/cf0c5c3e9f0d5abdb1cbc666285749b99a638a41) | `` maintainers: drop duplicate yarn entry ``            |
| [`40545758`](https://github.com/nix-community/home-manager/commit/40545758d839124ad4d238099a762361db28a9f7) | `` flake: bump nixpkgs from `89570f2` to `9e92285` ``   |
| [`bfb67e07`](https://github.com/nix-community/home-manager/commit/bfb67e07a3b35a4bb30d9c9b2208e8ac45f4c3fa) | `` difftastic: fix jujutsu integration ``               |
| [`a7209b67`](https://github.com/nix-community/home-manager/commit/a7209b6794f88585c9a6c1f52db6d8c6bf841d88) | `` syncthing: fix badly escaped ignore patterns test `` |