### PR TITLE
chore(flake/home-manager-stable): `868d0a69` -> `af2beae5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -629,11 +629,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782704057,
-        "narHash": "sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck=",
+        "lastModified": 1783221248,
+        "narHash": "sha256-ESQnuNHEDChsB4IxoLRhscVahqkDWkTb+qdIz8euYt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "868d0a692de703c2de98fab61968e4e310b7c28e",
+        "rev": "af2beae5f0fae0a4310cc0e6aef2572f56090353",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`af2beae5`](https://github.com/nix-community/home-manager/commit/af2beae5f0fae0a4310cc0e6aef2572f56090353) | `` flake: bump nixpkgs from `a037402` to `95ca1e2` `` |