### PR TITLE
chore(flake/nixpkgs-stable): `80d591ed` -> `a50de1b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -790,11 +790,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1782999065,
-        "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
+        "lastModified": 1783148766,
+        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "80d591ed473cfc46329932c2aadac9b435342c7c",
+        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`ba1f4720`](https://github.com/NixOS/nixpkgs/commit/ba1f4720f0869a51a2ff2f8632dd3efa167470d4) | `` purescript.tests.minimal-module: use lib.sources.sourceByGlobs ``                           |
| [`576870d9`](https://github.com/NixOS/nixpkgs/commit/576870d97cc2081b988a12ca46c4f857dbe7a8bc) | `` vimPluginsUpdater: use lib.sources.sourceByGlobs ``                                         |
| [`9dc23bf8`](https://github.com/NixOS/nixpkgs/commit/9dc23bf891b65d49130357aace01173b4e09e375) | `` pkgs.formats.javaProperties: use lib.sources.sourceByGlobs ``                               |
| [`8b870d76`](https://github.com/NixOS/nixpkgs/commit/8b870d76666838edc7e0b062f5bc3a5d5c4816cc) | `` lib.sources.sourceByGlobs: address review comments ``                                       |
| [`96d5ebc8`](https://github.com/NixOS/nixpkgs/commit/96d5ebc8c2e94a4ad2685ecca393e98ad6d9dca4) | `` lib.sources.sourceByGlobs: init function ``                                                 |
| [`73fcea12`](https://github.com/NixOS/nixpkgs/commit/73fcea124c8af970128ab3454a2e4814ad01f7c9) | `` thunderbird-latest-unwrapped: 152.0 -> 152.0.1 ``                                           |
| [`1cf4918a`](https://github.com/NixOS/nixpkgs/commit/1cf4918ad85e6a94830c8f037cbe1f495f8a9117) | `` asn1c: 0.9.28 -> 0.9.29 ``                                                                  |
| [`fd8e6b24`](https://github.com/NixOS/nixpkgs/commit/fd8e6b240246b28c29cdb60274da9ff15b28f5df) | `` xaos: fix desktop file install ``                                                           |
| [`4e29180a`](https://github.com/NixOS/nixpkgs/commit/4e29180a4c1fdf7f41c49547e31ca3902fa36bea) | `` ungoogled-chromium: 149.0.7827.200-1 -> 150.0.7871.46-1 ``                                  |
| [`dc180177`](https://github.com/NixOS/nixpkgs/commit/dc1801771382856f611cf724306c7673bc211419) | `` peertube: 8.1.8 -> 8.2.2 ``                                                                 |
| [`91a7def3`](https://github.com/NixOS/nixpkgs/commit/91a7def3f284cd13fa35c0f0173a3cefabe8b809) | `` r2modman: 3.2.17 -> 3.2.18 ``                                                               |
| [`517835d8`](https://github.com/NixOS/nixpkgs/commit/517835d82d1a6a7a4cb0970e915caaa6222267e0) | `` wol: fix clang build with gnu17 flag ``                                                     |
| [`3c77fd81`](https://github.com/NixOS/nixpkgs/commit/3c77fd819e9972e7a280f415306825edeb902cfa) | `` libxml2_13: fix CVE-2026-11979 ``                                                           |
| [`84928dbd`](https://github.com/NixOS/nixpkgs/commit/84928dbd5e89b7c8f081bb82a9eb310c37789669) | `` radicle-desktop: 0.12.0 -> 0.13.0 ``                                                        |
| [`5026b481`](https://github.com/NixOS/nixpkgs/commit/5026b481503d25d71e24635837d312ee364703f5) | `` nixos/adguardhome: fix shellcheck error in pre-start script ``                              |
| [`c5a54fd2`](https://github.com/NixOS/nixpkgs/commit/c5a54fd277ba3274606ac9365a8a2c5326724591) | `` shogihome: fix build on darwin ``                                                           |
| [`c816f279`](https://github.com/NixOS/nixpkgs/commit/c816f2791863f2c87e37e89bf5ff74bb2a599530) | `` shogihome: 1.27.3 -> 1.28.0 ``                                                              |
| [`48776202`](https://github.com/NixOS/nixpkgs/commit/487762020e6555d6e5df87db6c835f30a833626b) | `` pocket-casts: Bump electron version to 42 ``                                                |
| [`eb23ac0c`](https://github.com/NixOS/nixpkgs/commit/eb23ac0cf89ca48cd76d5870395f9c2a4e4a865d) | `` mattermost-desktop: 6.1.2 -> 6.2.2 ``                                                       |
| [`a2461c70`](https://github.com/NixOS/nixpkgs/commit/a2461c700f45071fc125668b362154f0ac267c54) | `` mattermostLatest: don't test unofficial patches ``                                          |
| [`2759ab2a`](https://github.com/NixOS/nixpkgs/commit/2759ab2a0014f15d60eddfe4892952da2e5cf5aa) | `` mattermostLatest: 11.8.1 -> 11.8.2 ``                                                       |
| [`b9e41410`](https://github.com/NixOS/nixpkgs/commit/b9e414106b701f7dc6275ff352530cf4dcf9dc35) | `` freeoffice: 2024.1220 -> 2024.1234 ``                                                       |
| [`56e9edea`](https://github.com/NixOS/nixpkgs/commit/56e9edea1016c07624f29ae1dfbac6ed88a596db) | `` pgdog: 0.1.46 -> 0.1.47 ``                                                                  |
| [`c62a615f`](https://github.com/NixOS/nixpkgs/commit/c62a615f74f271c8a4787a1e8d4c56ba51df416b) | `` spaceship-prompt: 4.22.4 -> 4.22.5 ``                                                       |
| [`bef13e6e`](https://github.com/NixOS/nixpkgs/commit/bef13e6ec68c8413a3f9ddb6c7561ca99bc77af1) | `` mesa: fix build on Darwin ``                                                                |
| [`ecdf2aba`](https://github.com/NixOS/nixpkgs/commit/ecdf2aba1dd03aa5aab2ced6a569a6be165d2ec8) | `` beam29Packages.erlang: 29.0.2 -> 29.0.3 ``                                                  |
| [`308ea41d`](https://github.com/NixOS/nixpkgs/commit/308ea41d87b5b1364276a67369b52baa322de296) | `` beam28Packages.erlang: 28.5.0.2 -> 28.5.0.3 ``                                              |
| [`2fecabd5`](https://github.com/NixOS/nixpkgs/commit/2fecabd5fbbd63f08730142bc1e29e3f534369cb) | `` beam27Packages.erlang: 27.3.4.13 -> 27.3.4.14 ``                                            |
| [`4a75a55e`](https://github.com/NixOS/nixpkgs/commit/4a75a55e50c2cbb1e44cbe8027144728b2f0fb4e) | `` fastdds: 3.6.1 -> 3.6.2 ``                                                                  |
| [`c2dba050`](https://github.com/NixOS/nixpkgs/commit/c2dba0508705052b7cdade77b2da6bb1b947c310) | `` archon-lite: add desktop entry ``                                                           |
| [`76808d3a`](https://github.com/NixOS/nixpkgs/commit/76808d3a9a49ccf2ec17456aeb2d4dde0f8a9eed) | `` hyprsunset: Enable separateDebugInfo ``                                                     |
| [`3f4ab5a7`](https://github.com/NixOS/nixpkgs/commit/3f4ab5a717dabaa0a40cc475ddaf349db06b9b68) | `` hyprpaper: Enable separateDebugInfo ``                                                      |
| [`e24bbbbf`](https://github.com/NixOS/nixpkgs/commit/e24bbbbf661980241b90c7eb72318acb434e4dd1) | `` hypridle: Enable separateDebugInfo ``                                                       |
| [`a1ad5846`](https://github.com/NixOS/nixpkgs/commit/a1ad58462ca1e1bbd77b5d13fc7050166985b54a) | `` hyprpicker: Don't strip debug builds and add separateDebugInfo otherwise ``                 |
| [`37de78bc`](https://github.com/NixOS/nixpkgs/commit/37de78bc45c4cdb2412c485a676ee02d79e44c96) | `` xdg-desktop-portal-hyprland: Enable separateDebugInfo ``                                    |
| [`66cc01d8`](https://github.com/NixOS/nixpkgs/commit/66cc01d829f3c77f75c1f02d01edbad9192ba49d) | `` hyprwire: Enable separateDebugInfo ``                                                       |
| [`30c63bf7`](https://github.com/NixOS/nixpkgs/commit/30c63bf7c6be6935e8eb0b792d19a9cd8258a9f5) | `` hyprlock: Enable separateDebugInfo ``                                                       |
| [`3bef06d3`](https://github.com/NixOS/nixpkgs/commit/3bef06d39855b756e24d15846f723b8c788b7de8) | `` hyprlang: Enable separateDebugInfo ``                                                       |
| [`a446c853`](https://github.com/NixOS/nixpkgs/commit/a446c8534197a89a26cbe11cd692cbce34e7ec1d) | `` hyprland-qtutils: Enable separateDebugInfo ``                                               |
| [`a33f8ea9`](https://github.com/NixOS/nixpkgs/commit/a33f8ea944ff7b32a07e114853837213e262f77f) | `` hyprgraphics: Enable separateDebugInfo ``                                                   |
| [`530b4ea7`](https://github.com/NixOS/nixpkgs/commit/530b4ea7b79c0149871c88311e05244f1de5f5fe) | `` hyprcursor: Enable separateDebugInfo ``                                                     |
| [`d9f42f4f`](https://github.com/NixOS/nixpkgs/commit/d9f42f4ff5e8d0666adbc6eff64cd53650fdd9c2) | `` hyprutils: Enable separateDebugInfo ``                                                      |
| [`1ee82d84`](https://github.com/NixOS/nixpkgs/commit/1ee82d841688eee3394bcd543934016dce6c2224) | `` aquamarine: Enable separateDebugInfo ``                                                     |
| [`71b3c974`](https://github.com/NixOS/nixpkgs/commit/71b3c9745451ec3dd641592d689d2c5af154a673) | `` hyprland: Enable separateDebugInfo ``                                                       |
| [`edc60047`](https://github.com/NixOS/nixpkgs/commit/edc60047bd569aa1e60c04d96846bb88df2e5987) | `` remnote: 1.26.11 -> 1.26.20 ``                                                              |
| [`8f2e1702`](https://github.com/NixOS/nixpkgs/commit/8f2e17029fcd6e8d463a2cb60841db09931543e9) | `` remnote: add NIXOS_OZONE_WL flags ``                                                        |
| [`95f204dd`](https://github.com/NixOS/nixpkgs/commit/95f204dd144ef3ab9cf44b9a7cf77b6aecd5340b) | `` remnote: add changelog to meta ``                                                           |
| [`6b6e9733`](https://github.com/NixOS/nixpkgs/commit/6b6e9733cf56986ea3952c4e8625473d6dfd7ffc) | `` remnote: add talal to maintainers ``                                                        |
| [`d164d4f9`](https://github.com/NixOS/nixpkgs/commit/d164d4f9ce58aeda7e39018e9115bc89ac59470b) | `` glitchtip: 6.1.8 -> 6.2.0 ``                                                                |
| [`8adafc6f`](https://github.com/NixOS/nixpkgs/commit/8adafc6f3572ac454077ab7570fdbfcb05a21a73) | `` python3Packages.django-vtasks: 2.1.1 -> 2.1.2 ``                                            |
| [`694702a4`](https://github.com/NixOS/nixpkgs/commit/694702a469246dbc2b641c4b7b29eea0b7cab035) | `` glitchtip: add missing dependency ``                                                        |
| [`4facb40b`](https://github.com/NixOS/nixpkgs/commit/4facb40bd35b0a8cddde9ad84677ce8140e8afe1) | `` python314Packages.django-async-backend: init at 6.0.7 ``                                    |
| [`2e47eefe`](https://github.com/NixOS/nixpkgs/commit/2e47eefe2254bf43a5475524391f91d71c3fd575) | `` python3Packages.protego: 0.6.0 -> 0.6.1 ``                                                  |
| [`4819e046`](https://github.com/NixOS/nixpkgs/commit/4819e0467d86f0873c6c83364d7a5a82be864462) | `` nixpkgs-vet: add Nixpkgs CI team as maintainers ``                                          |
| [`ea70c156`](https://github.com/NixOS/nixpkgs/commit/ea70c156a08b10dda966510e5cbb946d831f81ba) | `` it-tools: 2024.10.22-7ca5933 -> 0-unstable-2026-06-08 ``                                    |
| [`d5171cde`](https://github.com/NixOS/nixpkgs/commit/d5171cdebd8dd96fb37b62881e6b0513af6b3d7a) | `` steam-devices-udev-rules: 1.0.0.61-unstable-2026-06-11 -> 1.0.0.61-unstable-2026-06-25 ``   |
| [`a072b2a5`](https://github.com/NixOS/nixpkgs/commit/a072b2a52fbe01cab5f931317b4fecb946695b46) | `` kdePackages: Gear 26.04.2 -> 26.04.3 ``                                                     |
| [`6a42aae0`](https://github.com/NixOS/nixpkgs/commit/6a42aae02bea43f7d382acc0142d636b7574a1ce) | `` chhoto-url: 7.2.1 -> 7.4.1 ``                                                               |
| [`0a9cf500`](https://github.com/NixOS/nixpkgs/commit/0a9cf5004ace172449382658fde88628fcba0628) | `` limine: 12.3.3 -> 12.4.0 ``                                                                 |
| [`8bd87e86`](https://github.com/NixOS/nixpkgs/commit/8bd87e8605375cf79dc7a00e0f1908d3eac7d8fe) | `` vips: 8.18.2 -> 8.18.3 ``                                                                   |
| [`249d79da`](https://github.com/NixOS/nixpkgs/commit/249d79da7f6e0629f2254c1464c8af7316fc0fe5) | `` filebeat8: 8.19.16 -> 8.19.17 ``                                                            |
| [`2701da8a`](https://github.com/NixOS/nixpkgs/commit/2701da8aeee48de6387d9a45b25fcf296297378f) | `` podman-desktop: add krunkit to closure on darwin ``                                         |
| [`a6149576`](https://github.com/NixOS/nixpkgs/commit/a614957619a5921c591ddb1260a3b8ae453a5a3a) | `` krunkit: add boot regression test ``                                                        |
| [`41827151`](https://github.com/NixOS/nixpkgs/commit/4182715156b33b915471df04800e63753f75efd4) | `` krunkit: install missing firmware ``                                                        |
| [`4a351317`](https://github.com/NixOS/nixpkgs/commit/4a35131769a3c06c37232d60a1c3f1eb37392377) | `` xorg-server: disable false positive buffer overrun check ``                                 |
| [`d8d4551a`](https://github.com/NixOS/nixpkgs/commit/d8d4551aa15e1bb87c4f0bfc62d1d3ca9e1190bf) | `` xorg-server: enable SECURITY module on darwin ``                                            |
| [`e8f498bc`](https://github.com/NixOS/nixpkgs/commit/e8f498bc47ecc268978488864fc7a33bf381cc52) | `` xquartz: properly replace X utility paths ``                                                |
| [`8a86d3f0`](https://github.com/NixOS/nixpkgs/commit/8a86d3f03ee0852cc4955a993282cd71a63f45df) | `` gitify: pnpm_10_29_2 -> pnpm_10 ``                                                          |
| [`4bf1b5f4`](https://github.com/NixOS/nixpkgs/commit/4bf1b5f4f827f93c72f142a0394791e701d01e04) | `` gitify: 6.17.0 -> 6.20.0 ``                                                                 |
| [`5f0a65c1`](https://github.com/NixOS/nixpkgs/commit/5f0a65c129f312ef8a48388513a374eaefadf2e3) | `` serve: bump to pnpm 10 ``                                                                   |
| [`1e798c40`](https://github.com/NixOS/nixpkgs/commit/1e798c405db8d466592151f6fb8aaac201d1b403) | `` serve: 14.2.4 -> 14.2.6 ``                                                                  |
| [`fb43d1f1`](https://github.com/NixOS/nixpkgs/commit/fb43d1f15711a8066722010b7dd2175ab49db986) | `` serve: remove unused args ``                                                                |
| [`e037739e`](https://github.com/NixOS/nixpkgs/commit/e037739ebbf9118125ce167cf1428ca95165a2e6) | `` jackett: 0.24.2108 -> 0.24.2151 ``                                                          |
| [`59e981a6`](https://github.com/NixOS/nixpkgs/commit/59e981a602874d80d07ca958d4a40ff0c48f0d26) | `` legcord: pnpm_10_29_2 -> pnpm_10 ``                                                         |
| [`afe085b3`](https://github.com/NixOS/nixpkgs/commit/afe085b361ca54025b87bdb9c3e637e9508192e5) | `` python3Packages.pillow-heif: 1.3.0 -> 1.4.0 ``                                              |
| [`a60791ad`](https://github.com/NixOS/nixpkgs/commit/a60791ad16100a17a9fad06633f740847082fc75) | `` wamrc: 2.4.4 -> 2.4.5 ``                                                                    |
| [`bb638478`](https://github.com/NixOS/nixpkgs/commit/bb63847816ea007f8dcff9b7b6ca834429451686) | `` dragonflydb: 1.34.2 -> 1.39.0 ``                                                            |
| [`5c39f3b5`](https://github.com/NixOS/nixpkgs/commit/5c39f3b5ccb95ba3a3454fc7ec46dbde56da88e1) | `` stremio-linux-shell: 1.0.0 -> 1.0.2 ``                                                      |
| [`11e6a092`](https://github.com/NixOS/nixpkgs/commit/11e6a0921eddcb71b7fa6c040bed2b4dfa90ae07) | `` stremio-linux-shell: improve `meta` ``                                                      |
| [`cf34bebf`](https://github.com/NixOS/nixpkgs/commit/cf34bebfb7bd926754e91ce880ad36b3f91a4124) | `` stremio-linux-shell: 1.0.0-beta.13 -> 1.0.0 ``                                              |
| [`4794421a`](https://github.com/NixOS/nixpkgs/commit/4794421a6978681a8df14edb10c08dd26f464880) | `` quadrapassel: 50.1 → 50.2 ``                                                                |
| [`d63aa122`](https://github.com/NixOS/nixpkgs/commit/d63aa122e123f6ad0dca7bce437eed3bd646766a) | `` libshumate: 1.6.1 → 1.6.2 ``                                                                |
| [`b937e93a`](https://github.com/NixOS/nixpkgs/commit/b937e93a7740c041bbe13ea386096c8d925f3b7c) | `` gspell: 1.14.3 → 1.14.4 ``                                                                  |
| [`7ec59be1`](https://github.com/NixOS/nixpkgs/commit/7ec59be1272a6c89144a174d4e3c1ead544852b7) | `` gnome-sudoku: 50.1 → 50.2.1 ``                                                              |
| [`bd08d025`](https://github.com/NixOS/nixpkgs/commit/bd08d025224ec629aaf62fa36d6e7e296809feb9) | `` gnome-software: 50.2 → 50.3 ``                                                              |
| [`4460dd3a`](https://github.com/NixOS/nixpkgs/commit/4460dd3ab81bfbb61922da6d2acafa4dffd59fe3) | `` gnome-shell-extensions: 50.1 → 50.2 ``                                                      |
| [`12c48da7`](https://github.com/NixOS/nixpkgs/commit/12c48da7be83deac70fed157cf51dc38d6f2ef82) | `` gnome-nibbles: 4.5.1 → 4.5.2 ``                                                             |
| [`073f601d`](https://github.com/NixOS/nixpkgs/commit/073f601d9bdf2749e4e065cdce72831ab948a7c0) | `` gnome-music: 49.1 → 50.0 ``                                                                 |
| [`58465d6d`](https://github.com/NixOS/nixpkgs/commit/58465d6d31c0e6fd0d00e48974673c81d3d21d64) | `` gnome-maps: 50.1 → 50.2 ``                                                                  |
| [`8c0099bc`](https://github.com/NixOS/nixpkgs/commit/8c0099bcb05082b9ffaa3a1b594babfe8253c288) | `` gnome-control-center: 50.2 → 50.3 ``                                                        |
| [`98ef333b`](https://github.com/NixOS/nixpkgs/commit/98ef333b8e3c9c214512f2a4a87d062f8ca02582) | `` gvfs: 1.60.0 → 1.60.1 ``                                                                    |
| [`f3904b9d`](https://github.com/NixOS/nixpkgs/commit/f3904b9d9380b0d5e9dc66e4af4944ace9a0c744) | `` evolution-ews: 3.60.1 → 3.60.2 ``                                                           |
| [`7abc864f`](https://github.com/NixOS/nixpkgs/commit/7abc864f11a3297d5c89b0ed80403ddbacc6f714) | `` evolution: 3.60.1 → 3.60.2 ``                                                               |
| [`7a6c4196`](https://github.com/NixOS/nixpkgs/commit/7a6c4196306f2d676c19133fa8702b755249a16c) | `` file-roller: 44.6 → 44.7 ``                                                                 |
| [`66b6110b`](https://github.com/NixOS/nixpkgs/commit/66b6110b9ccfc1287fa85fc2c4afe3c4d9b6e72c) | `` ghdl-llvm-jit: init at 6.0.0 ``                                                             |
| [`fdb5350b`](https://github.com/NixOS/nixpkgs/commit/fdb5350b63314bf400f85f998af92b5a7d59362a) | `` rpcs3: add cmake flag to not build shared libs ``                                           |
| [`f11afdbc`](https://github.com/NixOS/nixpkgs/commit/f11afdbc6b490f540f238ff244a39fb35b7b7e57) | `` nixos/adw-bluetooth: init module ``                                                         |
| [`bbcb7d46`](https://github.com/NixOS/nixpkgs/commit/bbcb7d467ee67903744f6dc6b138a5e1a1644f64) | `` adw-bluetooth: 1.0.0 -> 1.1.0 ``                                                            |
| [`66c4b3ed`](https://github.com/NixOS/nixpkgs/commit/66c4b3edfa1ed51fa8020763cee7e6ac127594d3) | `` bottom: 0.13.0 -> 0.14.2 ``                                                                 |
| [`c4920c19`](https://github.com/NixOS/nixpkgs/commit/c4920c19693ac0530e658496a188680161650dce) | `` veilid: 0.5.3 -> 0.5.5 ``                                                                   |
| [`419efca0`](https://github.com/NixOS/nixpkgs/commit/419efca05e868d63aafca9d3ba5707a1f045720f) | `` nixos/tests/your_spotify: switch test to mongodb-ce ``                                      |
| [`36323c1c`](https://github.com/NixOS/nixpkgs/commit/36323c1c3649ccef4ef4ffc140f620b11c237bbf) | `` your_spotify: switch to pnpm 11 ``                                                          |
| [`7a69bda8`](https://github.com/NixOS/nixpkgs/commit/7a69bda88675e15474af3c72ac1d27134ca3703a) | `` your_spotify: 1.19.0 -> 1.20.0 ``                                                           |
| [`5d91bbb3`](https://github.com/NixOS/nixpkgs/commit/5d91bbb3f29ba5b71e73d8b182285c81eb8b2ee8) | `` temporal: 1.30.4 -> 1.30.5 ``                                                               |
| [`5b7d4fe8`](https://github.com/NixOS/nixpkgs/commit/5b7d4fe80e5f33c10c9e778ecab13c7c553819e8) | `` deluge: add missing libappindicator-gtk3 dependency ``                                      |
| [`e502d524`](https://github.com/NixOS/nixpkgs/commit/e502d5242dc94aeef8117d721032189b79fdfe1c) | `` geekbench6: add riscv64-linux ``                                                            |
| [`007b3957`](https://github.com/NixOS/nixpkgs/commit/007b3957bde89186f0ef90911be15dc135e20182) | `` geekbench_6: 6.4.0->6.7.1 ``                                                                |
| [`85bd4c15`](https://github.com/NixOS/nixpkgs/commit/85bd4c15016ee7162ae9e0bf26a93aad425499ef) | `` geekbench: move to by-name ``                                                               |
| [`d2091012`](https://github.com/NixOS/nixpkgs/commit/d2091012930a05ad0aec80cf4b196d1e1fb48b09) | `` pkgs/test/pnpm: test pnpmConfigHook with multiple pnpmWorkspaces under __structuredAttrs `` |
| [`b6fff018`](https://github.com/NixOS/nixpkgs/commit/b6fff0186b6ff126b013a98e1fbce05422df9953) | `` pnpmConfigHook: add support for __structuredAttrs = true ``                                 |