### PR TITLE
chore(flake/home-manager): `e473bdcd` -> `7566825d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783814254,
-        "narHash": "sha256-bsqgm3shjBFaLJ8kzQxhPtc3ftqMeTSVBeCTg7ELA3k=",
+        "lastModified": 1783823409,
+        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e473bdcd8786928b35061bc281568d91d752a2e6",
+        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7566825d`](https://github.com/nix-community/home-manager/commit/7566825d4652a1b885bd4ce65bd9e8def432fec9) | `` swayimg: support new lua config ``                                |
| [`ae6f9760`](https://github.com/nix-community/home-manager/commit/ae6f976083395174f29cccf8d85aaa7182f37bf9) | `` psd: remove aliased packages ``                                   |
| [`c74f4f6c`](https://github.com/nix-community/home-manager/commit/c74f4f6cdd3afbfda55995a4a97333ed5cf13f45) | `` opencode: document plugin option usage in settings description `` |