### PR TITLE
chore(flake/nixpkgs-stable): `0ad6f47e` -> `8f0500b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -806,11 +806,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1783389287,
-        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
+        "lastModified": 1783703440,
+        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
+        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`7a7b575b`](https://github.com/NixOS/nixpkgs/commit/7a7b575b9c85290066afad00b399ac84c722cff8) | `` charm-freeze: exclude test/input package ``                                            |
| [`a5875aa6`](https://github.com/NixOS/nixpkgs/commit/a5875aa6b236b52e68098ef2c4208161b8173f0b) | `` hugo: 0.163.2 -> 0.163.3 ``                                                            |
| [`4f38ab71`](https://github.com/NixOS/nixpkgs/commit/4f38ab71b6c3c55890cc9034a171aa8bf0f3e558) | `` hugo: 0.162.1 -> 0.163.2 ``                                                            |
| [`7c95708d`](https://github.com/NixOS/nixpkgs/commit/7c95708d481ae0e2fbac6947b87a727976a24573) | `` hugo: 0.161.1 -> 0.162.1 ``                                                            |
| [`32225a87`](https://github.com/NixOS/nixpkgs/commit/32225a87bd1ed06cc520ff215862eaec33832473) | `` pkgs/top-level/aliases.nix: Fix aliases introduced with lomiri-qt6 ``                  |
| [`27675fd9`](https://github.com/NixOS/nixpkgs/commit/27675fd9d8fc3f19ae4d14aa01264ed114fdde16) | `` acli: 1.3.21-stable -> 1.3.22-stable ``                                                |
| [`b37ac397`](https://github.com/NixOS/nixpkgs/commit/b37ac397f18a99ad1be7a29395493e1991992529) | `` mattermostLatest: 11.8.2 -> 11.8.3 ``                                                  |
| [`250cbaed`](https://github.com/NixOS/nixpkgs/commit/250cbaed995858e223e68d79670ca7554c430767) | `` blink-qt: 6.0.4 -> 6.0.6 ``                                                            |
| [`2f2a8aaf`](https://github.com/NixOS/nixpkgs/commit/2f2a8aaf8af0c4dca62d327540a4eb3acf301953) | `` forgejo: 15.0.3 -> 15.0.4 ``                                                           |
| [`9a2b64a6`](https://github.com/NixOS/nixpkgs/commit/9a2b64a626ebedd6ae8080b0504d30c96d8de59d) | `` rclone: 1.74.3 -> 1.74.4 ``                                                            |
| [`7fd15dd3`](https://github.com/NixOS/nixpkgs/commit/7fd15dd3820dec5a5bc66e36d2690a3b373475db) | `` navidrome: 0.62.0 -> 0.63.1 ``                                                         |
| [`e6a7921c`](https://github.com/NixOS/nixpkgs/commit/e6a7921c8b4096c88828454bb6dbb8b5e71e3d0e) | `` ungoogled-chromium: 150.0.7871.100-1 -> 150.0.7871.114-1 ``                            |
| [`c97ec052`](https://github.com/NixOS/nixpkgs/commit/c97ec0524c8bd24a969cf64e2ea5c143d66d704a) | `` chromium,chromedriver: 150.0.7871.100 -> 150.0.7871.114 ``                             |
| [`303b5b21`](https://github.com/NixOS/nixpkgs/commit/303b5b21148612b8bd57ea69490049ad75dcbaf2) | `` rgx: 0.14.1 -> 0.14.2 ``                                                               |
| [`b5ae9117`](https://github.com/NixOS/nixpkgs/commit/b5ae911707952360378d0c6ccf9a84176b37e806) | `` evcc: 0.309.1 -> 0.311.1 ``                                                            |
| [`c4489e89`](https://github.com/NixOS/nixpkgs/commit/c4489e8905bdb9c370d9d0f68dd900e9317ae3ff) | `` evcc: 0.309.0 -> 0.309.1 ``                                                            |
| [`1257fc38`](https://github.com/NixOS/nixpkgs/commit/1257fc38e26fda20569932c550a28b990cf37670) | `` evcc: 0.308.1 -> 0.309.0 ``                                                            |
| [`edcb2a03`](https://github.com/NixOS/nixpkgs/commit/edcb2a03841c2b713bfacb337900850002c98780) | `` evcc: 0.308.0 -> 0.308.1 ``                                                            |
| [`b04740f7`](https://github.com/NixOS/nixpkgs/commit/b04740f77ffd9395e5edfe6a9f49ddccd65b23d6) | `` evcc: 0.307.2 -> 0.308.0 ``                                                            |
| [`67ac48c3`](https://github.com/NixOS/nixpkgs/commit/67ac48c392a47783564194337301efaede0e7141) | `` evcc: 0.307.1 -> 0.307.2 ``                                                            |
| [`7a7b575b`](https://github.com/NixOS/nixpkgs/commit/7a7b575b9c85290066afad00b399ac84c722cff8) | `` charm-freeze: exclude test/input package ``                                            |
| [`a5875aa6`](https://github.com/NixOS/nixpkgs/commit/a5875aa6b236b52e68098ef2c4208161b8173f0b) | `` hugo: 0.163.2 -> 0.163.3 ``                                                            |
| [`4f38ab71`](https://github.com/NixOS/nixpkgs/commit/4f38ab71b6c3c55890cc9034a171aa8bf0f3e558) | `` hugo: 0.162.1 -> 0.163.2 ``                                                            |
| [`7c95708d`](https://github.com/NixOS/nixpkgs/commit/7c95708d481ae0e2fbac6947b87a727976a24573) | `` hugo: 0.161.1 -> 0.162.1 ``                                                            |
| [`32225a87`](https://github.com/NixOS/nixpkgs/commit/32225a87bd1ed06cc520ff215862eaec33832473) | `` pkgs/top-level/aliases.nix: Fix aliases introduced with lomiri-qt6 ``                  |
| [`27675fd9`](https://github.com/NixOS/nixpkgs/commit/27675fd9d8fc3f19ae4d14aa01264ed114fdde16) | `` acli: 1.3.21-stable -> 1.3.22-stable ``                                                |
| [`b37ac397`](https://github.com/NixOS/nixpkgs/commit/b37ac397f18a99ad1be7a29395493e1991992529) | `` mattermostLatest: 11.8.2 -> 11.8.3 ``                                                  |
| [`250cbaed`](https://github.com/NixOS/nixpkgs/commit/250cbaed995858e223e68d79670ca7554c430767) | `` blink-qt: 6.0.4 -> 6.0.6 ``                                                            |
| [`2f2a8aaf`](https://github.com/NixOS/nixpkgs/commit/2f2a8aaf8af0c4dca62d327540a4eb3acf301953) | `` forgejo: 15.0.3 -> 15.0.4 ``                                                           |
| [`9a2b64a6`](https://github.com/NixOS/nixpkgs/commit/9a2b64a626ebedd6ae8080b0504d30c96d8de59d) | `` rclone: 1.74.3 -> 1.74.4 ``                                                            |
| [`7fd15dd3`](https://github.com/NixOS/nixpkgs/commit/7fd15dd3820dec5a5bc66e36d2690a3b373475db) | `` navidrome: 0.62.0 -> 0.63.1 ``                                                         |
| [`e6a7921c`](https://github.com/NixOS/nixpkgs/commit/e6a7921c8b4096c88828454bb6dbb8b5e71e3d0e) | `` ungoogled-chromium: 150.0.7871.100-1 -> 150.0.7871.114-1 ``                            |
| [`c97ec052`](https://github.com/NixOS/nixpkgs/commit/c97ec0524c8bd24a969cf64e2ea5c143d66d704a) | `` chromium,chromedriver: 150.0.7871.100 -> 150.0.7871.114 ``                             |
| [`303b5b21`](https://github.com/NixOS/nixpkgs/commit/303b5b21148612b8bd57ea69490049ad75dcbaf2) | `` rgx: 0.14.1 -> 0.14.2 ``                                                               |
| [`b5ae9117`](https://github.com/NixOS/nixpkgs/commit/b5ae911707952360378d0c6ccf9a84176b37e806) | `` evcc: 0.309.1 -> 0.311.1 ``                                                            |
| [`c4489e89`](https://github.com/NixOS/nixpkgs/commit/c4489e8905bdb9c370d9d0f68dd900e9317ae3ff) | `` evcc: 0.309.0 -> 0.309.1 ``                                                            |
| [`1257fc38`](https://github.com/NixOS/nixpkgs/commit/1257fc38e26fda20569932c550a28b990cf37670) | `` evcc: 0.308.1 -> 0.309.0 ``                                                            |
| [`edcb2a03`](https://github.com/NixOS/nixpkgs/commit/edcb2a03841c2b713bfacb337900850002c98780) | `` evcc: 0.308.0 -> 0.308.1 ``                                                            |
| [`b04740f7`](https://github.com/NixOS/nixpkgs/commit/b04740f77ffd9395e5edfe6a9f49ddccd65b23d6) | `` evcc: 0.307.2 -> 0.308.0 ``                                                            |
| [`67ac48c3`](https://github.com/NixOS/nixpkgs/commit/67ac48c392a47783564194337301efaede0e7141) | `` evcc: 0.307.1 -> 0.307.2 ``                                                            |
| [`80f96b24`](https://github.com/NixOS/nixpkgs/commit/80f96b24d80cf6452e28f7d7b5f7e42b30487169) | `` teleport_18: 18.9.1 -> 18.9.2 ``                                                       |
| [`a56f450d`](https://github.com/NixOS/nixpkgs/commit/a56f450d653f13b0f1bd30c807e8b1d65dee658b) | `` wasm-bindgen-cli_0_2_122: init at 0.2.122 ``                                           |
| [`11a7d1fc`](https://github.com/NixOS/nixpkgs/commit/11a7d1fc0835687ee6391f6029de1c49c814e99a) | `` lighttpd: 1.4.84 -> 1.4.85 ``                                                          |
| [`93faec97`](https://github.com/NixOS/nixpkgs/commit/93faec9749f8745b7017aa8ddc8515a929de5c8f) | `` bluesky-pds: 0.4.5006 -> 0.4.5009; use pnpm 10 ``                                      |
| [`5a0dc321`](https://github.com/NixOS/nixpkgs/commit/5a0dc32193cf64c47da13655731f916360c0ddf8) | `` radicle-ci-broker: 0.29.0 -> 0.30.0 ``                                                 |
| [`cb6cc981`](https://github.com/NixOS/nixpkgs/commit/cb6cc981057a1253c046d0de0baac132d128720f) | `` lx-music-desktop: add long description about Electron's ozone platform selection ``    |
| [`91b911c5`](https://github.com/NixOS/nixpkgs/commit/91b911c526fca83ed3275e64d15a733b74986261) | `` lx-music-desktop: update Electron to v42 ``                                            |
| [`96e78df4`](https://github.com/NixOS/nixpkgs/commit/96e78df441000f7299f263cee8f8fd9d9053e807) | `` kanboard: patch CVE-2026-56774 ``                                                      |
| [`0048f541`](https://github.com/NixOS/nixpkgs/commit/0048f541685c5c62ef02059710c63f83fe07785a) | `` arti: 2.4.0 -> 2.5.0 ``                                                                |
| [`d6c525bd`](https://github.com/NixOS/nixpkgs/commit/d6c525bd716043571afe31fd4ff69ad8034938cb) | `` jay: 1.13.0 -> 1.14.0 ``                                                               |
| [`976e8b3e`](https://github.com/NixOS/nixpkgs/commit/976e8b3ee77f4ad2d938b8793951517f0e8949a7) | `` cinny-desktop: 4.12.2 -> 4.12.5 ``                                                     |
| [`dae9cd34`](https://github.com/NixOS/nixpkgs/commit/dae9cd34a1ec9fd7d9a6088ff95646fd65b4ca02) | `` cinny-unwrapped: 4.12.2 -> 4.12.3 ``                                                   |
| [`b1b80036`](https://github.com/NixOS/nixpkgs/commit/b1b80036878dc0cbd98195c0bfd0c6f971464099) | `` n8n: 2.27.4 -> 2.28.6 ``                                                               |
| [`720bf3fc`](https://github.com/NixOS/nixpkgs/commit/720bf3fc3455e7482d2b720ce7c6abebba981438) | `` brave: 1.91.180 -> 1.92.134 ``                                                         |
| [`bc6a975b`](https://github.com/NixOS/nixpkgs/commit/bc6a975b8536d5eb3cdd2c138aa03343943684dc) | `` xdg-desktop-portal-cosmic: migrate from make to just ``                                |
| [`d7453cb8`](https://github.com/NixOS/nixpkgs/commit/d7453cb8eb3dc03e27b88b203ab9f99dd5324dff) | `` lockbook-desktop: fix missing libxkbcommon at runtime; build lockbook-desktop crate `` |
| [`adba104e`](https://github.com/NixOS/nixpkgs/commit/adba104e85e3ef1454ff9cd338107ea56cad6c69) | `` thunderbird-latest-bin-unwrapped: 152.0 -> 152.0.1 ``                                  |
| [`4b1d195a`](https://github.com/NixOS/nixpkgs/commit/4b1d195a065f8bd9c2c1f101a2f06ff1339d5aab) | `` cosmic-edit: 1.1.0 -> 1.2.0 ``                                                         |
| [`c00693eb`](https://github.com/NixOS/nixpkgs/commit/c00693ebb505496708cd199cba26070a9ad16453) | `` cosmic-initial-setup: 1.1.0 -> 1.2.0 ``                                                |
| [`3f9fd311`](https://github.com/NixOS/nixpkgs/commit/3f9fd3115ad38922ae5bb4bc48d6718eae39a8b0) | `` cosmic-applets: 1.1.0 -> 1.2.0 ``                                                      |
| [`db5858cc`](https://github.com/NixOS/nixpkgs/commit/db5858cce73c8f8cb9afcb88bc9e94951f6102e1) | `` cosmic-comp: 1.1.0 -> 1.2.0 ``                                                         |
| [`b272866d`](https://github.com/NixOS/nixpkgs/commit/b272866daafd917dd0cc92e8e7e3911b519a8f6a) | `` cosmic-app-library: 1.1.0 -> 1.2.0 ``                                                  |
| [`5f0b9361`](https://github.com/NixOS/nixpkgs/commit/5f0b93615b3462148668d9470bbe80ae956d9bc3) | `` cosmic-settings: 1.1.0 -> 1.2.0 ``                                                     |
| [`bf95bfea`](https://github.com/NixOS/nixpkgs/commit/bf95bfea196ad098e022bbaa76bf3ff814213387) | `` cosmic-launcher: 1.1.0 -> 1.2.0 ``                                                     |
| [`7dec72f1`](https://github.com/NixOS/nixpkgs/commit/7dec72f18bcea0b10840276efcb5106e95a49ef4) | `` cosmic-greeter: 1.1.0 -> 1.2.0 ``                                                      |
| [`86b74ec8`](https://github.com/NixOS/nixpkgs/commit/86b74ec88f85f67c2d3f0f075e08f83c06403aa6) | `` cosmic-workspaces-epoch: 1.1.0 -> 1.2.0 ``                                             |
| [`6dbac19a`](https://github.com/NixOS/nixpkgs/commit/6dbac19a9363130eeb41e9d7c0d24403bf7c0d66) | `` cosmic-monitor: 1.1.0 -> 1.2.0 ``                                                      |
| [`1e7e952c`](https://github.com/NixOS/nixpkgs/commit/1e7e952c54ab7c87a67095d535ab4c4ea25608e5) | `` cosmic-settings-daemon: 1.1.0 -> 1.2.0 ``                                              |
| [`03ee7a89`](https://github.com/NixOS/nixpkgs/commit/03ee7a8943bb81f5de5678c2c6180591186be9e6) | `` cosmic-files: 1.1.0 -> 1.2.0 ``                                                        |
| [`56da54eb`](https://github.com/NixOS/nixpkgs/commit/56da54eb81dd17afcee7a685084ac80bb9627e6d) | `` cosmic-term: 1.1.0 -> 1.2.0 ``                                                         |
| [`5bc4b91a`](https://github.com/NixOS/nixpkgs/commit/5bc4b91a43ddae567afd3341cbeae980339dd2c2) | `` cosmic-player: 1.1.0 -> 1.2.0 ``                                                       |
| [`768f070c`](https://github.com/NixOS/nixpkgs/commit/768f070c8582d0447965f91dacc4913ee8c4fb03) | `` cosmic-notifications: 1.1.0 -> 1.2.0 ``                                                |
| [`e2e43319`](https://github.com/NixOS/nixpkgs/commit/e2e433192f526b5143a501b42f625efb83eaa2a8) | `` cosmic-store: 1.1.0 -> 1.2.0 ``                                                        |
| [`fef8f687`](https://github.com/NixOS/nixpkgs/commit/fef8f687860f8ef6e5f4365d69afc98c3f059e0c) | `` xdg-desktop-portal-cosmic: 1.1.0 -> 1.2.0 ``                                           |
| [`74a7399b`](https://github.com/NixOS/nixpkgs/commit/74a7399b2b6233864496595741b85dc04047d2ad) | `` cosmic-osd: 1.1.0 -> 1.2.0 ``                                                          |
| [`2b0bb7b8`](https://github.com/NixOS/nixpkgs/commit/2b0bb7b81645d2b0dba4cc96ec876d51c9f90919) | `` cosmic-wallpapers: 1.1.0 -> 1.2.0 ``                                                   |
| [`dcbfbc38`](https://github.com/NixOS/nixpkgs/commit/dcbfbc38d9cfe0effc14ba6974c8bbcd466262d7) | `` cosmic-screenshot: 1.1.0 -> 1.2.0 ``                                                   |
| [`e2fbc95f`](https://github.com/NixOS/nixpkgs/commit/e2fbc95fa83c380e3c9c26774f67a7fd389689dc) | `` cosmic-panel: 1.1.0 -> 1.2.0 ``                                                        |
| [`2492f125`](https://github.com/NixOS/nixpkgs/commit/2492f125ffa50aa2813e3afd342d8669c445430e) | `` cosmic-idle: 1.1.0 -> 1.2.0 ``                                                         |
| [`b7a4289e`](https://github.com/NixOS/nixpkgs/commit/b7a4289e515273cd6f27badafadb1e3ca2f7439a) | `` cosmic-bg: 1.1.0 -> 1.2.0 ``                                                           |
| [`55da453f`](https://github.com/NixOS/nixpkgs/commit/55da453fcd475810eeb6108ce60642b2640c48da) | `` cosmic-randr: 1.1.0 -> 1.2.0 ``                                                        |
| [`8ee9122a`](https://github.com/NixOS/nixpkgs/commit/8ee9122aee5f5a31e60c603be48232644532dcab) | `` cosmic-icons: 1.1.0 -> 1.2.0 ``                                                        |
| [`c8911b9a`](https://github.com/NixOS/nixpkgs/commit/c8911b9af9a41547f93d8e2858029dbd0bc7afdd) | `` cosmic-session: 1.1.0 -> 1.2.0 ``                                                      |
| [`af85eda4`](https://github.com/NixOS/nixpkgs/commit/af85eda4e289e65b63aac57184e1b8bf3f03f4b9) | `` mattermost: 11.7.4 -> 11.7.6 ``                                                        |
| [`de111da1`](https://github.com/NixOS/nixpkgs/commit/de111da1c5e99601e44b984fc1d9d23bf89d98a8) | `` mattermost: update patches ``                                                          |
| [`5f5ba517`](https://github.com/NixOS/nixpkgs/commit/5f5ba51711a4c520da4e791439e73ac3ae7dc095) | `` buildMozillaMach: enable structuredAttrs and strictDeps ``                             |
| [`9e602a77`](https://github.com/NixOS/nixpkgs/commit/9e602a778e4d1e3323d06c3cc2ba8b075d71fb8e) | `` cyberchef: 11.0.0 -> 11.2.0 ``                                                         |
| [`e173efe4`](https://github.com/NixOS/nixpkgs/commit/e173efe4c2ad08178a0dffd6de548d03b6012337) | `` temporal: 1.30.5 → 1.30.6 ``                                                           |
| [`b3482345`](https://github.com/NixOS/nixpkgs/commit/b348234516fc93d85fc31417ace779109bebe3dc) | `` copyparty: 1.20.16 -> 1.20.17 ``                                                       |
| [`c32d0fe6`](https://github.com/NixOS/nixpkgs/commit/c32d0fe6e84abbd0ae4a6563f06346e78af2dcd4) | `` copyparty: 1.20.14 -> 1.20.16 ``                                                       |
| [`4bda2099`](https://github.com/NixOS/nixpkgs/commit/4bda20995caaa15ca9bf08479a8381f4d84b3468) | `` typescript-go: 0-unstable-2026-06-25 -> 7.0.2 ``                                       |
| [`05519a6f`](https://github.com/NixOS/nixpkgs/commit/05519a6fa4cf1977b88a7c7d7738abc186b309cd) | `` typescript-go: 0-unstable-2026-06-17 -> 0-unstable-2026-06-25 ``                       |
| [`27b98434`](https://github.com/NixOS/nixpkgs/commit/27b9843410e2c99fd2c6b2659a4fb13024fd7b99) | `` wireshark: 4.6.6 -> 4.6.7 ``                                                           |
| [`70ca4005`](https://github.com/NixOS/nixpkgs/commit/70ca400558c98917cdffdebf8903c2f91b488930) | `` typescript-go: 0-unstable-2026-06-07 -> 0-unstable-2026-06-17 ``                       |
| [`3a4ed8d7`](https://github.com/NixOS/nixpkgs/commit/3a4ed8d7c988f8b69cfa9720c23c90f97cd42137) | `` typescript-go: 0-unstable-2026-05-29 -> 0-unstable-2026-06-07 ``                       |
| [`40adf087`](https://github.com/NixOS/nixpkgs/commit/40adf087c57b90c4fa5c6c811dc937bc1548c5bc) | `` typescript-go: 0-unstable-2026-05-20 -> 0-unstable-2026-05-29 ``                       |
| [`45b4e636`](https://github.com/NixOS/nixpkgs/commit/45b4e6369c1114405a3d4d90bc6e80cd398ef1e5) | `` podman-desktop: add extraPackages parameter ``                                         |
| [`3b91c24b`](https://github.com/NixOS/nixpkgs/commit/3b91c24b0d9043058c656a239246a4c8939b1548) | `` google-chrome: 150.0.7871.46 -> 150.0.7871.100 ``                                      |
| [`23b8a4b5`](https://github.com/NixOS/nixpkgs/commit/23b8a4b53a969d59a03f936fa9b8cab66d669578) | `` librewolf-unwrapped: 152.0.4-1 -> 152.0.5-1 ``                                         |
| [`2bea521c`](https://github.com/NixOS/nixpkgs/commit/2bea521c3431f990ae1e4ec1489b45a67297cbce) | `` ungoogled-chromium: 150.0.7871.46-1 -> 150.0.7871.100-1 ``                             |
| [`905f5bee`](https://github.com/NixOS/nixpkgs/commit/905f5bee781dc8f45975ab566eef574728221d89) | `` modrinth-app-unwrapped: 0.15.1 -> 0.15.7 ``                                            |
| [`4f682d32`](https://github.com/NixOS/nixpkgs/commit/4f682d3252e7166642a26b4eed3210b5a54563dd) | `` vikunja-desktop: pnpm_10_29_2 -> pnpm_10 ``                                            |
| [`ececbbf8`](https://github.com/NixOS/nixpkgs/commit/ececbbf868e6bc0f9ad086226ac8e86b6036ee36) | `` vikunja-desktop: fix darwin build ``                                                   |
| [`9604e093`](https://github.com/NixOS/nixpkgs/commit/9604e0937600b487f61c8b3894e8bd203f9d5f1d) | `` dorion: build with pnpm 10 ``                                                          |
| [`f2b99eee`](https://github.com/NixOS/nixpkgs/commit/f2b99eeec27b3363ee537b26a3d3fc580d2c79e2) | `` simplex-chat-desktop: 6.5.5 -> 6.5.6 ``                                                |
| [`fb644007`](https://github.com/NixOS/nixpkgs/commit/fb644007ef67409f6dcf3d8b9cfa735e49526681) | `` {nixos/channel,make-tarball.nix}: argue for unbounded compression threads ``           |
| [`5a052d98`](https://github.com/NixOS/nixpkgs/commit/5a052d98452d2015c47afde8ffe38c0ac24fc8c7) | `` nixos/doc/rl, doc/rl: announce nixexprs.tar.xz discontinuation ``                      |
| [`12684ce7`](https://github.com/NixOS/nixpkgs/commit/12684ce725792934e625184d0c000d2612d1ccf6) | `` nixos/channel: apply reproducibility fixes from make-tarball.nix ``                    |
| [`18d8df8f`](https://github.com/NixOS/nixpkgs/commit/18d8df8f4825f0783b8571371bc8a0d0bdf7d700) | `` make-tarball.nix: add zstd flavored nixexprs tarball ``                                |
| [`af2afa21`](https://github.com/NixOS/nixpkgs/commit/af2afa218f5e4c9b2a7eb589ca0916939d93a5e3) | `` nixos/channel: add zstd flavored nixexprs tarball ``                                   |
| [`ca8465b2`](https://github.com/NixOS/nixpkgs/commit/ca8465b26df2123af2515d26f29f886cdb21cf46) | `` etcd_3_6: 3.6.12 -> 3.6.13 ``                                                          |
| [`3c18145e`](https://github.com/NixOS/nixpkgs/commit/3c18145ebdedb2c09b10dd1977720356e3843bea) | `` weechat: 4.9.2 -> 4.9.3 ``                                                             |
| [`d82cdf7c`](https://github.com/NixOS/nixpkgs/commit/d82cdf7c42bc14a4eb48d77b455aa11125c7c306) | `` nodejs_26: 26.4.0 -> 26.5.0 ``                                                         |
| [`a5d4cb66`](https://github.com/NixOS/nixpkgs/commit/a5d4cb6638a2b0a7d4d8dd27bf3759ff085f503c) | `` equibop: 3.2.0 -> 3.2.1 ``                                                             |
| [`c2ff5249`](https://github.com/NixOS/nixpkgs/commit/c2ff52498c01307b4df5abb65e5ccbd44227e206) | `` traefik: 3.7.5 -> 3.7.6 ``                                                             |
| [`39514ab4`](https://github.com/NixOS/nixpkgs/commit/39514ab49c77b94ca8dcd9a1b909dcb57e029f70) | `` traefik: 3.7.4 -> 3.7.5 ``                                                             |
| [`958e6bae`](https://github.com/NixOS/nixpkgs/commit/958e6baefb850437f41d800051275484887b15e4) | `` traefik: 3.7.1 -> 3.7.4 ``                                                             |
| [`884d4f29`](https://github.com/NixOS/nixpkgs/commit/884d4f292a515c534ebdc6aaa65eb337ba8ce399) | `` zipline: 4.6.3 -> 4.6.4 ``                                                             |
| [`268f1ae6`](https://github.com/NixOS/nixpkgs/commit/268f1ae62a2004dc815f98bfcf7e3f118d54b459) | `` actual-server: 26.6.0 -> 26.7.0 ``                                                     |
| [`ba145f45`](https://github.com/NixOS/nixpkgs/commit/ba145f45332d5fcc0aaf014c2cfdf23e9e79327e) | `` rio: 0.4.5 -> 0.4.7 ``                                                                 |
| [`a30317c4`](https://github.com/NixOS/nixpkgs/commit/a30317c408d0181ca5c88be1223638aa315fc937) | `` apacheKafka: 4_2: 4.2.0 → 4.2.1 ``                                                     |
| [`4bd6faa7`](https://github.com/NixOS/nixpkgs/commit/4bd6faa7ee6a8f9fb509670a95c9b96334487a63) | `` ocamlPackages.js_of_ocaml: 6.4.0 → 6.4.1 ``                                            |
| [`bf7b4bed`](https://github.com/NixOS/nixpkgs/commit/bf7b4beded244662017df4e945a9c629d808ce57) | `` maintainers: fix githubId for fraioveio ``                                             |
| [`c012145b`](https://github.com/NixOS/nixpkgs/commit/c012145b7f6e93524b2eb3b5b31b33858319ebba) | `` gh-dash: 4.24.1 -> 4.25.0 ``                                                           |
| [`3cd42154`](https://github.com/NixOS/nixpkgs/commit/3cd42154d432e5fe7b4b42e620cff3182b563b16) | `` xorg-server: 21.1.23 -> 21.1.24 ``                                                     |
| [`e573bf1f`](https://github.com/NixOS/nixpkgs/commit/e573bf1f24384fc8f3dae354eebf4858126b7584) | `` xwayland: 24.1.12 -> 24.1.13 ``                                                        |
| [`2d7b18eb`](https://github.com/NixOS/nixpkgs/commit/2d7b18eb41367731d675f06821a12147bb26564e) | `` go_1_25: 1.25.11 -> 1.25.12 ``                                                         |
| [`ad4e00fb`](https://github.com/NixOS/nixpkgs/commit/ad4e00fbd1d13ebadf91c429d753aa7fcc5044a5) | `` nixfmt: 1.3.1 → 1.4.0 ``                                                               |
| [`92c67136`](https://github.com/NixOS/nixpkgs/commit/92c671367c21c8c0e578fac51dabd9412ea8d522) | `` nixos/sabnzbd: add secretValues option ``                                              |
| [`6b2d10b6`](https://github.com/NixOS/nixpkgs/commit/6b2d10b6303cdf310a4eafdf29a91c125fafc8fe) | `` chromium,chromedriver: 150.0.7871.46 -> 150.0.7871.100 ``                              |
| [`67480565`](https://github.com/NixOS/nixpkgs/commit/6748056585c343fe250dd047e4bf1c6a1f3686cb) | `` kbd-ergol: init at version 0-unstable-2026-07-03 (#5111b8c90c) ``                      |
| [`9a045dc8`](https://github.com/NixOS/nixpkgs/commit/9a045dc874a12b337227a6fa111aebd7757f65af) | `` maintainers: add xaltsc ``                                                             |
| [`b500a481`](https://github.com/NixOS/nixpkgs/commit/b500a48105c69463e27c9b04ace8a9f2ba863c16) | `` sops: 3.13.1 -> 3.13.2 ``                                                              |
| [`d8ea8f3d`](https://github.com/NixOS/nixpkgs/commit/d8ea8f3df0b6d0759ebcc487e04fb4a445777709) | `` polkit-stdin-agent: 0.3.0 -> 0.3.1 ``                                                  |
| [`91f0e0fc`](https://github.com/NixOS/nixpkgs/commit/91f0e0fcbecccacc4cc87a1f9b626ca21e40937a) | `` .github: Bump korthout/backport-action from 4.5.2 to 4.6.0 ``                          |
| [`c7124c89`](https://github.com/NixOS/nixpkgs/commit/c7124c89a96cf4d8a7c89597862e95af26e008c7) | `` firefox-bin-unwrapped: 152.0.4 -> 152.0.5 ``                                           |
| [`e70593b4`](https://github.com/NixOS/nixpkgs/commit/e70593b4d46b9fe2fd513a8feb151dc3ade228b8) | `` firefox-unwrapped: 152.0.4 -> 152.0.5 ``                                               |
| [`51909334`](https://github.com/NixOS/nixpkgs/commit/51909334de0486453b3a76bc7821128d305c8a54) | `` ci/eval: add opt-in instruction counting using perf ``                                 |
| [`5e76e9dc`](https://github.com/NixOS/nixpkgs/commit/5e76e9dc472ae45dfdfdbfb1c5725dc4d869c881) | `` ci/treefmt: add `gitMinimal` for `treefmt` ``                                          |
| [`e4c945dc`](https://github.com/NixOS/nixpkgs/commit/e4c945dc7fb385f3b0105a41e053a7bb6a1fdba6) | `` python313Packages.bilibili-api-python: drop, source unavailable ``                     |
| [`3c039c95`](https://github.com/NixOS/nixpkgs/commit/3c039c95ea7d53e1584e23e1d7bff6e6a039ddf4) | `` anydesk: 8.0.3 -> 8.0.4 ``                                                             |
| [`cda1cb63`](https://github.com/NixOS/nixpkgs/commit/cda1cb6331ebaaccfcee3e0efc8873a8881d0ebc) | `` matrix-tuwunel: 1.7.1 -> 1.8.0 ``                                                      |
| [`5433fac3`](https://github.com/NixOS/nixpkgs/commit/5433fac34de5686f5b3f960fefe0687ca00d5495) | `` kdePackages: Plasma 6.6.5 -> 6.6.6 ``                                                  |
| [`34fa03ea`](https://github.com/NixOS/nixpkgs/commit/34fa03eaf9ff881679c7f9c71ef7316e920ae16a) | `` yaookctl: 0-unstable-2026-06-23 -> 0-unstable-2026-07-02 ``                            |
| [`346f0d7c`](https://github.com/NixOS/nixpkgs/commit/346f0d7c1dfae5cfe8efd187a95a0fb607f25015) | `` yaookctl: 0-unstable-2026-06-18 -> 0-unstable-2026-06-23 ``                            |
| [`f5d5cc0e`](https://github.com/NixOS/nixpkgs/commit/f5d5cc0e88e3a4761b3b5cc161a7ce8af111cede) | `` llvmPackages_git: 23.0.0-unstable-2026-06-28 -> 23.0.0-unstable-2026-07-05 ``          |
| [`bae1206a`](https://github.com/NixOS/nixpkgs/commit/bae1206a002896298d95ab3f10aa21bb883aa203) | `` gtree: 1.14.5 -> 1.14.9 ``                                                             |
| [`fd3c140b`](https://github.com/NixOS/nixpkgs/commit/fd3c140badf96160e91720d4e64c93632e54a6ae) | `` gelly: 1.7.0 -> 1.9.0 ``                                                               |
| [`e8602513`](https://github.com/NixOS/nixpkgs/commit/e86025131c6bdcde14884199ec10175ebb6c86f8) | `` gelly: add nix-update-script ``                                                        |
| [`52b2636d`](https://github.com/NixOS/nixpkgs/commit/52b2636d11ab46652eda7241e7022420ea6a02f0) | `` dotnet_{8,9,10,11}.vmr: move env variable into env for structuredAttrs ``              |
| [`6b431842`](https://github.com/NixOS/nixpkgs/commit/6b431842eecb136ff2c308e365c12092a064cc4a) | `` yaookctl: 0-unstable-2026-04-24 -> 0-unstable-2026-06-18 ``                            |
| [`0850fde4`](https://github.com/NixOS/nixpkgs/commit/0850fde40f34b919203e80bee4233d352a728b9d) | `` openstack-rs: 0.13.5 -> 0.13.7 ``                                                      |
| [`d6be26e2`](https://github.com/NixOS/nixpkgs/commit/d6be26e25df7c6ead504e7f384f2db4efb0110a8) | `` microsoft-edge: remove maintainer bricklou ``                                          |
| [`403ab773`](https://github.com/NixOS/nixpkgs/commit/403ab77339d9ec7d9196eaadee6812d2bf710563) | `` dyalog: 20.0.52753 -> 20.0.53963 ``                                                    |
| [`5ab9cfd6`](https://github.com/NixOS/nixpkgs/commit/5ab9cfd6104bd6e6522523cf3af16585b6551a58) | `` xdp-tools: strip debug info from test binaries ``                                      |
| [`dbf6d887`](https://github.com/NixOS/nixpkgs/commit/dbf6d887166a48a88c69ea41b08d463a0a61c743) | `` roundcube: 1.7.1 -> 1.7.2 ``                                                           |