### PR TITLE
Stand up fredvps python-venv services (test-site + discord-bot)

### DIFF
--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   stateVersion,
   config,
   ...
@@ -9,7 +10,9 @@
     ./hardware-configuration.nix
     ../../../profiles/adsb-hub.nix
     ../../../modules/services/tailscale
+    ../../../modules/services/python-venv-app.nix
     ./nginx.nix
+    ./discord-backup.nix
   ];
 
   # Tailscale MagicDNS name — fill in your tailnet name, e.g. "fredvps.tail1234.ts.net"
@@ -38,7 +41,10 @@
     useNetworkd = true;
     useDHCP = false;
     networkmanager.enable = lib.mkForce false;
-    firewall.allowedTCPPorts = [ 2269 ];
+    firewall.allowedTCPPorts = [
+      2269
+      8078
+    ];
   };
 
   systemd.network = {
@@ -111,6 +117,31 @@
         port = "2269";
         filter = "sshd";
         maxretry = 3;
+      };
+    };
+
+    ###################################################################
+    # Python venv services — code is manually `git clone`d to
+    # /home/nik/<app>, dependencies are pinned in each app's
+    # requirements.txt far behind what nixpkgs ships, so pip (not
+    # nixpkgs) resolves them into a venv scoped to that directory.
+    # See modules/services/python-venv-app.nix.
+    ###################################################################
+    pythonVenvApps = {
+      test-site = {
+        path = "/home/nik/test_site";
+        user = "nik";
+        # scipy==1.10.1 (pinned in requirements.txt) has no cp312+ wheel.
+        python = pkgs.python311;
+        execStart = "$VENV/bin/uvicorn app.main:app --host 0.0.0.0 --port 8078 --workers 2";
+      };
+
+      discord-bot = {
+        path = "/home/nik/discord-bot";
+        user = "nik";
+        # matplotlib==3.7.5 (pinned in requirements.txt) has no cp313 wheel.
+        python = pkgs.python312;
+        execStart = "$VENV/bin/python main-discord.py";
       };
     };
 

--- a/hosts/linux/fredvps/discord-backup.nix
+++ b/hosts/linux/fredvps/discord-backup.nix
@@ -1,0 +1,57 @@
+# Discord DB filesystem layout + nightly backup for fredvps.
+#
+# /mnt/discord                 — live sqlite DB directory (hardcoded path
+#                                 in discord-bot/discord_db.py and
+#                                 db_vacuum.py; test_site falls back to it
+#                                 read-only when DATABASE_PATH isn't set).
+# /mnt/discord-storage          — backup destination.
+# /mnt/discord-storage/backups  — where dated backup copies land.
+#
+# All three are plain local directories, created once via an
+# activationScript (does not touch contents if already there — same
+# pattern as the adsbDockerCompose activationScript above) — how (or
+# whether) /mnt/discord-storage is actually backed by something else
+# (NFS, a separate disk, etc.) is handled outside this repo.
+_: {
+  system.activationScripts.discordDirs = {
+    text = ''
+      install -d -m0755 -o nik -g users /mnt/discord
+      install -d -m0755 -o nik -g users /mnt/discord-storage
+      install -d -m0755 -o nik -g users /mnt/discord-storage/backups
+    '';
+    deps = [ ];
+  };
+
+  systemd = {
+    services.discord-db-backup = {
+      description = "Backup discord bot sqlite DB";
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "nik";
+        Group = "users";
+      };
+
+      script = ''
+        while [ -e /mnt/discord/discord_db.sqlite-journal ]; do
+                sleep 5
+        done
+
+        cp /mnt/discord/discord_db.sqlite /mnt/discord-storage/backups/discord_db-$(date +"%Y-%m-%d-%H%M").sqlite
+
+
+        find /mnt/discord-storage/backups -mtime +30 -type f -delete
+      '';
+    };
+
+    timers.discord-db-backup = {
+      description = "Nightly discord bot DB backup";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        # Equivalent to cron's "0 1 * * *"
+        OnCalendar = "*-*-* 01:00:00";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/hosts/linux/fredvps/nginx.nix
+++ b/hosts/linux/fredvps/nginx.nix
@@ -1,3 +1,18 @@
+{ pkgs, ... }:
+let
+  # Self-signed throwaway cert for the catch-all default vhost below.
+  # There's no real domain to get an ACME cert for "_" / unmatched SNI --
+  # the point is just to stop leaking a *real* vhost's cert (acarshub.app)
+  # to clients presenting a Host/SNI we don't recognize.
+  snakeoilCert =
+    pkgs.runCommand "nginx-default-snakeoil-cert" { nativeBuildInputs = [ pkgs.openssl ]; }
+      ''
+        mkdir -p "$out"
+        openssl req -x509 -nodes -newkey rsa:2048 -days 36500 \
+          -keyout "$out/key.pem" -out "$out/cert.pem" \
+          -subj "/CN=invalid"
+      '';
+in
 {
   networking.firewall.allowedTCPPorts = [
     80
@@ -173,6 +188,31 @@
         locations."/" = {
           proxyPass = "http://127.0.0.1:8078/";
         };
+      };
+
+      # Explicit catch-all default: without this, nginx (and the NixOS
+      # module) fall back to whichever vhost happens to sort first
+      # alphabetically (attrsets are always key-sorted) as the *implicit*
+      # default_server for any Host/SNI that doesn't match a declared
+      # vhost -- serving that vhost's content AND its TLS cert to totally
+      # unrelated domains. That's exactly how a typo'd/unlisted domain
+      # (flipaholic.pro) ended up being served acarshub.app's cert. This
+      # block makes "no match" fail closed instead of silently leaking
+      # whatever happens to be alphabetically first.
+      "_" = {
+        default = true;
+        serverName = "_";
+        # addSSL (not forceSSL/onlySSL): serve the catch-all on *both*
+        # plain :80 and :443 as default_server, using the throwaway
+        # self-signed cert above -- forceSSL/enableACME would need a
+        # real domain to issue for, and onlySSL would drop the :80
+        # default, leaving port 80's implicit-default bug unfixed.
+        addSSL = true;
+        sslCertificate = "${snakeoilCert}/cert.pem";
+        sslCertificateKey = "${snakeoilCert}/key.pem";
+        extraConfig = ''
+          return 444;
+        '';
       };
     };
   };

--- a/hosts/linux/fredvps/nginx.nix
+++ b/hosts/linux/fredvps/nginx.nix
@@ -164,6 +164,16 @@
         serverAliases = [ "www.acarshub.com" ];
         globalRedirect = "acarshub.app";
       };
