### PR TITLE
feat(overlays): pin opencode to latest upstream release + auto-update

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -104,7 +104,7 @@ jobs:
                 global=true ;;
               flake.lock)
                 flake_lock_changed=true ;;
-              modules/*|profiles/*|home-profiles/*|dotfiles/*)
+              modules/*|profiles/*|home-profiles/*|dotfiles/*|overlays/*)
                 global=true ;;
               features/desktop/*)
                 desktop_global=true ;;

--- a/.github/workflows/update-opencode.yaml
+++ b/.github/workflows/update-opencode.yaml
@@ -76,7 +76,9 @@ jobs:
 
           # Unambiguous: the `src` fetch uses the `hash` key, while
           # node_modules (updated in the next step) uses `outputHash`.
-          sed -i "s/hash = \"sha256-.*\";/hash = \"${src_hash}\";/" overlays/opencode.nix
+          # `|` delimiter: SRI base64 hashes can contain `/`, which would
+          # break a `/`-delimited sed substitution.
+          sed -i "s|hash = \"sha256-.*\";|hash = \"${src_hash}\";|" overlays/opencode.nix
 
       - name: Recompute node_modules fixed-output hash
         if: steps.check.outputs.update == 'true'
@@ -93,14 +95,14 @@ jobs:
             exit 1
           }
 
-          real_hash=$(echo "$build_log" | grep -oP 'got:\s+\K\S+')
+          real_hash=$(echo "$build_log" | grep -oP 'got:\s+\K\S+' || true)
           if [ -z "$real_hash" ]; then
             echo "$build_log" >&2
             echo "could not extract the real node_modules hash from the build log above" >&2
             exit 1
           fi
 
-          sed -i "s/outputHash = \"sha256-.*\";/outputHash = \"${real_hash}\";/" overlays/opencode.nix
+          sed -i "s|outputHash = \"sha256-.*\";|outputHash = \"${real_hash}\";|" overlays/opencode.nix
 
       - name: Verify the full package builds
         if: steps.check.outputs.update == 'true'

--- a/.github/workflows/update-opencode.yaml
+++ b/.github/workflows/update-opencode.yaml
@@ -1,0 +1,131 @@
+---
+name: update-opencode
+
+# overlays/opencode.nix pins opencode to a specific upstream tag instead of
+# nixpkgs' (frequently stale) version — see that file for why. Renovate
+# can't maintain it: bumping requires recomputing the `node_modules`
+# fixed-output-derivation hash, which means actually running a Nix build,
+# not just a version-string/hash lookup. This workflow does that dance
+# daily (opencode ships multiple releases a week) and only opens a PR if
+# the resulting package actually builds.
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-opencode:
+    name: Update opencode overlay
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # PAT (not GITHUB_TOKEN) so the pushed branch triggers CI on the
+          # resulting PR — see the same note in renovate-relock.yaml.
+          token: ${{ secrets.PAT }}
+          persist-credentials: true
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: accept-flake-config = true
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github[bot]"
+
+      - name: Check for a newer opencode release
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          current_version=$(sed -n 's/^\s*version = "\(.*\)";/\1/p' overlays/opencode.nix | head -1)
+          latest_tag=$(gh api repos/anomalyco/opencode/releases/latest --jq .tag_name)
+          latest_version="${latest_tag#v}"
+
+          echo "current: $current_version"
+          echo "latest:  $latest_version"
+
+          if [ "$current_version" = "$latest_version" ]; then
+            echo "already up to date"
+            echo "update=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "update=true" >> "$GITHUB_OUTPUT"
+          echo "version=$latest_version" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version and source hash
+        if: steps.check.outputs.update == 'true'
+        env:
+          NEW_VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          sed -i "s/^\(\s*version = \)\".*\";/\1\"${NEW_VERSION}\";/" overlays/opencode.nix
+
+          src_hash=$(nix run nixpkgs#nix-prefetch-github -- anomalyco opencode --rev "v${NEW_VERSION}" \
+            | jq -r .hash)
+
+          # Unambiguous: the `src` fetch uses the `hash` key, while
+          # node_modules (updated in the next step) uses `outputHash`.
+          sed -i "s/hash = \"sha256-.*\";/hash = \"${src_hash}\";/" overlays/opencode.nix
+
+      - name: Recompute node_modules fixed-output hash
+        if: steps.check.outputs.update == 'true'
+        run: |
+          set -euo pipefail
+
+          # Force a hash mismatch to learn the real one, mirroring the
+          # manual bump procedure documented in overlays/opencode.nix.
+          sed -i 's/outputHash = "sha256-.*";/outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";/' \
+            overlays/opencode.nix
+
+          build_log=$(nix build '.#nixosConfigurations.Daytona.pkgs.opencode.node_modules' --no-link 2>&1) && {
+            echo "expected a hash mismatch but the build succeeded outright" >&2
+            exit 1
+          }
+
+          real_hash=$(echo "$build_log" | grep -oP 'got:\s+\K\S+')
+          if [ -z "$real_hash" ]; then
+            echo "$build_log" >&2
+            echo "could not extract the real node_modules hash from the build log above" >&2
+            exit 1
+          fi
+
+          sed -i "s/outputHash = \"sha256-.*\";/outputHash = \"${real_hash}\";/" overlays/opencode.nix
+
+      - name: Verify the full package builds
+        if: steps.check.outputs.update == 'true'
+        run: nix build '.#nixosConfigurations.Daytona.pkgs.opencode' --no-link
+
+      - name: Commit, push, and open a PR
+        if: steps.check.outputs.update == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          NEW_VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          branch="update-opencode-${NEW_VERSION}"
+          git checkout -b "$branch"
+          git add overlays/opencode.nix
+          git commit -m "chore(opencode): update overlay to v${NEW_VERSION}"
+          git push origin "$branch" --force
+
+          gh pr create \
+            --title "chore(opencode): update overlay to v${NEW_VERSION}" \
+            --body "Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: \`nix build .#nixosConfigurations.Daytona.pkgs.opencode\` succeeds." \
+            --base main \
+            --head "$branch" \
+          || echo "PR already open for this branch"
+
+          gh pr merge "$branch" --auto --squash \
+          || echo "auto-merge not enabled or not mergeable yet; leaving PR for manual merge"

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -75,7 +75,7 @@ while IFS= read -r path; do
     flake.lock)
       LOCK_CHANGED=1
       ;;
-    modules/*|profiles/*|home-profiles/*|dotfiles/*)
+    modules/*|profiles/*|home-profiles/*|dotfiles/*|overlays/*)
       GLOBAL=1
       ;;
     features/desktop/*)

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -17,6 +17,11 @@
 final: prev: {
   cider3 = final.callPackage ./cider.nix { };
 
+  # Pin opencode to the latest upstream release rather than nixpkgs'
+  # (frequently stale) pin. See overlays/opencode.nix for the bump
+  # procedure.
+  opencode = final.callPackage ./opencode.nix { inherit (prev) opencode; };
+
   # github-runner ≥ 2.333.1 has __noChroot = true set on its derivation
   # (nixpkgs commit 40231286, added as a darwin sandbox workaround).  On any
   # system with sandbox = true (the NixOS default), Nix refuses to even

--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -1,0 +1,44 @@
+# Track opencode's upstream release cadence instead of nixpkgs' lag.
+#
+# opencode ships multiple releases a week; nixpkgs' pin only moves when
+# someone bumps pkgs/by-name/op/opencode/package.nix, which lags upstream
+# by anywhere from days to weeks. This overlay repoints the existing
+# nixpkgs derivation at the newest upstream tag, reusing its buildPhase
+# / wrapper logic verbatim (see the upstream package.nix for why it's
+# structured this way: a fixed-output `node_modules` derivation feeding a
+# non-network build).
+#
+# Bumping this file:
+#   1. Update `version` below.
+#   2. Get the new source hash:
+#        nix run nixpkgs#nix-prefetch-github -- anomalyco opencode --rev v<version>
+#   3. Set `src.hash` to that value.
+#   4. Set `node_modules.outputHash` to a wrong placeholder
+#      (e.g. lib.fakeHash) and run:
+#        nix build .#nixosConfigurations.<host>.pkgs.opencode.node_modules
+#      to get the real hash from the mismatch error, then fill it in.
+#   5. `nix build .#nixosConfigurations.<host>.pkgs.opencode` to confirm.
+#
+# Usage in overlays/default.nix:
+#   opencode = final.callPackage ./opencode.nix { opencode = prev.opencode; };
+{
+  opencode,
+  fetchFromGitHub,
+}:
+opencode.overrideAttrs (
+  _finalAttrs: prevAttrs: rec {
+    version = "1.17.18";
+
+    src = fetchFromGitHub {
+      owner = "anomalyco";
+      repo = "opencode";
+      tag = "v${version}";
+      hash = "sha256-Y0rcO6r9yqhYux8IS5oAtgzcMXfJE8I1Lre4HdJ5nBg=";
+    };
+
+    node_modules = prevAttrs.node_modules.overrideAttrs (_: {
+      inherit version src;
+      outputHash = "sha256-kXdXw264JQdlNoZPv5GUyWZvb/A8h2CTRdiX79jyvys=";
+    });
+  }
+)


### PR DESCRIPTION
## Summary

nixpkgs' `opencode` pin lags upstream by days to weeks; opencode ships
multiple releases a week. This adds an overlay that repoints the
existing nixpkgs derivation at the newest upstream tag, plus a
scheduled workflow to keep it there automatically.

## Commits

1. **`fix(ci): treat overlays/* as global impact in Linux host filtering`**
   `ci-linux.yaml`'s changed-path filter didn't match `overlays/*`, so
   a change scoped only to `overlays/` triggered *no* host rebuilds on
   Linux CI at all (unlike `ci-darwin.yaml`, which already treats
   `overlays/*` as global). Fixed both `ci-linux.yaml` and the local
   `nixos-eval-impacted-hosts` skill script so they stay in sync.
   Without this fix, commit 2 below would have merged unvalidated.

2. **`feat(overlays): pin opencode to latest upstream release`**
   - `overlays/opencode.nix`: `opencode.overrideAttrs` bumping
     `version`/`src`/the `node_modules` fixed-output-derivation hash to
     track `v1.17.18` (current upstream latest), reusing nixpkgs'
     existing build logic verbatim.
   - `overlays/default.nix`: wires it in.
   - `.github/workflows/update-opencode.yaml`: daily cron that checks
     `anomalyco/opencode`'s latest release, recomputes both hashes
     (source hash via `nix-prefetch-github`, `node_modules` FOD hash
     via the fake-hash-mismatch trick), **actually builds the package**
     before doing anything else, and only then opens a PR (with
     `gh pr merge --auto`). If a future release breaks the reused build
     steps, the workflow fails loudly instead of opening a broken PR.

## Verification

- `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds,
  `--version` reports `1.17.18`.
- Confirmed (via `nix log`) this is a genuine source build via
  esbuild/vite, not a cache substitution -- verified against
  `cache.nixos.org` directly.
- `nixfmt --check`, `statix check`, `deadnix --fail` all clean on the
  new/changed `.nix` files.
- `actionlint` clean on the new workflow.
- Pre-commit hooks passed on both commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overlay that provides the latest upstream OpenCode release (with updated source/version wiring).
  * Introduced an automated daily/manual workflow to detect, validate, and open update PRs for OpenCode.
* **Bug Fixes**
  * Updated CI change-impact detection so modifications under `overlays/*` trigger global checks.
* **Documentation**
  * Added/updated guidance for updating the OpenCode release version and the related source/output hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->