### PR TITLE
chore(flake/catppuccin): `28731a36` -> `96799f24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783545128,
-        "narHash": "sha256-APzF91kOgKOHwx/KRu7710A8MYihVtKmUbjK5dAIltc=",
+        "lastModified": 1783674541,
+        "narHash": "sha256-vmUhEF/jBCZJeK0dInOls+HOAR0yiiQusN1+FZKaJss=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "28731a367cfd8fb1eaec31d72bb75fee43971db4",
+        "rev": "96799f24cf1366fe88e1293c3d27521a8f2129cf",
         "type": "github"
       },
       "original": {
@@ -886,11 +886,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782918843,
-        "narHash": "sha256-mFP086y1bNA1g9AsY/pCue3H3W2R7ayroHyRbZrcMf0=",
-        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
+        "lastModified": 1783279667,
+        "narHash": "sha256-2l8yOB5aYd+05Q9V9Y1YhgbSa1j1o5QX+nvYs5FL80A=",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1025900.e8273b29fe13/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1028110.f205b5574fd0/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                                          |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`96799f24`](https://github.com/catppuccin/nix/commit/96799f24cf1366fe88e1293c3d27521a8f2129cf) | `` chore(home-manager/gh-dash): use includes directive (#992) `` |
| [`2e66b245`](https://github.com/catppuccin/nix/commit/2e66b24545d4c66824b3c299a33b4b4b9a38beff) | `` chore: update flakes (#1007) ``                               |
| [`43d8d5e4`](https://github.com/catppuccin/nix/commit/43d8d5e4bc462f717a49a7c0b485e23da128f734) | `` chore: update port sources (#1008) ``                         |
| [`b69e0494`](https://github.com/catppuccin/nix/commit/b69e0494705aaf50cb2c6e0e005639b632044c6d) | `` fix(home-manager/cursors): v3 (#1005) ``                      |