### PR TITLE
chore(flake/catppuccin): `e3adb9b4` -> `cdc85139`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783068397,
-        "narHash": "sha256-B31MxW5os40h6NlnCUd+8fxresmVJlMnpYv2Kht0uWI=",
+        "lastModified": 1783525197,
+        "narHash": "sha256-BJYTl6uZ0PRzOjjxaPHnfEifkTwf63uXwWfjrplRoL0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "e3adb9b4815a3f934626626e6d6d1d8518717903",
+        "rev": "cdc85139e679f9764ec40abc0a157538e0ec93b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                          |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`cdc85139`](https://github.com/catppuccin/nix/commit/cdc85139e679f9764ec40abc0a157538e0ec93b1) | `` Revert "feat(home-manager/cursors): support global enable (#1000)" (#1001) `` |
| [`d88e830b`](https://github.com/catppuccin/nix/commit/d88e830b7bff7a591a49d031f6895312c15c27b1) | `` feat(home-manager/cursors): support global enable (#1000) ``                  |
| [`da2bb1bb`](https://github.com/catppuccin/nix/commit/da2bb1bb2ed82749c56b34f940e0af9339d72533) | `` feat(darwin): init (#477) ``                                                  |
| [`d01f92c2`](https://github.com/catppuccin/nix/commit/d01f92c2090c04c00319afea9e3c674abf533183) | `` chore(deps): update pnpm to v11.10.0 (#932) ``                                |
| [`f5563bfd`](https://github.com/catppuccin/nix/commit/f5563bfd49ed29d56c3a3e09989031b2eab7299d) | `` feat(home-manager): add support for clipse (#996) ``                          |
| [`cf1750da`](https://github.com/catppuccin/nix/commit/cf1750da1bdabcd549d2476f387d39e90bb20228) | `` chore: update deps (#998) ``                                                  |