### PR TITLE
chore(flake/nixvim): `8a95c224` -> `4fd45857`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -838,11 +838,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1783214977,
-        "narHash": "sha256-0lkauQbtrljJqwtzTCILPAiHAJyMvn6XDo264moDv30=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6edbf1a6a03e75886a6609c088801a0856449e88",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -1016,11 +1016,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1783263374,
-        "narHash": "sha256-JM0KZ9qqavwQ0JMNfUUUk6FpXCLwWD5byad9j6hAWFU=",
+        "lastModified": 1783349931,
+        "narHash": "sha256-aYE76ATiGBg7/cQ2dHASRq97WvNum4OOIPgZ8xIK0QI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8a95c224e3a1b130ec5c18e612b80995e7b418ac",
+        "rev": "4fd45857deecb90d2732c87e0315daa48505515e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`4fd45857`](https://github.com/nix-community/nixvim/commit/4fd45857deecb90d2732c87e0315daa48505515e) | `` flake: Update ``                                                             |
| [`fee8f332`](https://github.com/nix-community/nixvim/commit/fee8f3328485fe7ef5885fbe156a2773fe205cbd) | `` modules/opts: docs on difference between opts, global opts and local opts `` |
| [`8f102380`](https://github.com/nix-community/nixvim/commit/8f102380abc462bb10a822bb784351d1e5ba4518) | `` docs/user-configs: update carl0xs url ``                                     |