+
+      "flipaholics.pro" = {
+        forceSSL = true;
+        enableACME = true;
+        serverAliases = [ "www.flipaholics.pro" ];
+
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:8078/";
+        };
+      };
     };
   };
 }

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -89,6 +89,10 @@ in
       enable = true;
 
       settings = {
+        remote-control = {
+          control-enable = true;
+        };
+
         server = {
           interface = [ "127.0.0.1" ];
           port = 5335;

--- a/modules/services/python-venv-app.nix
+++ b/modules/services/python-venv-app.nix
@@ -1,0 +1,217 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.pythonVenvApps;
+
+  # Idempotent venv bootstrap + dependency sync, run as ExecStartPre.
+  # The venv itself lives inside the app's own (non-Nix-store) directory,
+  # so it survives across nixos-rebuild / colmena deploys. Dependencies
+  # are only reinstalled when requirements.txt actually changes, tracked
+  # via a sha256 stamp file next to the venv.
+  mkSetupScript =
+    name: app:
+    pkgs.writeShellScript "python-venv-setup-${name}" ''
+      set -euo pipefail
+
+      APP_DIR=${lib.escapeShellArg app.path}
+      VENV_DIR="$APP_DIR/${app.venvDir}"
+      REQ_FILE="$APP_DIR/${app.requirementsFile}"
+      STAMP_FILE="$VENV_DIR/.requirements.sha256"
+
+      if [ ! -d "$VENV_DIR" ]; then
+        echo "pyapp-${name}: creating venv at $VENV_DIR"
+        ${app.python.interpreter} -m venv "$VENV_DIR"
+      fi
+
+      if [ ! -f "$REQ_FILE" ]; then
+        echo "pyapp-${name}: WARNING $REQ_FILE not found, skipping dependency sync" >&2
+        exit 0
+      fi
+
+      NEW_HASH="$(${pkgs.coreutils}/bin/sha256sum "$REQ_FILE" | ${pkgs.coreutils}/bin/cut -d' ' -f1)"
+      OLD_HASH="$(cat "$STAMP_FILE" 2>/dev/null || true)"
+
+      if [ "$NEW_HASH" != "$OLD_HASH" ]; then
+        echo "pyapp-${name}: requirements.txt changed, syncing venv"
+        "$VENV_DIR/bin/pip" install --upgrade pip
+        "$VENV_DIR/bin/pip" install -r "$REQ_FILE"
+        echo "$NEW_HASH" > "$STAMP_FILE"
+      fi
+    '';
+
+  mkService =
+    name: app:
+    lib.nameValuePair "pyapp-${name}" {
+      inherit (app) enable after wants;
+      description = "Python venv app: ${name}";
+      wantedBy = [ "multi-user.target" ];
+
+      environment = app.environment // {
+        VENV = "${app.path}/${app.venvDir}";
+        # manylinux wheels assume libstdc++/libgcc_s are just present on any
+        # normal distro (unlike e.g. libpng, which auditwheel vendors into
+        # the wheel itself) — NixOS has no FHS paths, so nothing provides
+        # them unless pointed at explicitly. app.extraLibraryPaths lets a
+        # host add more (e.g. gfortran's runtime for scipy).
+        LD_LIBRARY_PATH = lib.makeLibraryPath app.extraLibraryPaths;
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = app.user;
+        Group = app.group;
+        WorkingDirectory = app.path;
+
+        ExecStartPre = "${mkSetupScript name app}";
+        # systemd applies its own $VAR/${VAR} substitution to the whole
+        # ExecStart= line before bash ever sees it — regardless of quoting,
+        # since systemd's quotes only affect argv splitting, not expansion
+        # semantics. Escape literal `$` as `$$` so systemd passes a literal
+        # `$` through untouched, letting bash (which inherits VENV via
+        # `environment` below) do the actual expansion.
+        ExecStart = "${pkgs.bash}/bin/bash -c ${
+          lib.escapeShellArg (lib.replaceStrings [ "$" ] [ "$$" ] app.execStart)
+        }";
+
+        EnvironmentFile = lib.mkIf (app.environmentFile != null) app.environmentFile;
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        # Modest hardening. Deliberately no ProtectHome / ProtectSystem —
+        # the whole point of this module is that the app's code + venv
+        # live under the service user's own $HOME, outside the Nix store,
+        # and need full read/write access there.
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+      };
+    };
+in
+{
+  options.services.pythonVenvApps = lib.mkOption {
+    default = { };
+    description = ''
+      Python applications whose dependencies are deliberately *not*
+      sourced from nixpkgs (e.g. unmaintained upstreams pinned to
+      package versions far behind what nixpkgs ships). Each app gets
+      its own venv, created on first start and kept in sync with its
+      `requirements.txt` via plain `pip`, scoped entirely to the app's
+      own directory — which lives outside the Nix store (typically a
+      manually `git clone`d checkout). Nix only manages the systemd
+      unit and the interpreter used to create the venv; every
+      dependency is resolved straight from PyPI at service-start time.
+    '';
+    type = lib.types.attrsOf (
+      lib.types.submodule {
+        options = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether to generate the systemd unit for this app.";
+          };
+
+          path = lib.mkOption {
+            type = lib.types.path;
+            description = ''
+              Absolute path to the app's checkout (e.g. /home/nik/test_site).
+              Must already exist — Nix does not manage its contents.
+            '';
+          };
+
+          user = lib.mkOption {
+            type = lib.types.str;
+            description = "System user the service runs as, and that owns `path`.";
+          };
+
+          group = lib.mkOption {
+            type = lib.types.str;
+            default = "users";
+            description = "System group the service runs as.";
+          };
+
+          python = lib.mkOption {
+            type = lib.types.package;
+            default = pkgs.python3;
+            description = ''
+              Interpreter used only to create the venv (`python -m venv`).
+              Pin this per-app when a pinned dependency has no wheel for
+              the default interpreter's ABI — e.g. scipy==1.10.1 has no
+              cp312+ wheel, matplotlib==3.7.5 has no cp313 wheel.
+            '';
+          };
+
+          venvDir = lib.mkOption {
+            type = lib.types.str;
+            default = ".venv";
+            description = "Venv directory name, relative to `path`.";
+          };
+
+          requirementsFile = lib.mkOption {
+            type = lib.types.str;
+            default = "requirements.txt";
+            description = "Requirements file name, relative to `path`.";
+          };
+
+          extraLibraryPaths = lib.mkOption {
+            type = lib.types.listOf lib.types.package;
+            default = [ pkgs.stdenv.cc.cc.lib ];
+            description = ''
+              Packages whose `lib` output is joined into `LD_LIBRARY_PATH`
+              for the service, so compiled C-extension wheels (scipy,
+              matplotlib, Pillow, etc.) can find runtime shared libraries
+              that manylinux assumes are just present on a normal distro
+              (libstdc++.so.6, libgcc_s.so.1 — provided by the default)
+              but that don't exist anywhere on NixOS's FHS-less
+              filesystem otherwise. Add more per-app as needed, e.g.
+              `pkgs.gfortran.cc.lib` for scipy's libgfortran/libquadmath.
+            '';
+          };
+
+          execStart = lib.mkOption {
+            type = lib.types.str;
+            description = ''
+              Shell command used to start the app. Reference the venv
+              via the `$VENV` environment variable, e.g.
+              `"$VENV/bin/uvicorn app.main:app --host 0.0.0.0 --port 8078"`.
+            '';
+          };
+
+          environment = lib.mkOption {
+            type = lib.types.attrsOf lib.types.str;
+            default = { };
+            description = "Extra environment variables for the service.";
+          };
+
+          environmentFile = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = "Optional EnvironmentFile= (e.g. a sops secret) for the service.";
+          };
+
+          after = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ "network-online.target" ];
+            description = "systemd `After=` units.";
+          };
+
+          wants = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ "network-online.target" ];
+            description = "systemd `Wants=` units.";
+          };
+        };
+      }
+    );
+  };
+
+  config.systemd.services = lib.listToAttrs (lib.mapAttrsToList mkService cfg);
+}


