### PR TITLE
chore(flake/frext): `46b250dd` -> `8bce6eac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1782866676,
-        "narHash": "sha256-yCkIkiEBAOj6pgRVpz4cEFmCU69e/8iRKaG7ln/eiCc=",
+        "lastModified": 1783989792,
+        "narHash": "sha256-dTcXDTF6I0lTfFMmxKvFzpJ3uXYtsRLRLVL1KDAq0yU=",
         "owner": "FredSystems",
         "repo": "frext",
-        "rev": "46b250ddd9e0b74e1d228f37e3242eb4e3145c2b",
+        "rev": "8bce6eacf94e305e9b759667df7ee944c64547ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                               |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`a260ad66`](https://github.com/fredsystems/frext/commit/a260ad6610d3317f5216874f7f44b52850650270) | `` chore(deps): update rust crate regex to v1.13.0 ``                                 |
| [`1621d9f5`](https://github.com/fredsystems/frext/commit/1621d9f5a7a42de044dee6b33c6b730a6b15069c) | `` chore(deps): update rust crate harfrust to 0.12.0 ``                               |
| [`49713d96`](https://github.com/fredsystems/frext/commit/49713d96d4e42885ec7d6549cc366042312c8842) | `` chore(deps): update determinatesystems/determinate-nix-action digest to c70cb8a `` |