### PR TITLE
fix(libreoffice): spelling dictionaries

### DIFF
--- a/features/desktop/libreoffice/default.nix
+++ b/features/desktop/libreoffice/default.nix
@@ -3,10 +3,36 @@ import ../../../modules/lib/mk-simple-package-module.nix {
   optionPath = "desktop.libreoffice";
   description = "LibreOffice";
   packages =
-    pkgs: with pkgs; [
-      libreoffice-qt
+    pkgs:
+    with pkgs;
+    let
+      # The libreoffice wrapper only discovers hunspell/hyphen dictionaries by
+      # scanning $NIX_PROFILES at runtime. That variable is exported by
+      # /etc/set-environment for interactive shells but is NOT present in the
+      # systemd graphical/D-Bus session, so dictionaries silently vanish when
+      # LibreOffice is launched from the app launcher. Bake DICPATH into the
+      # wrapper at build time so it works regardless of how it is started.
+      hunspellDictionaries = [ hunspellDicts.en_US-large ];
+      hyphenDictionaries = [ hyphenDicts.en_US ];
+      dictionaries = hunspellDictionaries ++ hyphenDictionaries;
+      dicPath = lib.concatStringsSep ":" (
+        map (d: "${d}/share/hunspell") hunspellDictionaries
+        ++ map (d: "${d}/share/hyphen") hyphenDictionaries
+      );
+      libreoffice = libreoffice-qt.override {
+        extraMakeWrapperArgs = [
+          "--prefix"
+          "DICPATH"
+          ":"
+          dicPath
+        ];
+      };
+    in
+    [
+      libreoffice
       hunspell
-      hunspellDicts.en_US
-    ];
+    ]
+    ++ dictionaries;
+
   systemWide = true;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LibreOffice dictionary discovery and availability.
  * Dictionary paths are now configured consistently, helping spell-checking and hyphenation work reliably without runtime profile scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->