### PR TITLE
chore(flake/nixpkgs-stable): `a50de1b7` -> `0ad6f47e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -790,11 +790,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1783148766,
-        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`a55147f9`](https://github.com/NixOS/nixpkgs/commit/a55147f91bfad8dbe3dc144249ae10a70c053184) | `` podman-desktop: remove obsolete workaround ``                             |
| [`76339b3e`](https://github.com/NixOS/nixpkgs/commit/76339b3ea964b9843b5040d964a9a7b41cc12d37) | `` maintainers/github-teams.json: Automated sync ``                          |
| [`6962c72f`](https://github.com/NixOS/nixpkgs/commit/6962c72f2e397b4cdeeca721c41c804dbfa41fdc) | `` rlottie: 0.2-unstable-2025-10-01 -> 0.2-unstable-2026-07-03 ``            |
| [`07bdbb19`](https://github.com/NixOS/nixpkgs/commit/07bdbb193d2ca66f57b08d41e80500445f2617a7) | `` miniz: 3.1.1 -> 3.1.2 ``                                                  |
| [`27b2adf0`](https://github.com/NixOS/nixpkgs/commit/27b2adf0e070396f8c9d6c4ea8f756250a88a366) | `` gopher64: fix build on aarch64-linux ``                                   |
| [`e8a45b7c`](https://github.com/NixOS/nixpkgs/commit/e8a45b7c597f205c5c8a6567fe5da735fa5d671f) | `` electrum: 4.7.2 -> 4.8.0 ``                                               |
| [`eb16254d`](https://github.com/NixOS/nixpkgs/commit/eb16254dfda3fe90d0afbf2115d1064e76eb60df) | `` weechat-unwrapped: 4.9.1 -> 4.9.2 ``                                      |
| [`d1db9a2e`](https://github.com/NixOS/nixpkgs/commit/d1db9a2e8122a0bb07094515178be7e1189f729b) | `` frigate: 0.17.1 -> 0.17.2 ``                                              |
| [`003598b5`](https://github.com/NixOS/nixpkgs/commit/003598b5caf0d97aa3eb0a17e00af504c2be1a37) | `` cargo-tarpaulin: 0.35.5 -> 0.36.0 ``                                      |
| [`44689001`](https://github.com/NixOS/nixpkgs/commit/44689001f1e8f62b1bcef9e8fec0722c4a9609f1) | `` linux_testing: 7.2-rc1 -> 7.2-rc2 ``                                      |
| [`19411a96`](https://github.com/NixOS/nixpkgs/commit/19411a968b5688d957181c04824486516ea8aa9c) | `` doc/javascript.section: recommend fetcherVersion 4 ``                     |
| [`5e014993`](https://github.com/NixOS/nixpkgs/commit/5e0149938f976825fb36b8f02384f3770d7027c2) | `` syncthing: 2.1.0 -> 2.1.1 ``                                              |
| [`79a3e61d`](https://github.com/NixOS/nixpkgs/commit/79a3e61dce0b94985670325ec574d13ea84f3aee) | `` seafile-shared: 9.0.15 -> 9.0.20 ``                                       |
| [`f8819929`](https://github.com/NixOS/nixpkgs/commit/f8819929758fd5db02a1f3d96ef2378bdb5dcabc) | `` mysql84: 8.4.9 -> 8.4.10 ``                                               |
| [`f29510d7`](https://github.com/NixOS/nixpkgs/commit/f29510d7306acace793d46cc4632bd81c2f70e40) | `` extism-js-core: mark as broken on darwin ``                               |
| [`572d809e`](https://github.com/NixOS/nixpkgs/commit/572d809e8a2e58e380b687fd5e31343315592cab) | `` seafile-client: 9.0.15 -> 9.0.20 ``                                       |
| [`ee902615`](https://github.com/NixOS/nixpkgs/commit/ee902615f4309383047e316650df041f3cdd6124) | `` seafile-client: add update script ``                                      |
| [`1551b416`](https://github.com/NixOS/nixpkgs/commit/1551b416e70a65c7f55addf6127215183365685c) | `` bazarr: 1.5.6 -> 1.6.0 ``                                                 |
| [`eddcb5f2`](https://github.com/NixOS/nixpkgs/commit/eddcb5f228506f46a0572f9802b4b1ad8d13f9be) | `` lib/tests/release: stop testing nix_2_28 ``                               |
| [`670dd202`](https://github.com/NixOS/nixpkgs/commit/670dd202a7aa6c1c5644c5b2c890defe6661adc6) | `` openvpn: 2.6.19 -> 2.6.21 ``                                              |
| [`5861a003`](https://github.com/NixOS/nixpkgs/commit/5861a003fe10dbbd01907cc109b07fb4e43792a6) | `` google-chrome: 149.0.7827.201 -> 150.0.7871.47 (Darwin only) ``           |
| [`7b56f8b5`](https://github.com/NixOS/nixpkgs/commit/7b56f8b571d76521d5320066b14dd5f82707f02e) | `` maintainers: fix wrong githubId and github for aaravrav ``                |
| [`b40b6d67`](https://github.com/NixOS/nixpkgs/commit/b40b6d6776c61e97101fd63944992a7b9201e16d) | `` ci: update pinned ``                                                      |
| [`e0d7f9ab`](https://github.com/NixOS/nixpkgs/commit/e0d7f9abebb885f4e967b688caa7e91c0d0105a0) | `` ci: nix_2_28 → stable ``                                                  |
| [`7ff8480f`](https://github.com/NixOS/nixpkgs/commit/7ff8480fa7edd29b07e7fe18e420927a0643e5bc) | `` ci/update-pinned.sh: import Nixpkgs relative to script ``                 |
| [`804b536e`](https://github.com/NixOS/nixpkgs/commit/804b536e843e0ca9b8e048f5b34f90a225eb7b12) | `` ocamlPackages.tw: init at 0-unstable-2026-06-23 ``                        |
| [`8d4ea8c9`](https://github.com/NixOS/nixpkgs/commit/8d4ea8c9ec563fc02c9173073148d653d1554112) | `` ocamlPackages.cascade: init at 0-unstable-2026-06-26 ``                   |
| [`0362fecd`](https://github.com/NixOS/nixpkgs/commit/0362fecd69b74614125d6d76e4cf19a6a3a984e7) | `` ocamlPackages.alcobar: init at 0.3.1 ``                                   |
| [`65bbac3e`](https://github.com/NixOS/nixpkgs/commit/65bbac3e20c82faafdb5e5d919fd8b02a80a2784) | `` ariang: Pin nodejs to version 22 ``                                       |
| [`f9e3bf7e`](https://github.com/NixOS/nixpkgs/commit/f9e3bf7e1e7e344cb129108e3e446472047fb546) | `` librewolf-bin-unwrapped: 152.0.2-1 -> 152.0.4-1 ``                        |
| [`156c7753`](https://github.com/NixOS/nixpkgs/commit/156c77537126c2a97e57374922b458b2a34170e8) | `` etcd_3_5: 3.5.31 -> 3.5.32 ``                                             |
| [`1a9206e0`](https://github.com/NixOS/nixpkgs/commit/1a9206e05e5c04c42a9434dd7715030364c61379) | `` jetbrains.idea: 2026.1.3 -> 2026.1.4 ``                                   |
| [`75c9e046`](https://github.com/NixOS/nixpkgs/commit/75c9e046d9c18701aed5e99cc658d34c325491c3) | `` jetbrains.rider: 2026.1.2 -> 2026.1.4 ``                                  |
| [`f1aa894e`](https://github.com/NixOS/nixpkgs/commit/f1aa894e5573c5bc7f07b7c602374161df2174e6) | `` jetbrains.clion: 2026.1.2 -> 2026.1.4 ``                                  |
| [`1b00ee29`](https://github.com/NixOS/nixpkgs/commit/1b00ee2940c114ec144d7b5238eec95f2b153299) | `` jetbrains.goland: 2026.1.2 -> 2026.1.4 ``                                 |
| [`d5c36ad9`](https://github.com/NixOS/nixpkgs/commit/d5c36ad918553de078ad3db804522e6305ea13b5) | `` jetbrains.phpstorm: 2026.1.3 -> 2026.1.4 ``                               |
| [`e2ee29b2`](https://github.com/NixOS/nixpkgs/commit/e2ee29b2e30dcad64584c512e0c16bc84da84a88) | `` jetbrains.ruby-mine: 2026.1.3 -> 2026.1.4 ``                              |
| [`c80a846e`](https://github.com/NixOS/nixpkgs/commit/c80a846e56d4c2a0aba861d290d1a6ec2ebab686) | `` jetbrains.rust-rover: 2026.1.3 -> 2026.1.4 ``                             |
| [`db8c62b5`](https://github.com/NixOS/nixpkgs/commit/db8c62b59c35b91fb79555110fc60c38ce255301) | `` nimlsp: 0.4.6 → 0.4.7 ``                                                  |
| [`47439557`](https://github.com/NixOS/nixpkgs/commit/4743955714667ee563bd1b5cf86fec0548c0e335) | `` rmapi: add wamserma to maintainers ``                                     |
| [`1b2f3062`](https://github.com/NixOS/nixpkgs/commit/1b2f306209ad858363f9f53f7a462ed3d53b4dc6) | `` youtrack: 2026.1.13757 -> 2026.2.17012 ``                                 |
| [`9c3bf744`](https://github.com/NixOS/nixpkgs/commit/9c3bf744244a127aed6bcf56cd86acc15aa711a0) | `` nh-unwrapped: 4.3.2 -> 4.4.0 ``                                           |
| [`e3b3ed0d`](https://github.com/NixOS/nixpkgs/commit/e3b3ed0d68c2a33b255e0bb8c3b4a3f7f70ac8ff) | `` linux_xanmod_latest: 7.0.14 -> 7.1.3 ``                                   |
| [`e6eb968b`](https://github.com/NixOS/nixpkgs/commit/e6eb968bbe34ddc3c0bfb191160babdb9707e118) | `` linux_xanmod: 6.18.37 -> 6.18.38 ``                                       |
| [`e59533ad`](https://github.com/NixOS/nixpkgs/commit/e59533ad17cf69c7c5c04885ae0bf3aada546ad7) | `` thunderbird-esr-bin-unwrapped: 140.12.0esr -> 140.12.1esr ``              |
| [`99a01c6d`](https://github.com/NixOS/nixpkgs/commit/99a01c6d8f27d31b59dacb20d3eaee3d07d112b5) | `` linux_5_10: 5.10.259 -> 5.10.260 ``                                       |
| [`6e8fc16b`](https://github.com/NixOS/nixpkgs/commit/6e8fc16bfc238cfbd38f85bb2dd4af55a09be81d) | `` linux_5_15: 5.15.210 -> 5.15.211 ``                                       |
| [`06ad75ee`](https://github.com/NixOS/nixpkgs/commit/06ad75ee26af6332f672a09844939abad18210b8) | `` linux_6_1: 6.1.176 -> 6.1.177 ``                                          |
| [`5190a024`](https://github.com/NixOS/nixpkgs/commit/5190a0248a9e41b6176671f5c25ccf613208aa05) | `` linux_6_6: 6.6.143 -> 6.6.144 ``                                          |
| [`49304e54`](https://github.com/NixOS/nixpkgs/commit/49304e546108dac5878cd21590efed37660732ee) | `` linux_6_12: 6.12.94 -> 6.12.95 ``                                         |
| [`4c1179d9`](https://github.com/NixOS/nixpkgs/commit/4c1179d95a508a69cd10c2a2916f367b84802616) | `` linux_6_18: 6.18.37 -> 6.18.38 ``                                         |
| [`7065eaf2`](https://github.com/NixOS/nixpkgs/commit/7065eaf28424569c85fb301d06a906b443f1ff25) | `` linux_7_1: 7.1.2 -> 7.1.3 ``                                              |
| [`b11c4056`](https://github.com/NixOS/nixpkgs/commit/b11c4056e1568dd59199b70cae2ecdd117664c87) | `` grav: 1.7.53 -> 1.7.53.2 ``                                               |
| [`62f5d522`](https://github.com/NixOS/nixpkgs/commit/62f5d5222cd49babc8c90d6f3c1613abc4b0162e) | `` sambaFull: fix samba-tool missing cryptography module ``                  |
| [`d4ad1dbf`](https://github.com/NixOS/nixpkgs/commit/d4ad1dbfb7f9e23aae4a856fb2ac3ce65fd2abaa) | `` keycloak: 26.6.3 -> 26.6.4 ``                                             |
| [`88f5e714`](https://github.com/NixOS/nixpkgs/commit/88f5e71492e70e79a41b0f9fa5c2a9bbc90a206d) | `` coreboot-toolchain: 26.03 -> 26.06 ``                                     |
| [`25fa5d5f`](https://github.com/NixOS/nixpkgs/commit/25fa5d5fc1558d3a5f71e794c52ae578f37dc105) | `` nvidia-x11: 580.142 -> 580.173.02 (backport to release-26.05) ``          |
| [`e3d8cae9`](https://github.com/NixOS/nixpkgs/commit/e3d8cae9178e8323045257d7fab85321aec54f49) | `` syncthing: 2.0.15 -> 2.1.0 ``                                             |
| [`fd8e6605`](https://github.com/NixOS/nixpkgs/commit/fd8e660555fa6f33bc3b6afdcd876dedfc85290c) | `` syncthing: add zainkergaye as maintainer ``                               |
| [`276eeaa8`](https://github.com/NixOS/nixpkgs/commit/276eeaa868939d6adba7aca9f50b708f3bb6b834) | `` idevicerestore: add flokli to maintainers ``                              |
| [`5e0dceb9`](https://github.com/NixOS/nixpkgs/commit/5e0dceb97a07b2d38f83babbdbde694433091217) | `` idevicerestore: 1.0.0-unstable-2025-10-02 -> 1.0.0-unstable-2026-07-26 `` |
| [`6bdb6c02`](https://github.com/NixOS/nixpkgs/commit/6bdb6c023f7085627c7e8f03a248f178a078a585) | `` linuxPackages.bcachefs: support kernel 7.2 ``                             |
| [`81a60f55`](https://github.com/NixOS/nixpkgs/commit/81a60f55a7f4b448c388870de0749ffb8cca3ceb) | `` linuxPackages.bcachefs: build with rust support ``                        |
| [`ba4e16da`](https://github.com/NixOS/nixpkgs/commit/ba4e16daef37903a1c48d7537179113ca7b58cd2) | `` bcachefs-tools: 1.38.6 -> 1.38.8 ``                                       |
| [`2b8b4479`](https://github.com/NixOS/nixpkgs/commit/2b8b447948abd3983616d0b1918327b2efb478cf) | `` space-station-14-launcher: 0.38.0 -> 0.39.0 ``                            |
| [`3109dcb9`](https://github.com/NixOS/nixpkgs/commit/3109dcb94e6afecd6d08c4085f4b7237ab9b3050) | `` umami: 3.1.0 -> 3.2.0 ``                                                  |
| [`e0526ede`](https://github.com/NixOS/nixpkgs/commit/e0526ede6eac819eb701251d28bc4cd3b78d0dc3) | `` iredis: modernize ``                                                      |
| [`cda195bd`](https://github.com/NixOS/nixpkgs/commit/cda195bdcbffa872c903be5265993faabf1257e1) | `` iredis: 1.15.2 -> 1.16.1 ``                                               |
| [`80d4b8cb`](https://github.com/NixOS/nixpkgs/commit/80d4b8cb95c1bd72f22c323bd904befc47653831) | `` podman-desktop: 1.27.2 -> 1.28.2 ``                                       |
| [`582d3914`](https://github.com/NixOS/nixpkgs/commit/582d3914901ff02ad5dc7f720d11f63bbd7e191e) | `` podman-desktop: 1.26.2 -> 1.27.2 ``                                       |
| [`25dd1cab`](https://github.com/NixOS/nixpkgs/commit/25dd1cab88105acba1f9923cdbd74c1ec2f5f341) | `` snouty: enable networking on darwin ``                                    |
| [`f967783f`](https://github.com/NixOS/nixpkgs/commit/f967783fb70618f51b7eac28228443e3b58890ac) | `` python3Packages.locust-cloud: disable set of flaky tests ``               |
| [`54ed7885`](https://github.com/NixOS/nixpkgs/commit/54ed788545c0ff55618427bb0305371d8a814183) | `` modrinth-app-unwrapped: 0.14.8 -> 0.15.1 ``                               |
| [`400f2e0d`](https://github.com/NixOS/nixpkgs/commit/400f2e0dbcc3076141c96f49187514dc1f2baada) | `` mastodon: 4.6.2 -> 4.6.3 ``                                               |
| [`5f771633`](https://github.com/NixOS/nixpkgs/commit/5f771633cfc95e22e45c7def132f55ca7798204c) | `` vrcx: Use electron 41 ``                                                  |
| [`14bf0e2d`](https://github.com/NixOS/nixpkgs/commit/14bf0e2d25b0bfe72743f49c3df0226666cc590d) | `` obsidian: drop electron version pin ``                                    |
| [`15061a39`](https://github.com/NixOS/nixpkgs/commit/15061a39c958771308a39168ae6029b179c860d9) | `` python311.pkgs.pip: fix eval ``                                           |
| [`c0aa4308`](https://github.com/NixOS/nixpkgs/commit/c0aa4308ff5a3b02f955b0c4b1f0ab42c3226d99) | `` linux_7_0: remove ``                                                      |
| [`bbbbb60a`](https://github.com/NixOS/nixpkgs/commit/bbbbb60ab891607fe6465fedb46889f0e4560872) | `` plakar: 1.1.3 -> 1.1.4 ``                                                 |
| [`3ddba35e`](https://github.com/NixOS/nixpkgs/commit/3ddba35e266b4b0d0a725336fd4889a3c3b4547f) | `` plakar: 1.0.6 -> 1.1.3 ``                                                 |
| [`b65b505a`](https://github.com/NixOS/nixpkgs/commit/b65b505a3512c84143168abad60fc5eac1202c67) | `` plakar: add nadir-ishiguro to maintainers ``                              |
| [`a0b4d72b`](https://github.com/NixOS/nixpkgs/commit/a0b4d72b2d3150bfbc916d8980d1f43550c92ff7) | `` gh: 2.95.0 -> 2.96.0 ``                                                   |
| [`ffc28406`](https://github.com/NixOS/nixpkgs/commit/ffc2840633b84702afb8a6d97cc5ee43e6cdb910) | `` gh: 2.94.0 -> 2.95.0 ``                                                   |
| [`2c123639`](https://github.com/NixOS/nixpkgs/commit/2c123639c34cf0246663d7a1aa0b8d09a2c0e385) | `` gh: 2.93.0 -> 2.94.0 ``                                                   |
| [`0b0b9aa3`](https://github.com/NixOS/nixpkgs/commit/0b0b9aa32d89628c5ea741e92bbdb7909afb9711) | `` vtsls: add lsp initialization smoke test ``                               |
| [`b258e214`](https://github.com/NixOS/nixpkgs/commit/b258e214324be01a213ef5040954809aab8d354f) | `` vtsls: 0.2.9 -> 0.3.0 ``                                                  |
| [`3d96bb1c`](https://github.com/NixOS/nixpkgs/commit/3d96bb1c322e767f91883b84d90c082d3cd31116) | `` electron-mail: 5.3.7 -> 5.3.8 ``                                          |
| [`67c11a1b`](https://github.com/NixOS/nixpkgs/commit/67c11a1b0c0b16bbfdeef17bbb4b99e9052951d5) | `` busybox: backport tar symlink bug fix ``                                  |
| [`1baf38c4`](https://github.com/NixOS/nixpkgs/commit/1baf38c46b4d214c2e436b0e29290caa98373ee6) | `` haproxy: 3.3.9 -> 3.3.11 ``                                               |
| [`42b17b7f`](https://github.com/NixOS/nixpkgs/commit/42b17b7fbfac7af16b01f92a985f296f12e9b24d) | `` nvramtool: 26.03 -> 26.06 ``                                              |
| [`15a8dc0f`](https://github.com/NixOS/nixpkgs/commit/15a8dc0f13ecffdaf4160ff8216f8571f7486608) | `` vicinae: 0.21.7 -> 0.22.0 ``                                              |
| [`6d31b174`](https://github.com/NixOS/nixpkgs/commit/6d31b174a6bb2d302c951fd91e710c316d9165b7) | `` rmapi: 0.0.32 -> 0.0.34 ``                                                |
| [`0804b469`](https://github.com/NixOS/nixpkgs/commit/0804b469356ea66d67aff99f5a96a03fa0a04c6e) | `` gsasl: 2.2.2 -> 2.2.3 ``                                                  |