### PR TITLE
chore(flake/nixvim): `4fd45857` -> `6d1424ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1783349931,
-        "narHash": "sha256-aYE76ATiGBg7/cQ2dHASRq97WvNum4OOIPgZ8xIK0QI=",
+        "lastModified": 1783544129,
+        "narHash": "sha256-qN9Z9Tw6sPp1vLeEz0RfrsiBOYS1yP+3919S+Gy8sYQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4fd45857deecb90d2732c87e0315daa48505515e",
+        "rev": "6d1424cefd041c595a517ee9f46adcb250938e24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`6d1424ce`](https://github.com/nix-community/nixvim/commit/6d1424cefd041c595a517ee9f46adcb250938e24) | `` Revert "tests/platforms/darwin: disable docs" `` |
| [`caffcb4f`](https://github.com/nix-community/nixvim/commit/caffcb4ff144ddd8cf4ebfbf5b8302105cfdfd73) | `` flake: Update ``                                 |