### PR TITLE
chore(flake/nixvim): `6d1424ce` -> `ebffdb62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1016,11 +1016,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1783544129,
-        "narHash": "sha256-qN9Z9Tw6sPp1vLeEz0RfrsiBOYS1yP+3919S+Gy8sYQ=",
+        "lastModified": 1783647864,
+        "narHash": "sha256-gtVkWD4SbsvQQ8aSFEsrUTxxyuim4/ZC6lBJmA+sE/k=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6d1424cefd041c595a517ee9f46adcb250938e24",
+        "rev": "ebffdb62cd1604537ee51d4d23258c002f1c90f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`ebffdb62`](https://github.com/nix-community/nixvim/commit/ebffdb62cd1604537ee51d4d23258c002f1c90f8) | `` flake: Update ``                               |
| [`511a763e`](https://github.com/nix-community/nixvim/commit/511a763e20ca8a39c4182c046074cc772b9d29d5) | `` docs: use GFM alert patches from Nixpkgs PR `` |