### PR TITLE
chore(flake/niri): `882672a8` -> `cb2b70a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -629,11 +629,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1783944946,
-        "narHash": "sha256-69nS32CnDRGayoOrg0BTl3/Lw24PxrFTQFZKn0ath74=",
+        "lastModified": 1784046451,
+        "narHash": "sha256-To9gdRLJbyPzcBI3nwYsu7VsQkTXyNjLbslPxu7V/oo=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "882672a8ccb920631e6b17d45dfdf20def9a513d",
+        "rev": "cb2b70a7902c1deac4dbe514e934a0efabe13f7a",
         "type": "github"
       },
       "original": {
@@ -766,11 +766,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1783856661,
-        "narHash": "sha256-ZGP04e+Q6WyQJGA9ZvI5CL6+heGQldbAG9U1T9NGvmU=",
+        "lastModified": 1784011430,
+        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "569d578509928497eddc3fdbf94a799027050be4",
+        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
         "type": "github"
       },
       "original": {
@@ -971,11 +971,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`cb2b70a7`](https://github.com/epireyn/niri-flake/commit/cb2b70a7902c1deac4dbe514e934a0efabe13f7a) | `` Update flake.lock `` |
| [`fe90d013`](https://github.com/epireyn/niri-flake/commit/fe90d0130df5511778cd43ecdad3ea87e361d174) | `` Update flake.lock `` |