### PR TITLE
chore(flake/niri): `fd5efd81` -> `380a19e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -653,11 +653,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1783684911,
-        "narHash": "sha256-zcPkbn0/mpzyPUTw0h8BjViSPQaFdwAlYeI68TW9CSo=",
+        "lastModified": 1783827352,
+        "narHash": "sha256-gVX8c9XpccJDWrhI79TtDnyol54cFn2S4kXyV/QdOm8=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "fd5efd8106069ae6f2740ddf9d2f9611792ccf35",
+        "rev": "380a19e504036daf1be24a88afc0f0a7f5bf0467",
         "type": "github"
       },
       "original": {
@@ -790,11 +790,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1783389287,
-        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
+        "lastModified": 1783703440,
+        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
+        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
         "type": "github"
       },
       "original": {
@@ -995,11 +995,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`380a19e5`](https://github.com/epireyn/niri-flake/commit/380a19e504036daf1be24a88afc0f0a7f5bf0467) | `` Update flake.lock `` |
| [`9e22e613`](https://github.com/epireyn/niri-flake/commit/9e22e61351bc17ae963314bba6b6fa2c87ef38af) | `` Update flake.lock `` |
| [`0b564489`](https://github.com/epireyn/niri-flake/commit/0b564489fcf053113636b758b610dfc5f3909029) | `` Update flake.lock `` |