### PR TITLE
chore(flake/catppuccin): `cdc85139` -> `28731a36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783525197,
-        "narHash": "sha256-BJYTl6uZ0PRzOjjxaPHnfEifkTwf63uXwWfjrplRoL0=",
+        "lastModified": 1783545128,
+        "narHash": "sha256-APzF91kOgKOHwx/KRu7710A8MYihVtKmUbjK5dAIltc=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "cdc85139e679f9764ec40abc0a157538e0ec93b1",
+        "rev": "28731a367cfd8fb1eaec31d72bb75fee43971db4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                    |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`28731a36`](https://github.com/catppuccin/nix/commit/28731a367cfd8fb1eaec31d72bb75fee43971db4) | `` feat(home-manager/cursors): support global enable v2 `` |
| [`e64533ee`](https://github.com/catppuccin/nix/commit/e64533ee6fbcb54febed00bbf7b4bcc6a64e3b2a) | `` vscode: set nodejs-slim instead of nodejs (#1004) ``    |