### PR TITLE
chore(flake/freminal): `499e97aa` -> `0abc8b5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1783980085,
-        "narHash": "sha256-IVjtfQGPNOnXZJTrfkd8e7MUxfGAjzMar4Wnkt95rsY=",
+        "lastModified": 1784072532,
+        "narHash": "sha256-fZGSS9Amm1xnGXBrDyXEGV31hg3Kwt+4y//2lSc2kIU=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "499e97aae0ed5921ae429ff02a63e59152f2d809",
+        "rev": "0abc8b5d77bf08eb0165f81f13d6b1d2be88d5d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`59408c60`](https://github.com/fredsystems/freminal/commit/59408c600d4878a77a60880b007d5c84b260fdf1) | `` fix: 118 -- macOS test SIGABRT + CodeRabbit review remediations ``                 |
| [`1e0e3d63`](https://github.com/fredsystems/freminal/commit/1e0e3d63f3865d6434b63cf20547aac25b6f7eca) | `` docs: refine the plan ``                                                           |
| [`a2eae840`](https://github.com/fredsystems/freminal/commit/a2eae84063e0227dca4b1ae256a868260b8634d0) | `` chore(version): 0.12.0-beta.1 ``                                                   |
| [`fb8704a8`](https://github.com/fredsystems/freminal/commit/fb8704a892f138da5fa5e0eb8ebe4f4202d27adf) | `` docs: 118 -- record deferred compaction, lazy-reflow stub, cleanup status ``       |
| [`292ce878`](https://github.com/fredsystems/freminal/commit/292ce8784526aaa20b346ced6ecb2b855078259e) | `` test: 118 -- harden memory benches to model real-world scrollback ``               |
| [`fe00ff2c`](https://github.com/fredsystems/freminal/commit/fe00ff2cf7eae9cafc87246d6acd846461d4eeb9) | `` perf: 118.9 -- deferred idle-driven scrollback compaction on the PTY thread ``     |
| [`71900d50`](https://github.com/fredsystems/freminal/commit/71900d50c2dd13dfe54912d9ae9ad839b6801478) | `` perf: 118.3 + 118.4 + 118.5 -- compact scrollback rows + raise default ``          |
| [`fa7cfd1d`](https://github.com/fredsystems/freminal/commit/fa7cfd1d4c056db337eac5109ae04ee1b9be1ece) | `` docs: 118.3 -- record Row-internal storage + decompact-on-resize decisions ``      |
| [`5b950199`](https://github.com/fredsystems/freminal/commit/5b95019971de3f7b24462a98b7bc9a4959358b61) | `` perf: 118.2 -- CompactRow type + lossless Row<->CompactRow round-trip ``           |
| [`8843be7d`](https://github.com/fredsystems/freminal/commit/8843be7df70a27324cfddb28f28d9c4cf3f69a68) | `` perf: 118.1 -- add Buffer::heap_bytes measurement API + memory baseline bench ``   |
| [`88e363fd`](https://github.com/fredsystems/freminal/commit/88e363fd3bf6583a0a975c9d96f832dddcd28842) | `` chore(deps): update taiki-e/install-action action to v2.83.2 ``                    |
| [`59d6478d`](https://github.com/fredsystems/freminal/commit/59d6478dbe07eead3b9cadbd7f59fa50f0f6785c) | `` chore(deps): update dependency rust to v1.97.0 ``                                  |
| [`cbe0a5b9`](https://github.com/fredsystems/freminal/commit/cbe0a5b97dbedeaee8a1d8cd1e08c9f1ce9e0f3a) | `` chore(deps): update softprops/action-gh-release digest to 3d0d988 ``               |
| [`0d0d3ec3`](https://github.com/fredsystems/freminal/commit/0d0d3ec3e644f26e9f18ddc06ae6cdf3a1b8e596) | `` chore(deps): update determinatesystems/determinate-nix-action digest to c70cb8a `` |