### PR TITLE
chore(flake/nixvim): `ebffdb62` -> `4ef28e44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -854,11 +854,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1783279667,
-        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "lastModified": 1783791668,
+        "narHash": "sha256-zbcZ1dmBTPfJ7Mlqh/yLEPGpgJnwuv4Xr1xucy2WqMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "rev": "716c7a2664ca8325617b8a7fbb609273f2c4cae7",
         "type": "github"
       },
       "original": {
@@ -1032,11 +1032,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1783647864,
-        "narHash": "sha256-gtVkWD4SbsvQQ8aSFEsrUTxxyuim4/ZC6lBJmA+sE/k=",
+        "lastModified": 1783869492,
+        "narHash": "sha256-47qs7UofgjxU6m7c90RycaHjvEXnVM5DeVEAtaPVPUA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ebffdb62cd1604537ee51d4d23258c002f1c90f8",
+        "rev": "4ef28e447b9003b67ff7fa9488a3be93c43312db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`4ef28e44`](https://github.com/nix-community/nixvim/commit/4ef28e447b9003b67ff7fa9488a3be93c43312db) | `` Revert "tests: disable vectorcode" ``                              |
| [`c2faafac`](https://github.com/nix-community/nixvim/commit/c2faafacaf9379cb5e725e09a639f54821bc73cc) | `` Revert "tests/all-package-defaults: disable codex on darwin" ``    |
| [`ea95b028`](https://github.com/nix-community/nixvim/commit/ea95b028a30383ff7ff9c03db85a8d1c845d3049) | `` docs: drop nixos-render-docs overlay ``                            |
| [`0cc0a3d0`](https://github.com/nix-community/nixvim/commit/0cc0a3d0b4cf83bdc2caa0b35ea88a20f4a2279e) | `` flake: Update ``                                                   |
| [`992c9c0f`](https://github.com/nix-community/nixvim/commit/992c9c0f743822d68b51b7a11c6a07b4b50e27e9) | `` tests/all-package-defaults: disable R on darwin ``                 |
| [`31035453`](https://github.com/nix-community/nixvim/commit/310354533126909f8dec4cc4312298210bd73843) | `` tests/all-package-defaults: disable codex on darwin ``             |
| [`adc03a3d`](https://github.com/nix-community/nixvim/commit/adc03a3d705b49a7e5b27b269d714023b30b23c7) | `` tests/all-package-defaults: disable godot on darwin ``             |
| [`637d4598`](https://github.com/nix-community/nixvim/commit/637d45981ffa8a09484880546eba5e194ff10aeb) | `` tests/all-package-defaults: disable sioyek on darwin ``            |
| [`1aee8fbd`](https://github.com/nix-community/nixvim/commit/1aee8fbd1f0eba1eb44ddaf2d283d46ceefc3cff) | `` tests: disable cpplint ``                                          |
| [`ebd0f063`](https://github.com/nix-community/nixvim/commit/ebd0f063f85f88403876ea1e4005d3f6dc193e9f) | `` modules/doc: disable man-docs on darwin ``                         |
| [`b275f90b`](https://github.com/nix-community/nixvim/commit/b275f90bee52bf0e143893844e36dfe5536496f5) | `` tests: disable fstar ``                                            |
| [`7204212d`](https://github.com/nix-community/nixvim/commit/7204212dd066403e0384ceec8416ce5766901472) | `` tests: disable swiftformat ``                                      |
| [`1b06626c`](https://github.com/nix-community/nixvim/commit/1b06626c1736995d228d141a122d7ecd6da4167f) | `` tests: disable vectorcode ``                                       |
| [`787af2e4`](https://github.com/nix-community/nixvim/commit/787af2e44dfb0e07a2540242b39fe0c1545fb2dc) | `` tests: disable slither-analyzer ``                                 |
| [`64b8f4d7`](https://github.com/nix-community/nixvim/commit/64b8f4d7fe96538195516cc7bd123c2593018140) | `` plugins/efmls-configs/packages: declare oxfmt & oxlint packages `` |
| [`9350b370`](https://github.com/nix-community/nixvim/commit/9350b3700afe0a3bcda86508d475a6ea12618f16) | `` plugins/vimtex: update default texlive to top-level package ``     |
| [`dd0e044f`](https://github.com/nix-community/nixvim/commit/dd0e044f8f3e5f3e4ba56056480e21066db56e83) | `` generated: Updated efmls-configs-sources.json ``                   |
| [`6fe08ab8`](https://github.com/nix-community/nixvim/commit/6fe08ab8f9defb0d9616e91c6b6fa88be6e6909e) | `` flake: Update ``                                                   |