### PR TITLE
chore(flake/nixpkgs): `65179426` -> `d4079514`

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -40,7 +40,7 @@
   "fixes": [
     {
       "id": "gh-dash-829-browser-stderr",
-      "done": false,
+      "done": true,
       "summary": "gh-dash leaks browser launcher stderr into the TUI (GTK theme warnings corrupt the display).",
       "repo": "dlvhdr/gh-dash",
       "check": "release-contains-commit",
@@ -50,7 +50,7 @@
         "https://github.com/dlvhdr/gh-dash/pull/861"
       ],
       "workaround": "features/shell/gh-dash/default.nix -- `keybindings` block overriding the `o` key with a detached/silenced opener (search FIXME(gh-dash-829)).",
-      "revert_action": "Delete the `keybindings` block (and `openDetached` / unused `pkgs` arg) once pkgs.gh-dash ships a release containing the fix commit; let the builtin `o` handle opening again."
+      "revert_action": "DONE. gh-dash v4.25.0 (the version our pinned nixpkgs now resolves) is `ahead` of the fix commit ae6e94a, so the upstream io.Discard fix is present. Removed the `keybindings` block, the `openDetached` helper, and the now-unused `pkgs` arg from features/shell/gh-dash/default.nix; the builtin `o` handles opening again."
     },
     {
       "id": "nix-darwin-1817-toc-depth",

--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -53,6 +53,21 @@
       "revert_action": "Delete the `keybindings` block (and `openDetached` / unused `pkgs` arg) once pkgs.gh-dash ships a release containing the fix commit; let the builtin `o` handle opening again."
     },
     {
+      "id": "nix-darwin-1817-toc-depth",
+      "done": false,
+      "summary": "nixpkgs dropped `--toc-depth`/`--chunk-toc-depth` from `nixos-render-docs manual html` (use `--sidebar-depth`), but the nix-darwin pin we follow still passes the old flags, so `darwin-manual-html` fails and breaks every Darwin build on a nixpkgs bump.",
+      "repo": "nix-darwin/nix-darwin",
+      "check": "issue-closed",
+      "issue": 1817,
+      "tracking": [
+        "https://github.com/nix-darwin/nix-darwin/issues/1817",
+        "https://github.com/nix-darwin/nix-darwin/pull/1819",
+        "https://github.com/nix-darwin/nix-darwin/pull/1818"
+      ],
+      "workaround": "profiles/darwin.nix -- BOTH `documentation.doc.enable = false;` AND `system.tools.darwin-uninstaller.enable = false;` (see FIXME(nix-darwin-1817-toc-depth)). Disabling docs alone is insufficient: the darwin-uninstaller package evaluates a second inner nix-darwin system that rebuilds the broken HTML manual with docs re-enabled, so it must be disabled too.",
+      "revert_action": "Once #1819/#1818 merges (issue #1817 closes) and the `darwin` flake input is bumped to a commit containing the `--sidebar-depth` fix, delete BOTH the `documentation.doc.enable = false;` and `system.tools.darwin-uninstaller.enable = false;` lines from profiles/darwin.nix and their FIXME, confirm a Darwin build passes in CI (this repo has no local Darwin builder), then set `done: true`. NOTE: `issue-closed` is the weakest signal; the actual precondition is that our `darwin` input pins a commit with the fix, so verify the input revision before reverting."
+    },
+    {
       "id": "nix-15638-opencode-darwin",
       "done": false,
       "summary": "opencode build-time `--version` smoke test is SIGKILLed (exit 137) on aarch64-darwin due to Mach-O page-hash code-signing corruption from the nix daemon; needs a patched daemon that has actually landed in our pinned nixpkgs.",

--- a/features/shell/gh-dash/default.nix
+++ b/features/shell/gh-dash/default.nix
@@ -2,41 +2,10 @@
   user,
   extraUsers ? [ ],
   lib,
-  pkgs,
   ...
 }:
 let
   allUsers = [ user ] ++ extraUsers;