### PR DESCRIPTION
## Summary

Stands up two new pip-managed Python services on `fredvps` (`test-site` and `discord-bot`), whose upstreams pin dependency versions far behind what nixpkgs ships, via a reusable systemd + venv module. Also includes an unrelated small `sdrhub` fix picked up along the way.

- **`feat(services): add reusable python-venv-app systemd module`**
  New `modules/services/python-venv-app.nix`: runs a Python app in a venv scoped to its own directory (outside the Nix store -- a manually `git clone`d checkout). Nix manages only the systemd unit and the interpreter used to create the venv; every dependency is resolved by `pip` straight from PyPI at service-start time, kept in sync with `requirements.txt` via a sha256-stamp check. Also sets `LD_LIBRARY_PATH` (default `stdenv.cc.cc.lib`) since manylinux wheels assume `libstdc++`/`libgcc_s` are just present on a normal distro -- NixOS has no FHS paths.

- **`feat(fredvps): stand up test-site and discord-bot services`**
  Wires the module to both apps (code lives at `/home/nik/<app>`):
  - `test-site`: uvicorn on `:8078`, `python311` (`scipy==1.10.1` has no cp312+ wheel)
  - `discord-bot`: `python312` (`matplotlib==3.7.5` has no cp313 wheel)

  Also opens `:8078` on the firewall, adds the discord DB filesystem layout (`/mnt/discord`, `/mnt/discord-storage/backups`) + nightly backup timer, and exposes test-site at `flipaholics.pro` via nginx.

