### PR TITLE
chore(flake/home-manager): `7566825d` -> `a45a7c45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783823409,
-        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
+        "lastModified": 1783963347,
+        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
+        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`a45a7c45`](https://github.com/nix-community/home-manager/commit/a45a7c451455a51ae740ec3bce4024b312809c29) | `` opencode: use `meta.mainProgram` to wrap the main binary `` |