### PR TITLE
chore(flake/freminal): `5a8b3fb9` -> `499e97aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1783551425,
-        "narHash": "sha256-dCgqQaxawB1G651lYD8zEhrtev5C8KrgG0fNsZRUD/8=",
+        "lastModified": 1783980085,
+        "narHash": "sha256-IVjtfQGPNOnXZJTrfkd8e7MUxfGAjzMar4Wnkt95rsY=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "5a8b3fb9b7533629579c93c69ba0e1b5de82d753",
+        "rev": "499e97aae0ed5921ae429ff02a63e59152f2d809",
         "type": "github"
       },
       "original": {
@@ -447,7 +447,6 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "freminal",
           "precommit",
@@ -455,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -471,7 +470,7 @@
     "git-hooks_2": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "gitignore": "gitignore_2",
+        "gitignore": "gitignore",
         "nixpkgs": [
           "frext",
           "precommit",
@@ -495,7 +494,7 @@
     "git-hooks_3": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "gitignore": "gitignore_3",
+        "gitignore": "gitignore_2",
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
@@ -537,29 +536,6 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "freminal",
-          "precommit",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
           "frext",
           "precommit",
           "git-hooks",
@@ -580,7 +556,7 @@
         "type": "github"
       }
     },
-    "gitignore_3": {
+    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "nixos-needsreboot",
@@ -931,11 +907,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -1065,11 +1041,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1780504325,
-        "narHash": "sha256-EU52VleXVEQrX/CxqdoeQdJNSoWd1yr+0uyCtNFddYg=",
+        "lastModified": 1783875506,
+        "narHash": "sha256-Hx7uYdd6XyBohpAyIJwzjsJrUsY9ucOpzxoGMV+AYsI=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "0fe4cc46813614423b1cd54c9de1c74a448c7f3d",
+        "rev": "7ffbe4d244ef810e871ff616988753131c9595e8",
         "type": "github"
       },
       "original": {
@@ -1153,11 +1129,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1780456895,
-        "narHash": "sha256-CvRZn3Ut0scqLJ1xwQFkZwKGVBUUNBPrFVXRTMZpbfU=",
+        "lastModified": 1783834461,
+        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7cc96a6a3fd6613cafd633250a3934483479b9a1",
+        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
         "type": "github"
       },
       "original": {
@@ -1174,11 +1150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782703273,
-        "narHash": "sha256-WJPfr9EAWVIuTMyb/ilHKUYlg/RNa0xrNiWR+p1iHUg=",
+        "lastModified": 1783921439,
+        "narHash": "sha256-DsSIQSRMrLOz40LrGZ03sp2RlJ9sz3wKpd8XPTOzXnw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5106a604b3d67cffe8eb51a8bd9f04e607f0d31d",
+        "rev": "e013376c32a8fcf07ddb6ec71739552bc118b7bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`a5519d69`](https://github.com/fredsystems/freminal/commit/a5519d6958a194aca439b00d77e8f7e9d2e2dede) | `` docs: correct handle_osc_ftcs comment re: the P marker exception ``                   |
| [`b656b634`](https://github.com/fredsystems/freminal/commit/b656b63452df5a16f4775b346464f5b1600b4788) | `` test: broaden OSC 133 foreign-marker test instead of duplicating ``                   |
| [`24052c7e`](https://github.com/fredsystems/freminal/commit/24052c7ec83781e5542a916d9cebf2857f729771) | `` test: add dedicated unit test for current_trace_escaped ``                            |
| [`75453484`](https://github.com/fredsystems/freminal/commit/754534843ff6b90d23d789f4d8aaf9afa93a3a2f) | `` fix: escape double quotes in escape_sequence_for_log ``                               |
| [`cb5220e7`](https://github.com/fredsystems/freminal/commit/cb5220e7cee5333157755a82b8d7288034a6c1b7) | `` fix: saturate TabId counter to avoid overflow at u64::MAX ``                          |
| [`274e7bc8`](https://github.com/fredsystems/freminal/commit/274e7bc8e3c0b2a3d02d893ad66efed799cce9d9) | `` fix: preserve actual CSI introducer in unhandled-sequence diagnostics ``              |
| [`3fde9809`](https://github.com/fredsystems/freminal/commit/3fde9809dbba1313add044adbb280d1755b03862) | `` fix: satisfy Rust 1.97 clippy pedantic lints (manual_assert_eq, byte_char_slices) ``  |
| [`c8ec31e1`](https://github.com/fredsystems/freminal/commit/c8ec31e188620a36c9d1c4db344ac320f2718f02) | `` chore(cargo+flake): bump deps, update cargo, update flake, update freminal version `` |
| [`362cea51`](https://github.com/fredsystems/freminal/commit/362cea51e3a04ff0c5b3c109f4765e19e164b6b6) | `` docs: plan scrollback memory work (Task 118 in v0.12.0, Task 119 stub v0.13.1) ``     |
| [`385ce6b6`](https://github.com/fredsystems/freminal/commit/385ce6b6ed42c1b992633befbf010aafa6164263) | `` feat: log full raw byte sequence on unhandled escape sequences ``                     |
| [`1437b703`](https://github.com/fredsystems/freminal/commit/1437b70364ef79d72efe5750ebc72fcab0079ef8) | `` fix: prevent duplicate TabId collision after layout restore ``                        |