### PR TITLE
feat(desktop): add Flatpak support via nix-flatpak

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -145,6 +145,7 @@ jobs:
               [freminal]="desktop"
               [frext]="desktop"
               [solaar]="desktop"
+              [nix-flatpak]="desktop"
               [apple-fonts]="desktop"
               [walls-catppuccin]="desktop"
               [walls-zhichaoh]="desktop"

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -110,6 +110,7 @@ declare -A INPUT_CATEGORY=(
   [freminal]="desktop"
   [frext]="desktop"
   [solaar]="desktop"
+  [nix-flatpak]="desktop"
   [apple-fonts]="desktop"
   [walls-catppuccin]="desktop"
   [walls-zhichaoh]="desktop"

--- a/features/desktop/default.nix
+++ b/features/desktop/default.nix
@@ -30,6 +30,7 @@ in
     ./brave
     ./discord
     ./firefox
+    ./flatpak
     ./fonts
     ./freminal
     ./frext
@@ -68,6 +69,7 @@ in
       discord.enable = cfg.enable_extra;
       environments.enable = true;
       firefox.enable = true;
+      flatpak.enable = true;
       fonts.enable = true;
       freminal.enable = true;
       frext.enable = true;

--- a/features/desktop/flatpak/default.nix
+++ b/features/desktop/flatpak/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.desktop.flatpak;
+in
+{
+  options.desktop.flatpak = {
+    enable = lib.mkEnableOption "Flatpak";
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.flatpak = {
+      enable = true;
+
+      packages = [
+        "com.sublimehq.SublimeText"
+      ];
+
+      update = {
+        onActivation = true;
+        auto = {
+          enable = true;
+          onCalendar = "weekly";
+        };
+      };
+    };
+
+    # NOTE: nix-flatpak reuses nixpkgs' native `services.flatpak.enable`
+    # option, so nixpkgs' own services/desktops/flatpak.nix module fires
+    # alongside nix-flatpak's. That native module already appends
+    # `$HOME/.local/share/flatpak/exports` and `/var/lib/flatpak/exports`
+    # to `environment.profiles`, and NixOS's default
+    # `environment.profileRelativeSessionVariables.XDG_DATA_DIRS = [ "/share" ]`
+    # automatically derives the correctly-suffixed XDG_DATA_DIRS entries
+    # from every profile — including these two. Manually adding
+    # `environment.sessionVariables.XDG_DATA_DIRS` here would just
+    # duplicate those same two entries in the final PATH-like string, so
+    # it's deliberately omitted. Verified via:
+    #   nix eval .#nixosConfigurations.Daytona.config.environment.profiles
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -699,6 +699,22 @@
         "type": "github"
       }
     },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1767983141,
+        "narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "440818969ac2cbd77bfe025e884d0aa528991374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "ref": "v0.7.0",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -1117,6 +1133,7 @@
         "home-manager": "home-manager",
         "home-manager-stable": "home-manager-stable",
         "niri": "niri",
+        "nix-flatpak": "nix-flatpak",
         "nixos-needsreboot": "nixos-needsreboot",
         "nixpkgs": "nixpkgs_11",
         "nixpkgs-kernel": "nixpkgs-kernel",

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,11 @@
       url = "github:numtide/flake-utils";
     };
 
+    # CI: desktop
+    nix-flatpak = {
+      url = "github:gmodena/nix-flatpak?ref=v0.7.0"; # unstable branch. Use github:gmodena/nix-flatpak/?ref=<tag> to pin releases.
+    };
+
     # CI: global
     nixvim = {
       url = "github:nix-community/nixvim";
@@ -228,6 +233,7 @@
       sops-nix-stable,
       apple-fonts,
       nixvim,
+      nix-flatpak,
       niri,
       darwin,
       walls-catppuccin,
@@ -352,6 +358,7 @@
           walls-cozypixels
           freminal
           frext
+          nix-flatpak
           ;
       };
     in

--- a/flake/hosts/nixos.nix
+++ b/flake/hosts/nixos.nix
@@ -19,6 +19,7 @@
   solaar,
   freminal,
   frext,
+  nix-flatpak,
   ...
 }:
 
@@ -36,6 +37,7 @@
     extraModules = [
       niri.nixosModules.niri
       solaar.nixosModules.default
+      nix-flatpak.nixosModules.nix-flatpak
     ];
   };
 
@@ -50,6 +52,7 @@
     extraModules = [
       niri.nixosModules.niri
       solaar.nixosModules.default
+      nix-flatpak.nixosModules.nix-flatpak
     ];
   };
 }


### PR DESCRIPTION
## Summary

Wires up declarative Flatpak management for the desktop hosts (Daytona, maranello) via the `nix-flatpak` flake input.

- Add the `nix-flatpak` flake input (`v0.7.0`), categorized as a `desktop`-only CI input.
- Add `features/desktop/flatpak`, enabled for all desktop hosts. Installs Sublime Text (as a proof of concept) and schedules weekly auto-updates via `nix-flatpak`'s `update.auto` mechanism.
- Wire `nix-flatpak.nixosModules.nix-flatpak` into Daytona and maranello via `flake/hosts/nixos.nix` `extraModules` (this module was previously missing, so `services.flatpak` had no effect beyond nixpkgs' own bare-bones native module).
- Sync the `nix-flatpak -> desktop` CI category into `ci-linux.yaml` and the `impacted-hosts.sh` eval script (per the four-place sync invariant), so future `flake.lock`-only bumps of this input only trigger desktop rebuilds, not the whole fleet.

## Notes

- `nix-flatpak` reuses nixpkgs' native `services.flatpak.enable` option rather than redeclaring it, so nixpkgs' own `services/desktops/flatpak.nix` module fires alongside `nix-flatpak`'s. That native module already appends the Flatpak export directories to `environment.profiles`, and NixOS's default `profileRelativeSessionVariables.XDG_DATA_DIRS = [ "/share" ]` derives the correctly-suffixed `XDG_DATA_DIRS` entries automatically — verified in the built system's `/etc/set-environment` and `/etc/pam/environment`. No extra session-variable plumbing was needed (a manual addition was tried and reverted after confirming it just duplicated the entries).
- Fixed a copy-paste bug in the (new, previously unwired) flatpak feature module: it referenced `config.desktop.appimage` instead of `config.desktop.flatpak`, which meant `desktop.flatpak.enable` had no effect.

## Verification

- `nix flake check` passes.
- Full `nix build` of both `nixosConfigurations.Daytona` and `nixosConfigurations.maranello` toplevels succeeds with no evaluation warnings.
- Spot-checked all server hosts' `system.build.toplevel.drvPath` eval unaffected (fredhub, acarshub, vdlmhub, hfdlhub1, hfdlhub2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flatpak support to desktop configurations.
  * Enabled automatic weekly Flatpak updates.
  * Added Sublime Text installation through Flatpak.
  * Enabled Flatpak integration for selected desktop systems.

* **CI Improvements**
  * Changes affecting the Flatpak configuration now correctly trigger desktop-scoped builds and evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->