### PR TITLE
chore(flake/home-manager): `79e60825` -> `e473bdcd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783689750,
-        "narHash": "sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb+A9ehn8k=",
+        "lastModified": 1783814254,
+        "narHash": "sha256-bsqgm3shjBFaLJ8kzQxhPtc3ftqMeTSVBeCTg7ELA3k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79e6082586b3680ff32c8e75127545058f074fa4",
+        "rev": "e473bdcd8786928b35061bc281568d91d752a2e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`e473bdcd`](https://github.com/nix-community/home-manager/commit/e473bdcd8786928b35061bc281568d91d752a2e6) | `` home-cursor: update URL to Freedesktop.org specs ``               |
| [`564bc37d`](https://github.com/nix-community/home-manager/commit/564bc37de50075e03ccfba5dc894ae25804ef3ce) | `` kitty: fix diff.conf being generated regardless of user config `` |
| [`0992a294`](https://github.com/nix-community/home-manager/commit/0992a2948749a61d54065e96df26d75d1b1da50f) | `` television: add extraPackages option with default dependencies `` |
| [`2afec152`](https://github.com/nix-community/home-manager/commit/2afec152df4e284d264f8489d16004c264aebf4c) | `` tests/darwinScrublist: add podman ``                              |
| [`d29a1c0f`](https://github.com/nix-community/home-manager/commit/d29a1c0f34263781a79c15d61afcabb8e73ec3ce) | `` flake: bump nixpkgs from `9e92285` to `767b0d3` ``                |
| [`3e2af6c9`](https://github.com/nix-community/home-manager/commit/3e2af6c9e5d32d6fa766d4ca675bace5bfe01dc6) | `` tests/darwinScrublist: add colima, gurk-rs ``                     |
| [`f9382775`](https://github.com/nix-community/home-manager/commit/f938277527aa084929261879d50d9832b9eab6d3) | `` claude-code: tighten module implementation ``                     |
| [`437ae5be`](https://github.com/nix-community/home-manager/commit/437ae5be42e6fba5b72f196ba4ab212c347e2afd) | `` claude-code: test plugin collisions ``                            |
| [`5c7199cd`](https://github.com/nix-community/home-manager/commit/5c7199cd3b8321d89830a3dee3cf6991433a38cf) | `` claude-code: split module files ``                                |
| [`1c029fb0`](https://github.com/nix-community/home-manager/commit/1c029fb0dc9bd2c7623c6e0fa19bf64230dac25d) | `` claude-code: load plugins without wrapper ``                      |