### PR TITLE
chore(flake/precommit-base): `edc9ac49` -> `53d43fa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1086,11 +1086,11 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1783874182,
-        "narHash": "sha256-bVDZieE6WK0/+EtpzZjVVKOOSxpu3iRmw5MuB1VbtFI=",
+        "lastModified": 1783875114,
+        "narHash": "sha256-cWt7QWPQXCRFFJl7+MeDTrKNFiDxB84pjwjIAVGmsPc=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "53d43fa05b4de2c1041d41a21d58efae2b674c59",
+        "rev": "538e1735c9dc44bb8fc3bc2918a3a5618896a60d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1086,11 +1086,11 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1783875114,
-        "narHash": "sha256-cWt7QWPQXCRFFJl7+MeDTrKNFiDxB84pjwjIAVGmsPc=",
+        "lastModified": 1783875506,
+        "narHash": "sha256-Hx7uYdd6XyBohpAyIJwzjsJrUsY9ucOpzxoGMV+AYsI=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "538e1735c9dc44bb8fc3bc2918a3a5618896a60d",
+        "rev": "7ffbe4d244ef810e871ff616988753131c9595e8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -870,11 +870,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -1086,11 +1086,11 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1783675727,
-        "narHash": "sha256-GJifPCjdc61jDJbAk9f6SCX79oeixqiZduhyjSQsy+c=",
+        "lastModified": 1783874182,
+        "narHash": "sha256-bVDZieE6WK0/+EtpzZjVVKOOSxpu3iRmw5MuB1VbtFI=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "edc9ac49ba8bcf968fcdad3d0605cf8aaddfab90",
+        "rev": "53d43fa05b4de2c1041d41a21d58efae2b674c59",
         "type": "github"
       },
       "original": {
@@ -1231,11 +1231,11 @@
         "nixpkgs": "nixpkgs_14"
       },
       "locked": {
-        "lastModified": 1783663825,
-        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
+        "lastModified": 1783834461,
+        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
+        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                                                    |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`53d43fa0`](https://github.com/fredsystems/pre-commit-checks/commit/53d43fa05b4de2c1041d41a21d58efae2b674c59) | `` chore(flake/nixpkgs): 0bb7ec54 -> e7a3ca80 ``                           |
| [`fc8d9b93`](https://github.com/fredsystems/pre-commit-checks/commit/fc8d9b9382519b7f1c256da05eebe82aa7aedfaf) | `` chore(flake/rust-overlay): 072adf9b -> a286e5b9 ``                      |
| [`3076ff29`](https://github.com/fredsystems/pre-commit-checks/commit/3076ff29e23e52d8c3cd4c18d8ec086ed6ba8380) | `` chore(flake/nixpkgs): b5aa0fbd -> 0bb7ec54 ``                           |
| [`bc538894`](https://github.com/fredsystems/pre-commit-checks/commit/bc53889457a8989d181d68d3d0d40fbe5f0d0a50) | `` fix(checks): stop failing CI over markdown table widths ``              |
| [`b1c8ac3f`](https://github.com/fredsystems/pre-commit-checks/commit/b1c8ac3f736a4b1a05650867d1492beb2b875b6b) | `` fix(nix): skip flaky nixpkgs pre-commit test_output_isatty on darwin `` |