### PR TITLE
chore(flake/freminal): `c82fe8e6` -> `5a8b3fb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1782915266,
-        "narHash": "sha256-BKHY5H2pFtApomJnzxYFqBlqoHnw7FO5Frc9TXQIwtU=",
+        "lastModified": 1783551425,
+        "narHash": "sha256-dCgqQaxawB1G651lYD8zEhrtev5C8KrgG0fNsZRUD/8=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "c82fe8e64f93ad160f01e1a252dc8f5793e6c789",
+        "rev": "5a8b3fb9b7533629579c93c69ba0e1b5de82d753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`dbe69de4`](https://github.com/fredsystems/freminal/commit/dbe69de46284088acc55820b65065b55ca4ef594) | `` docs: add freminal-windows-crosscheck skill; mandate check-windows before PR ``                       |
| [`0ab5e83a`](https://github.com/fredsystems/freminal/commit/0ab5e83a787f11f55bc95954394505c454dd379f) | `` fix: use platform-absolute path in kitty nonexistent-file test ``                                     |
| [`14ccd7ca`](https://github.com/fredsystems/freminal/commit/14ccd7caefaba745f3622c7185ccc7a801f3cc2c) | `` feat(xtask): add Windows cross-check via mingw toolchain in dev shell ``                              |
| [`db353fa9`](https://github.com/fredsystems/freminal/commit/db353fa9b92160fb4950ffe5f3412f2cc2328a66) | `` fix(portable-pty): capture Send handle wrapper whole in waiter closure ``                             |
| [`4caf44df`](https://github.com/fredsystems/freminal/commit/4caf44df1fd36e0637bb29bd566d6d98dd00fa04) | `` fix: drop redundant clone in Windows kitty shm round-trip test ``                                     |
| [`3a7c7505`](https://github.com/fredsystems/freminal/commit/3a7c7505f3b1634395de4b1c4630128658782399) | `` chore(portable-pty): bump to 0.9.2, adopt workspace edition (2024) ``                                 |
| [`1a043aa5`](https://github.com/fredsystems/freminal/commit/1a043aa535907bca99bd03aafeb1e4e50f69c244) | `` ci: drop nightly from the check matrix (stable + MSRV only) ``                                        |
| [`745145a1`](https://github.com/fredsystems/freminal/commit/745145a1f04bf4fdf3dd58aeda032d26543962a2) | `` fix: resolve Windows-only clippy lints in vendored portable-pty ``                                    |
| [`1a702b5e`](https://github.com/fredsystems/freminal/commit/1a702b5e1171f1f7ff39c710ede5760f14e8e0bb) | `` fix: resolve clippy lints in macOS/Windows read_cwd path ``                                           |
| [`05666941`](https://github.com/fredsystems/freminal/commit/056669411cd8c71ef119cb7a71bf253f6d39239d) | `` ci: install clippy component for pinned-version toolchains in check matrix ``                         |
| [`c32e98fe`](https://github.com/fredsystems/freminal/commit/c32e98fe9139a2788a28322617b25fbdc09f2954) | `` ci: make cargo xtask check a fail-on-warning clippy gate ``                                           |
| [`d5c925ed`](https://github.com/fredsystems/freminal/commit/d5c925ede9a78141378e7b9c9790461b1cdea337) | `` fix: scope OSC 99 report-builder dead-code allow to macOS and Windows ``                              |
| [`6bc306fb`](https://github.com/fredsystems/freminal/commit/6bc306fb5c995f8fe25229fdadec96f9919dfa78) | `` fix: gate XDG_DATA_DIRS shell-integration lookup to Unix ``                                           |
| [`2b387e8b`](https://github.com/fredsystems/freminal/commit/2b387e8b178231a880eb3c0234ff878597649fdb) | `` ci: run test suite natively on macOS, Windows, and Linux matrix ``                                    |
| [`50634bbf`](https://github.com/fredsystems/freminal/commit/50634bbf59ce67ba9d6d6902789a894d28d72bed) | `` fix: shorten test shm-object names to fit macOS 31-char limit ``                                      |
| [`18e0edcd`](https://github.com/fredsystems/freminal/commit/18e0edcdf3fdcf83e58da7dcdada305589dcf346) | `` fix: address CodeRabbit review on PR #383 (Task 117) ``                                               |
| [`c67984bf`](https://github.com/fredsystems/freminal/commit/c67984bf6a3c0fe13653fdb732c9fcd5a65eaaaa) | `` docs: mark v0.11.1 (Tasks 115-117) complete in MASTER_PLAN ``                                         |
| [`90b90230`](https://github.com/fredsystems/freminal/commit/90b9023040759be3076741af562de70ec6edb441) | `` chore: bump version 0.11.0 -> 0.11.1 ``                                                               |
| [`0c10fe2d`](https://github.com/fredsystems/freminal/commit/0c10fe2da7e3d9570d42e2d32c8f2544c7a4368a) | `` docs: 115.4 -- mark DECSCNM cell-level reverse video complete ``                                      |
| [`2c1d70e8`](https://github.com/fredsystems/freminal/commit/2c1d70e875e99b0f19d470a7b7c5a81daa5738ac) | `` fix: 115.1 + 115.2 + 115.3 -- DECSCNM per-pane, per-cell reverse video ``                             |
| [`a3ab9f9d`](https://github.com/fredsystems/freminal/commit/a3ab9f9d2b1e43c092236673a1d5fa3f4a67bae2) | `` fix: 116.1 + 116.2 + 116.3 + 116.4 -- text selection release/stuck fixes ``                           |
| [`68516e14`](https://github.com/fredsystems/freminal/commit/68516e1415a25f3f27fbcf290a1496fedf420409) | `` docs: 117.4 -- mark DECSCNM-adjacent SU/SD/DECDWL gaps closed in escape-sequence docs ``              |
| [`047cb826`](https://github.com/fredsystems/freminal/commit/047cb8268e65ac014026d9a24de1222957afbc20) | `` fix: 117.1 + 117.2 + 117.5 -- DECDWL/DECDHL half-width wrap and DECSLRM scroll confinement ``         |
| [`25d29f59`](https://github.com/fredsystems/freminal/commit/25d29f596a9c01ecd0a24415542466970368a8c2) | `` More docs + cargo lock ``                                                                             |
| [`23999c84`](https://github.com/fredsystems/freminal/commit/23999c84a16dc311abecbd3c2b6734ddaf055872) | `` Update version ``                                                                                     |
| [`48cada0f`](https://github.com/fredsystems/freminal/commit/48cada0f44f891afbdce198992682333d5cb53db) | `` Update cargo deps ``                                                                                  |
| [`6ce424fb`](https://github.com/fredsystems/freminal/commit/6ce424fbc6fcbdb9ab0e230943290f5af26f48ae) | `` Update docs ``                                                                                        |
| [`b2c27f9d`](https://github.com/fredsystems/freminal/commit/b2c27f9d196bba7e8c520e4943d47e842bdb478c) | `` fix: Kitty image data persists across scroll-out (PR #382 review) ``                                  |
| [`d04dd0b9`](https://github.com/fredsystems/freminal/commit/d04dd0b98ec0de161d8e2bcb3b70917b096e4d34) | `` fix: raw-key drain correctness for egui-blocked keys (PR #382 review) ``                              |
| [`c833fe94`](https://github.com/fredsystems/freminal/commit/c833fe94672d35165352a55f5fec808134aafa17) | `` fix: bound image animation catch-up loop per tick (PR #382 review) ``                                 |
| [`70d1887f`](https://github.com/fredsystems/freminal/commit/70d1887f4c77f7e05448fcb2a2cad6502015cdec) | `` fix: harden OSC 99 notifications against untrusted input (PR #382 review) ``                          |
| [`883a9047`](https://github.com/fredsystems/freminal/commit/883a90470db47d1f12f21fc2ce368506a0ff8041) | `` fix: kitty graphics placement/quota correctness (PR #382 review) ``                                   |
| [`bfd3dd16`](https://github.com/fredsystems/freminal/commit/bfd3dd16da1205d7edaadc5467d94fdc7c47c171) | `` Document updates for 0.11 ``                                                                          |
| [`02bc6d97`](https://github.com/fredsystems/freminal/commit/02bc6d97f14f0fcdaa583b23dd753e6f00f7dccd) | `` docs(v0.11.0): cite freminal#380 tracking issue for reverted lock-state ``                            |
| [`a001a636`](https://github.com/fredsystems/freminal/commit/a001a636b5a428473c1a69fe5cae23441b5a819f) | `` docs(v0.11.0): revert lock-state claims; document the reverted gap + upstream tracking ``             |
| [`4d1a8fb1`](https://github.com/fredsystems/freminal/commit/4d1a8fb14264cfc1cf0eadeb61382472b3bead3b) | `` revert(v0.11.0): remove kitty lock-state work, keep keypad/media delivery ``                          |
| [`9d59cef7`](https://github.com/fredsystems/freminal/commit/9d59cef7126b217d03f8812df7d402d8986fc618) | `` docs(v0.11.0): 114.10 -- mark Task 114 complete ``                                                    |
| [`e7e88e15`](https://github.com/fredsystems/freminal/commit/e7e88e15803ce50b99cfafeda33979ec3a78e98f) | `` docs(v0.11.0): 114.9 -- escape-sequence dual-doc + reference update for Task 114 ``                   |
| [`5f37d7cf`](https://github.com/fredsystems/freminal/commit/5f37d7cfd21e037be2af45c7482d76cc46cd9634) | `` feat(v0.11.0): 114.8 -- clear held-key tracking on focus-loss ``                                      |
| [`ef55fd5a`](https://github.com/fredsystems/freminal/commit/ef55fd5afb1741a3c2c1fa6274dfd2e1d5493070) | `` feat(v0.11.0): 114.7 -- encode egui-blocked raw keys to the active pane ``                            |
| [`1e68d250`](https://github.com/fredsystems/freminal/commit/1e68d2505cb7bfa0a3e86713c41c272c13b6d2bb) | `` docs(v0.11.0): 114.7 architecture decision -- queue raw keys, encode at render time ``                |
| [`428d4983`](https://github.com/fredsystems/freminal/commit/428d49836759e890d8b207c18a6f31d144e48732) | `` docs(v0.11.0): 114.7 execution notes from 114.5 review ``                                             |
| [`8e3b8c44`](https://github.com/fredsystems/freminal/commit/8e3b8c44976e8bdfca05cfd4b9f5d4652dc5d518) | `` feat(v0.11.0): 114.5 -- App::on_raw_key_event delivery seam + narrow winit intercept ``               |
| [`9bb470d7`](https://github.com/fredsystems/freminal/commit/9bb470d79536dd4b5005f635c9b70475724afb2d) | `` feat(v0.11.0): 114.6 -- kitty functional-key codepoint tables ``                                      |
| [`a3288519`](https://github.com/fredsystems/freminal/commit/a3288519e5ff83ad3a6019e7cdada49779bceaa6) | `` feat(v0.11.0): 114.4 -- wire ambient lock state into KeyModifiers ``                                  |
| [`4ea9dcde`](https://github.com/fredsystems/freminal/commit/4ea9dcde0bde883df08869b41aadc0b7be312de1) | `` docs(v0.11.0): 114.4 execution decisions -- GUI-layer requery, per-window cache ``                    |
| [`3c043780`](https://github.com/fredsystems/freminal/commit/3c0437809a5158cb00c2400f3d702c8a97acbddb) | `` feat(v0.11.0): 114.3 -- macOS CGEventSourceFlagsState caps-lock query ``                              |
| [`527daf62`](https://github.com/fredsystems/freminal/commit/527daf6267c50be40f8d16129a7d12803b71ea4f) | `` feat(v0.11.0): 114.2 -- Windows GetKeyState lock-state query ``                                       |
| [`0e5c802f`](https://github.com/fredsystems/freminal/commit/0e5c802faf0b5af9116cdf326ae48a027c6dc1e1) | `` feat(v0.11.0): 114.1 -- Linux evdev lock-state query ``                                               |
| [`a84b18aa`](https://github.com/fredsystems/freminal/commit/a84b18aae1a26f4bad58e84e28706788bbfd1e97) | `` docs(v0.11.0): activate Task 114 -- decompose egui-blocked keyboard keys ``                           |
| [`7c3b7238`](https://github.com/fredsystems/freminal/commit/7c3b723886f2f03f3d34eecf32ab807a41ba1643) | `` docs(v0.11.0): mark Task 101 complete in plan + master tracking ``                                    |
| [`8d3e64d8`](https://github.com/fredsystems/freminal/commit/8d3e64d8fd8b7605a15f539fc3120b45c52a20da) | `` docs(v0.11.0): 101.4 -- record kitty keyboard encoding-only compliance ``                             |
| [`0c20cfca`](https://github.com/fredsystems/freminal/commit/0c20cfcae74192a8297760448c90e006fdace75e) | `` feat(v0.11.0): 101.3 -- KKP F13-F35, modifier-keys-as-keys, F3 normalization ``                       |
| [`04c61ce4`](https://github.com/fredsystems/freminal/commit/04c61ce4891513c3203d5b624702369379876527) | `` feat(v0.11.0): 101.2 -- populate kitty keyboard super modifier bit ``                                 |
| [`d045cd63`](https://github.com/fredsystems/freminal/commit/d045cd63191629e4a26c64856b5aafa3dda4bc5c) | `` bump cargo versions and freminal version ``                                                           |
| [`ea02c70f`](https://github.com/fredsystems/freminal/commit/ea02c70f1d79497278dae49e81004aa20358906d) | `` Update docs ``                                                                                        |
| [`d780c6f1`](https://github.com/fredsystems/freminal/commit/d780c6f1f66b2ef6e5f5348ba6e7b075fc31b860) | `` docs(v0.11.0): reconcile graphics done-list after render-path fixes ``                                |
| [`10bd846e`](https://github.com/fredsystems/freminal/commit/10bd846e9c704085089532a381fec20ecb7019ee) | `` docs(v0.11.0): 100.18-100.20 -- record execution decisions ``                                         |
| [`2370b84f`](https://github.com/fredsystems/freminal/commit/2370b84f2bf9462c136f6770083b996eebc77675) | `` fix(v0.11.0): 100.18 + 100.19 + 100.20 -- per-placement identity, X/Y offset, edge gaps ``            |
| [`37f789b9`](https://github.com/fredsystems/freminal/commit/37f789b9f2f888e9a183f9a49f5c7f0d2c288c3b) | `` docs(v0.11.0): 100.18-100.20 -- track per-placement identity + X/Y offset + edge gaps ``              |
| [`8a9d42ef`](https://github.com/fredsystems/freminal/commit/8a9d42ef7560acb9f2f60f4999261130d8c6fbe1) | `` feat(v0.11.0): 100.17b -- render NativePixels images at native size ``                                |
| [`64fdd98f`](https://github.com/fredsystems/freminal/commit/64fdd98fcc54c9983fa320f33dc99317904afe58) | `` feat(v0.11.0): 100.17a -- add ImageSizeMode to InlineImage (all protocols) ``                         |
| [`5ce2fcb3`](https://github.com/fredsystems/freminal/commit/5ce2fcb377ec89a69513bcc29ddc78f32084179a) | `` docs(v0.11.0): 100.17 -- track cross-protocol native-pixel image sizing bug ``                        |
| [`dc487377`](https://github.com/fredsystems/freminal/commit/dc4873774d0bcff47a3cccb5143510dcd683d7f3) | `` docs(v0.11.0): 100.15 + 100.16 -- track shared-root-cause image bug + C=1 gap ``                      |
| [`091b1caa`](https://github.com/fredsystems/freminal/commit/091b1caa4dce455c3b8f59355f9be01e22e04f6a) | `` fix(v0.11.0): 100.15 + 100.16 -- keep displayed images alive; honour C=1 on a=T ``                    |
| [`bf15236d`](https://github.com/fredsystems/freminal/commit/bf15236de48bc10b3c433eff4ab31e704c54240a) | `` docs(v0.11.0): 100.12 + 100.14 -- record live-bug fix execution decisions ``                          |
| [`f7d77ac2`](https://github.com/fredsystems/freminal/commit/f7d77ac282b3d0fbb012c2f599a8c883304a4d0b) | `` fix(v0.11.0): 100.12 -- force rebuild on store-only image pixel mutation ``                           |
| [`004d2eb2`](https://github.com/fredsystems/freminal/commit/004d2eb2a6c0f901f942c8d03158f0b41ab8ff00) | `` fix(v0.11.0): 100.14 -- record real-placement origin post-scrollback-drain ``                         |
| [`9130298f`](https://github.com/fredsystems/freminal/commit/9130298f701cdf032d03aa66fc6f273a10c96acc) | `` docs(v0.11.0): 100.11-100.14 -- track live graphics render bugs ``                                    |
| [`4561a275`](https://github.com/fredsystems/freminal/commit/4561a2753d050807241c837fb4071c804aa889fa) | `` graphics ``                                                                                           |
| [`a5a14778`](https://github.com/fredsystems/freminal/commit/a5a14778925c2087c0e39e79ca5e2dce5ede8493) | `` feat(v0.11.0): 100.10 -- Windows t=s shared memory (winapi file-mapping) ``                           |
| [`999b9ddf`](https://github.com/fredsystems/freminal/commit/999b9ddffba2cd0b982289a1b8f08a639ff8ee59) | `` feat(v0.11.0): 100.9 -- apply kitty a=p source-rect crop (x/y/w/h) ``                                 |
| [`2ad58713`](https://github.com/fredsystems/freminal/commit/2ad587133caa0670dc6726767f83ea1fac6da29b) | `` docs(v0.11.0): 100.8 -- kitty graphics escape-sequence dual-doc + reference refresh ``                |
| [`110ae7ea`](https://github.com/fredsystems/freminal/commit/110ae7ea754493b58a02584cdb2d54c5cbc64d1d) | `` feat(v0.11.0): 100.7b -- render kitty image quads in z-index order ``                                 |
| [`55e249bf`](https://github.com/fredsystems/freminal/commit/55e249bfb841d2f67bec37f71283bcb46ecb4553) | `` feat(v0.11.0): 100.7a -- kitty image delete-target correctness ``                                     |
| [`eb66d9d9`](https://github.com/fredsystems/freminal/commit/eb66d9d9f45bb14e007928c7672cb524b2fef3b5) | `` feat(v0.11.0): 100.6 -- kitty graphics t=s shared memory + o=z zlib + O= offset ``                    |
| [`b8b39e55`](https://github.com/fredsystems/freminal/commit/b8b39e555426879d8fa703c374004418795234dd) | `` feat(v0.11.0): 100.5 -- kitty graphics storage quotas + LRU eviction ``                               |
| [`a3e29d50`](https://github.com/fredsystems/freminal/commit/a3e29d505885e6ef1d8abaf6a465319c34c9edd7) | `` feat(v0.11.0): 100.4b -- relative placements follow a virtual (placeholder) parent ``                 |
| [`1dfd82eb`](https://github.com/fredsystems/freminal/commit/1dfd82ebce66091b2ea544d7714791354447d1bd) | `` feat(v0.11.0): 100.4a -- kitty relative placements (registry, validation, real-parent positioning) `` |
| [`6c822052`](https://github.com/fredsystems/freminal/commit/6c8220522f16d91d921ac1f3f30dac1e70598ffb) | `` fix(v0.11.0): 100.4.0 -- keep image rectangles intact under reflow ``                                 |
| [`f2c08209`](https://github.com/fredsystems/freminal/commit/f2c082097c73c02e85693706af54f7a874bf2e0f) | `` feat(v0.11.0): 100.3 -- kitty graphics image-number (I=) reference-by-number ``                       |
| [`f48ac368`](https://github.com/fredsystems/freminal/commit/f48ac368942b9336d4600eca44b9f20dab79f80c) | `` feat(v0.11.0): 100.2c -- GUI wall-clock animation frame selector + renderer ``                        |
| [`17e1f28b`](https://github.com/fredsystems/freminal/commit/17e1f28bc301ffca9cd88704d7598a1c6d15b20c) | `` feat(v0.11.0): 100.2b -- kitty graphics animation handler (a=f/a=a/a=c) ``                            |
| [`b8ca4016`](https://github.com/fredsystems/freminal/commit/b8ca4016811e47948efacf38211909ca26226c14) | `` feat(v0.11.0): 100.2a -- kitty graphics frame model + response p= gap ``                              |
| [`f02ee13d`](https://github.com/fredsystems/freminal/commit/f02ee13d0adf62ff280a664c91304378054e71f7) | `` chore: use claude-sonnet-5 for opencode sub-agents ``                                                 |
| [`ce27be8e`](https://github.com/fredsystems/freminal/commit/ce27be8e0a782a5b1db33a758631dc4f5c86e3ca) | `` test(v0.11.0): 99 -- OSC 99 manual exerciser script ``                                                |
| [`da6dd0e5`](https://github.com/fredsystems/freminal/commit/da6dd0e5e7964315e83bfb5cd8b731e81bea8650) | `` feat(v0.11.0): 99.8 -- OSC 99 config kill-switch gate + escape-sequence docs ``                       |
| [`e08f2965`](https://github.com/fredsystems/freminal/commit/e08f29653b7aff6cd77530eaadf24124964dd4ed) | `` feat(v0.11.0): 99.7 -- OSC 99 p=? capability handshake (truthful advertisement) ``                    |
| [`c5101394`](https://github.com/fredsystems/freminal/commit/c51013940c9df528fb65a84f85ade33a45fa28b9) | `` feat(v0.11.0): 99.5b+99.6 -- OSC 99 reverse reports (activation/close/alive) ``                       |
| [`c008a26a`](https://github.com/fredsystems/freminal/commit/c008a26afd792356b30b02cecfec4d6aa2c1cbcf) | `` feat(v0.11.0): 99.5c -- OSC 99 reverse-path prerequisites (control variant + pane-tx) ``              |
| [`d5b7c988`](https://github.com/fredsystems/freminal/commit/d5b7c988b6de182382c722dd77a37c4e49ecc1d8) | `` feat(v0.11.0): 99.5a -- render OSC 99 notifications (toast + OS, no handle retention) ``              |
| [`512ad6c2`](https://github.com/fredsystems/freminal/commit/512ad6c2cb6cbaae8698e79b3503c176f7210bc5) | `` feat(v0.11.0): 99.9 -- OSC 99 button-label extraction (cleanup from 99.4) ``                          |
| [`32204c47`](https://github.com/fredsystems/freminal/commit/32204c47e206bdb5cf1597c0ff5a0cbf44f509ff) | `` feat(v0.11.0): 99.4 -- emit OSC 99 as WindowManipulation::Notification99 ``                           |
| [`384d64b7`](https://github.com/fredsystems/freminal/commit/384d64b7f2b91a22dbb1527321ab3735a599386a) | `` feat(v0.11.0): 99.3 -- OSC 99 notification identity + chunk reassembly state ``                       |
| [`c9598970`](https://github.com/fredsystems/freminal/commit/c9598970bb0669e3c30ff2702b21de6f7841a56b) | `` feat(v0.11.0): 99.2 -- OSC 99 dispatch wiring (parse path only) ``                                    |
| [`51551e4b`](https://github.com/fredsystems/freminal/commit/51551e4bb7caebe5ce3882377fe3c1703dc6787b) | `` feat(v0.11.0): 99.1 -- OSC 99 metadata parser + typed command in freminal-common ``                   |
| [`29e06943`](https://github.com/fredsystems/freminal/commit/29e06943f08a53a5aa5c73b8e1c801165dc97c02) | `` feat(v0.11.0): 110.0 -- shared foundation type shells for kitty v0.11.0 ``                            |
| [`7e9fb7cc`](https://github.com/fredsystems/freminal/commit/7e9fb7cc089e5aa9e155237ccb43e61f29e9e044) | `` docs(v0.11.0): fold audit findings into plan (100.1/101.1/99-seam) ``                                 |
| [`b5c53ead`](https://github.com/fredsystems/freminal/commit/b5c53eadbfa5092512f73ab3fcd5c088187484c0) | `` docs(v0.11.0): add shared-foundation subtask 110.0 + branch/parallelism model ``                      |
| [`505db334`](https://github.com/fredsystems/freminal/commit/505db33493a4b34064781f7be28ba03debf9ead1) | `` Document updates for 0.11 ``                                                                          |