### PR TITLE
chore(flake/home-manager): `f4d01c1d` -> `79e60825`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783550008,
-        "narHash": "sha256-qbbZUk9IG9dLNwCPwdPBs6I5clxwugRpP+1YU+GPK20=",
+        "lastModified": 1783689750,
+        "narHash": "sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb+A9ehn8k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f4d01c1d87c7c2ec909549165d5a8338f1bd3315",
+        "rev": "79e6082586b3680ff32c8e75127545058f074fa4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`79e60825`](https://github.com/nix-community/home-manager/commit/79e6082586b3680ff32c8e75127545058f074fa4) | `` launchd: treat absent domain as harmless in bootoutAgent `` |
| [`144f4e36`](https://github.com/nix-community/home-manager/commit/144f4e36d0186195037da9fce80a727108978070) | `` files: respect executable for recursive directories ``      |