-
-  # gh-dash shells out to open the selected item in the browser. The default
-  # `openGithub` builtin spawns the browser as a child that inherits gh-dash's
-  # controlling TTY, so any stderr the browser (or its GTK theme parser) emits
-  # is written straight into the bubbletea draw buffer and corrupts the TUI.
-  # Override the `o` keybind in both views with a fully detached opener:
-  # setsid + redirect both streams to /dev/null so nothing can leak back.
-  #
-  # FIXME(gh-dash-829): This whole `keybindings` override is a WORKAROUND, not
-  # a fix. Upstream root-caused and fixed this in gh-dash by discarding the
-  # browser launcher's stdout/stderr (`io.Discard`):
-  #   - issue:  https://github.com/dlvhdr/gh-dash/issues/829
-  #   - fix PR: https://github.com/dlvhdr/gh-dash/pull/861
-  #   - commit: ae6e94aeadead9bdea3fac14d139a2adc3500d51 (merged 2026-05-23)
-  # As of nixpkgs gh-dash v4.24.1 (the latest release, published 2026-05-13)
-  # the fix is NOT yet in a tagged release, so we still need this hack.
-  # The downside of this workaround is a brief screen flash on `o`, because a
-  # custom `command` keybind suspends/restores the alt-screen whereas the
-  # builtin `openGithub` path does not.
-  #
-  # WHEN TO REVERT: once `pkgs.gh-dash` moves to a version that contains the
-  # fix commit, delete the entire `keybindings` block below (and `openDetached`
-  # + the `pkgs` arg if otherwise unused) and let the builtin `o` handle it.
-  # The `.github/workflows/track-upstream-fixes.yaml` workflow watches for this
-  # and will open/flag an issue when the pinned gh-dash version crosses the fix.
-  openDetached =
-    url:
-    "${lib.getExe' pkgs.util-linux "setsid"} -f "
-    + "${lib.getExe' pkgs.xdg-utils "xdg-open"} ${url} "
-    + ">/dev/null 2>&1";
 in
 {
   config = {
@@ -44,20 +13,6 @@ in
       programs.gh-dash = {
         enable = true;
         settings = {
-          keybindings = {
-            prs = [
-              {
-                key = "o";
-                command = openDetached "https://github.com/{{.RepoName}}/pull/{{.PrNumber}}";
-              }
-            ];
-            issues = [
-              {
-                key = "o";
-                command = openDetached "https://github.com/{{.RepoName}}/issues/{{.IssueNumber}}";
-              }
-            ];
-          };
           prSections = [
             {
               title = "fredsystems";

--- a/flake.lock
+++ b/flake.lock
@@ -822,11 +822,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -29,6 +29,34 @@
     variables.EDITOR = "nvim";
   };
 
+  # FIXME(nix-darwin-1817-toc-depth): These two lines are a WORKAROUND, not a
+  # fix. nixpkgs removed the `--toc-depth` / `--chunk-toc-depth` flags from
+  # `nixos-render-docs manual html` in favour of `--sidebar-depth`, but the
+  # nix-darwin pin we follow still passes the old flags when building the
+  # nix-darwin HTML manual (`darwin-manual-html`). That derivation now fails
+  # with `--toc-depth has been removed, use --sidebar-depth instead`, which
+  # breaks the whole Darwin system build the moment `nixpkgs` is bumped.
+  #   - issue:  https://github.com/nix-darwin/nix-darwin/issues/1817
+  #   - fix PR: https://github.com/nix-darwin/nix-darwin/pull/1819 (and #1818)
+  # Two independent code paths build that broken HTML manual, so BOTH knobs
+  # are required (per the issue thread; disabling docs alone is not enough):
+  #   1. `documentation.doc.enable = false` drops the outer system's consumers
+  #      of the broken build (`manual.manualHTML` + the `darwin-help` script),
+  #      while leaving man pages (`nixos-render-docs options manpage`, which
+  #      does NOT use the removed flags) intact.
+  #   2. `system.tools.darwin-uninstaller.enable = false` drops the
+  #      `darwin-uninstaller` package. That package (pkgs/darwin-uninstaller)
+  #      evaluates a *second, inner* nix-darwin system with default options,
+  #      which rebuilds its own `darwin-manual-html` and fails identically --
+  #      unaffected by knob (1) because it re-enables docs internally.
+  #
+  # WHEN TO REVERT: once the `darwin` flake input advances to a commit that
+  # contains the PR #1819/#1818 fix (uses `--sidebar-depth`), delete BOTH lines
+  # below so the HTML manual and the uninstaller build again.
+  # The `.github/workflows/track-upstream-fixes.yaml` workflow watches for this.
+  documentation.doc.enable = false;
+  system.tools.darwin-uninstaller.enable = false;
+
   system = {
     defaults = {
       dock = {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`e3aa4813`](https://github.com/NixOS/nixpkgs/commit/e3aa4813c27b267b41878e3ba377614275e713fe) | `` python3Packages.plotly: 6.7.0 -> 6.8.0 ``                                                  |
| [`9dbfa1b9`](https://github.com/NixOS/nixpkgs/commit/9dbfa1b923bd92b33c5f25f0d3560d239dfd1697) | `` secretspec: 0.12.2 -> 0.13.0 ``                                                            |
| [`cb3c5372`](https://github.com/NixOS/nixpkgs/commit/cb3c5372ea1eeffd70963f4a10de2a8e0ab89588) | `` diskwatch: 0.1.1 -> 0.1.2 ``                                                               |
| [`419dbda9`](https://github.com/NixOS/nixpkgs/commit/419dbda9a0a2fe971474de0071b624fbb2123c66) | `` code-cursor: 3.9.8 -> 3.9.16 ``                                                            |
| [`98c5f7cb`](https://github.com/NixOS/nixpkgs/commit/98c5f7cb28f7018df1c45278eba62069f9aae559) | `` retroarch-assets: 1.22.0-unstable-2026-04-11 -> 1.22.0-unstable-2026-06-27 ``              |
| [`24e0dd57`](https://github.com/NixOS/nixpkgs/commit/24e0dd57fe0c2c07929a80a63e734dde06b0f886) | `` jjui: 0.10.7 -> 0.10.8 ``                                                                  |
| [`f95ba6fb`](https://github.com/NixOS/nixpkgs/commit/f95ba6fbb8ddf0ccc5483b9205e8e29c07d4b5c8) | `` linux_5_10: 5.10.259 -> 5.10.260 ``                                                        |
| [`77c8470b`](https://github.com/NixOS/nixpkgs/commit/77c8470b04eb90c4cd31e654f7a06038cab18cf5) | `` linux_5_15: 5.15.210 -> 5.15.211 ``                                                        |
| [`072138c7`](https://github.com/NixOS/nixpkgs/commit/072138c75ff9c17f766491828f3232d584dec4c2) | `` linux_6_1: 6.1.176 -> 6.1.177 ``                                                           |
| [`577b2f9c`](https://github.com/NixOS/nixpkgs/commit/577b2f9caec2fb96c982404fe4f2ef47c21166a2) | `` rqlite: 10.2.4 -> 10.2.6 ``                                                                |
| [`5ec65ba5`](https://github.com/NixOS/nixpkgs/commit/5ec65ba5803e1ec9fd106810a961b071db58f758) | `` linux_6_6: 6.6.143 -> 6.6.144 ``                                                           |
| [`c11603a1`](https://github.com/NixOS/nixpkgs/commit/c11603a1923ada856cea74cffba085e9f831a27c) | `` linux_6_12: 6.12.94 -> 6.12.95 ``                                                          |
| [`feb9b141`](https://github.com/NixOS/nixpkgs/commit/feb9b141d796d15b8295edd9e5c500cd23e3e9a6) | `` linux_6_18: 6.18.37 -> 6.18.38 ``                                                          |
| [`d1f61e4f`](https://github.com/NixOS/nixpkgs/commit/d1f61e4f485a57f6de1ad5767e672edebd63f0a0) | `` linux_7_1: 7.1.2 -> 7.1.3 ``                                                               |
| [`2241e00b`](https://github.com/NixOS/nixpkgs/commit/2241e00b81228d2ce7101589c2810de482cc6ab6) | `` beeper: 4.2.948 -> 4.2.957 ``                                                              |
| [`6d9f3e30`](https://github.com/NixOS/nixpkgs/commit/6d9f3e3006722d00a561ac628b1e872ae86001f4) | `` mongodb-compass: 1.49.9 -> 1.49.10 ``                                                      |
| [`e80c4032`](https://github.com/NixOS/nixpkgs/commit/e80c403287da10bd26aa7e816c0472c548c3bc36) | `` terraform-providers.yandex-cloud_yandex: 0.209.0 -> 0.213.0 ``                             |
| [`dcfe7833`](https://github.com/NixOS/nixpkgs/commit/dcfe7833820b396779037236c4db251c523d4bb8) | `` rmux: 0.7.0 -> 0.8.0 ``                                                                    |
| [`3d92a88d`](https://github.com/NixOS/nixpkgs/commit/3d92a88d7df0941754e43595ab23f78ba30ac9e0) | `` grav: 1.7.53 -> 1.7.53.2 ``                                                                |
| [`1f61bf56`](https://github.com/NixOS/nixpkgs/commit/1f61bf56b5e27ae8fdf082aa02ad431c15881f09) | `` python3Packages.ai-edge-litert: mark as broken ``                                          |
| [`f6c3e9f7`](https://github.com/NixOS/nixpkgs/commit/f6c3e9f7d1861bbb3589f0ecedfed5ecb7f04c3e) | `` nagstamon: 3.16.2 -> 3.18.2 ``                                                             |
| [`cc02ad6d`](https://github.com/NixOS/nixpkgs/commit/cc02ad6df4eb79b2b9ea6980e22b26d014e52366) | `` python3Packages.ai-edge-litert: use badPlatforms instead of broken to disable on darwin `` |
| [`31dd6711`](https://github.com/NixOS/nixpkgs/commit/31dd67110e771ac993075e9f317ab8a11b79c41a) | `` snip: 0.15.0 -> 0.20.0 ``                                                                  |
| [`6b81af20`](https://github.com/NixOS/nixpkgs/commit/6b81af202361de12d52f56ba6ba5e6f22c9beb48) | `` docs/readme: clarify future scope of source files in doc folder ``                         |
| [`aa19ec52`](https://github.com/NixOS/nixpkgs/commit/aa19ec523158b0c80c917f4ae5aa7bb9ce6bb19c) | `` nixos-containers: fix dummyConfig localMacAddress default ``                               |
| [`531f8c6f`](https://github.com/NixOS/nixpkgs/commit/531f8c6fe4fa05fb0b3300c1172437b8d520e442) | `` python3Packages.ggml-python: 0.0.44 -> 0.0.45 ``                                           |
| [`5c406c84`](https://github.com/NixOS/nixpkgs/commit/5c406c84cefa687f282a5328cb29e7d53cd2a8c7) | `` python3Packages.nicegui-highcharts: 3.2.1 -> 3.3.0 ``                                      |
| [`7b10c4fb`](https://github.com/NixOS/nixpkgs/commit/7b10c4fb196cef88d7cfc24bcdd7c06739dc2e28) | `` vscode-extensions.anthropic.claude-code: 2.1.199 -> 2.1.201 ``                             |
| [`6697fe13`](https://github.com/NixOS/nixpkgs/commit/6697fe1302f8fcecc495e0e6f6d3f05b7934fc1d) | `` claude-code: 2.1.199 -> 2.1.201 ``                                                         |
| [`4146c3e4`](https://github.com/NixOS/nixpkgs/commit/4146c3e4c27635fdcdb8f50344ae8ae08014bb8b) | `` home-assistant-custom-components.dreo: 1.9.20 -> 1.9.23 ``                                 |
| [`a949442c`](https://github.com/NixOS/nixpkgs/commit/a949442ca2ac5b498780a96dd458e92372e41a09) | `` pyhanko-cli: use pyprojectVersionPatchHook ``                                              |
| [`7b4bb150`](https://github.com/NixOS/nixpkgs/commit/7b4bb150cfa93e66eba7af8d6742563f4b4f7773) | `` python3Packages.zha: use pyprojectVersionPatchHook ``                                      |
| [`ff58e678`](https://github.com/NixOS/nixpkgs/commit/ff58e678db1001db10034933b12d023688f70562) | `` python3Packages.sendspin: use pyprojectVersionPatchHook ``                                 |
| [`d105df09`](https://github.com/NixOS/nixpkgs/commit/d105df0916dc7eadbc8eab4880cdeb3ef0c4f018) | `` python3Packages.zigpy-xbee: use pyprojectVersionPatchHook ``                               |
| [`86ba5d4e`](https://github.com/NixOS/nixpkgs/commit/86ba5d4e9b921dc4f659036bc0a97d444f705d6e) | `` python3Packages.aiosendspin: use pyprojectVersionPatchHook ``                              |
| [`78ff7228`](https://github.com/NixOS/nixpkgs/commit/78ff722824895b45e9c4c310b230fa3e58373729) | `` python3Packages.pyhanko: use pyprojectVersionPatchHook ``                                  |
| [`ff19be7f`](https://github.com/NixOS/nixpkgs/commit/ff19be7fd1abf240725088d6830bcc9ae0618105) | `` python3Packages.pyprojectVersionPatchHook: init ``                                         |
| [`0e3bfa61`](https://github.com/NixOS/nixpkgs/commit/0e3bfa61ddf40f436b34d41ff584357033ba98bf) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.83.6 -> 1.83.7 ``                    |
| [`516e7623`](https://github.com/NixOS/nixpkgs/commit/516e7623c357e3e6cf7b30b734867d13fe070730) | `` nixpkgs-vet: 0.3.3 -> 0.3.4 ``                                                             |
| [`dfb96430`](https://github.com/NixOS/nixpkgs/commit/dfb964308f976c6dc13fc6a644a1d060d54d433c) | `` zoxide: 0.9.9 -> 0.10.0 ``                                                                 |
| [`ef3d91f6`](https://github.com/NixOS/nixpkgs/commit/ef3d91f6808a3ae87ba44dd000a4bd55bc8d3be6) | `` dix: 2.1.0 -> 2.2.0 ``                                                                     |
| [`82ac1c75`](https://github.com/NixOS/nixpkgs/commit/82ac1c75d1a503ecef9d15485d0c2b41807883b0) | `` gardendevd: init at 0.2 ``                                                                 |
| [`f35ddc4b`](https://github.com/NixOS/nixpkgs/commit/f35ddc4b17b6bbd64c1a17296e3da8b497f2661b) | `` libudev-garden: init at 0.2.1 ``                                                           |
| [`910bad25`](https://github.com/NixOS/nixpkgs/commit/910bad259d846e2897ad75df11b80bd5c8062766) | `` treewide: follow some GitHub redirects for `fetchFromGitHub` ``                            |
| [`43c852ab`](https://github.com/NixOS/nixpkgs/commit/43c852abe810a1d1ca16d278fd59b4009bfd6f25) | `` python3Packages.yfinance: migrate to finalAttrs ``                                         |
| [`51cf2a71`](https://github.com/NixOS/nixpkgs/commit/51cf2a71ad2f839ef057067a7327717d745367b2) | `` libretro.pcsx2: 0-unstable-2026-06-24 -> 0-unstable-2026-06-29 ``                          |
| [`b0b5ca6f`](https://github.com/NixOS/nixpkgs/commit/b0b5ca6f17b61a44e380dfafeb042f0dec8b3c60) | `` python3Packages.yfinance: 1.3.0 -> 1.5.1 ``                                                |
| [`f4e0ce20`](https://github.com/NixOS/nixpkgs/commit/f4e0ce20d6e338cccfa7f6f80678537daab03d18) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 1.6.1 -> 1.6.2 ``                |
| [`280b6947`](https://github.com/NixOS/nixpkgs/commit/280b69479efe26aa44202d8e3dd248ab1f808ea4) | `` libretro.mame2010: 0-unstable-2026-06-16 -> 0-unstable-2026-07-03 ``                       |
| [`bc3c89ba`](https://github.com/NixOS/nixpkgs/commit/bc3c89badd7a259fe3f25ace084b99dfea3e35d3) | `` concord-tui: 2.2.12 -> 2.2.13 ``                                                           |
| [`8a63795e`](https://github.com/NixOS/nixpkgs/commit/8a63795e8b672306b80a213ddde16280194b98e5) | `` scala-cli: 1.14.0 -> 1.15.0 ``                                                             |
| [`221463fb`](https://github.com/NixOS/nixpkgs/commit/221463fbecd91a78ebc0f802bdaaaaabc7d68bd7) | `` gh-dash: 4.24.1 -> 4.25.0 ``                                                               |
| [`f091e9bb`](https://github.com/NixOS/nixpkgs/commit/f091e9bb47f7286a43d639ddd9b605557ffe8b9e) | `` python3Packages.env-canada: 0.16.0 -> 0.16.1 ``                                            |
| [`c2e2997d`](https://github.com/NixOS/nixpkgs/commit/c2e2997da05cbd9e96e9ceae9177f71850073497) | `` maigret: 0.6.1 -> 0.6.2 ``                                                                 |
| [`bf2ce402`](https://github.com/NixOS/nixpkgs/commit/bf2ce402b65433c69e0e17562a714cb51b4ff49e) | `` trufflehog: 3.95.7 -> 3.95.8 ``                                                            |
| [`123ab7dd`](https://github.com/NixOS/nixpkgs/commit/123ab7dd87d7044ee33438d67e642716a5bea392) | `` python3Packages.pytenable: 26.5.1 -> 26.6.1 ``                                             |
| [`75393e01`](https://github.com/NixOS/nixpkgs/commit/75393e01daa043b08885c5abceba83f3925a2256) | `` python3Packages.publicsuffixlist: 1.0.2.20260702 -> 1.0.2.20260703 ``                      |
| [`fe853156`](https://github.com/NixOS/nixpkgs/commit/fe85315685845db6d76ed760c8c88efadc9820d3) | `` python3Packages.iamdata: 0.1.202607031 -> 0.1.202607041 ``                                 |
| [`8c37adb5`](https://github.com/NixOS/nixpkgs/commit/8c37adb51d5e3f7b3d7329a08e84473d8b196f5d) | `` lux-cli: 0.35.0 -> 0.35.1 ``                                                               |
| [`5ae799ee`](https://github.com/NixOS/nixpkgs/commit/5ae799eea0ab021a091815989057d1e666efa5cc) | `` python3Packages.playwrightcapture: 1.40.0 -> 1.40.1 ``                                     |
| [`91e34a3c`](https://github.com/NixOS/nixpkgs/commit/91e34a3c20f3fa9b419d0657dc1b7f3526935363) | `` zapzap: 6.5.2.4 -> 6.5.2.5 ``                                                              |
| [`134d5e3c`](https://github.com/NixOS/nixpkgs/commit/134d5e3c67a388460fa5e0a1923687632381181b) | `` devin-cli: 2026.8.18 -> 3000.1.23 ``                                                       |
| [`8ff13bdd`](https://github.com/NixOS/nixpkgs/commit/8ff13bdd16013052436f417ddde55b65d2b1b219) | `` wappalyzergo: 0.2.85 -> 0.2.87 ``                                                          |
| [`506f473a`](https://github.com/NixOS/nixpkgs/commit/506f473a49aacf71a6d1da79b04b745deedb5b81) | `` dinit: 0.22.0 -> 0.22.1 ``                                                                 |
| [`e18b99e4`](https://github.com/NixOS/nixpkgs/commit/e18b99e4307ff808c2fc6752628cf58c8c1caaad) | `` idevicerestore: add flokli to maintainers ``                                               |
| [`108b0263`](https://github.com/NixOS/nixpkgs/commit/108b0263ca953a4d7763f8cbb34b3f0aaf6e4c23) | `` idevicerestore: 1.0.0-unstable-2025-10-02 -> 1.0.0-unstable-2026-07-26 ``                  |
| [`22ded466`](https://github.com/NixOS/nixpkgs/commit/22ded46682c17e2a9b1091b3fa2252e0143897cd) | `` nixosTests.scx: add missing rustscheds ``                                                  |
| [`b3c3a965`](https://github.com/NixOS/nixpkgs/commit/b3c3a965fd41c37c5b243b862502e83eebecb2e7) | `` python3Packages.torchaudio: remove broken fairseq from dependencies ``                     |
| [`d8a5ca07`](https://github.com/NixOS/nixpkgs/commit/d8a5ca07ff59392671e622edee3c3170dbb9ff82) | `` zed-editor: update to 1.9.0 ``                                                             |
| [`42efb68c`](https://github.com/NixOS/nixpkgs/commit/42efb68c84ccb6b23ed5d03799ed0e2e7e6c2a5d) | `` python3Packages.labelbox: fix meta.changelog ``                                            |
| [`9bb5c308`](https://github.com/NixOS/nixpkgs/commit/9bb5c308eb06d0f5e03d0d055a6fa8cc75d0596a) | `` nixosTests.scx: remove cscheds ``                                                          |
| [`dfd5b26b`](https://github.com/NixOS/nixpkgs/commit/dfd5b26b41dfd519ee25d236dd2f61ecd4821f5e) | `` scx.rustscheds: 1.1.1 -> 1.1.2 ``                                                          |
| [`084023c7`](https://github.com/NixOS/nixpkgs/commit/084023c72af0071afc8d7a4476f267c328746693) | `` nixos/matrix-authentication-service: fix formatting of description ``                      |
| [`0d214bd8`](https://github.com/NixOS/nixpkgs/commit/0d214bd808d18bb62f5a611096e3aba79e925d41) | `` nixos/matrix-authentication-service: escape CREDENTIALS_DIRECTORY correctly ``             |
| [`24f95988`](https://github.com/NixOS/nixpkgs/commit/24f95988be9cc36d829360e9ddb01f744f198e8b) | `` nixos/matrix-authentication-service: test credentials behavior in VM-test ``               |
| [`0ab75569`](https://github.com/NixOS/nixpkgs/commit/0ab75569e6ff3f1039581758ecc7ae48d8e2c1cd) | `` nixos/matrix-authentication-service: add option credentials ``                             |
| [`a21fe825`](https://github.com/NixOS/nixpkgs/commit/a21fe8255337ec3e5ce52c99924fb5290abef2f4) | `` nixpkgs-openjdk-updater: ignore new lint failure ``                                        |
| [`7a4c51d7`](https://github.com/NixOS/nixpkgs/commit/7a4c51d7be00e08ac1dfb7cb4b748ae119cdb0b7) | `` nh-unwrapped: 4.3.2 -> 4.4.0 ``                                                            |
| [`3d4512e2`](https://github.com/NixOS/nixpkgs/commit/3d4512e239b6c514785b7d98643c7e08ca1345d4) | `` hacksguard: adjust license ``                                                              |
| [`e5bb833e`](https://github.com/NixOS/nixpkgs/commit/e5bb833e0e3cc88744579dda5b9d711b39c5ef56) | `` sshamble: init at 0.3.9 ``                                                                 |
| [`6cc3d60d`](https://github.com/NixOS/nixpkgs/commit/6cc3d60de204045a3dccccb1bc0b7e55e065ec02) | `` iredis: modernize ``                                                                       |
| [`22b0bb03`](https://github.com/NixOS/nixpkgs/commit/22b0bb03262762fcb0405d8632311e3486ca9bf2) | `` iredis: 1.15.2 -> 1.16.1 ``                                                                |
| [`5027ff73`](https://github.com/NixOS/nixpkgs/commit/5027ff7314bc6183d39f4c5fe8923e38c72b2f0d) | `` orca-slicer: build with clang ``                                                           |
| [`186834db`](https://github.com/NixOS/nixpkgs/commit/186834db39ea905e5ff7a0bbad96ff2031a34174) | `` xclock: add booxter as maintainer ``                                                       |
| [`5b1f2ce8`](https://github.com/NixOS/nixpkgs/commit/5b1f2ce84a8d3bc846be011ebb89d2cdbf858948) | `` xclock: add version check ``                                                               |
| [`ed374aff`](https://github.com/NixOS/nixpkgs/commit/ed374affd1167188e97835e643b5a18fe37ea5fe) | `` nixosTests.unbound: support doq ``                                                         |
| [`47584421`](https://github.com/NixOS/nixpkgs/commit/47584421cd9a53030d02cf224b5700177ba60548) | `` xclock: 1.1.1 -> 1.2.0 ``                                                                  |
| [`e967abd4`](https://github.com/NixOS/nixpkgs/commit/e967abd42f14160f21f67ca5e6ac99b0be4d2f9e) | `` unbound: add DNS-over-QUIC support ``                                                      |
| [`0a49e151`](https://github.com/NixOS/nixpkgs/commit/0a49e1513030e0e2b29b96dbe78f61af877c4434) | `` cargo-tally: 1.0.74 -> 1.0.75 ``                                                           |
| [`1c60a387`](https://github.com/NixOS/nixpkgs/commit/1c60a3879cf53c4a76609ea6347bde68667b6e8d) | `` dnsproxy: 0.81.4 -> 0.82.1 ``                                                              |
| [`9ab8fa73`](https://github.com/NixOS/nixpkgs/commit/9ab8fa73753fa9b1f20eb27eaf526556bcd72429) | `` check-meta: compare with null instead of using isNull ``                                   |
| [`110fec6e`](https://github.com/NixOS/nixpkgs/commit/110fec6e02f263fdaf23c16e84e876aec8c70fe3) | `` thunderbird-latest-unwrapped: 152.0 -> 152.0.1 ``                                          |
| [`bb6e0bdd`](https://github.com/NixOS/nixpkgs/commit/bb6e0bdd29cd868ebb363e1d806c0cca0e5da435) | `` ungoogled-chromium: 149.0.7827.200-1 -> 150.0.7871.46-1 ``                                 |
| [`99f3e057`](https://github.com/NixOS/nixpkgs/commit/99f3e057bb3ea44ad2f5ba6fe78ef6413a6cfc03) | `` opencode-desktop: fix desktop file name and StartupWMClass to match app_id ``              |
| [`69320a12`](https://github.com/NixOS/nixpkgs/commit/69320a1261f224228dd297ed2b4cc1686418cf7c) | `` opensplat: cleanup, fix rocm build ``                                                      |
| [`195b95f5`](https://github.com/NixOS/nixpkgs/commit/195b95f5acea38cdc9f00738326b2892b393cc7f) | `` peertube: 8.1.8 -> 8.2.2 ``                                                                |
| [`88ef8023`](https://github.com/NixOS/nixpkgs/commit/88ef80234b8137b8d14bb2dad887ee40096f7657) | `` vimPlugins.neovim-session-manager: init at 0-unstable-2026-01-26 ``                        |
| [`6507a11a`](https://github.com/NixOS/nixpkgs/commit/6507a11a46009c66b7310c52f682a8ce2bd188a6) | `` python3Packages.torchmd-net: allow test to run without MPS support on darwin ``            |
| [`219b2365`](https://github.com/NixOS/nixpkgs/commit/219b236583e83255913d1da7a6d79e0261da8194) | `` python3Packages.compressed-tensors: skip failing test on darwin ``                         |
| [`a74832c7`](https://github.com/NixOS/nixpkgs/commit/a74832c7732d22f485db72d83ff00bc65a3f598f) | `` python3Packages.torchaudio: add missing test dependencies ``                               |
| [`589077b0`](https://github.com/NixOS/nixpkgs/commit/589077b08ac0139f013342a9ea3e044bdd0f5a73) | `` python3Packages.skorch: cleanup ``                                                         |
| [`b3f0f905`](https://github.com/NixOS/nixpkgs/commit/b3f0f9057fa40226c7192faea38e94158a1ae8d4) | `` python3Packages.skorch: re-enable on darwin ``                                             |
| [`08114f95`](https://github.com/NixOS/nixpkgs/commit/08114f95db01f307ab5ad776ea13348189510353) | `` python3Packages: remove unnecessary llvmPackages.openmp inclusions ``                      |
| [`c1f04f37`](https://github.com/NixOS/nixpkgs/commit/c1f04f375c0e8ecf8d8fa81e99b0d41f2c1788b3) | `` python3Packages.torch: fix inductor on darwin ``                                           |
| [`3a6a36c8`](https://github.com/NixOS/nixpkgs/commit/3a6a36c8c39d7707f13b23f9602a340dcfa81e43) | `` terraform-providers.ubiquiti-community_unifi: 0.53.0 -> 0.54.0 ``                          |
| [`da2a179a`](https://github.com/NixOS/nixpkgs/commit/da2a179a76e823dfe3e2bb9ac10b9e71a96204d7) | `` hardinfo2: 2.2.16 -> 2.3.1 ``                                                              |
| [`355d67a1`](https://github.com/NixOS/nixpkgs/commit/355d67a12faf6edf8d5c49c698f36160fc6cbb8b) | `` thunderbird-esr-bin-unwrapped: 140.12.0esr -> 140.12.1esr ``                               |
| [`e7398213`](https://github.com/NixOS/nixpkgs/commit/e7398213b8a19e40ac7e43521f8d6ac896386d56) | `` samrewritten: 1.4.3 -> 1.4.4 ``                                                            |
| [`4b5dd73e`](https://github.com/NixOS/nixpkgs/commit/4b5dd73e8e87ed6f6e00823734cbf29c771d5608) | `` python3Packages.boto3-stubs: 1.43.39 -> 1.43.40 ``                                         |
| [`b0acbf0b`](https://github.com/NixOS/nixpkgs/commit/b0acbf0b17a18f30610aab8f81e37ec64d58705a) | `` python3Packages.mypy-boto3-outposts: 1.43.31 -> 1.43.40 ``                                 |
| [`36f8f47d`](https://github.com/NixOS/nixpkgs/commit/36f8f47d64ae2888e664b9cb6af9d26a2cd8fa7e) | `` python3Packages.mypy-boto3-mediatailor: 1.43.4 -> 1.43.40 ``                               |
| [`cf00f6a9`](https://github.com/NixOS/nixpkgs/commit/cf00f6a9f37ca4e4aed2a6fc9699f6dff79019c0) | `` python3Packages.mypy-boto3-customer-profiles: 1.43.17 -> 1.43.40 ``                        |
| [`6849d2e6`](https://github.com/NixOS/nixpkgs/commit/6849d2e65fba358fc965dabd186060e23f03a0cb) | `` python3Packages.mypy-boto3-config: 1.43.23 -> 1.43.40 ``                                   |
| [`e7624884`](https://github.com/NixOS/nixpkgs/commit/e7624884f725a74ef0689dfc9183dca0ce17580a) | `` python3Packages.mypy-boto3-cognito-idp: 1.43.33 -> 1.43.40 ``                              |
| [`84820487`](https://github.com/NixOS/nixpkgs/commit/84820487702f8f2f79d4cc4b93ad6f8d029fe64d) | `` python3Packages.rns: 1.3.6 -> 1.3.7 ``                                                     |
| [`a51f20a4`](https://github.com/NixOS/nixpkgs/commit/a51f20a4d73896c8fad10d05bf7b3d4b5f890b3c) | `` rusthound-ce: 2.4.9 -> 2.4.91 ``                                                           |
| [`49c8c5e4`](https://github.com/NixOS/nixpkgs/commit/49c8c5e45f4bcc23f58d080f09ab6cef8a273ed0) | `` python3Packages.stix2: migrate to finalAttrs ``                                            |
| [`1e2886df`](https://github.com/NixOS/nixpkgs/commit/1e2886dfa3cb4bb44b29a2686b700bd652edefba) | `` python3Packages.stix2: 3.0.1 -> 3.0.2 ``                                                   |
| [`0f7b0b0a`](https://github.com/NixOS/nixpkgs/commit/0f7b0b0ab3a98928acd153ab0786d8ec616d3571) | `` python3Packages.stix2-validator: migrate to finalAttrs ``                                  |
| [`926605cf`](https://github.com/NixOS/nixpkgs/commit/926605cf30ae9e60ac479d13955ca53081f96818) | `` python3Packages.stix2-validator: 3.2.0 -> 3.3.1 ``                                         |
| [`572d23eb`](https://github.com/NixOS/nixpkgs/commit/572d23eb3518814411648e5f5180b862570b744e) | `` python3Packages.stix2-patterns: 2.0.0 -> 2.1.2 ``                                          |
| [`2522c876`](https://github.com/NixOS/nixpkgs/commit/2522c876111eb36ff3a0d7a2ac74f11927345f87) | `` awsebcli: 3.27.2 -> 3.27.3 ``                                                              |
| [`4055b857`](https://github.com/NixOS/nixpkgs/commit/4055b857d7a3c7fa62f624fe3cbc89182ca6c005) | `` tmuxp: 1.71.0 -> 1.73.0 ``                                                                 |
| [`1ec413ad`](https://github.com/NixOS/nixpkgs/commit/1ec413ad635782eb17d5475f8092618fb11dc62c) | `` python3Packages.libtmux: 0.59.0 -> 0.60.0 ``                                               |
| [`b67cbb59`](https://github.com/NixOS/nixpkgs/commit/b67cbb5907e32726ad0829cf0015f4d3e34e242c) | `` pyrefly: 1.1.1 -> 1.2.0-dev.1 ``                                                           |
| [`62588547`](https://github.com/NixOS/nixpkgs/commit/62588547a1e2cc5ab4cd235a89a2e4eb7ee593be) | `` python3Packages.rns: 1.3.5 -> 1.3.6 ``                                                     |
| [`a48b3e7c`](https://github.com/NixOS/nixpkgs/commit/a48b3e7c7d6e5cb3ce208ea7ab50a9d333fbb112) | `` python3Packages.valhallaapi: init at 0.5.2 ``                                              |
| [`1e9013a7`](https://github.com/NixOS/nixpkgs/commit/1e9013a7fd0b9959bebc6a289d4c26db71892fd9) | `` linuxPackages.bcachefs: support kernel 7.2 ``                                              |
| [`b83fae51`](https://github.com/NixOS/nixpkgs/commit/b83fae5195ebd6feb1b6d3f7d898cd5678309d39) | `` linuxPackages.bcachefs: build with rust support ``                                         |
| [`a8836279`](https://github.com/NixOS/nixpkgs/commit/a8836279a68e1e42b4c55b3eb6ec5d54f09cf4d2) | `` bcachefs-tools: 1.38.6 -> 1.38.8 ``                                                        |
| [`87e4ff40`](https://github.com/NixOS/nixpkgs/commit/87e4ff403f8d58eacb616afd5865ecd964cf8f64) | `` mcp-gateway: 2.19.0 -> 3.0.1 ``                                                            |
| [`9e2158d2`](https://github.com/NixOS/nixpkgs/commit/9e2158d29d485ec6c73ccb823b2989fba79d2adf) | `` python3Packages.pymisp: init at 2.5.34.1 ``                                                |
| [`541b3201`](https://github.com/NixOS/nixpkgs/commit/541b3201ffea61cf28338e597506a24d64220490) | `` mathjax: 4.1.2 -> 4.1.3 ``                                                                 |
| [`125ba423`](https://github.com/NixOS/nixpkgs/commit/125ba423c86f6765332eb3d9f6fb565a73d97709) | `` terraform-providers.hashicorp_google-beta: 7.38.0 -> 7.39.0 ``                             |
| [`f827eb15`](https://github.com/NixOS/nixpkgs/commit/f827eb15c2c8eb8a864acb1373c51460c9bcd606) | `` terraform-providers.aiven_aiven: 4.59.0 -> 4.60.0 ``                                       |
| [`66db2a07`](https://github.com/NixOS/nixpkgs/commit/66db2a07b50ab36d98ef786c6e54ea31734c930c) | `` python3Packages.pydeep2: init at 0.5.1 ``                                                  |
| [`00f0d465`](https://github.com/NixOS/nixpkgs/commit/00f0d46542ac86e8676bb95c916838362e9a1580) | `` pineapple-pictures: 1.4.1 -> 1.5.0 ``                                                      |
| [`990f3a5c`](https://github.com/NixOS/nixpkgs/commit/990f3a5ccaf4fbecdc99c22ecd95764f081de139) | `` vue-language-server: 3.2.9 -> 3.3.6 ``                                                     |
| [`4ed0e688`](https://github.com/NixOS/nixpkgs/commit/4ed0e68851d523833197e5de09d0bceda3aac395) | `` obliteratus: 0.1.2-unstable-2026-03-05 -> 0-unstable-2026-06-17 ``                         |
| [`3b7103bd`](https://github.com/NixOS/nixpkgs/commit/3b7103bd9184d91fd48f1b932e9664b86550d4bc) | `` grok-build: init @ 0.2.82 ``                                                               |
| [`4af07410`](https://github.com/NixOS/nixpkgs/commit/4af074100f497298d819887b22a1b4efead158f3) | `` mdfried: move env variables into env for structuredAttrs ``                                |
| [`e886b7d9`](https://github.com/NixOS/nixpkgs/commit/e886b7d92cc68c4db521596bbdb428f372c88c65) | `` radicle-desktop: 0.12.0 -> 0.13.0 ``                                                       |
| [`efe13f56`](https://github.com/NixOS/nixpkgs/commit/efe13f56f7a1b9b16b4748360865e63cf270991a) | `` mastodon: 4.6.2 -> 4.6.3 ``                                                                |
| [`22c5a89e`](https://github.com/NixOS/nixpkgs/commit/22c5a89ecd435fa33e1ef90d4696e8449885f48a) | `` credspy: init at 1.0.0-unstable-2026-06-22 ``                                              |
| [`c1f215af`](https://github.com/NixOS/nixpkgs/commit/c1f215aff8fd0051618054f2324d3de844514a61) | `` rsync: fix pkgsStatic itemize test failure ``                                              |
| [`d8f802c8`](https://github.com/NixOS/nixpkgs/commit/d8f802c855afc68761e81270a64088c37ed094fb) | `` nixos/nginx/gitweb: move into gitweb module ``                                             |
| [`653c4a35`](https://github.com/NixOS/nixpkgs/commit/653c4a3515d187078eeb29a03d2d3d9a70fe9e63) | `` nano-syntax-highlighting: 2026.05.01 -> 2026.07.01 ``                                      |
| [`1355a38d`](https://github.com/NixOS/nixpkgs/commit/1355a38d2d3040cd0dfabade997fadfa1cf02984) | `` netbird: 0.74.0 -> 0.74.2 ``                                                               |
| [`6b6b3a6c`](https://github.com/NixOS/nixpkgs/commit/6b6b3a6cd82e2f05c460aa9a8f26fac4ab1bf644) | `` nixos/captive-browser: update default arguments passed to Chromium ``                      |
| [`9fbff166`](https://github.com/NixOS/nixpkgs/commit/9fbff166f6f7c34a8d3c1aa13be7cc9fe0de17bf) | `` pg-schema-diff: 1.0.5 -> 1.0.7 ``                                                          |
| [`fbcc46ed`](https://github.com/NixOS/nixpkgs/commit/fbcc46ede8d65346948910a3a00f4fa50d39cfab) | `` maintainers: add kayoubi13 ``                                                              |
| [`be696e37`](https://github.com/NixOS/nixpkgs/commit/be696e37b1b5812445e40a797951c4a64c134299) | `` pretender: modernize ``                                                                    |
| [`cedce323`](https://github.com/NixOS/nixpkgs/commit/cedce323bbb181cb92b459eb5890873e4c5649b6) | `` python3Packages.alexapy: 1.29.24 -> 1.29.25 ``                                             |
| [`21056d4a`](https://github.com/NixOS/nixpkgs/commit/21056d4afcb0a3ee2d3f5189539b5777f9b67e00) | `` libretro.fceumm: 0-unstable-2026-06-23 -> 0-unstable-2026-06-30 ``                         |
| [`c64c2cf7`](https://github.com/NixOS/nixpkgs/commit/c64c2cf7f35a5d2ef3828401fc6dd874f29a0c8f) | `` monsoon: modernize ``                                                                      |
| [`d9114b31`](https://github.com/NixOS/nixpkgs/commit/d9114b31e57e71bb896630f4cc18c226180d9d0d) | `` umami: 3.1.0 -> 3.2.0 ``                                                                   |
| [`dcc6fe72`](https://github.com/NixOS/nixpkgs/commit/dcc6fe72fae7378098fd3a119b2ac8d1a59f3b16) | `` python3Packages.uproot: 5.7.4 -> 5.7.5 ``                                                  |
| [`658c5fef`](https://github.com/NixOS/nixpkgs/commit/658c5fefa7ebbab19e637bfea02b26b65863180f) | `` nixos/matrix-authentication-services: fix extraConfigFiles param permission issue ``       |
| [`d61795ea`](https://github.com/NixOS/nixpkgs/commit/d61795eaa207b2cbac673150a16c08cd8530e519) | `` nixos/matrix-authentication-service: small cleanup ``                                      |
| [`3aad7978`](https://github.com/NixOS/nixpkgs/commit/3aad7978d0a4288db782f6145f2fce7dabdbaa19) | `` python3Packages.gradio: 6.9.0 -> 6.19.0 ``                                                 |
| [`346fcfc0`](https://github.com/NixOS/nixpkgs/commit/346fcfc04ef54ab0aa4624c45339173da930f0a0) | `` hacksguard: init at 0.1 ``                                                                 |
| [`81c0a9a1`](https://github.com/NixOS/nixpkgs/commit/81c0a9a17add2285fac35003fea11ffadea005e7) | `` terraform-providers.sacloud_sakuracloud: 2.36.0 -> 2.36.1 ``                               |
| [`81237ed5`](https://github.com/NixOS/nixpkgs/commit/81237ed5cf32dd63987e9fbb81b3c60746c049df) | `` prow: 0-unstable-2026-06-24 -> 0-unstable-2026-07-02 ``                                    |
| [`5502f844`](https://github.com/NixOS/nixpkgs/commit/5502f844b225147985f1fb200f2b187f4f14f969) | `` Reapply "nixos/pipewire: minor refactor" ``                                                |
| [`a4a2a9aa`](https://github.com/NixOS/nixpkgs/commit/a4a2a9aa8ccc7ca9cd1fb5fdc338e2b66fc17dab) | `` ocamlPackages.x509: 1.1.0 -> 1.1.1 ``                                                      |
| [`c67d6040`](https://github.com/NixOS/nixpkgs/commit/c67d60408f13df42653b39bfe290ab7a19c8c4a4) | `` clickhouse-lts: 26.3.15.4-lts -> 26.3.17.4-lts ``                                          |
| [`f8225c39`](https://github.com/NixOS/nixpkgs/commit/f8225c39df4421cc40726adbd57ffebf94126c65) | `` nixos/comma: init ``                                                                       |
| [`dc68e7fd`](https://github.com/NixOS/nixpkgs/commit/dc68e7fd1532f8dd107627dc42fcf1bc856b3a07) | `` nixos/nginx: Always symlink nginx configuration to /etc/nginx/nginx.conf ``                |
| [`032cb047`](https://github.com/NixOS/nixpkgs/commit/032cb0477b804c38eab0e3140c0fcd3b4bc823b4) | `` mo-viewer: 1.6.2 -> 1.6.3 ``                                                               |
| [`8bb07fcc`](https://github.com/NixOS/nixpkgs/commit/8bb07fcc0f6c720004c133dbc1d5844fe7565db6) | `` pocket-casts: Bump electron version to 42 ``                                               |
| [`7a157c35`](https://github.com/NixOS/nixpkgs/commit/7a157c354fc29029fd594d388fd7f8c69e6e4b3c) | `` stalwart-cli: 1.0.9 -> 1.0.10 ``                                                           |
| [`45d0a72b`](https://github.com/NixOS/nixpkgs/commit/45d0a72ba723e2bb2c826da78ca8fc1b964067f5) | `` opentofu-mcp-server: 1.0.0 -> 1.0.0-unstable-2026-06-09, pnpm_8 -> pnpm_10 ``              |
| [`64ee61cb`](https://github.com/NixOS/nixpkgs/commit/64ee61cb64cb05458e9d00e35effc4a922bb4c15) | `` smfh: 1.5 -> 1.6 ``                                                                        |
| [`140264dc`](https://github.com/NixOS/nixpkgs/commit/140264dc3289592c85a68f109e35c4abdc76019a) | `` pkgs/nixos-render-docs: remove dead {examples,figures} table ``                            |
| [`1943e1e9`](https://github.com/NixOS/nixpkgs/commit/1943e1e9da91c57ce6fcc1308c700bec41dcb6a1) | `` luaPackages.neotest: 5.18.0-1 -> 5.19.0-1 ``                                               |
| [`ced951f3`](https://github.com/NixOS/nixpkgs/commit/ced951f38c56eee829446c100cc5e39fe274660d) | `` doc/style.css: make admonition styles container-agnostic ``                                |
| [`e73b7d65`](https://github.com/NixOS/nixpkgs/commit/e73b7d657ebdcc531ccbe11366462889cc673939) | `` python3Packages.dpcontracts: fix version ``                                                |
| [`e58f103a`](https://github.com/NixOS/nixpkgs/commit/e58f103a37bd5a7938e82da7ed508af91227bcbf) | `` pretender: 1.3.2 -> 1.4.1 ``                                                               |
| [`b39852ac`](https://github.com/NixOS/nixpkgs/commit/b39852acfb2e1a3ee3bd736c71d0bc039faf8162) | `` murmure: 1.9.0 -> 1.10.0 ``                                                                |
| [`b2f49162`](https://github.com/NixOS/nixpkgs/commit/b2f49162a52e4e8d1f32d65e95589c09f66183f6) | `` doc/styles: distinct colors for admonitions ``                                             |
| [`42041751`](https://github.com/NixOS/nixpkgs/commit/4204175122a053e92d4d83549dddcf044015cb0b) | `` python3Packages.dpcontracts: enable tests ``                                               |
| [`900ed180`](https://github.com/NixOS/nixpkgs/commit/900ed1808da96b6620556c64f958ab4170b774b1) | `` nixos/captive-browser: drop setcap wrapper ``                                              |
| [`8c57ddf3`](https://github.com/NixOS/nixpkgs/commit/8c57ddf379d11c0f84afad0e682ff1798b1a64b5) | `` captive-browser: 0-unstable-2021-08-01 -> 0-unstable-2025-11-05 ``                         |
| [`06632e34`](https://github.com/NixOS/nixpkgs/commit/06632e3436cc10a16362f5240c80aa967cadd599) | `` terraform-providers.hashicorp_vault: 5.9.0 -> 5.10.1 ``                                    |
| [`91c20926`](https://github.com/NixOS/nixpkgs/commit/91c209262d84fbb375fcc6ce1310dcef74061030) | `` r2modman: 3.2.17 -> 3.2.18 ``                                                              |
| [`acfc12be`](https://github.com/NixOS/nixpkgs/commit/acfc12be479ffe69ca1a57e72cac21fac15a8bf0) | `` doc/manual: init example packaging guide ``                                                |
| [`97ed7497`](https://github.com/NixOS/nixpkgs/commit/97ed749796d9e3fbba376a1b3488193657ab356b) | `` django-upgrade: 1.30.0 -> 1.31.1 ``                                                        |
| [`eb435dcd`](https://github.com/NixOS/nixpkgs/commit/eb435dcd1f5bbbcbcdc72a77ecc9cb99f04dc5b1) | `` mattermostLatest: don't test unofficial patches ``                                         |
| [`e6e86ce2`](https://github.com/NixOS/nixpkgs/commit/e6e86ce2a9669c3db1ff6a9449c4fe5d677eabd2) | `` meilisearch: 1.48.2 -> 1.48.3 ``                                                           |
| [`8deae9c9`](https://github.com/NixOS/nixpkgs/commit/8deae9c9de9d78f3df4502367c57e5054f2e3e00) | `` home-assistant-custom-components.yandex-station: 3.21.2 -> 3.21.3 ``                       |
| [`5dd08dc6`](https://github.com/NixOS/nixpkgs/commit/5dd08dc6340a096f0f70d1638b1c6ea0c736740b) | `` zennotes-desktop: 2.8.0 -> 2.10.0 ``                                                       |
| [`87ce5e1f`](https://github.com/NixOS/nixpkgs/commit/87ce5e1f34d2ec0fee11415daf49357dba6a4273) | `` python3Packages.fuzzywuzzy: disambiguate license ``                                        |
| [`a22886c5`](https://github.com/NixOS/nixpkgs/commit/a22886c580b2939f09450903b40ccfdc55b613fe) | `` openobserve: 0.50.3 -> 0.91.1 ``                                                           |
| [`d1618571`](https://github.com/NixOS/nixpkgs/commit/d161857196fbab4305e876c565f296defa6fbc32) | `` python3Packages.tuya-device-handlers: 0.0.22 -> 0.0.24 ``                                  |
| [`9bab1987`](https://github.com/NixOS/nixpkgs/commit/9bab1987d8fe3475630fddba04554ceeeef7673a) | `` sandbox-runtime: 0.0.59 -> 0.0.63 ``                                                       |
| [`f0db91eb`](https://github.com/NixOS/nixpkgs/commit/f0db91eb3493089675707691a30d9eca7008389e) | `` mise: 2026.6.13 -> 2026.7.0 ``                                                             |
| [`e566cbb5`](https://github.com/NixOS/nixpkgs/commit/e566cbb5c4a673ab40bea469a3777700eb47e8fb) | `` maintainers: add ad030 ``                                                                  |
| [`276f50ae`](https://github.com/NixOS/nixpkgs/commit/276f50ae6695bf6258907dea1e826a8f6c959135) | `` obsidian: drop electron version pin ``                                                     |
| [`6f555d44`](https://github.com/NixOS/nixpkgs/commit/6f555d44da4a34c51fdb314b6c416bf03b9a2561) | `` kotatogram-desktop: 1.4.9-unstable-2024-09-27 -> 1.4.9-unstable-2026-07-03 ``              |
| [`8b4d99bc`](https://github.com/NixOS/nixpkgs/commit/8b4d99bc1d20d13221e8ce5fc86e348ca80c0fe0) | `` findomain: adopt ``                                                                        |
| [`3935e010`](https://github.com/NixOS/nixpkgs/commit/3935e0103ad1dbabd51ef334e409ee8039f9b27e) | `` delve: 1.26.3 -> 1.27.0 ``                                                                 |
| [`7aa035f8`](https://github.com/NixOS/nixpkgs/commit/7aa035f8b3bda018963e599c6a8233d87ee53bbd) | `` python3Packages.onnxscript: 0.7.0 -> 0.7.1 ``                                              |
| [`07dd6824`](https://github.com/NixOS/nixpkgs/commit/07dd6824d42a3dcf915329f3f12fa9b173a52c78) | `` findomain: modernize ``                                                                    |
| [`0fc6f4e0`](https://github.com/NixOS/nixpkgs/commit/0fc6f4e0ea8162b33f7b83d64588840b88802489) | `` entire: 0.6.3 -> 0.7.8 ``                                                                  |
| [`af24e675`](https://github.com/NixOS/nixpkgs/commit/af24e675e55bc4a2e883e8ffd0f1129ab1db7baa) | `` treewide: follow some GitHub redirects for `fetchFromGitHub` ``                            |
| [`3c127b57`](https://github.com/NixOS/nixpkgs/commit/3c127b57b629107fcbcab0ea365ab6fcc68144b7) | `` shelter: pnpm_9 -> pnpm_10 ``                                                              |
| [`4a92ed86`](https://github.com/NixOS/nixpkgs/commit/4a92ed8616ab7fc6a612aa816eb338583788abb6) | `` spaceship-prompt: 4.22.4 -> 4.22.5 ``                                                      |
| [`94b29b15`](https://github.com/NixOS/nixpkgs/commit/94b29b15e7479bc4df4307db1a8557a5a3a5fc1f) | `` gopodder: init at 1.2.1 ``                                                                 |
| [`66241985`](https://github.com/NixOS/nixpkgs/commit/66241985dcf268ef8e2fd020d73b86c4d1b03d15) | `` doc/treewide: replace "in order to" with "to" ``                                           |
| [`2fa75540`](https://github.com/NixOS/nixpkgs/commit/2fa7554065defd166e019426849ace88d7dc8a73) | `` python3Packages.crawl4ai: init at 0.9.0 ``                                                 |
| [`acf7b12e`](https://github.com/NixOS/nixpkgs/commit/acf7b12ebb6d457b9823b28f01b8d209d2c59c17) | `` python3Packages.unclecode-litellm: init at 1.81.13 ``                                      |
| [`2920ff39`](https://github.com/NixOS/nixpkgs/commit/2920ff399d36fdffc2c26c2d93241fa3fae670d5) | `` python3Packages.patchright: init at 1.58.0 ``                                              |
| [`20701d54`](https://github.com/NixOS/nixpkgs/commit/20701d54228d74ede003b354b726e6cf89001774) | `` python3Packages.tf-playwright-stealth: init at 1.2.2-unstable-2026-06-30 ``                |
| [`522d597d`](https://github.com/NixOS/nixpkgs/commit/522d597d2af77e49db2856af82e6cba00350f4d0) | `` mattermost-desktop: 6.1.2 -> 6.2.2 ``                                                      |
| [`42f2ec45`](https://github.com/NixOS/nixpkgs/commit/42f2ec4584eec9dd9eee6c6072257c534cc0a2c1) | `` python3Packages.mscerts: 2026.4.30 -> 2026.7.1 ``                                          |
| [`108e2223`](https://github.com/NixOS/nixpkgs/commit/108e22238724b73f95b5512754a8c8b12d9ed049) | `` goshs: 2.1.3 -> 2.1.4 ``                                                                   |
| [`17e28d19`](https://github.com/NixOS/nixpkgs/commit/17e28d19248ce66d26562929c327b768871138ac) | `` python3Packages.iamdata: 0.1.202607021 -> 0.1.202607031 ``                                 |
| [`7d96dec2`](https://github.com/NixOS/nixpkgs/commit/7d96dec2c8c889fc7319520d38aafea0df125ad4) | `` neowall: 0.5.0 -> 0.5.1 ``                                                                 |
| [`994c1f3d`](https://github.com/NixOS/nixpkgs/commit/994c1f3d017712bec91cd1198b3ee8fb66fd3868) | `` sd-image-aarch64: support rpi5 ``                                                          |
| [`afacd7d0`](https://github.com/NixOS/nixpkgs/commit/afacd7d03f3cae63600e09277e4d9b7735514a53) | `` asn1c: 0.9.28 -> 0.9.29 ``                                                                 |
| [`0f6ad288`](https://github.com/NixOS/nixpkgs/commit/0f6ad288ba280acb6f28f453ae9f94a1a53d58b7) | `` immich-kiosk: 0.31.0 -> 0.39.3 ``                                                          |
| [`c35813ff`](https://github.com/NixOS/nixpkgs/commit/c35813ffd77ec1a1fc44a8b8fcf85a30aae6e295) | `` libphonenumber: 9.0.33 -> 9.0.34 ``                                                        |
| [`e91af37d`](https://github.com/NixOS/nixpkgs/commit/e91af37d4e094b7af9f06db7ab7f806c899b3ce7) | `` librewolf-bin-unwrapped: 152.0.2-1 -> 152.0.4-1 ``                                         |
| [`1086cde4`](https://github.com/NixOS/nixpkgs/commit/1086cde474c7d23bdb68106e711360e641bfdefb) | `` vscode-extensions.anthropic.claude-code: 2.1.198 -> 2.1.199 ``                             |
| [`ca6fb256`](https://github.com/NixOS/nixpkgs/commit/ca6fb256501adbf37fdf9c8253a3624c7022a057) | `` claude-code: 2.1.198 -> 2.1.199 ``                                                         |
| [`3be6deec`](https://github.com/NixOS/nixpkgs/commit/3be6deec5e0610f92ecea64dd082fc6f960c2b0e) | `` usbvfiod: 0.1.0 -> 0.2.0 ``                                                                |
| [`3062c171`](https://github.com/NixOS/nixpkgs/commit/3062c171a48ec954472f9ba6dbe30ac9e407eb75) | `` unifont: 17.0.04 -> 17.0.05 ``                                                             |
| [`544d585a`](https://github.com/NixOS/nixpkgs/commit/544d585a05017acdaf6148e6edf846c1eabc38ee) | `` orca-slicer: 2.4.0 -> 2.4.1 ``                                                             |
| [`cebb05c7`](https://github.com/NixOS/nixpkgs/commit/cebb05c799e96f6acdddd262a0e7c8c648ade52b) | `` todoist-cli: 1.75.2 -> 1.75.3 ``                                                           |
| [`b84977ec`](https://github.com/NixOS/nixpkgs/commit/b84977ec2a9aa8693fccc1925e8e2592b59b5a1c) | `` webdav: 5.11.11 -> 5.12.0 ``                                                               |
| [`dedef958`](https://github.com/NixOS/nixpkgs/commit/dedef95861092059b8cd43420ee5caa0c8e2717d) | `` tree-sitter: fix webUISupport build ``                                                     |
| [`95533ecf`](https://github.com/NixOS/nixpkgs/commit/95533ecf3d93fba9749df4808c2bf8ab6d12a904) | `` xaos: fix desktop file install ``                                                          |
| [`5f6aeca1`](https://github.com/NixOS/nixpkgs/commit/5f6aeca1d73ce7a6a0e903ac79f7e9cb738987e6) | `` anchor: 1.0.2 -> 1.1.2 ``                                                                  |
| [`4056e9ae`](https://github.com/NixOS/nixpkgs/commit/4056e9ae9e85c26b7d9e35df87c78a1b8222144f) | `` concord-tui: 2.2.7 -> 2.2.12 ``                                                            |
| [`509a095d`](https://github.com/NixOS/nixpkgs/commit/509a095d5fc707730cd25cea36fbadb8712da488) | `` wol: fix clang build with gnu17 flag ``                                                    |
| [`830489c0`](https://github.com/NixOS/nixpkgs/commit/830489c00f70682726bc59d914f84046a968f832) | `` pgdog: 0.1.46 -> 0.1.47 ``                                                                 |
| [`eb2e0707`](https://github.com/NixOS/nixpkgs/commit/eb2e0707be43829e43b66dfee161933753974b5b) | `` restate: 1.6.2 -> 1.7.0 ``                                                                 |
| [`4c447950`](https://github.com/NixOS/nixpkgs/commit/4c4479506c26bbb7e6ad482598384d8dcf63008e) | `` objfw: 1.5.5 -> 1.5.6 ``                                                                   |
| [`151a944e`](https://github.com/NixOS/nixpkgs/commit/151a944e8be2c11e86d8b9a892430205a4639e67) | `` nvidia-mig-parted: 0.14.2 -> 0.14.3 ``                                                     |
| [`92976f46`](https://github.com/NixOS/nixpkgs/commit/92976f467219d225816d836a365d533c6979de3a) | `` yaziPlugins.zoom: init at 0-unstable-2026-06-20 ``                                         |
| [`29d01066`](https://github.com/NixOS/nixpkgs/commit/29d010664662e3aaaeb64e16e079e71f6f42d0a8) | `` lima-full: 2.1.3 -> 2.1.4 ``                                                               |
| [`7493c1c2`](https://github.com/NixOS/nixpkgs/commit/7493c1c27d300414314aaffd48bddbbdd40a187e) | `` gh: 2.95.0 -> 2.96.0 ``                                                                    |
| [`bd6fb4b8`](https://github.com/NixOS/nixpkgs/commit/bd6fb4b88d2dce44e9b6086779b864d14614c62b) | `` treewide: remove redundant SETUPTOOLS_SCM_PRETEND_VERSION setters ``                       |
| [`4ae55400`](https://github.com/NixOS/nixpkgs/commit/4ae55400650b2acd7cf3f57a3d873f586531a2c2) | `` herdr: add darwin support, fix meta, and improve update script ``                          |
| [`053a7ddd`](https://github.com/NixOS/nixpkgs/commit/053a7dddb2e0461cae63213a51731c1839a3059f) | `` sif: 0-unstable-2026-06-23 -> 0-unstable-2026-07-03 ``                                     |
| [`b9c2759b`](https://github.com/NixOS/nixpkgs/commit/b9c2759bb5eda150eeb9a4bdff209144e41fc3a4) | `` mesa: fix build on Darwin ``                                                               |
| [`a9fab8e3`](https://github.com/NixOS/nixpkgs/commit/a9fab8e3b4186648e4a7c78e97bd281dc9e888b1) | `` go-passbolt-cli: 0.5.0 -> 0.5.1 ``                                                         |
| [`9d1bd701`](https://github.com/NixOS/nixpkgs/commit/9d1bd7016c5321eaa3135da107415408e35d60af) | `` kubernetes-helmPlugins.helm-unittest: add smoke passthru test ``                           |
| [`de8d75f0`](https://github.com/NixOS/nixpkgs/commit/de8d75f06f985e48422e9a6e111ddff6efe26a4f) | `` lightdm-slick-greeter: 2.2.6 -> 2.2.7 ``                                                   |
| [`9fa6dd7c`](https://github.com/NixOS/nixpkgs/commit/9fa6dd7cb9190bfee4d5bd1ecf45fff44d1dfe27) | `` gpclient: patch libexec fallback paths ``                                                  |
| [`741d9fe4`](https://github.com/NixOS/nixpkgs/commit/741d9fe43a26e7494b783634cddc9af69e6c8203) | `` breaktimer: Use electron 41 ``                                                             |
| [`820c4460`](https://github.com/NixOS/nixpkgs/commit/820c44602a62d8b7c0d1712ad5b72e14138ed132) | `` lagrange-tui: 1.20.8 -> 1.20.9 ``                                                          |
| [`6e8fd6e4`](https://github.com/NixOS/nixpkgs/commit/6e8fd6e43df180c83168010bd631d9d227fb4bd5) | `` ocamlPackages.aeneas: sync version on charon ``                                            |
| [`acf7edcb`](https://github.com/NixOS/nixpkgs/commit/acf7edcb2d111dd3de6a44a38bac1b0bb3fbdf05) | `` ocamlPackages.charon: 2026.06.22 -> 2026.07.01 ``                                          |
| [`4276bb8c`](https://github.com/NixOS/nixpkgs/commit/4276bb8c974d723a897b94451d50d777d7ebf652) | `` delta: generate latest shell completions ``                                                |
| [`9eff7cfc`](https://github.com/NixOS/nixpkgs/commit/9eff7cfc4c222166a964979724d8cd826c09913b) | `` maintainers: add nielmin ``                                                                |
| [`b647f021`](https://github.com/NixOS/nixpkgs/commit/b647f0216bbed044e3cac4a12f312f7a18a19a6b) | `` visual-paradigm-ce: 18.0.20260521 -> 18.1.20260623 ``                                      |
| [`37b5aa64`](https://github.com/NixOS/nixpkgs/commit/37b5aa645017f19911bbd5262a62224c0b2c5753) | `` python3Packages.pycaption: 2.2.23 -> 2.2.26 ``                                             |
| [`f961efa5`](https://github.com/NixOS/nixpkgs/commit/f961efa543454e1b71efae733c4196d6558d6c3a) | `` python311.pkgs.pip: fix eval ``                                                            |
| [`aa3aea32`](https://github.com/NixOS/nixpkgs/commit/aa3aea3241a4d392cec493cfcab73e05ca1003bf) | `` python3Packages.pyannote-audio: add undeclared pyyaml dependency ``                        |
| [`1c9a787a`](https://github.com/NixOS/nixpkgs/commit/1c9a787ac4b4b3c29d51bf5e9fb5e9df64b948f3) | `` vimPlugins.gitportal-nvim: update, moved to codeberg ``                                    |
| [`d42663c1`](https://github.com/NixOS/nixpkgs/commit/d42663c1e2cd886b499b53c5da581047909fcc90) | `` python3Packages.fake-http-header: init at 0.3.5-unstable-2025-07-09 ``                     |
| [`627d8c6c`](https://github.com/NixOS/nixpkgs/commit/627d8c6c4727313531bf418ee54a2504fbfc1400) | `` fluxcd: 2.8.8 -> 2.9.0 ``                                                                  |
| [`bf6a7649`](https://github.com/NixOS/nixpkgs/commit/bf6a764936d4680b57d667f41a9dca80ba3b3eae) | `` python3Packages.publicsuffixlist: 1.0.2.20260625 -> 1.0.2.20260702 ``                      |
| [`24a3c59b`](https://github.com/NixOS/nixpkgs/commit/24a3c59b412141826b3df39b9b19e92af0b8ab2f) | `` overturemaps: 0.20.0 -> 1.0.1 ``                                                           |
| [`afd9ab83`](https://github.com/NixOS/nixpkgs/commit/afd9ab832d2dd447f22d59161070005f2b4d154a) | `` cnspec: 13.27.0 -> 13.27.4 ``                                                              |
| [`cb50a58e`](https://github.com/NixOS/nixpkgs/commit/cb50a58e36c6b57ed12784bf66cac016f4a6fd1d) | `` nerva: 1.36.0 -> 1.37.0 ``                                                                 |
| [`53b95311`](https://github.com/NixOS/nixpkgs/commit/53b953115ba4e72bcf9c772b278bf647ca69cd86) | `` actual-server: 26.6.0 -> 26.7.0 ``                                                         |
| [`38302920`](https://github.com/NixOS/nixpkgs/commit/38302920594edea5695b3f3d09ff4a4591315369) | `` ddccontrol-db: 20260611 -> 20260702 ``                                                     |
| [`000a9048`](https://github.com/NixOS/nixpkgs/commit/000a904846b5100f4cfc6b3925c2fe4b315597ca) | `` python3Packages.awkward: 2.9.1 -> 2.10.0 ``                                                |
| [`1cc6bd3f`](https://github.com/NixOS/nixpkgs/commit/1cc6bd3fd0ee4fb3cbd93ba8c506626b1517cfc6) | `` python3Packages.awkward-cpp: 53 -> 54 ``                                                   |
| [`f8cbe1a7`](https://github.com/NixOS/nixpkgs/commit/f8cbe1a7c205a39f085846af9fbbb0269e4d74a8) | `` panache: 2.58.0 -> 2.60.0 ``                                                               |
| [`ccc62b2d`](https://github.com/NixOS/nixpkgs/commit/ccc62b2d76d639c1e496a9aa474072deedcfa6d2) | `` libretro.flycast: 0-unstable-2026-06-23 -> 0-unstable-2026-06-26 ``                        |
| [`f81690e6`](https://github.com/NixOS/nixpkgs/commit/f81690e6bfa65dd64b03150f29bf025a77aa6dde) | `` freecad: pick patch for coin3d 4.0.10 ``                                                   |
| [`e3799560`](https://github.com/NixOS/nixpkgs/commit/e37995605daecf2f5c321c00c71bcc965387ed79) | `` python3Packages.caido-sdk-client: init at 0.2.0 ``                                         |
| [`4ad209cd`](https://github.com/NixOS/nixpkgs/commit/4ad209cd88da495bafe0155b68017cf00644effd) | `` python3Packages.caido-schema-proxy: init at 0.57.0 ``                                      |
| [`35ab3d59`](https://github.com/NixOS/nixpkgs/commit/35ab3d593f1d82100734d52f5241b5408da73e36) | `` python3Packages.caido-server-auth: init at 0.1.2 ``                                        |
| [`2aceefaa`](https://github.com/NixOS/nixpkgs/commit/2aceefaa883b224f8a5986089e060973687b248c) | `` phpPackages.composer: 2.10.1 -> 2.10.2 ``                                                  |
| [`35f3e189`](https://github.com/NixOS/nixpkgs/commit/35f3e189a453b61656021a7fb7d0262f38a07f37) | `` xmage: 1.4.58-dev_2025-10-06_20-40 -> 1.4.60-dev_2-26-06-28_13-19 ``                       |
| [`0e7d2c46`](https://github.com/NixOS/nixpkgs/commit/0e7d2c4689ea854c0692d2081080e4680dd4beea) | `` gram: 2.2.0 -> 3.0.1 ``                                                                    |
| [`d6157477`](https://github.com/NixOS/nixpkgs/commit/d6157477703e6d9b9ecd47a4465343589ee78933) | `` i18next-cli: 1.64.1 -> 1.65.0 ``                                                           |
| [`41eb67d2`](https://github.com/NixOS/nixpkgs/commit/41eb67d2c8abd7f99f9b9b171727d33cfbdcf660) | `` slint-tr-extractor: 1.16.1 -> 1.17.0 ``                                                    |
| [`33223e67`](https://github.com/NixOS/nixpkgs/commit/33223e67c440e4e1a885dee343f3c663028f9115) | `` ollama: 0.30.7 -> 0.31.1 ``                                                                |
| [`646a7289`](https://github.com/NixOS/nixpkgs/commit/646a72895193a07057d0acddb7dd6ff5e8623a3a) | `` python3Packages.textual: 8.2.7 -> 8.2.8 ``                                                 |
| [`e8a74940`](https://github.com/NixOS/nixpkgs/commit/e8a749404b74343c22c5c94a570939b48b7c0dee) | `` shairport-sync-airplay2: 5.0.4 -> 5.1 ``                                                   |
| [`7f02913e`](https://github.com/NixOS/nixpkgs/commit/7f02913ea757bdb4c6e5eb3aca55c55ff363c0d6) | `` tev: 2.12.2 -> 2.13.0 ``                                                                   |
| [`021f28c2`](https://github.com/NixOS/nixpkgs/commit/021f28c292411f9a3ea3af45226c1c5bddce14ae) | `` malwoverview: 8.0.4 -> 8.0.5 ``                                                            |
| [`0a3e36da`](https://github.com/NixOS/nixpkgs/commit/0a3e36dab5e6a51d67992e9f35feea89e54ee391) | `` yek: 0.25.4 -> 0.25.5 ``                                                                   |
| [`669ae94b`](https://github.com/NixOS/nixpkgs/commit/669ae94b3827a3344ac119149358a41cfa6c3051) | `` python3Packages.tesla-fleet-api: 1.4.7 -> 1.5.1 ``                                         |
| [`2bfec925`](https://github.com/NixOS/nixpkgs/commit/2bfec9251e5871b424c879531e4763ad6fbc51dd) | `` vrcx: Use electron 41 ``                                                                   |
| [`7cb7e835`](https://github.com/NixOS/nixpkgs/commit/7cb7e835aa5e1ead2f5d4e5571941e0bdcc84e15) | `` freeoffice: 2024.1220 -> 2024.1234 ``                                                      |
| [`160afeb5`](https://github.com/NixOS/nixpkgs/commit/160afeb5630e9fad0b10f4293cfa57d7b55ea2df) | `` python3Packages.xonsh: 0.23.7 -> 0.24.0 ``                                                 |
| [`7416acd0`](https://github.com/NixOS/nixpkgs/commit/7416acd0d55d9408c7d3180bdd84022fe8fa5ff2) | `` beam29Packages.erlang: 29.0.2 -> 29.0.3 ``                                                 |
| [`71d10c24`](https://github.com/NixOS/nixpkgs/commit/71d10c2425df4d9798e2ad69c066e38b71eb5e8a) | `` beam28Packages.erlang: 28.5.0.2 -> 28.5.0.3 ``                                             |
| [`31c99738`](https://github.com/NixOS/nixpkgs/commit/31c99738268a27c5f5663b4e522b860a7400e521) | `` beam27Packages.erlang: 27.3.4.13 -> 27.3.4.14 ``                                           |
| [`2970e072`](https://github.com/NixOS/nixpkgs/commit/2970e07266cc964976e3210061af54e4e88fddbd) | `` hyprsunset: Enable separateDebugInfo ``                                                    |
| [`0b5763d6`](https://github.com/NixOS/nixpkgs/commit/0b5763d605cd081f1001cd29e6dc3f45c0fc341e) | `` hyprpaper: Enable separateDebugInfo ``                                                     |
| [`ff659d85`](https://github.com/NixOS/nixpkgs/commit/ff659d853bfec43dc24e16b7b04031c6ae559f33) | `` hypridle: Enable separateDebugInfo ``                                                      |
| [`235b0a64`](https://github.com/NixOS/nixpkgs/commit/235b0a649a3392bd5615e8c68e76ccc0160d6919) | `` hyprpicker: Don't strip debug builds and add separateDebugInfo otherwise ``                |
| [`dcfe551b`](https://github.com/NixOS/nixpkgs/commit/dcfe551ba991df55a846bc2414d0139710e2bec0) | `` xdg-desktop-portal-hyprland: Enable separateDebugInfo ``                                   |
| [`6f5c092b`](https://github.com/NixOS/nixpkgs/commit/6f5c092beaf0a4aedcfa1d711519115bec976cc6) | `` uwsm: 0.26.5 -> 0.26.6 ``                                                                  |
| [`22400349`](https://github.com/NixOS/nixpkgs/commit/22400349c0f611575356e9fb48a738c205581ce8) | `` m1n1: expose rustPlatform ``                                                               |
| [`3a113540`](https://github.com/NixOS/nixpkgs/commit/3a113540e022653e4c7ab58032573ff944d03dd6) | `` libgedit-gtksourceview: 299.7.0 -> 299.7.1 ``                                              |
| [`cb300c3c`](https://github.com/NixOS/nixpkgs/commit/cb300c3c71cfbaa3ce4df26f01d9cace9773c31c) | `` treewide: follow some GitHub redirects for `fetchFromGitHub` ``                            |
| [`8ab40bfc`](https://github.com/NixOS/nixpkgs/commit/8ab40bfc59d08686666524b3ea89129e5e31f1e8) | `` terraform-providers.hashicorp_google: 7.37.0 -> 7.39.0 ``                                  |
| [`a7dc04b8`](https://github.com/NixOS/nixpkgs/commit/a7dc04b8e09d6ba0c8430cdcc3b87ee2e29966b5) | `` lfk: 0.10.2 -> 0.14.19 ``                                                                  |
| [`cffd6449`](https://github.com/NixOS/nixpkgs/commit/cffd6449c85b3b0b8b4c338749f0c4f79aaba2cf) | `` vscode-extensions.github.codespaces: 1.18.13 -> 1.18.14 ``                                 |
| [`6ad40648`](https://github.com/NixOS/nixpkgs/commit/6ad406483bc5f7da4f356642f6897aa3b907f904) | `` git-spice: 0.29.2 -> 0.30.1 ``                                                             |
| [`c03414ca`](https://github.com/NixOS/nixpkgs/commit/c03414ca22b0b173b14055f74b6d078c42cc8dc1) | `` shogihome: fix build on darwin ``                                                          |
| [`ebe133d0`](https://github.com/NixOS/nixpkgs/commit/ebe133d0c583282fd34eaa59ab3883516d1b3006) | `` katvan: init at 0.12.1 ``                                                                  |
| [`dec8c3ab`](https://github.com/NixOS/nixpkgs/commit/dec8c3ab78b4c4e9449a0301a783e50a12238397) | `` lux-cli: 0.33.3 -> 0.35.0 ``                                                               |
| [`e69584ac`](https://github.com/NixOS/nixpkgs/commit/e69584ac86fda14a95426c1ea0c272edfe204bab) | `` python3Packages.wsdiscovery: fix hash ``                                                   |
| [`d95cdc9e`](https://github.com/NixOS/nixpkgs/commit/d95cdc9e2bc35ca632ae8d59a196f740673a8a1a) | `` cargo-codspeed: 5.0.0 -> 5.0.1 ``                                                          |
| [`3be1d06f`](https://github.com/NixOS/nixpkgs/commit/3be1d06f6d7f0a5dec618f98384f08430a968ee3) | `` hyprwire: Enable separateDebugInfo ``                                                      |
| [`c74c7bf9`](https://github.com/NixOS/nixpkgs/commit/c74c7bf9e49db3d9ef948fce50a3a4c37c2ed4f4) | `` hyprlock: Enable separateDebugInfo ``                                                      |
| [`335e15a7`](https://github.com/NixOS/nixpkgs/commit/335e15a79cad4617e78047d37116348c23518e71) | `` hyprlang: Enable separateDebugInfo ``                                                      |
| [`2baaf742`](https://github.com/NixOS/nixpkgs/commit/2baaf742c5937818e96dd8531bfd9844cf55f681) | `` hyprland-qtutils: Enable separateDebugInfo ``                                              |
| [`fb1ea5c4`](https://github.com/NixOS/nixpkgs/commit/fb1ea5c439c943d8561b25293a75c298bc73fc9d) | `` hyprgraphics: Enable separateDebugInfo ``                                                  |
| [`05f71f7d`](https://github.com/NixOS/nixpkgs/commit/05f71f7de4f48871f3845733a8d558fe08fe6805) | `` hyprcursor: Enable separateDebugInfo ``                                                    |
| [`8df44530`](https://github.com/NixOS/nixpkgs/commit/8df445308194ca6a3a978709184df030cbb41474) | `` hyprutils: Enable separateDebugInfo ``                                                     |
| [`f5e305c6`](https://github.com/NixOS/nixpkgs/commit/f5e305c6b2a9650bcd2c82ad948f2e9b1eb43b7a) | `` renderdoc: 1.44 -> 1.45 ``                                                                 |
| [`d0ebef36`](https://github.com/NixOS/nixpkgs/commit/d0ebef36dba75768f81edd10fde3116265d08cd0) | `` aquamarine: Enable separateDebugInfo ``                                                    |
| [`bfe091d1`](https://github.com/NixOS/nixpkgs/commit/bfe091d105fdb4f95cbeda4a26521615c6c45642) | `` hyprland: Enable separateDebugInfo ``                                                      |
| [`df745a3b`](https://github.com/NixOS/nixpkgs/commit/df745a3b2f9272b6607b6c280c88b68b22d9b7ef) | `` Revert "nixos/pipewire: minor refactor" ``                                                 |
| [`056ca617`](https://github.com/NixOS/nixpkgs/commit/056ca617d68b978a8b9377391615cfcffc9c827f) | `` phpactor: 2026.05.30.2 -> 2026.06.25.0 ``                                                  |
| [`af53f654`](https://github.com/NixOS/nixpkgs/commit/af53f654b196f4d3083a35463017ef31fff21e4a) | `` docker-compose: 5.2.0 -> 5.3.0 ``                                                          |
| [`45ce10c0`](https://github.com/NixOS/nixpkgs/commit/45ce10c079831fa3fbdc68cd79a59aa54b1d998a) | `` psysh: 0.12.23 -> 0.12.24 ``                                                               |
| [`024ad092`](https://github.com/NixOS/nixpkgs/commit/024ad092fe9e9fd2d2c3d847c8f7074eef0cb77c) | `` python3Packages.shodan: modernize ``                                                       |
| [`c196cfc8`](https://github.com/NixOS/nixpkgs/commit/c196cfc8dd5a507a880a1e1938e03939f2c0e836) | `` dawarich: 1.9.1 -> 1.9.2 ``                                                                |
| [`e4f7bfed`](https://github.com/NixOS/nixpkgs/commit/e4f7bfed18b5a9b5532cfbcab7f02df338e40545) | `` pkgs/nixos-render-docs: add sidebar-open and popover for mobile support ``                 |
| [`04bb933e`](https://github.com/NixOS/nixpkgs/commit/04bb933edfd72b0acf7a92364e08a33e5a82e758) | `` python3Packages.pyannote-audio: 4.0.5 -> 4.0.7 ``                                          |
| [`02709853`](https://github.com/NixOS/nixpkgs/commit/02709853357944fea7679fd27cf46ee149a766f7) | `` fastdds: 3.6.1 -> 3.6.2 ``                                                                 |
| [`1e061f68`](https://github.com/NixOS/nixpkgs/commit/1e061f681d644baad798f0ee8abbe01d44370ecf) | `` libmodbus: 3.1.12 -> 3.2.0 ``                                                              |

*... and 486 more commits (truncated)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the gh-dash setup to use standard browser behavior, avoiding suppressed browser output when opening items.
  * Added a temporary workaround for a Darwin documentation build issue by disabling the affected doc and uninstaller components.
  * Marked one upstream fix as completed and clarified rollback steps for another pending fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->