- **`fix(fredvps): add explicit nginx default vhost`**
  Without an explicit `default_server`, nginx's implicit default falls back to whichever vhost sorts first alphabetically (Nix attrsets always enumerate keys alphabetically) -- which was silently serving `acarshub.app`'s content *and* TLS cert to any unmatched Host/SNI (including a typo'd domain during testing). Adds an explicit `"_"` catch-all vhost (with a generated self-signed cert so it also claims the `:443`/SNI default) that returns `444` instead. Verified by force-building the generated `nginx.conf` derivation (`nginx -t` + `gixy` both pass).

- **`feat(sdrhub): enable Unbound remote-control`**
  Unrelated small fix picked up in the same session -- enables `unbound-control` for runtime cache management without a restart.

## Testing

- `nixfmt --check` / `statix check` / `deadnix --fail` clean on all touched files.
- `nix eval` on `fredvps` and `sdrhub` toplevel `system.build.toplevel.drvPath` succeeds for every commit.
- Deployed live to `fredvps` via `colmena apply` during development; both `pyapp-test-site` and `pyapp-discord-bot` confirmed `active (running)`.
- Forced a real build of the generated `nginx.conf` derivation (`nginx -t` + `gixy`) to validate the vhost changes beyond just Nix eval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running Python virtual-environment applications as managed services.
  * Added the test site at `flipaholics.pro`, including HTTPS and reverse proxy support.
  * Added nightly Discord database backups with automatic 30-day retention.
  * Added a secure default response for unrecognized web traffic.
* **Networking**
  * Opened the required port for the test site.
  * Enabled remote control for the SDRHub DNS resolver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->