### PR TITLE
chore(flake/nixpkgs-stable): `8f0500b9` -> `569d5785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -806,11 +806,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1783856661,
+        "narHash": "sha256-ZGP04e+Q6WyQJGA9ZvI5CL6+heGQldbAG9U1T9NGvmU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "569d578509928497eddc3fdbf94a799027050be4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`8e9b075a`](https://github.com/NixOS/nixpkgs/commit/8e9b075a57159ee58a0a16c5f18663128d27d3a9) | `` fastmail: 1.2.1 -> 1.3.0, add aarch64-linux support ``                                |
| [`13589be1`](https://github.com/NixOS/nixpkgs/commit/13589be17f214b9e1a7b07618c437d8839fafce1) | `` olivetin-3k: 3000.15.0 -> 3000.17.0 ``                                                |
| [`2259c901`](https://github.com/NixOS/nixpkgs/commit/2259c901d7961c9adcb0007351866ba209219ab8) | `` typstPackages: Do not build in Hydra ``                                               |
| [`4b9584ca`](https://github.com/NixOS/nixpkgs/commit/4b9584ca2317dabe7d4599eb671bd4d329e6cee1) | `` workflows/{check,lint}: prevent git timeouts ``                                       |
| [`feaebe9d`](https://github.com/NixOS/nixpkgs/commit/feaebe9d26e47aa026b165d596e6d4f55f255d60) | `` emmet-language-server: add smoke test ``                                              |
| [`9e724364`](https://github.com/NixOS/nixpkgs/commit/9e72436441fe352903ffb8808b927abfc4cef4fd) | `` emmet-language-server: switch to nodejs-slim ``                                       |
| [`d4c82d18`](https://github.com/NixOS/nixpkgs/commit/d4c82d1800739704de7c07849ebe738b855219a8) | `` emmet-language-server: migrate from pnpm_9 to pnpm_11 ``                              |
| [`9bca7148`](https://github.com/NixOS/nixpkgs/commit/9bca71489c8e771af94f33c1c24b0799a166f6e0) | `` emmet-language-server: use pnpmBuildHook ``                                           |
| [`80b76e2f`](https://github.com/NixOS/nixpkgs/commit/80b76e2f294441cbd13124429dfb54a151c06449) | `` deadlock-mod-manager: 0.18.0 -> 1.0.0 ``                                              |
| [`eddcf3ac`](https://github.com/NixOS/nixpkgs/commit/eddcf3acbe30624168efa62c03f487a6ee59156f) | `` nixos/nfsd: allow exports to be an attrset ``                                         |
| [`85f16723`](https://github.com/NixOS/nixpkgs/commit/85f167237ed455d7fbeb8e2533750f8bcc2a5b06) | `` vivaldi: 8.0.4033.54 -> 8.1.4087.48 ``                                                |
| [`493608d8`](https://github.com/NixOS/nixpkgs/commit/493608d8a88e229dc0bec442e3514dc187412fe4) | `` libuv: fix riscv64-linux build ``                                                     |
| [`e5267851`](https://github.com/NixOS/nixpkgs/commit/e5267851e8ddff318acb4c0ea087a85265f8724a) | `` angle: add riscv64-linux support ``                                                   |
| [`219caa76`](https://github.com/NixOS/nixpkgs/commit/219caa76f22d3a4a6a93a1937ff60d3c13c2ef11) | `` feishin-web: init at 1.13.0 ``                                                        |
| [`443481a2`](https://github.com/NixOS/nixpkgs/commit/443481a2f20d7c38d3daf6fe77c894d4ec9dbb64) | `` feishin: add override for web version ``                                              |
| [`a42237ac`](https://github.com/NixOS/nixpkgs/commit/a42237acb2083f03755840d2cee79435b81ce3de) | `` openlinkhub: 0.8.8 -> 0.8.9 ``                                                        |
| [`0e9beea9`](https://github.com/NixOS/nixpkgs/commit/0e9beea9ac97f7126096158a1aebeb3d7916f9d2) | `` cliamp: fix darwin build ``                                                           |
| [`b56b6144`](https://github.com/NixOS/nixpkgs/commit/b56b614426689d4e1c9f585fefa90974a6dee1b6) | `` nextcloud*: enable structuredAttrs, strictDeps ``                                     |
| [`d97c3cd4`](https://github.com/NixOS/nixpkgs/commit/d97c3cd4ab8739b80b633ac2ef0e19c0e7b68ad7) | `` terraform-config-inspect: 0-unstable-2026-02-24 -> 0-unstable-2026-07-09 ``           |
| [`a26dae7e`](https://github.com/NixOS/nixpkgs/commit/a26dae7e713a856387f3be40b2be06abc99c44ca) | `` wget: add patches for several CVEs ``                                                 |
| [`8cf31eea`](https://github.com/NixOS/nixpkgs/commit/8cf31eeaf96ea6de550113f164def03fb5fa25aa) | `` archon-lite: 9.3.85 -> 9.3.172 ``                                                     |
| [`384a342a`](https://github.com/NixOS/nixpkgs/commit/384a342a1565ab8300ad2a298db46861c59330a5) | `` pnpm: 11.10.0 -> 11.11.0 ``                                                           |
| [`dd06b076`](https://github.com/NixOS/nixpkgs/commit/dd06b07608b7b75d923749ac4703f04ed7226dc6) | `` nextcloud34Packages.apps.recognize: init at 12.0.0 ``                                 |
| [`3c770842`](https://github.com/NixOS/nixpkgs/commit/3c770842698d6a8f629bb30ea520ab4d808637a1) | `` nextcloud33Packages.apps.memories: 8.0.1 -> 8.1.0, add support for nextcloud 34 ``    |
| [`f78d741c`](https://github.com/NixOS/nixpkgs/commit/f78d741c3ad06cc28bf68934cbecc69e3587542b) | `` nextcloudPackages: update ``                                                          |
| [`a7134f9a`](https://github.com/NixOS/nixpkgs/commit/a7134f9a3888ab2f08faf2f628c72b9d87df2e2c) | `` nextcloud34: init at 34.0.1 ``                                                        |
| [`b731fff6`](https://github.com/NixOS/nixpkgs/commit/b731fff6a15375093cc42cfcb2423f562b9d1ef6) | `` openlist: 4.2.2 -> 4.2.3 ``                                                           |
| [`01589bdb`](https://github.com/NixOS/nixpkgs/commit/01589bdb4b05dd510627e8e309f5077a553fdb8e) | `` shaka-packager: 3.7.2 -> 3.8.0 ``                                                     |
| [`bf93e6c8`](https://github.com/NixOS/nixpkgs/commit/bf93e6c808cbe76305f0debc206d45b308640577) | `` librewolf-bin-unwrapped: 152.0.4-1 -> 152.0.5-1 ``                                    |
| [`94954ea2`](https://github.com/NixOS/nixpkgs/commit/94954ea21f8f8b1a2cb4e1146fb4ca38859a4485) | `` nh-unwrapped: 4.4.0 -> 4.4.1 ``                                                       |
| [`909d3cca`](https://github.com/NixOS/nixpkgs/commit/909d3cca2b5a7fb5d8963e39f196a5ace3561c42) | `` jackett: 0.24.2151 -> 0.24.2200 ``                                                    |
| [`5d9a1a75`](https://github.com/NixOS/nixpkgs/commit/5d9a1a757788f223a15cbdbd25769de0ab1cc495) | `` chhoto-url: 7.4.1 -> 7.4.10 ``                                                        |
| [`ad901f64`](https://github.com/NixOS/nixpkgs/commit/ad901f6443c7d5c89cff0fdbf03f0a8cf3c516a0) | `` pnpm: 11.9.0 -> 11.10.0 ``                                                            |
| [`19bb828e`](https://github.com/NixOS/nixpkgs/commit/19bb828e4815ba475fce2bcb09caae5aa00fcd38) | `` tui-journal: fix changelog link ``                                                    |
| [`7a4e858c`](https://github.com/NixOS/nixpkgs/commit/7a4e858cb34aaa6013a6b60313de6f0a07bd42e0) | `` tui-journal: 0.16.1 -> 0.17.0 ``                                                      |
| [`1e22edf6`](https://github.com/NixOS/nixpkgs/commit/1e22edf6470f731e6d99a0bdb7a567d26fc846e0) | `` pdfding: fix build on darwin ``                                                       |
| [`e72c59fb`](https://github.com/NixOS/nixpkgs/commit/e72c59fb2ec089ec8ca53622ed0d39ccc311881e) | `` matrix-synapse-unwrapped: 1.155.0 -> 1.156.0 ``                                       |
| [`caa7b7c1`](https://github.com/NixOS/nixpkgs/commit/caa7b7c19ac40d53a479f8b59416fce99f99852a) | `` limine-full: 12.4.0 -> 12.4.1 ``                                                      |
| [`eb906409`](https://github.com/NixOS/nixpkgs/commit/eb9064090a3a260d7342ad29f65bae2232dbd5cf) | `` postfix: 3.11.4 -> 3.11.5 ``                                                          |
| [`885ed28b`](https://github.com/NixOS/nixpkgs/commit/885ed28bc48c396b578587f586ce90acf9e8d03e) | `` nezha-theme-user: 2.3.1 -> 2.4.0 ``                                                   |
| [`1da3faec`](https://github.com/NixOS/nixpkgs/commit/1da3faec1206250e725e7ce1363f99be2b85c4bf) | `` ghostfolio: 3.18.0 -> 3.22.0 ``                                                       |
| [`cf6748ee`](https://github.com/NixOS/nixpkgs/commit/cf6748ee3d2741be24210bd7aefa7b706d374e7d) | `` postfix: 3.11.3 -> 3.11.4 ``                                                          |
| [`2d64c4dd`](https://github.com/NixOS/nixpkgs/commit/2d64c4dd3df31d4f6f6d2b933d76aae4ca8098eb) | `` bs-manager.depotdownloader: 2.7.4-unstable-2024-12-01 -> 3.4.0-unstable-2026-05-14 `` |
| [`9a1741ac`](https://github.com/NixOS/nixpkgs/commit/9a1741ac48eb4c3513f876de08361e5d4214739c) | `` python3Packages.restrictedpython: 8.1 -> 8.4 ``                                       |
| [`caaf4fc5`](https://github.com/NixOS/nixpkgs/commit/caaf4fc57c4801fada673e8b60a809962dab38d6) | `` .github: Bump cachix/install-nix-action from 31.10.6 to 31.10.7 ``                    |
| [`b6a63ad9`](https://github.com/NixOS/nixpkgs/commit/b6a63ad97d0e39b2ae47f9a65cdb2dd0819c2e01) | `` fluentd: 1.18.0 -> 1.19.3 ``                                                          |
| [`75f45c53`](https://github.com/NixOS/nixpkgs/commit/75f45c530f910731c87bfbf809ef366bc634182e) | `` .github: Bump actions/labeler from 6.1.0 to 6.2.0 ``                                  |
| [`31db7972`](https://github.com/NixOS/nixpkgs/commit/31db7972e88122e1e9349a2297f6adfc077829b1) | `` actions/checkout: retry transient API failures ``                                     |
| [`e5be1b2d`](https://github.com/NixOS/nixpkgs/commit/e5be1b2d102ca2812fcfb4c8d93c4a197b061f2e) | `` google-chrome: 150.0.7871.100 -> 150.0.7871.114 ``                                    |
| [`bcad02af`](https://github.com/NixOS/nixpkgs/commit/bcad02af5584b3b81d3f4c2808eaa8e8bc8aa0a1) | `` edhm-ui: 3.0.67 -> 3.0.69 ``                                                          |
| [`8f67afe3`](https://github.com/NixOS/nixpkgs/commit/8f67afe320d416ef8d310aedd92c7999bfc1fd21) | `` mdns-scanner: 0.27.3 -> 0.27.4 ``                                                     |
| [`2dd216fa`](https://github.com/NixOS/nixpkgs/commit/2dd216fa401a061b865b702333db7e8c93e2b526) | `` present: use mistune_2 ``                                                             |
| [`cace96c2`](https://github.com/NixOS/nixpkgs/commit/cace96c2a419c937f8c2cea7ef5bfc7f745c7105) | `` lektor: use mistune_2 ``                                                              |
| [`913437e7`](https://github.com/NixOS/nixpkgs/commit/913437e72d86b4e9fbeacfda5acdf8714a341ac9) | `` python3Packages.mistune_2: init at 2.0.5 ``                                           |
| [`78dba10b`](https://github.com/NixOS/nixpkgs/commit/78dba10b76e99b1ecd1e4c02a430114a05ac1b57) | `` plover_5: 5.3.0 -> 5.4.0 ``                                                           |
| [`b3ed7a13`](https://github.com/NixOS/nixpkgs/commit/b3ed7a1359ba286c1ce4458d346a03280a8a0bcd) | `` nixosTests.dashy: use systemd-nspawn instead of qemu ``                               |
| [`39c6d66d`](https://github.com/NixOS/nixpkgs/commit/39c6d66dcab5c8defc857138f3b37ca118868142) | `` dashy-ui: 4.3.11 -> 4.4.2 ``                                                          |
| [`683bb45e`](https://github.com/NixOS/nixpkgs/commit/683bb45e6c3ae5a34aa6cb854fd9d859bfc9f9ed) | `` dashy-ui: 4.3.3 -> 4.3.11 ``                                                          |
| [`90db05cc`](https://github.com/NixOS/nixpkgs/commit/90db05ccad5157d50472c4f4f72d4a9caf37c494) | `` dashy-ui: 4.2.2 -> 4.3.3 ``                                                           |
| [`7bf673eb`](https://github.com/NixOS/nixpkgs/commit/7bf673ebfa01c953af5bfbc5ea50c4adf8f5eacf) | `` dashy-ui: 4.0.7 -> 4.2.2 ``                                                           |
| [`a06848cb`](https://github.com/NixOS/nixpkgs/commit/a06848cb8c090599662179f53347e08d186c3beb) | `` nixosTests.pdfding: fix on aarch64-linux ``                                           |
| [`8918cbc3`](https://github.com/NixOS/nixpkgs/commit/8918cbc3ae7a259094eafe70e32b36b39e317858) | `` nixosTests.pdfding.s3-backup: fix test ``                                             |
| [`05dc7586`](https://github.com/NixOS/nixpkgs/commit/05dc7586454cae6bb4a8261f3a72f9ce9dd57a3d) | `` kbd-ergol: 0-unstable-2026-07-03 -> 0-unstable-2026-07-07 ``                          |
| [`c8b934ca`](https://github.com/NixOS/nixpkgs/commit/c8b934ca9824cc2931a24ccf748c3eaff58a951c) | `` [Backport release-26.05] pdfding: 1.9.0 -> 1.10.0 ``                                  |
| [`180c433b`](https://github.com/NixOS/nixpkgs/commit/180c433b1c7df383175d9f4eb95a622ceabf1959) | `` forgejo-runner: 12.12.0 -> 12.13.0 ``                                                 |
| [`558f994f`](https://github.com/NixOS/nixpkgs/commit/558f994f7058794eabf3692f4f836b6ac9f1358c) | `` lockbook-desktop: 26.6.22 -> 26.7.4 ``                                                |
| [`8f8f97aa`](https://github.com/NixOS/nixpkgs/commit/8f8f97aac4b0d2ffa7bec836730bd202d166b554) | `` mailpit: 1.30.3 -> 1.30.4 ``                                                          |
| [`2b9d0a1e`](https://github.com/NixOS/nixpkgs/commit/2b9d0a1ec65bdb0519a11ea17f6cc90a4836bbc9) | `` softmaker-{office,nx}: 1230 -> 1234 ``                                                |
| [`b126c524`](https://github.com/NixOS/nixpkgs/commit/b126c5241dad85da7c124c2ec5a500d4f4c4239d) | `` discord: don't strip upstream binaries on darwin ``                                   |
| [`0ec51ef6`](https://github.com/NixOS/nixpkgs/commit/0ec51ef662a06789f0e15cf8bc588008a62d4d17) | `` nodejs_24: fix riscv64-linux build ``                                                 |
| [`e61d5179`](https://github.com/NixOS/nixpkgs/commit/e61d51798421d6a9d2f9266d5adad3ffcd807dee) | `` nixos/fish: `programs.fish.generateCompletions` fix spaces in filenames ``            |
| [`0f2d4e38`](https://github.com/NixOS/nixpkgs/commit/0f2d4e38342b8fedb23c3654fe76691b481a9b2c) | `` victoriametrics: 1.145.0 -> 1.146.0 ``                                                |
| [`6fbcf952`](https://github.com/NixOS/nixpkgs/commit/6fbcf952e1a78f04786617fd80f7339b501cd1a5) | `` docker-sbx: init at 0.34.0 ``                                                         |
| [`adaf8e70`](https://github.com/NixOS/nixpkgs/commit/adaf8e7070b6078e93ff931aa74da6b9caae3474) | `` maintainers: add erics118 ``                                                          |
| [`5d6ebc92`](https://github.com/NixOS/nixpkgs/commit/5d6ebc92db1f49330d5f04aaa8bfb72361c8dd08) | `` bencher-cli: init at 0.6.8 ``                                                         |
| [`f632b5c5`](https://github.com/NixOS/nixpkgs/commit/f632b5c54dfdf6578e5990df80941d1603f7a316) | `` pipeweaver: init at 0.1.6 ``                                                          |
| [`2f77fad1`](https://github.com/NixOS/nixpkgs/commit/2f77fad1216696c85cfb728f5e3284879216efa8) | `` pnpm_9: mark insecure ``                                                              |
| [`58ddca0e`](https://github.com/NixOS/nixpkgs/commit/58ddca0e1af00896d94b594d7b02b82b0d2fa89d) | `` pnpm_8: mark insecure ``                                                              |
| [`27c4287b`](https://github.com/NixOS/nixpkgs/commit/27c4287b9d5deac6b339b9c6f14685c106c93f2d) | `` vlc: remove unused variables and update --replace ``                                  |
| [`e6a06595`](https://github.com/NixOS/nixpkgs/commit/e6a065952418e71e13877ca80ffebcba5dfea22b) | `` vlc: add libaacs to build and rpath ``                                                |
| [`2818e459`](https://github.com/NixOS/nixpkgs/commit/2818e459b76b3476b96d0938be0b602313a3efce) | `` firewalld: 2.4.2 -> 2.4.3 ``                                                          |
| [`5701c8c0`](https://github.com/NixOS/nixpkgs/commit/5701c8c01e4893a17dcef2af0ed9a18cc7868532) | `` firewalld: remove -gui only files ``                                                  |
| [`36eaf968`](https://github.com/NixOS/nixpkgs/commit/36eaf968cffdcb99bda8241f32470a55f3b0c75b) | `` nvibrant: 1.2.0-unstable-595.58.03 -> 1.2.1-unstable-610.43.02 ``                     |
| [`cdbe15fc`](https://github.com/NixOS/nixpkgs/commit/cdbe15fc94fa1afd082ef2ecbfc8bd4981967abc) | `` nvibrant: 1.1.0 -> 1.2.0-unstable-595.58.03 ``                                        |
| [`4e795915`](https://github.com/NixOS/nixpkgs/commit/4e795915a9c0802eab75669283d7e306973971b4) | `` gpaste: 45.3 → 45.5 ``                                                                |