### PR TITLE
chore(flake/colmena): `1ebe1b55` -> `e4250e61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1782904768,
-        "narHash": "sha256-tu/otndlmVoSxoQVkNL5cvMFAMyekO2mCVYTl0DRlfs=",
+        "lastModified": 1783265280,
+        "narHash": "sha256-n+TVzNkFtsW+ghl7JeFJYwIbXaZ2tn/WgjVMXwlzybI=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "1ebe1b5526099a3b108a599c59ce0e6422a1a663",
+        "rev": "e4250e61da7e007e19e8e17d8675b88ad27d6c06",
         "type": "github"
       },
       "original": {
@@ -1374,11 +1374,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1782851755,
-        "narHash": "sha256-91ODtG9bUk4AMsgPfGlHzHxh+3r64DClTRxaiTHevIQ=",
+        "lastModified": 1783021296,
+        "narHash": "sha256-WYOmcI0zSkkU4VpR7xda8o0AWNC9xuqkEM7n4tKjJY8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3fb8f32d52b627190abb82438bdcc75a9c77b4e",
+        "rev": "d3474199ff806484bfccd1fdef7afc27fb8d74b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`0834d3fe`](https://github.com/nix-community/colmena/commit/0834d3feccd8f1740a843736aa4720e066dbfd25) | `` flake: bump stable from `f3fb8f3` to `d347419` in the inputs group `` |
| [`aa09197a`](https://github.com/nix-community/colmena/commit/aa09197abcf24aa0ca190ba2982dfdc8882fae41) | `` ci: bump docker/setup-qemu-action in the actions group ``             |
| [`cfb1b0a7`](https://github.com/nix-community/colmena/commit/cfb1b0a75f0956effc9ef2e2ebddc614fba10b90) | `` cargo: bump the cargo group with 3 updates ``                         |
| [`985963ad`](https://github.com/nix-community/colmena/commit/985963adb1408dd265c15445d334890104975b47) | `` ssh: Put extra_ssh_options before internal options ``                 |