### PR TITLE
chore(flake/darwin): `a1fa429e` -> `d5bd9cd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`b2217f80`](https://github.com/nix-darwin/nix-darwin/commit/b2217f80511506e60d5100a53b22433fd1c5c220) | `` flake.lock: Update ``                        |
| [`320cbf53`](https://github.com/nix-darwin/nix-darwin/commit/320cbf535b80ffde6c1dbe2f80e29c791e84f494) | `` manualHTML: adopt to nixos/nixpkgs#537810 `` |