### PR TITLE
chore(flake/home-manager): `1aac8895` -> `f4d01c1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783525612,
-        "narHash": "sha256-OEFYdbtG6Qy04KGteknnrx15Uo2XXkYVuUvBvFNEn+Q=",
+        "lastModified": 1783550008,
+        "narHash": "sha256-qbbZUk9IG9dLNwCPwdPBs6I5clxwugRpP+1YU+GPK20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1aac8895fea6fcabc6a0184c63a80fb2f99fd208",
+        "rev": "f4d01c1d87c7c2ec909549165d5a8338f1bd3315",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`f4d01c1d`](https://github.com/nix-community/home-manager/commit/f4d01c1d87c7c2ec909549165d5a8338f1bd3315) | `` posting: add module ``       |
| [`a1fc9a1c`](https://github.com/nix-community/home-manager/commit/a1fc9a1cc39863fefb0e0296ef464ff2f4fe13ea) | `` maintainers: add reesilva `` |