### PR TITLE
chore(flake/home-manager): `a1645f40` -> `1aac8895`

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -135,6 +135,21 @@
       "tracking": ["https://github.com/NixOS/nixpkgs/pull/526476"],
       "workaround": "features/common/system/default.nix -- second `polkit.addRule` block granting fwupd refresh actions to the fwupd-refresh user (see the comment referencing NixOS/nixpkgs#526476).",
       "revert_action": "Once the merge commit of #526476 is contained in our pinned nixpkgs, remove the fwupd-refresh polkit rule block from features/common/system/default.nix and set `done: true`. NOTE: gated on the `nixpkgs` (unstable) input where the fix merged; if the affected hosts are on a different channel, retarget `pin_node` and confirm the fix is present there too."
+    },
+    {
+      "id": "catppuccin-nix-cursors-pointerCursor-enable",
+      "done": false,
+      "summary": "catppuccin's cursors home-manager module sets `home.pointerCursor` (name/package) without `home.pointerCursor.enable`, so home-manager falls back to its deprecated non-null-implies-enabled path and emits an `evaluation warning:` that fails our CI on desktops.",
+      "repo": "catppuccin/nix",
+      "check": "release-contains-commit",
+      "fix_commit": "0000000000000000000000000000000000000000",
+      "tracking": [
+        "https://github.com/catppuccin/nix/pull/1003",
+        "https://github.com/catppuccin/nix/pull/1000",
+        "https://github.com/catppuccin/nix/pull/1001"
+      ],
+      "workaround": "features/desktop/default.nix -- `home.pointerCursor.enable = true;` added to the per-user home-manager block alongside `catppuccin.cursors.enable = true;` (see FIXME(catppuccin-nix-cursors-pointerCursor-enable)).",
+      "revert_action": "BLOCKED intentionally until the fix ships. The fix is proposed in catppuccin/nix#1003 (head 5843e4f: sets `home.pointerCursor.enable = true;` in the cursors module's `config` block; verified locally against ~/GitHub/catnix to silence the warning on both desktops). It is NOT yet merged. `fix_commit` is a zero placeholder so `release-contains-commit` can never falsely resolve. WHEN #1003 MERGES: set `fix_commit` to its merge commit sha; the checker then resolves once catppuccin's latest release contains it. THEN delete the `home.pointerCursor.enable = true;` line + its FIXME from features/desktop/default.nix, eval the desktop hosts to confirm no `evaluation warning:`, and set `done: true`. History: the earlier attempt #1000 was reverted by #1001 and never set `.enable` regardless."
     }
   ]
 }

--- a/features/desktop/default.nix
+++ b/features/desktop/default.nix
@@ -100,6 +100,16 @@ in
 
     home-manager.users = lib.genAttrs allUsers (_: {
       catppuccin.cursors.enable = true;
+      # FIXME(catppuccin-nix-cursors-pointerCursor-enable): WORKAROUND, not a
+      # fix. The catppuccin cursors home-manager module sets `home.pointerCursor`
+      # (name/package) without setting `home.pointerCursor.enable`, so
+      # home-manager falls back to its deprecated "non-null implies enabled"
+      # path and emits an `evaluation warning:` that fails our CI. Setting
+      # `.enable` explicitly here silences it. Upstream fix in flight:
+      # catppuccin/nix#1003. Delete this line once that lands in a catppuccin
+      # release our flake follows. Tracked by
+      # .github/workflows/track-upstream-fixes.yaml.
+      home.pointerCursor.enable = true;
     });
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783222121,
-        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
+        "lastModified": 1783525612,
+        "narHash": "sha256-OEFYdbtG6Qy04KGteknnrx15Uo2XXkYVuUvBvFNEn+Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
+        "rev": "1aac8895fea6fcabc6a0184c63a80fb2f99fd208",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`1aac8895`](https://github.com/nix-community/home-manager/commit/1aac8895fea6fcabc6a0184c63a80fb2f99fd208) | `` home-cursor: warn before removing implicit enable ``                          |
| [`cee3f0e7`](https://github.com/nix-community/home-manager/commit/cee3f0e7fec85d80c149c7afc29926747f7bd3c2) | `` yubikey-agent: switch to gui domain for hardware key PIN prompts ``           |
| [`7a62d637`](https://github.com/nix-community/home-manager/commit/7a62d637072e1f5609fac7031b287e1adfd26771) | `` gpg-agent: switch to gui domain for graphical pinentry support ``             |
| [`53ebbdc4`](https://github.com/nix-community/home-manager/commit/53ebbdc405acc04acd9bb73ccca462b51ddb8c6d) | `` proton-pass-agent: switch to gui domain to prevent error accessing keyring `` |
| [`2ad49968`](https://github.com/nix-community/home-manager/commit/2ad49968c36044ff10bffc515dc687ea00b4d609) | `` home-cursor: remove legacy enable ``                                          |
| [`3c6f1244`](https://github.com/nix-community/home-manager/commit/3c6f1244ed6b26e40763bd72b1d9af6e908abe41) | `` firefox: allow setting persistent StoreID ``                                  |
| [`f09af494`](https://github.com/nix-community/home-manager/commit/f09af49406ffad37acb6538d3207189a1a1e0b7e) | `` opencode: assume most recent version when `package=null` ``                   |
| [`cd863288`](https://github.com/nix-community/home-manager/commit/cd863288d41a5025dd610faf17816227274dd467) | `` codex: stop duplicating hook script deployment ``                             |
| [`52f93adb`](https://github.com/nix-community/home-manager/commit/52f93adbac32fb52d4a8152ae0a7270d4109cb2d) | `` walker: fix systemd dependency cycle with elephant ``                         |
| [`16acb8c7`](https://github.com/nix-community/home-manager/commit/16acb8c7ffd899b71d7117bdab6e73df76d0b604) | `` maintainers: add ratakor to walker & elephant ``                              |
| [`8de7488a`](https://github.com/nix-community/home-manager/commit/8de7488af203647190a878d76b34f95c5998e07c) | `` elephant: fix service unit ``                                                 |
| [`ed10fd39`](https://github.com/nix-community/home-manager/commit/ed10fd394e75fce260fede1a9976f611d5fc488b) | `` clipse: support store paths for theme option ``                               |
| [`63d02d1c`](https://github.com/nix-community/home-manager/commit/63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6) | `` attic-client: init module ``                                                  |
| [`0d33882b`](https://github.com/nix-community/home-manager/commit/0d33882bd46c1f9ef62276700f5e5f2bd6ff6604) | `` codex: support path-backed hooks ``                                           |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated desktop cursor settings so the pointer cursor is explicitly enabled, improving cursor behavior in user sessions.
  * Added tracking for an upstream-related fix to ensure the workaround can be safely removed once the issue is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->