### PR TITLE
chore(flake/nixpkgs): `e7a3ca80` -> `18b9261c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -814,11 +814,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`6403100a`](https://github.com/NixOS/nixpkgs/commit/6403100a314e6b10d83af1cdb27503ac93ec8354) | `` terraform-providers.yandex-cloud_yandex: 0.213.0 -> 0.215.0 ``                                |
| [`e7725b83`](https://github.com/NixOS/nixpkgs/commit/e7725b83f898a4bcc7cfe1c61f1d6b49ff1e63f6) | `` gajim: 2.4.7 -> 2.4.7.1 ``                                                                    |
| [`f6ec6d2e`](https://github.com/NixOS/nixpkgs/commit/f6ec6d2e354033a69bd661551aa941b7a284eef8) | `` nixVersions.latest: 2.34.8 -> 2.35.1 ``                                                       |
| [`d3547a83`](https://github.com/NixOS/nixpkgs/commit/d3547a8375cc5440fee49f82a6d02859660e0975) | `` python3Packages.urllib3-future: 2.22.900 -> 2.22.901 ``                                       |
| [`bda163c4`](https://github.com/NixOS/nixpkgs/commit/bda163c4dad63bdca53971f6b6076bfef6185e8e) | `` layerx: 1.5.0 -> 1.5.2 ``                                                                     |
| [`0eb2aad8`](https://github.com/NixOS/nixpkgs/commit/0eb2aad8213547b2f7ec1d3d60dae2d87a00d9d7) | `` tuicr: 0.18.0 -> 0.19.1 ``                                                                    |
| [`0058f85b`](https://github.com/NixOS/nixpkgs/commit/0058f85b416141327a05c090b8a7b4a2222b9622) | `` darwin.mkAppleDerivation: add build-platform xcodeHash test ``                                |
| [`e30337ef`](https://github.com/NixOS/nixpkgs/commit/e30337ef36303edcc876e29d14613734e3f42d07) | `` darwin.PowerManagement: update xcodeHash ``                                                   |
| [`65e06c62`](https://github.com/NixOS/nixpkgs/commit/65e06c62fbf54ba323133da0a6cd31aa10bf93fb) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.83.7 -> 1.83.10 ``                      |
| [`56ea501f`](https://github.com/NixOS/nixpkgs/commit/56ea501f3bae76e95d20268b700800121f70b47d) | `` opentrack: add macOS support ``                                                               |
| [`dd2ea746`](https://github.com/NixOS/nixpkgs/commit/dd2ea746ce040136d557c5f3ae8e6f5c5e59fe8c) | `` graphite-cli: fix darwin build ``                                                             |
| [`d6efce88`](https://github.com/NixOS/nixpkgs/commit/d6efce881a22ca0c0b7de3ed00b4c0b08f6ce020) | `` incus-ui-canonical: Use stdenvNoCC ``                                                         |
| [`971d6acb`](https://github.com/NixOS/nixpkgs/commit/971d6acbb0e7fd25793ef7099e394a2ed920dfe2) | `` incus-ui-canonical: 0.21.3 -> 0.21.4 ``                                                       |
| [`33765019`](https://github.com/NixOS/nixpkgs/commit/33765019fd0b28ecc453646a50ce3a46fb8c6a1a) | `` opentofu: 1.12.3 -> 1.12.4 ``                                                                 |
| [`443017ff`](https://github.com/NixOS/nixpkgs/commit/443017ff4cf2a29d6a2babc0b7114237bf6c42f6) | `` maintainers/github-teams.json: Automated sync ``                                              |
| [`237cd777`](https://github.com/NixOS/nixpkgs/commit/237cd7774b46eee57950b779c6c736df9fb9189e) | `` sesh: 2.26.2 -> 2.27.0 ``                                                                     |
| [`174bd66b`](https://github.com/NixOS/nixpkgs/commit/174bd66b7677fa2dae76e6c3c4047125f5f35bb5) | `` sketchybar: fix darwin build ``                                                               |
| [`865cf8ae`](https://github.com/NixOS/nixpkgs/commit/865cf8aee4f12d81645b3908110aa6dbcf5cf758) | `` sssnake: 0.3.2 -> 0.4.0 ``                                                                    |
| [`d1c5dde9`](https://github.com/NixOS/nixpkgs/commit/d1c5dde9c639f48c9d8da9567cb0962213d3c362) | `` vmaware: init at 2.8.0 ``                                                                     |
| [`0a85a557`](https://github.com/NixOS/nixpkgs/commit/0a85a557ca9169135d6f66fa9f78a53996f3f223) | `` python3Packages.types-retry: 0.9.9.20250322 -> 0.9.9.20260408 ``                              |
| [`83c8b087`](https://github.com/NixOS/nixpkgs/commit/83c8b087be213a7b6661c3fb66dec607cb415763) | `` nixtamal: 1.8.2 → 1.9.0 ``                                                                    |
| [`7f9595d9`](https://github.com/NixOS/nixpkgs/commit/7f9595d96b639b4ff3c86dc89e889250e646c904) | `` terraform-providers.aminueza_minio: 3.38.1 -> 3.38.3 ``                                       |
| [`95625fdc`](https://github.com/NixOS/nixpkgs/commit/95625fdc0540b6a2980b3b5aaff4304682aa59bd) | `` gh-dash: 4.25.0 -> 4.25.2 ``                                                                  |
| [`8e9cb597`](https://github.com/NixOS/nixpkgs/commit/8e9cb59730c80f4b043cbad726339651f69617c8) | `` lux-cli: 0.35.1 -> 0.36.1 ``                                                                  |
| [`fa9d5cf7`](https://github.com/NixOS/nixpkgs/commit/fa9d5cf7b6d4804b94df26e872a5e9a34ea7fa52) | `` home-assistant-custom-components.garmin_connect: 3.0.12 -> 3.0.13 ``                          |
| [`985e4f7e`](https://github.com/NixOS/nixpkgs/commit/985e4f7ef0dc31244085e7ac86fe98e51aa297ad) | `` apko: 1.2.21 -> 1.2.25 ``                                                                     |
| [`db491cd7`](https://github.com/NixOS/nixpkgs/commit/db491cd7129a237b070a65fe26e17865a7bb1ff3) | `` domoticz: 2026.2 -> 2026.2-unstable-2026-07-09 ``                                             |
| [`a9be645a`](https://github.com/NixOS/nixpkgs/commit/a9be645aea36d5cb111bf27b51165b9b5e1e8996) | `` thunderbird-mcp: 0.6.0 -> 0.7.3 ``                                                            |
| [`0790ee82`](https://github.com/NixOS/nixpkgs/commit/0790ee8222f4c6a88ac185574aa85358d4f1b878) | `` devin-cli: 3000.1.23 -> 3000.1.27 ``                                                          |
| [`05a9be4e`](https://github.com/NixOS/nixpkgs/commit/05a9be4e35c68df99fc1d1994a0b0fd7a912c062) | `` cloud-hypervisor: 52.0 -> 53.0 ``                                                             |
| [`c55e7562`](https://github.com/NixOS/nixpkgs/commit/c55e756288ca8e426cebbd3d4ba1708c192085b2) | `` koffan: 2.12.0 -> 2.12.2 ``                                                                   |
| [`f41e5e02`](https://github.com/NixOS/nixpkgs/commit/f41e5e02ceda36055ce763f02e96a2b6140fed3d) | `` python3Packages.python-fsutil: 0.16.1 -> 0.17.0 ``                                            |
| [`3bb83122`](https://github.com/NixOS/nixpkgs/commit/3bb83122adf9d511c8f01afa48daae80916dca20) | `` plezy: add BatteredBunny to maintainers ``                                                    |
| [`e518df93`](https://github.com/NixOS/nixpkgs/commit/e518df93df50ff46071e787a32271c5b890ec9c0) | `` plezy: 2.8.0 -> 2.9.1 ``                                                                      |
| [`5ae1dbe5`](https://github.com/NixOS/nixpkgs/commit/5ae1dbe5f450b1905dce024d7e874ab32e463317) | `` wappalyzergo: 0.2.87 -> 0.2.89 ``                                                             |
| [`f84d85f0`](https://github.com/NixOS/nixpkgs/commit/f84d85f00820135ab0ef2fde6af8da4de366c5bb) | `` stalwart_0_16: 0.16.12 -> 0.16.13 ``                                                          |
| [`9376e3c5`](https://github.com/NixOS/nixpkgs/commit/9376e3c5e1cb0056b7e3e903bac603eecbcee756) | `` go-judge: 1.12.0 -> 1.12.1 ``                                                                 |
| [`0c3674a9`](https://github.com/NixOS/nixpkgs/commit/0c3674a9ee2deb8919bc0e7a448929aa07557d89) | `` nocturne: 1.3.0 -> 1.3.2 ``                                                                   |
| [`90898ec2`](https://github.com/NixOS/nixpkgs/commit/90898ec27750adf4058994ac37e66f6bd5012f81) | `` terraform-providers.hashicorp_aws: 6.52.0 -> 6.54.0 ``                                        |
| [`e1b3e066`](https://github.com/NixOS/nixpkgs/commit/e1b3e06602b97a0cff0d05c55929a8a6b7d55391) | `` terraform-providers.datadog_datadog: 4.13.0 -> 4.15.0 ``                                      |
| [`1ea38906`](https://github.com/NixOS/nixpkgs/commit/1ea389064973ea5596ec68f613ee07a13031fd36) | `` terraform-providers.integrations_github: 6.12.1 -> 6.13.0 ``                                  |
| [`5a6fc050`](https://github.com/NixOS/nixpkgs/commit/5a6fc050a27ef1c30a9ca342b0803e3c95e487ab) | `` zigfetch: 0.27.1 -> 0.27.2 ``                                                                 |
| [`107b7748`](https://github.com/NixOS/nixpkgs/commit/107b7748d87b057034e10e95d115b3592a1d87df) | `` art: 1.26.6 -> 1.26.7 ``                                                                      |
| [`cb9f58ec`](https://github.com/NixOS/nixpkgs/commit/cb9f58ecc8f68f7b2a7d3e45d8ce4c121eabe44d) | `` diesel-cli: 2.3.10 -> 2.3.11 ``                                                               |
| [`d019a2c0`](https://github.com/NixOS/nixpkgs/commit/d019a2c089b47ec29b589749b46f7ec15d0da1b9) | `` python3Packages.layoutparser: fix build failure ``                                            |
| [`68c473cb`](https://github.com/NixOS/nixpkgs/commit/68c473cb2b6fdd0aa642c1ed1d6b6ddd6ee73aeb) | `` git-mit: 6.5.2 -> 6.5.3 ``                                                                    |
| [`dc8dc73d`](https://github.com/NixOS/nixpkgs/commit/dc8dc73d4a6e5fcc5d63474a7d3baae0b237b25e) | `` goeland: 0.25.0 -> 0.26.0 ``                                                                  |
| [`d403db1d`](https://github.com/NixOS/nixpkgs/commit/d403db1d85085a12bd4db947f9c5e5813230bec5) | `` rnsapi: 0-unstable-2026-07-06 -> 0-unstable-2026-07-09 ``                                     |
| [`82f8c9dd`](https://github.com/NixOS/nixpkgs/commit/82f8c9dd91ee8a9c77dcddd27886eff9f2373a57) | `` lammps: add mpich to nativeBuildInputs if needed ``                                           |
| [`4804262c`](https://github.com/NixOS/nixpkgs/commit/4804262cb2e9af36b53de2c6d094aceb143b8c47) | `` lammps: small nativeBuildInputs formatting ``                                                 |
| [`a823d0d8`](https://github.com/NixOS/nixpkgs/commit/a823d0d8ac5905001acef97c4bbe4334ea788c8f) | `` python3Packages.cleanit: fix build ``                                                         |
| [`4e0b3e5c`](https://github.com/NixOS/nixpkgs/commit/4e0b3e5c4597d255231023e4dca64e17a2cc3055) | `` python3Packages.helium: 7.0.2 -> 7.0.3 ``                                                     |
| [`a5d90875`](https://github.com/NixOS/nixpkgs/commit/a5d908753dc71e1a4805f7b46a84a419360bd393) | `` libqalculate: 5.11.0 -> 5.12.0 ``                                                             |
| [`d32063f3`](https://github.com/NixOS/nixpkgs/commit/d32063f3b80c8d556da118d7f2ec11b76aef31b4) | `` cdk8s-cli: 2.207.29 -> 2.207.40 ``                                                            |
| [`a51a9663`](https://github.com/NixOS/nixpkgs/commit/a51a9663f7414ad8c565efd90d5687b60f1e4bf2) | `` mediawriter: 5.3.1 -> 5.3.2 ``                                                                |
| [`b3257fd8`](https://github.com/NixOS/nixpkgs/commit/b3257fd89a3ef8dfb4222c1df4076f1639f4cc0c) | `` mpvScripts.thumbfast: 0-unstable-2025-02-04 -> 0-unstable-2026-06-28 ``                       |
| [`5175e6a4`](https://github.com/NixOS/nixpkgs/commit/5175e6a4951c4769a5595848160a98dbcbb0ba6a) | `` nomad-driver-podman: 0.6.4 -> 0.6.5 ``                                                        |
| [`e5f329a4`](https://github.com/NixOS/nixpkgs/commit/e5f329a406d1d248637dae048164ecb9eafedec5) | `` androidenv.test-suite: b32174c25099306e -> bf983fbce7b915ee ``                                |
| [`658559b4`](https://github.com/NixOS/nixpkgs/commit/658559b4cd1bbdc69b8954362efc4a25d2cd9d2d) | `` bluetuith: 0.2.6 -> 0.2.7 ``                                                                  |
| [`21587330`](https://github.com/NixOS/nixpkgs/commit/2158733090fc48ff2b1a3ac340f4f7ff3cd32c62) | `` netwatch: 0.25.8 -> 0.26.1 ``                                                                 |
| [`d84b9444`](https://github.com/NixOS/nixpkgs/commit/d84b94446772bc00a27213cafc8922223c8eb767) | `` qalculate-gtk: 5.11.0 -> 5.12.0 ``                                                            |
| [`6a820351`](https://github.com/NixOS/nixpkgs/commit/6a8203513eb75bdf6f063eb8ae38074346f590e7) | `` pwru: 1.0.11 -> 1.0.12 ``                                                                     |
| [`7c1a8c45`](https://github.com/NixOS/nixpkgs/commit/7c1a8c45bfdc733fce69f18f5970c84c7cf85528) | `` nixos/doc: inject custom header via nixos-render-docs --header ``                             |
| [`f26adbb4`](https://github.com/NixOS/nixpkgs/commit/f26adbb436a470975638bc2fd7f2386bba52bed9) | `` libretro.play: 0-unstable-2026-06-22 -> 0-unstable-2026-07-11 ``                              |
| [`0c53928c`](https://github.com/NixOS/nixpkgs/commit/0c53928ce05c7750084328db9986cf92559f2581) | `` pvetui: 1.4.1 -> 1.4.2 ``                                                                     |
| [`e80288ee`](https://github.com/NixOS/nixpkgs/commit/e80288eefef293bf684c9fb6e72b8387d01d3484) | `` python3Packages.uploadserver: 6.0.2 -> 6.0.3 ``                                               |
| [`e6b56690`](https://github.com/NixOS/nixpkgs/commit/e6b56690a15aeed8e7643b4b79365da86808b916) | `` python3Packages.tencentcloud-sdk-python: 3.1.130 -> 3.1.131 ``                                |
| [`d345ca63`](https://github.com/NixOS/nixpkgs/commit/d345ca63cb7c2a29ec74cf3ad0e926e9ffd342c4) | `` pwvucontrol: add ilkecan to maintainers ``                                                    |
| [`2e791201`](https://github.com/NixOS/nixpkgs/commit/2e79120138ad14253811feef0ea7b6f175346a6b) | `` pwvucontrol: 0.5.2 -> 0.5.3 ``                                                                |
| [`4388cd79`](https://github.com/NixOS/nixpkgs/commit/4388cd791a882669b46fda4333b4fd0eb9f7ab9d) | `` doc/doc-support: inject custom header via nixos-render-docs --header ``                       |
| [`9dfe7560`](https://github.com/NixOS/nixpkgs/commit/9dfe7560d5e6ae6a7aaaa9a991f71f048608626b) | `` pkgs/nixos-render-docs: add --header, and --no-navheader ``                                   |
| [`f3aef3c2`](https://github.com/NixOS/nixpkgs/commit/f3aef3c2bb9d26f66834f27965ca08b59a2be971) | `` pkl-lsp: 0.7.1 -> 0.8.0 ``                                                                    |
| [`c31d8815`](https://github.com/NixOS/nixpkgs/commit/c31d88156e9bd3f480dc94b9882750ef7d769d7a) | `` context7-mcp: 3.2.2 -> 3.2.3 ``                                                               |
| [`e6266935`](https://github.com/NixOS/nixpkgs/commit/e6266935b356312ddacac7ba698be1bb0e6844c6) | `` udiskie: add meta.mainProgram ``                                                              |
| [`55a77ee0`](https://github.com/NixOS/nixpkgs/commit/55a77ee0eff68c7fa800d411f4aeae48d8c60f93) | `` kubeshark: fix homepage ``                                                                    |
| [`0ebc1fef`](https://github.com/NixOS/nixpkgs/commit/0ebc1fef63b67bb73bad00137660a6639cafd4c3) | `` sprite: 0.0.1-rc44 -> 0.0.1-rc45 ``                                                           |
| [`76f41a21`](https://github.com/NixOS/nixpkgs/commit/76f41a213baa367eaac012acce93eff247fd6b3c) | `` python3Packages.oslo-db: 18.0.0 -> 18.1.0 ``                                                  |
| [`2c171cee`](https://github.com/NixOS/nixpkgs/commit/2c171cee2c8a6f0cb1b81dbbed06c60bd75624ac) | `` python3Packages.tplink-omada-client: 1.5.8 -> 1.5.9 ``                                        |
| [`1f248f34`](https://github.com/NixOS/nixpkgs/commit/1f248f342be91912eca40f657c5eabe12645d565) | `` tests.problems: Fix `invalid-kind-error` failure ``                                           |
| [`00ec5f0e`](https://github.com/NixOS/nixpkgs/commit/00ec5f0eaf00877df594b64b379ec7ea4ba942a8) | `` doc/release-notes: Add changelog entry for the now deprecated allowBrokenPredicate setting `` |
| [`4aef6f76`](https://github.com/NixOS/nixpkgs/commit/4aef6f76d4f610367b57d7fb9f389ca035c291df) | `` tests.problems: adjust test code for oldestSupportedRelease=26.05 ``                          |
| [`02ff67c8`](https://github.com/NixOS/nixpkgs/commit/02ff67c8db6abff115128961ef2cef885a2ecfcb) | `` vscode-extensions.coder.coder-remote: 1.15.0 -> 1.15.2 ``                                     |
| [`c428ae6e`](https://github.com/NixOS/nixpkgs/commit/c428ae6e00bfbaf329f0f011db2402b128ead417) | `` smbclient-ng: 3.0.0 -> 3.1.0 ``                                                               |
| [`8137c8f9`](https://github.com/NixOS/nixpkgs/commit/8137c8f971cb41731206c18dee9ad94952be7e60) | `` cc-switch: 3.16.3 -> 3.16.5 ``                                                                |
| [`251cf50f`](https://github.com/NixOS/nixpkgs/commit/251cf50f0cc620f1e4621dca06dcbd3c50e5557b) | `` rattler-build: 0.67.0 -> 0.68.0 ``                                                            |
| [`66bb3089`](https://github.com/NixOS/nixpkgs/commit/66bb3089db9200d592727749a498f5a7d6e74073) | `` spruce: 1.35.9 -> 1.35.11 ``                                                                  |
| [`b5e31136`](https://github.com/NixOS/nixpkgs/commit/b5e311369cc4f25121b95128262aa900c4d26154) | `` duplicati: 2.3.0.3 -> 2.3.0.4 ``                                                              |
| [`79a58900`](https://github.com/NixOS/nixpkgs/commit/79a589006c97368f29b0f43b61744ef5b1964307) | `` ip2unix: fix build by using python313Packages ``                                              |
| [`7e70f175`](https://github.com/NixOS/nixpkgs/commit/7e70f175719ed0a8256ad5706c21feefcc218946) | `` python3Packages.types-colorama: modernize ``                                                  |
| [`4abe0c81`](https://github.com/NixOS/nixpkgs/commit/4abe0c81a77a07d8bb6f20ef8c6653334ea07548) | `` various: replace deprecated os.system with subprocess calls ``                                |
| [`5eed20cf`](https://github.com/NixOS/nixpkgs/commit/5eed20cf67b999d9218f3810f7807fda105a7981) | `` python3Packages.types-webencodings: migrate to finalAttrs ``                                  |
| [`025d03f3`](https://github.com/NixOS/nixpkgs/commit/025d03f394d5d78d31b5194e7c9156f6e34b1ee2) | `` scantpaper: 3.0.9 -> 3.0.11 ``                                                                |
| [`e7a70984`](https://github.com/NixOS/nixpkgs/commit/e7a70984b1fe48c391e97a3dd69330df3da991f9) | `` terraform-providers.heroku_heroku: 5.3.2 -> 5.4.0 ``                                          |
| [`b134454e`](https://github.com/NixOS/nixpkgs/commit/b134454ee1f61e6f8d97e98b551b2aa56064ab3e) | `` python3Packages.boto3-stubs: 1.43.45 -> 1.43.46 ``                                            |
| [`fac6442d`](https://github.com/NixOS/nixpkgs/commit/fac6442de35dea59c8d575eaeaab29b0840d2cc5) | `` python3Packages.mypy-boto3-sagemaker: 1.43.33 -> 1.43.46 ``                                   |
| [`c0d97630`](https://github.com/NixOS/nixpkgs/commit/c0d97630b0e0c3af7349792d45bedb141e6ebf25) | `` python3Packages.mypy-boto3-quicksight: 1.43.39 -> 1.43.46 ``                                  |
| [`9c796c68`](https://github.com/NixOS/nixpkgs/commit/9c796c685f620eadfdca2a51fd5584a9c82da1fe) | `` copacetic: 0.14.1 -> 0.14.2 ``                                                                |
| [`29c504d5`](https://github.com/NixOS/nixpkgs/commit/29c504d58d299a217030ef82dbaa13ca017e9e23) | `` python3Packages.mypy-boto3-license-manager: 1.43.0 -> 1.43.46 ``                              |
| [`c2e6f6d1`](https://github.com/NixOS/nixpkgs/commit/c2e6f6d15840d049dde1fd91a1de5353a50196e3) | `` python3Packages.mypy-boto3-lambda: 1.43.42 -> 1.43.46 ``                                      |
| [`53f60def`](https://github.com/NixOS/nixpkgs/commit/53f60defdf1501e70f4e089e11b42f709abcdfad) | `` proto: 0.58.0 -> 0.58.2 ``                                                                    |
| [`d056caac`](https://github.com/NixOS/nixpkgs/commit/d056caac8c99d9942b11107cfd8f9fe871c94068) | `` python3Packages.mypy-boto3-inspector2: 1.43.42 -> 1.43.46 ``                                  |
| [`b7be638f`](https://github.com/NixOS/nixpkgs/commit/b7be638f97535275a62c68ee51a85415449ae0b6) | `` python3Packages.mypy-boto3-ec2: 1.43.45 -> 1.43.46 ``                                         |
| [`51fb0c37`](https://github.com/NixOS/nixpkgs/commit/51fb0c374320b733df11933a09a71e643ddb1d8e) | `` python3Packages.mypy-boto3-cloudwatch: 1.43.38 -> 1.43.46 ``                                  |
| [`2fef3bc5`](https://github.com/NixOS/nixpkgs/commit/2fef3bc538772c7ecfb203f70491d6fb33ae5d86) | `` ov: add Holiu618 to maintainers ``                                                            |
| [`e2604517`](https://github.com/NixOS/nixpkgs/commit/e26045170c8b8b3d831b87251737c780bb51f33e) | `` ov: 0.51.1 -> 0.54.0 ``                                                                       |
| [`7178f32a`](https://github.com/NixOS/nixpkgs/commit/7178f32a7a06d1898d59c2b00e54a77a1725238b) | `` cdncheck: 1.2.43 -> 1.2.44 ``                                                                 |
| [`84094e8c`](https://github.com/NixOS/nixpkgs/commit/84094e8cd4d1bda05c5c9bdf0df2f19680f5371a) | `` kargo: 1.10.7 -> 1.10.8 ``                                                                    |
| [`080b6cb2`](https://github.com/NixOS/nixpkgs/commit/080b6cb2cdde1a58ff2701dfb422f467ac6e2bb2) | `` tinygo: Change Go version in tinygo build from 1.25 to 1.26 ``                                |
| [`e664c0e5`](https://github.com/NixOS/nixpkgs/commit/e664c0e5dde7cb80470ab0642fe9c6d5b8423ca1) | `` ani-skip: 1.0.1 -> 1.2.1 ``                                                                   |
| [`a9fc3ca5`](https://github.com/NixOS/nixpkgs/commit/a9fc3ca5506234f5b54e612faf71c1397ecaa260) | `` git-spice: 0.30.1 -> 0.31.0 ``                                                                |
| [`450617b6`](https://github.com/NixOS/nixpkgs/commit/450617b66659960ce4332a691246b9730a8616a5) | `` grpcui: 1.5.1 -> 1.5.2 ``                                                                     |
| [`e52db9ba`](https://github.com/NixOS/nixpkgs/commit/e52db9ba4db2a229b862f277fd2ef90923b359b2) | `` yaziPlugins.projects: 0-unstable-2026-05-30 → 0-unstable-2026-07-11 ``                        |
| [`b7b1a445`](https://github.com/NixOS/nixpkgs/commit/b7b1a4452929552f50304c8952c8a5c8c772a8b6) | `` python3Packages.ha-garmin: 0.1.27 -> 0.1.29 ``                                                |
| [`0afcfbb7`](https://github.com/NixOS/nixpkgs/commit/0afcfbb73e0c31cd07124a85e280b812f3b32275) | `` home-assistant-custom-components.closest_intent: 0.2.0 -> 0.2.1 ``                            |
| [`382fce72`](https://github.com/NixOS/nixpkgs/commit/382fce7223a2f364d4203fe93fef4afeed02ee4f) | `` matrix-tuwunel: 1.8.0 -> 1.8.1 ``                                                             |
| [`edd245e4`](https://github.com/NixOS/nixpkgs/commit/edd245e447c67603743e7435b76bc8f0bc83f790) | `` zs: 0.4.1 -> 0.4.5 ``                                                                         |
| [`58a0a5ef`](https://github.com/NixOS/nixpkgs/commit/58a0a5effc260914f00812f7987feae234c5f15f) | `` yffi: 0.24.0 -> 0.27.3 ``                                                                     |
| [`976e3b7e`](https://github.com/NixOS/nixpkgs/commit/976e3b7eb30401c2123aa485a46b2642e8d213b1) | `` home-assistant-custom-components.daikin_onecta: 4.6.10 -> 4.6.12 ``                           |
| [`65a1f97a`](https://github.com/NixOS/nixpkgs/commit/65a1f97ad77dc1c5abd38356d4288c08a0541c80) | `` terraform-providers.vancluever_acme: 2.48.1 -> 2.48.3 ``                                      |
| [`ff7e147c`](https://github.com/NixOS/nixpkgs/commit/ff7e147c187796bedbe06610a14bca5df5b9e190) | `` zsh-artisan: init at 0-unstable-2015-12-08 ``                                                 |
| [`222f2a06`](https://github.com/NixOS/nixpkgs/commit/222f2a064d6c4a26b6bcc5e0303374e1e00dc15a) | `` gelly: 1.9.0 -> 1.9.2 ``                                                                      |
| [`08e2d92d`](https://github.com/NixOS/nixpkgs/commit/08e2d92d786eb15eb97f9bb9a4c3d3136195c2f2) | `` rectangle: fix darwin build ``                                                                |
| [`1f1964ac`](https://github.com/NixOS/nixpkgs/commit/1f1964ac3df2ff2966c91942898204e39cc449ad) | `` terminal-notifier: fix darwin build ``                                                        |
| [`81838fb3`](https://github.com/NixOS/nixpkgs/commit/81838fb3b7e93cec09790eb02f1a4ec2dac9ca84) | `` mpdris2-rs: 1.1.1 -> 1.1.2 ``                                                                 |
| [`14521b8e`](https://github.com/NixOS/nixpkgs/commit/14521b8ec1b655dcd687401be034d794dad04f85) | `` brutespray: 2.6.2 -> 2.6.3 ``                                                                 |
| [`e718bf5f`](https://github.com/NixOS/nixpkgs/commit/e718bf5f8cc938cda66b12130ffb5eb32975b43b) | `` git-repo: 2.59 -> 2.65 ``                                                                     |
| [`dcf3bad7`](https://github.com/NixOS/nixpkgs/commit/dcf3bad7177c31de3c87b6631a7b6bcda08e3900) | `` whipper: fix build ``                                                                         |
| [`618ccd10`](https://github.com/NixOS/nixpkgs/commit/618ccd102fff1e6900dcc431e4539cfaf1c30dad) | `` packetry: 0.4.0 -> 0.5.0 ``                                                                   |
| [`077a8340`](https://github.com/NixOS/nixpkgs/commit/077a834073acd53e6725ce5354acaeda665c839e) | `` python3Packages.kafka-python: 3.0.6 -> 3.0.8 ``                                               |
| [`542f97ad`](https://github.com/NixOS/nixpkgs/commit/542f97ad56b88d6675d39f9de2158d48e0b4134f) | `` kitty-bin: init at 0.47.4 ``                                                                  |
| [`d5b877ed`](https://github.com/NixOS/nixpkgs/commit/d5b877ed10d7ee4ad06d6bc2767e7a2b8e9c47e7) | `` rainfrog: 0.3.19 -> 0.3.20 ``                                                                 |
| [`131549af`](https://github.com/NixOS/nixpkgs/commit/131549afe408b01fad09274cfa1eb95776979854) | `` motus: 0.4.0 -> 0.5.0 ``                                                                      |
| [`5690096b`](https://github.com/NixOS/nixpkgs/commit/5690096bbf9e36e7a9ce6eab48bac0b1fa705bbe) | `` onlyoffice-documentserver: revert back to standard icu ``                                     |
| [`fb1098a4`](https://github.com/NixOS/nixpkgs/commit/fb1098a45c2fab12474f4a1ddfdec34605fc0409) | `` python314Packages.vtherm-api: don't propagate home-assistant ``                               |
| [`fd6218fb`](https://github.com/NixOS/nixpkgs/commit/fd6218fb7a57d4748ed1b4d145dbef3baa75613c) | `` libretro.dosbox-pure: 0-unstable-2026-06-26 -> 0-unstable-2026-07-06 ``                       |
| [`684605e1`](https://github.com/NixOS/nixpkgs/commit/684605e11c8d13f6f7087bf1b3c98bb2d66bd97b) | `` hmcl: 3.15.2 -> 3.15.3 ``                                                                     |
| [`66cafe6c`](https://github.com/NixOS/nixpkgs/commit/66cafe6c0f4a27f16564ebcd6934b1ac9cc48137) | `` txm: init at 0.1.4 ``                                                                         |
| [`46ba397f`](https://github.com/NixOS/nixpkgs/commit/46ba397fff9782269b38f5e507a1531182a0957a) | `` mole-cleaner: init at 1.31.0 ``                                                               |
| [`bb01c8c8`](https://github.com/NixOS/nixpkgs/commit/bb01c8c8fdd2ad82261964bf3aeb6bb3e6dcc12e) | `` orion-browser: init at 149 ``                                                                 |
| [`46245eb3`](https://github.com/NixOS/nixpkgs/commit/46245eb385310f844d6c366014a289018ee6e47f) | `` passless: 0.12.0 -> 0.13.0 ``                                                                 |
| [`72992f84`](https://github.com/NixOS/nixpkgs/commit/72992f8463e49cf800959e6ad3422862a17d07bc) | `` notion-app: 7.24.0 -> 7.25.1 ``                                                               |
| [`e5e2256d`](https://github.com/NixOS/nixpkgs/commit/e5e2256d453f928a112562d9a3bff3be3988a188) | `` container: add Br1ght0ne to maintainers ``                                                    |
| [`3861a8ec`](https://github.com/NixOS/nixpkgs/commit/3861a8ec329427dc5581357d030ba6e8106b3527) | `` container: 1.0.0 -> 1.1.0 ``                                                                  |
| [`9b7cb711`](https://github.com/NixOS/nixpkgs/commit/9b7cb71122aca97ef5108ab41728ffe374fe7819) | `` cockpit-zfs: 1.2.27-3 -> 1.2.30 ``                                                            |
| [`94ed25df`](https://github.com/NixOS/nixpkgs/commit/94ed25df38e7cd7ba51a518476ea42b019b302d5) | `` llvmPackages_git: 23.0.0-unstable-2026-07-05 -> 23.0.0-unstable-2026-07-12 ``                 |
| [`0d2c276e`](https://github.com/NixOS/nixpkgs/commit/0d2c276e3eb1e91ea8501d249f506f0de7e0be9e) | `` python3Packages.sabctools: 9.5.0 -> 9.6.1 ``                                                  |
| [`b92d7358`](https://github.com/NixOS/nixpkgs/commit/b92d7358ff94f165aac22bbc4dedf0f97d1b0fb3) | `` claude-agent-acp: 0.52.0 -> 0.58.1 ``                                                         |
| [`8bdd9b08`](https://github.com/NixOS/nixpkgs/commit/8bdd9b08f3ed16965f357de510f7bcccbb156de6) | `` sioyek: 2.0.0-unstable-2026-06-13 -> 2.0.0-unstable-2026-07-11 ``                             |
| [`39434a41`](https://github.com/NixOS/nixpkgs/commit/39434a41fb5dcaf197647f6dfd694698dc3f0ed5) | `` wttrbar: 0.14.5 -> 0.15.0 ``                                                                  |
| [`0cd4659e`](https://github.com/NixOS/nixpkgs/commit/0cd4659eada6119f475711aed1ca883a30724946) | `` various: replace os.system with subprocess.run ``                                             |
| [`16a5d8d8`](https://github.com/NixOS/nixpkgs/commit/16a5d8d871cb9cdce2a1c4bd1b5e624192973de1) | `` memtier-benchmark: 2.4.3 -> 2.4.4 ``                                                          |
| [`6e83d7c6`](https://github.com/NixOS/nixpkgs/commit/6e83d7c6fa34b9b3c40f9432354fdd1288cec4e5) | `` rust-petname: 3.0.0 -> 3.1.0 ``                                                               |
| [`f393868f`](https://github.com/NixOS/nixpkgs/commit/f393868fde2be54677e3712537511af4255c9c92) | `` vscode-extensions.detachhead.basedpyright: 1.39.8 -> 1.39.9 ``                                |
| [`3ab4f86a`](https://github.com/NixOS/nixpkgs/commit/3ab4f86a2d0ad41da6c5eb736ae650329ecdd27d) | `` grafanaPlugins.grafana-metricsdrilldown-app: 2.1.0 -> 2.2.0 ``                                |
| [`fb3caa9c`](https://github.com/NixOS/nixpkgs/commit/fb3caa9c0862ad3c5dbcfffddb6e20ead05d9af5) | `` libretro.gambatte: 0-unstable-2026-06-19 -> 0-unstable-2026-07-03 ``                          |
| [`aa71b6f0`](https://github.com/NixOS/nixpkgs/commit/aa71b6f0ff0e610a66e676803d0a24513b88d2b8) | `` runpodctl: 2.3.0 -> 2.6.1 ``                                                                  |
| [`dc8ffab5`](https://github.com/NixOS/nixpkgs/commit/dc8ffab5042f0432a6f03c845ac7177774d9a7ef) | `` linux_testing: 7.2-rc2 -> 7.2-rc3 ``                                                          |
| [`66b8bf79`](https://github.com/NixOS/nixpkgs/commit/66b8bf79bd973f2024299b6113f2cf01806bf961) | `` openrct2: add `verifyAssets` argument for disabling asset version checks ``                   |
| [`8e636ef9`](https://github.com/NixOS/nixpkgs/commit/8e636ef9bd8f593ffa3973e61c4678024dbafe7c) | `` openrct2: refactor assets for `overrideAttrs` support ``                                      |
| [`9f53e2e0`](https://github.com/NixOS/nixpkgs/commit/9f53e2e035d68afd3d124450313fb96041322ccb) | `` application-title-bar: 0.9.1 -> 0.10.0 ``                                                     |
| [`70143e77`](https://github.com/NixOS/nixpkgs/commit/70143e77b975d5dd6b9910841bad7bb1e88e86ab) | `` openrct2: remove patch (issue fixed upstream) ``                                              |
| [`742c9ebf`](https://github.com/NixOS/nixpkgs/commit/742c9ebf778df7e1ab66a5f55d18fe8e603b4c87) | `` openrct2: add `zstd` to `buildInputs` ``                                                      |
| [`9a57e7f8`](https://github.com/NixOS/nixpkgs/commit/9a57e7f8313cf9c91f39c26a568bb150fcd33801) | `` openrct2: add `__structuredAttrs` and `strictDeps` attributes ``                              |
| [`c1e2fbb4`](https://github.com/NixOS/nixpkgs/commit/c1e2fbb4b1568ae730f600505d0efe1b6a32124a) | `` nezha: 2.2.9 -> 2.2.10 ``                                                                     |
| [`bbc5f642`](https://github.com/NixOS/nixpkgs/commit/bbc5f642aa59b59866ff131ac4fd0985ec27d13a) | `` daisydisk: 4.33.3 -> 4.34.2 ``                                                                |
| [`2fe6984e`](https://github.com/NixOS/nixpkgs/commit/2fe6984e45cc9b10328169263d94723af7104f10) | `` home-assistant-custom-lovelace-modules.horizon-card: 1.4.0 -> 1.4.2 ``                        |
| [`99f19ac2`](https://github.com/NixOS/nixpkgs/commit/99f19ac25454cac0a26fb4e02b70b0003a197a8f) | `` geeqie: 2.8 -> 2.9 ``                                                                         |
| [`aedfc6e5`](https://github.com/NixOS/nixpkgs/commit/aedfc6e5ae39778fffb10ced56437e4749d2be00) | `` diskonaut-ng: init at 0.13.2 ``                                                               |
| [`4f76c293`](https://github.com/NixOS/nixpkgs/commit/4f76c2931f80f023a695c87946cdbe262b1a0a8d) | `` snx-rs: 6.1.2 -> 6.2.0 ``                                                                     |
| [`f1b59d97`](https://github.com/NixOS/nixpkgs/commit/f1b59d97c81379101f573128acc662ea7a412f6f) | `` maintainers: add gregshuflin ``                                                               |
| [`3def5f9c`](https://github.com/NixOS/nixpkgs/commit/3def5f9c6860d288115c3f34d13dd11f6636e64f) | `` python3Packages.types-webencodings: 0.5.0.20251108 -> 0.5.0.20260408 ``                       |
| [`f23a9fa4`](https://github.com/NixOS/nixpkgs/commit/f23a9fa420a995a967cb2108f3c04f22c307b59b) | `` skim: 5.0.0 -> 5.1.0 ``                                                                       |
| [`34745874`](https://github.com/NixOS/nixpkgs/commit/347458742024fff290416e8927016d7934bd9f1c) | `` grafana-image-renderer: 5.9.0 -> 5.9.1 ``                                                     |
| [`ec457e97`](https://github.com/NixOS/nixpkgs/commit/ec457e97c96e0c307aff1160fb7cbef5c6a019ae) | `` oh-my-posh: 29.20.0 -> 29.26.1 ``                                                             |
| [`6692a57d`](https://github.com/NixOS/nixpkgs/commit/6692a57d756f38df999f55677499298939e87e98) | `` scrcpy: 4.0 -> 4.1 ``                                                                         |
| [`b7dd57b3`](https://github.com/NixOS/nixpkgs/commit/b7dd57b33f0edf1c1cfa0f0e142c768b9275fe7a) | `` nixos/tests/matter-server: use default python3Packages ``                                     |
| [`ad443129`](https://github.com/NixOS/nixpkgs/commit/ad44312900cf051fbd355ef2c198232c32434323) | `` goperf: 0-unstable-2026-06-15 -> 0-unstable-2026-07-08 ``                                     |
| [`74d2f397`](https://github.com/NixOS/nixpkgs/commit/74d2f39773933ba2b511ff9c816b5a45b785c8e9) | `` olympus-unwrapped: 26.06.06.03 -> 26.07.12.04 ``                                              |
| [`ee4109ba`](https://github.com/NixOS/nixpkgs/commit/ee4109badce41aa56428285807361763816afd8f) | `` fnox: 1.29.0 -> 1.30.0 ``                                                                     |
| [`2f852c21`](https://github.com/NixOS/nixpkgs/commit/2f852c210864ef1483e4d3f813d05016d7b17b11) | `` concord-tui: 2.2.13 -> 2.3.5 ``                                                               |
| [`3bd158e7`](https://github.com/NixOS/nixpkgs/commit/3bd158e72e6a22a4505479360e05a84b0c83a503) | `` cgt-calc: fix build by backporting uv-build relaxation ``                                     |
| [`9af64550`](https://github.com/NixOS/nixpkgs/commit/9af645506c710799906e7a45bdcaa00fc9552b93) | `` matrix-continuwuity: 26.6.1 -> 26.6.2 ``                                                      |
| [`a112bd30`](https://github.com/NixOS/nixpkgs/commit/a112bd3058db874e9fb4d5eddac8b14368a4e557) | `` libretro.vba-next: 0-unstable-2026-06-06 -> 0-unstable-2026-06-29 ``                          |
| [`121c8c22`](https://github.com/NixOS/nixpkgs/commit/121c8c223a6741c2fb5ce635eaa5077c0b3a626b) | `` python3Packages.svgdigitizer: modernize ``                                                    |
| [`dfc8eaa1`](https://github.com/NixOS/nixpkgs/commit/dfc8eaa1321362e2e13b91a8efde20b7335e4cbe) | `` python3Packages.svgdigitizer: relax deps on astropy to allow building ``                      |
| [`cc4f407d`](https://github.com/NixOS/nixpkgs/commit/cc4f407d133ef4d5cc28acce791a1bba35f24cb2) | `` timbreid: specify gpl3Plus license ``                                                         |
| [`f6a3ebb1`](https://github.com/NixOS/nixpkgs/commit/f6a3ebb1281b93927fb5ae1021fd7f5c036728c8) | `` python3Packages.corner: 2.2.3 -> 2.3.0 ``                                                     |
| [`78dd8308`](https://github.com/NixOS/nixpkgs/commit/78dd83087469b88f54ed5736fd88031a48900037) | `` searchix: 0.4.8 -> 0.4.9 ``                                                                   |
| [`35a4d854`](https://github.com/NixOS/nixpkgs/commit/35a4d8543e3cd6d272f9843555ee6d1e218107c6) | `` python3Packages.swcgeom: 0.21.5 -> 0.21.6 ``                                                  |
| [`446396e2`](https://github.com/NixOS/nixpkgs/commit/446396e2daf975a44bddced4b29a347e1149a134) | `` python3Packages.swcgeom: modernize ``                                                         |
| [`cbbbe1d2`](https://github.com/NixOS/nixpkgs/commit/cbbbe1d201904f91021640c105cdc6e33d37d633) | `` mermaid-cli: 11.12.0 -> 11.16.0 ``                                                            |
| [`f65a4701`](https://github.com/NixOS/nixpkgs/commit/f65a47019632f1ad6e05a5b924f0ab0d2a756ffc) | `` python3Packages.arviz-base: ignore failing warning ``                                         |
| [`e2619a65`](https://github.com/NixOS/nixpkgs/commit/e2619a652d533cbffc5bd48f153e413e39f76ffc) | `` folia-major: 0.5.26 -> 0.5.27 ``                                                              |
| [`5efedf22`](https://github.com/NixOS/nixpkgs/commit/5efedf2208d6310c7c0162ffc226ebc9750acc53) | `` python3Packages.ckzg: 2.1.7 -> 2.1.8 ``                                                       |
| [`895db8b6`](https://github.com/NixOS/nixpkgs/commit/895db8b608929bba887291b5e6978ee063b32d28) | `` postgresql.withPackages: expose tests passthru ``                                             |
| [`5cefe928`](https://github.com/NixOS/nixpkgs/commit/5cefe928eef1f37ea02cd31a03bf313853ef10a3) | `` python3Packages.pygraphviz: unbreak on Darwin ``                                              |
| [`92f9eaae`](https://github.com/NixOS/nixpkgs/commit/92f9eaaed49989f1f4f568408b63b5df92251177) | `` gomplate: 5.1.0 -> 5.2.0 ``                                                                   |
| [`3acfab61`](https://github.com/NixOS/nixpkgs/commit/3acfab615efbcbc886247c1b628cd21784dd96fd) | `` graphviz: support building Quartz plugin on Darwin ``                                         |
| [`c11ef722`](https://github.com/NixOS/nixpkgs/commit/c11ef722638031b362942fac5b13182846785ccf) | `` python3Packages.vllm: add more known vulnerabilities ``                                       |
| [`483003db`](https://github.com/NixOS/nixpkgs/commit/483003dbd182901f1efc2a76b5dd092835e00a57) | `` orioledb: 17.20 -> 18.1 (orioledb-postgres) ``                                                |
| [`0d76345c`](https://github.com/NixOS/nixpkgs/commit/0d76345cd23fb2b0679a47944cb3550d67d5907c) | `` timbreid: enable parallel building ``                                                         |
| [`e36b20e2`](https://github.com/NixOS/nixpkgs/commit/e36b20e25e2748ccde541ddd7bcb976a4edffcd5) | `` python3Packages.qh3: 1.9.2 -> 1.9.3 ``                                                        |
| [`895f7ded`](https://github.com/NixOS/nixpkgs/commit/895f7deddc7515f5c094c8af312a274e3f90e570) | `` openllm: mark insecure ``                                                                     |
| [`d634535d`](https://github.com/NixOS/nixpkgs/commit/d634535db18fdab6b85e768e3c3b7db247d6a53f) | `` python3Packages.bentoml: mark insecure ``                                                     |
| [`9c9caec8`](https://github.com/NixOS/nixpkgs/commit/9c9caec86fedc8ec80087aad4ff95253cfaa4890) | `` codechecker: 6.24.0 -> 6.28.0 ``                                                              |
| [`7234c843`](https://github.com/NixOS/nixpkgs/commit/7234c843ad93baae6c157a95b0035c590959b638) | `` infer: init at 1.3.0 ``                                                                       |
| [`90c9bbb8`](https://github.com/NixOS/nixpkgs/commit/90c9bbb890c0e1b780ede2cfccb710f4c6b763ff) | `` mympd: 25.2.2 -> 25.3.0 ``                                                                    |
| [`2f0b459b`](https://github.com/NixOS/nixpkgs/commit/2f0b459b260125897fa1109ef0fc5b39b26fa41a) | `` pyml: 20231101 -> 20250807 ``                                                                 |
| [`492251d9`](https://github.com/NixOS/nixpkgs/commit/492251d9ea1d3afe6e7223ba466685904a2940d6) | `` maintainers: add kacper-uminski ``                                                            |
| [`e3629cd4`](https://github.com/NixOS/nixpkgs/commit/e3629cd4f0921bd44e5d161d00c4e70e677ae7f9) | `` terraform-providers.hashicorp_tfe: 0.78.0 -> 0.79.0 ``                                        |
| [`69640f6d`](https://github.com/NixOS/nixpkgs/commit/69640f6d1f788e631b7457681ec278010dfd9a74) | `` doc/style.css: clamp content max-width ``                                                     |
| [`08acb1b0`](https://github.com/NixOS/nixpkgs/commit/08acb1b09f2d5224b42c9045b43a752cc845b5cd) | `` python3Packages.dataset: 1.6.2 -> 2.0.0 ``                                                    |
| [`c3cdc7f1`](https://github.com/NixOS/nixpkgs/commit/c3cdc7f12625f43b50d9eded00987b174d9a98fa) | `` nexttrace: 1.7.0 -> 1.7.1 ``                                                                  |
| [`0897fed1`](https://github.com/NixOS/nixpkgs/commit/0897fed1ad28b2196bebd97873b59e162d138fc7) | `` python3Packages.statmake: update dependencies ``                                              |
| [`c850aa14`](https://github.com/NixOS/nixpkgs/commit/c850aa1420a7a128def76875aba2ee96611e7d09) | `` python3Packages.ufolint: update dependencies ``                                               |
| [`5c54aeaa`](https://github.com/NixOS/nixpkgs/commit/5c54aeaa1b1e88b3fc67bf04b90710dc2601bb2a) | `` python3Packages.fontfeatures: update dependencies ``                                          |
| [`66e34083`](https://github.com/NixOS/nixpkgs/commit/66e34083af508a84ad33f71c88491c70aee4f8f7) | `` python313Packages.fs: mark broken ``                                                          |
| [`30f2fa0c`](https://github.com/NixOS/nixpkgs/commit/30f2fa0ce11e48b79815b75b7591b1f484c5ca3e) | `` privatebin: 2.0.4 -> 2.0.5 ``                                                                 |
| [`1953bbb3`](https://github.com/NixOS/nixpkgs/commit/1953bbb33657a668a4a7744517400af661a462a0) | `` home-assistant-custom-components.local_openai: 1.8.0 -> 1.8.1 ``                              |
| [`ccfaa326`](https://github.com/NixOS/nixpkgs/commit/ccfaa326e0bcf5d80f15bfc43d50cb98727adc0b) | `` jenkins: 2.555.3 -> 2.568.1 ``                                                                |
| [`c33f83b4`](https://github.com/NixOS/nixpkgs/commit/c33f83b46f9c9d7a50eac5075a4b0bcc49afb8f5) | `` timbreid: replace explicit phases with nix flags ``                                           |
| [`1b844a8e`](https://github.com/NixOS/nixpkgs/commit/1b844a8e744ea2be7eeb22c6124ae6825fd475dd) | `` Revert "python313Packages.fs: pin to setuptools_80" ``                                        |
| [`08ebc6c0`](https://github.com/NixOS/nixpkgs/commit/08ebc6c0b25bf025a2809887e61c591aa25b59e5) | `` displaycal: 3.9.17 → 3.9.18 ``                                                                |
| [`f93cef19`](https://github.com/NixOS/nixpkgs/commit/f93cef19e8c20f24cd5aff2617ac99917b489ea6) | `` topgrade: fix Darwin build ``                                                                 |
| [`6252b63d`](https://github.com/NixOS/nixpkgs/commit/6252b63db2800e851cedc3d3d54d6006d570a746) | `` python3Packages.aiohomematic: use __structuredAttrs ``                                        |
| [`9b2041b0`](https://github.com/NixOS/nixpkgs/commit/9b2041b06ddc58783a81e54d383d342f21a25b5c) | `` python3Packages.aiohomematic: use finalAttrs ``                                               |
| [`dbf2c2b6`](https://github.com/NixOS/nixpkgs/commit/dbf2c2b6411809d9f21f96fb251b60641e342c54) | `` vrc-get: 1.9.1 -> 1.9.2 ``                                                                    |
| [`d585b4c9`](https://github.com/NixOS/nixpkgs/commit/d585b4c95840e265a9d46c84986ebcb0bb426499) | `` home-assistant-custom-components.homematicip_local: 2.8.2 -> 2.8.3 ``                         |
| [`80c285e5`](https://github.com/NixOS/nixpkgs/commit/80c285e543c54971298780eb9960d141f6ff59cc) | `` python3Packages.openccu-loom-client: 2026.7.4 -> 2026.7.6 ``                                  |
| [`8a8a6b49`](https://github.com/NixOS/nixpkgs/commit/8a8a6b490a77514527a80845b63d64a7c80e3ab4) | `` python3Packages.openccu-loom-types: 0.1.52 -> 0.1.53 ``                                       |
| [`c4ae77b8`](https://github.com/NixOS/nixpkgs/commit/c4ae77b8cf54abfe585d08fc0c21fb23151d687f) | `` python3Packages.aiohomematic: 2026.7.2 -> 2026.7.6 ``                                         |
| [`3bcccb11`](https://github.com/NixOS/nixpkgs/commit/3bcccb11994638e3b6274a3aee2c3818c001cbdf) | `` python3Packages.exa-py: 2.14.0 -> 2.16.1 ``                                                   |
| [`1e80ac70`](https://github.com/NixOS/nixpkgs/commit/1e80ac708e3f6da0be52fa728487a89abe7c1999) | `` terraform-providers.f5networks_bigip: 1.27.0 -> 1.28.0 ``                                     |
| [`b9222837`](https://github.com/NixOS/nixpkgs/commit/b92228378d23e20da483d56ed6d8745bc708cf7b) | `` aube: fix build ``                                                                            |
| [`23c12980`](https://github.com/NixOS/nixpkgs/commit/23c12980be11e7e08746b7bdb44b371d2d9e4e3c) | `` python3Packages.seaborn: disable flaky test on Darwin ``                                      |
| [`fd61dd3a`](https://github.com/NixOS/nixpkgs/commit/fd61dd3ad6e19806937a7797f08a0365f9c3b920) | `` python3Packages.seaborn: modernize ``                                                         |
| [`141e1fce`](https://github.com/NixOS/nixpkgs/commit/141e1fceda64625892f47857d69d554f22b3c6cc) | `` ctx7: 0.5.3 -> 0.5.4 ``                                                                       |
| [`f2493a4a`](https://github.com/NixOS/nixpkgs/commit/f2493a4a77a621f42b18a0fea69f0d50e6635ab3) | `` terraform-providers.sumologic_sumologic: 3.2.8 -> 3.2.9 ``                                    |
| [`a2227067`](https://github.com/NixOS/nixpkgs/commit/a22270679d2986df996cf56fea5c229942572723) | `` terraform-providers.spotinst_spotinst: 1.237.0 -> 1.238.0 ``                                  |
| [`203070b2`](https://github.com/NixOS/nixpkgs/commit/203070b2cd491bdf683c3fa5317a9e80b80b0066) | `` plasmusic-toolbar: 4.1.0 -> 4.2.0 ``                                                          |
| [`626e303d`](https://github.com/NixOS/nixpkgs/commit/626e303ddc7b8b307234be8b5a60ba795ae2bff3) | `` bloop: 2.1.0 -> 2.1.1 ``                                                                      |
| [`627c7cc7`](https://github.com/NixOS/nixpkgs/commit/627c7cc75e92a372a329991c328f853a34796f55) | `` zabbix74: 7.4.11 -> 7.4.12 ``                                                                 |
| [`8836d92c`](https://github.com/NixOS/nixpkgs/commit/8836d92ccdbe17dcd259e497f67133af23c91f60) | `` python3Packages.structlog: use finalAttrs ``                                                  |
| [`f6cfa2ca`](https://github.com/NixOS/nixpkgs/commit/f6cfa2ca77b39de8b9ad25c08ff36214daf9267b) | `` python3Packages.functions-framework: 3.10.1 -> 3.10.2 ``                                      |
| [`c9e406bc`](https://github.com/NixOS/nixpkgs/commit/c9e406bc4309ed6f1d84eb19e9af705b2788a092) | `` python3Packages.structlog: 25.5.0 -> 26.1.0 ``                                                |
| [`9d368209`](https://github.com/NixOS/nixpkgs/commit/9d36820963be1523b3a40c39c045265918cdc943) | `` python3Packages.redisvl: fix build with redis 8.0.1 ``                                        |
| [`0d67c99f`](https://github.com/NixOS/nixpkgs/commit/0d67c99f886080b3c698d491dfeef6d4bf4beab7) | `` screen: 5.0.1 -> 5.0.2 ``                                                                     |
| [`f25ea673`](https://github.com/NixOS/nixpkgs/commit/f25ea67363554d72514f16859242835d85c1c09e) | `` python3Packages.qbittorrent-api: 2026.6.0 -> 2026.7.0 ``                                      |
| [`9bfbbc61`](https://github.com/NixOS/nixpkgs/commit/9bfbbc61f6e0e2528f44fa87394b7bf348dcfdb2) | `` ananicy-rules-cachyos: 0-unstable-2026-06-24 -> 0-unstable-2026-07-11 ``                      |
| [`9408e891`](https://github.com/NixOS/nixpkgs/commit/9408e8912ec13330665ec22857f42a98a7929ab9) | `` mtail: 3.4.0 -> 3.4.3 ``                                                                      |
| [`867f50f5`](https://github.com/NixOS/nixpkgs/commit/867f50f5db661852a3d59e0fc4c87ed2919a5b83) | `` clickhouse-backup: 2.7.3 -> 2.7.4 ``                                                          |
| [`fdbd3630`](https://github.com/NixOS/nixpkgs/commit/fdbd3630e12ec2d6d3f588fd3720ab2bfc70b355) | `` python3Packages.pyvers: 0.2.2 -> 0.2.3 ``                                                     |
| [`fd141a26`](https://github.com/NixOS/nixpkgs/commit/fd141a2647a7d0e8506c15b45b61a4af6f96a1ec) | `` flytectl.tests: fix the eval ``                                                               |
| [`98b4497a`](https://github.com/NixOS/nixpkgs/commit/98b4497a4f6e1232c1779468750d4e6e524d8fe5) | `` python3Packages.python-open-router: 0.3.3 -> 0.4.0 ``                                         |
| [`55f67a8d`](https://github.com/NixOS/nixpkgs/commit/55f67a8dc70e884624f0f7b259f3acf5dd2b0a7e) | `` maintainers: remove shardy ``                                                                 |
| [`5cfd76ff`](https://github.com/NixOS/nixpkgs/commit/5cfd76ff6e7b33ba1eb433b84247db6b15dd8f58) | `` yabai: remove inactive maintainer ``                                                          |
| [`47cff4e3`](https://github.com/NixOS/nixpkgs/commit/47cff4e38cbd9d3debbc40ff3d5c0497d437bb6f) | `` python3Packages.caido-schema-proxy: 0.57.0 -> 0.57.1 ``                                       |
| [`eaca8761`](https://github.com/NixOS/nixpkgs/commit/eaca87611000e7b626f8fa13997faed34110f7ba) | `` github-copilot-cli: remove dbreyfogle as maintainer ``                                        |
| [`432c1759`](https://github.com/NixOS/nixpkgs/commit/432c1759a6568b2e24773ceff3b7c7f6bf70ddff) | `` python3Packages.guntamatic: 1.9.0 -> 1.9.1 ``                                                 |
| [`61159270`](https://github.com/NixOS/nixpkgs/commit/61159270ad8a56f8dc59341e38fdbee85976881c) | `` dnsproxy: 0.82.1 -> 0.83.0 ``                                                                 |
| [`5636f934`](https://github.com/NixOS/nixpkgs/commit/5636f9347d939c2eeb98fa5f99c03d54bc969561) | `` python3Packages.timezonefinder: 8.2.4 -> 8.2.5 ``                                             |
| [`801701ec`](https://github.com/NixOS/nixpkgs/commit/801701ec970d16f9f06458f3652b7631714674f6) | `` nixos/oo7: fix option description ``                                                          |
| [`52d46d77`](https://github.com/NixOS/nixpkgs/commit/52d46d77f7d0cb0bc5d5a9dcb04144f228e91a73) | `` search-vulns: 1.1.0 -> 1.2.1 ``                                                               |
| [`a846cde4`](https://github.com/NixOS/nixpkgs/commit/a846cde45365799b1fd83eafaee57c03a92d89bc) | `` gdalMinimal: skip test_zarr_read_simple_sharding ``                                           |
| [`1e51f5cb`](https://github.com/NixOS/nixpkgs/commit/1e51f5cb1d5efd803d6e10082722593d55e583c8) | `` blueman: Fix double wrapping ``                                                               |
| [`94850e56`](https://github.com/NixOS/nixpkgs/commit/94850e563aa659b8d485ed21f76b4b25772fa4bf) | `` rumdl: add faukah to maintainers ``                                                           |
| [`879f9ce3`](https://github.com/NixOS/nixpkgs/commit/879f9ce3d2e2ffa183744acd1f3e0c839078da65) | `` rumdl: modernise ``                                                                           |
| [`3aeb31cf`](https://github.com/NixOS/nixpkgs/commit/3aeb31cff937491658c7daed7c0ca835fa8af894) | `` rumdl: 0.2.30 -> 0.2.31 ``                                                                    |
| [`652362a6`](https://github.com/NixOS/nixpkgs/commit/652362a62b3debd815b2ed74abd79f752224c3c0) | `` liblouis: 3.33.0 → 3.38.0 ``                                                                  |
| [`a39b911a`](https://github.com/NixOS/nixpkgs/commit/a39b911a0bb7c06481965f52545f6bb85132b1d2) | `` ramus: init at 2.0 ``                                                                         |
| [`e3e2b200`](https://github.com/NixOS/nixpkgs/commit/e3e2b200aea2ce3c18f8039309b581e90be20612) | `` maintainers: add mootfrost ``                                                                 |
| [`a8ad3473`](https://github.com/NixOS/nixpkgs/commit/a8ad3473cd9697f16ffe0629292530b0d5386ad9) | `` yamlscript: 0.2.24 -> 0.2.27 ``                                                               |
| [`66707db4`](https://github.com/NixOS/nixpkgs/commit/66707db40b8d28851e439bea3d2be9dc92d6dcff) | `` skills: 1.5.14 -> 1.5.16 ``                                                                   |
| [`b352dc2e`](https://github.com/NixOS/nixpkgs/commit/b352dc2e9ef3bfd3500a6de33dec4d48fe256255) | `` aasvg: 0.5.2 -> 0.5.3 ``                                                                      |
| [`39f6aa28`](https://github.com/NixOS/nixpkgs/commit/39f6aa28a3fa46b998bc0cdcfabb1644eb950e7f) | `` osu-lazer: 2026.624.0 -> 2026.711.0 ``                                                        |
| [`92b2793f`](https://github.com/NixOS/nixpkgs/commit/92b2793f8b3aafe0f2f157095828ba33c668b07f) | `` llama-cpp: do not overwrite the actual llama cli ``                                           |
| [`b67e88e3`](https://github.com/NixOS/nixpkgs/commit/b67e88e3a0849b363b9190793aa3f1d1ff39ceab) | `` osu-lazer-bin: 2026.624.0 -> 2026.711.0 ``                                                    |
| [`fe14acf0`](https://github.com/NixOS/nixpkgs/commit/fe14acf0621e0fc630560c714a7318dcb08eef9a) | `` nixos/nordvpn: init module ``                                                                 |
| [`cb8b2d7f`](https://github.com/NixOS/nixpkgs/commit/cb8b2d7ff4ceda0154df18c6c9511fba3d9fcf78) | `` llama-cpp: remove unnecessary argument ``                                                     |
| [`daa55b26`](https://github.com/NixOS/nixpkgs/commit/daa55b26c62e6940e12a3a92c2efcd7c1a603287) | `` mongodb-7_0: pin to setuptools_80 ``                                                          |
| [`eb3871d0`](https://github.com/NixOS/nixpkgs/commit/eb3871d0482225fb1743cb0c0854c00b4f3c32bc) | `` hyprlax: 2.2.4 -> 2.2.5 ``                                                                    |
| [`019ca14a`](https://github.com/NixOS/nixpkgs/commit/019ca14a55f8149d0872ce5e44c561f9f92298da) | `` await: 2.4.0 -> 2.7.0 ``                                                                      |
| [`daa94dce`](https://github.com/NixOS/nixpkgs/commit/daa94dce6256a0da8e7f5cecca486a03ef7d8391) | `` terraform-providers.ubiquiti-community_unifi: 0.54.0 -> 0.55.0 ``                             |
| [`fee0991f`](https://github.com/NixOS/nixpkgs/commit/fee0991f4bb7bf47e370e61c0f8d6c1f2efce2d2) | `` mindustry: 159.2 → 159.3 ``                                                                   |
| [`7c02eba5`](https://github.com/NixOS/nixpkgs/commit/7c02eba582c11cb1085b509ea6cd9ad057c2a05a) | `` libretro.genesis-plus-gx: 0-unstable-2026-06-19 -> 0-unstable-2026-07-10 ``                   |
| [`f8b7e2fc`](https://github.com/NixOS/nixpkgs/commit/f8b7e2fca7c74b5d58176f7333f5b2df317de7da) | `` muse-sounds-manager: 2.1.1.912 -> 2.2.1.953 ``                                                |
| [`2d4248e0`](https://github.com/NixOS/nixpkgs/commit/2d4248e0f9bc253ef9efbddaf00724467f230c01) | `` pyrefly: 1.2.0-dev.1 -> 1.2.0-dev.2 ``                                                        |
| [`0d29e4c4`](https://github.com/NixOS/nixpkgs/commit/0d29e4c4b6d7aed14815b65afc79acae08092860) | `` karmor: 1.4.7 -> 1.4.9 ``                                                                     |
| [`dc83a880`](https://github.com/NixOS/nixpkgs/commit/dc83a880ab439c8bf819a80cc35e5b046c15fc02) | `` nixos/zeronet: Update TOR settings ``                                                         |
| [`9ce44004`](https://github.com/NixOS/nixpkgs/commit/9ce44004662cf3d1b9bdd0833f79ae52ae43283c) | `` mcp-gateway: 3.0.1 -> 3.3.0 ``                                                                |
| [`89536158`](https://github.com/NixOS/nixpkgs/commit/89536158dd3bfd5c59651f28289983034834ce81) | `` prometheus-alertmanager: 0.33.0 -> 0.33.1 ``                                                  |
| [`85fc5a13`](https://github.com/NixOS/nixpkgs/commit/85fc5a135e84136f92c58f1884fe7066fd410db3) | `` fwupd: fix seal check rejecting files on tmpfs ``                                             |
| [`c4422952`](https://github.com/NixOS/nixpkgs/commit/c44229527a4e46bb3680b998e9d5a5108ea7a8a8) | `` fwupd: clarify efi_app_location comment ``                                                    |
| [`08fb0cb2`](https://github.com/NixOS/nixpkgs/commit/08fb0cb20d3f218b6817ca12c08a72626bd52333) | `` cargo-release: 1.1.2 -> 1.1.3 ``                                                              |
| [`765d8b63`](https://github.com/NixOS/nixpkgs/commit/765d8b639152af6f2642c2eafab1258096512921) | `` cargo-tarpaulin: 0.36.0 -> 0.37.0 ``                                                          |
| [`3d6034e8`](https://github.com/NixOS/nixpkgs/commit/3d6034e8fac44207ecdc34f330fd7a16f62a5ef1) | `` nixos/lasuite-meet: fix RuntimeDirectory nonsense ``                                          |
| [`0953a2b7`](https://github.com/NixOS/nixpkgs/commit/0953a2b7f43c3666d604b0a3d5fa6cad1db23db1) | `` boringtun: 0.6.0 -> 0.7.1 ``                                                                  |
| [`5ce128c4`](https://github.com/NixOS/nixpkgs/commit/5ce128c4d99036a72c5c4c2044a954ebcd8e0801) | `` lima: fix build on Darwin by linking with lld ``                                              |
| [`ec145f08`](https://github.com/NixOS/nixpkgs/commit/ec145f08f2d7b19808d3e23c614abab2a5221e8d) | `` breakpad: fix build on musl and modernise ``                                                  |
| [`68fc0ec5`](https://github.com/NixOS/nixpkgs/commit/68fc0ec563db4fdf7960e79e7ff602d8f664e7f2) | `` vscode-extensions.discloud.discloud: 2.29.7 -> 2.29.8 ``                                      |
| [`3bade317`](https://github.com/NixOS/nixpkgs/commit/3bade317fdc455e5d4aa4e894fd8bea40eceba53) | `` astal.source: 0-unstable-2026-06-21 -> 0-unstable-2026-07-03 ``                               |
| [`62a87bee`](https://github.com/NixOS/nixpkgs/commit/62a87bee4917fb98cb38b533e97d58942be6430f) | `` backrest: 1.13.0 -> 1.14.1 ``                                                                 |
| [`2c276e7d`](https://github.com/NixOS/nixpkgs/commit/2c276e7d4e65c273cc73711dafe899a6fd75963c) | `` hunk: init at v0.17.0 ``                                                                      |
| [`ada8a569`](https://github.com/NixOS/nixpkgs/commit/ada8a569823a7c0ba0858d4013d7e8eb347d3791) | `` claude-usage-tracker: 3.1.1 -> 3.2.0 ``                                                       |
| [`dd66f060`](https://github.com/NixOS/nixpkgs/commit/dd66f060542b225ba2f10c291566220750dd46cb) | `` python3Packages.python3-application: 3.0.10 -> 3.0.11 ``                                      |
| [`a32781b6`](https://github.com/NixOS/nixpkgs/commit/a32781b63c6c814c359fe700062700a85618dacb) | `` xlsfonts: 1.0.8 -> 1.0.9 ``                                                                   |
| [`506c6f09`](https://github.com/NixOS/nixpkgs/commit/506c6f092551afc2c5f9a5ff11892696e34bcf5b) | `` wavelog: 2.5 -> 3.0.1 ``                                                                      |
| [`b5e43344`](https://github.com/NixOS/nixpkgs/commit/b5e433449ad2c266342eaea7d16d0b1305ddb0d7) | `` tun2socks: 2.6.0 -> 2.7.0 ``                                                                  |
| [`ee2893e9`](https://github.com/NixOS/nixpkgs/commit/ee2893e98a19d0266a9eb4413a2bd9d80080f312) | `` signalbackup-tools: 20260615 -> 20260712 ``                                                   |
| [`710dc349`](https://github.com/NixOS/nixpkgs/commit/710dc3494e22b5314b5e1d3b96cbb8ea72567685) | `` switch-to-configuration-ng: fix clippy errors ``                                              |
| [`aa15810a`](https://github.com/NixOS/nixpkgs/commit/aa15810a3974fd7830aac2958e5a5d68da87b1c3) | `` nixos/isso: add secret file option ``                                                         |
| [`48500158`](https://github.com/NixOS/nixpkgs/commit/485001582244f552fc1be2a3780f2724410d764a) | `` restate: 1.7.0 -> 1.7.2 ``                                                                    |
| [`d59ab689`](https://github.com/NixOS/nixpkgs/commit/d59ab689eead5c981f0d90aeff93cf94c6e1f1c6) | `` libretro.fceumm: 0-unstable-2026-06-30 -> 0-unstable-2026-07-06 ``                            |
| [`2c9bd5b0`](https://github.com/NixOS/nixpkgs/commit/2c9bd5b0a7b78b3b986236f15c31a8dd28708801) | `` folia-major: init at 0.5.26 ``                                                                |
| [`92f38bfb`](https://github.com/NixOS/nixpkgs/commit/92f38bfbfcc91644e49ca1d51408b77045fc2886) | `` lstr: 0.2.1 -> 0.3.0 ``                                                                       |
| [`69789203`](https://github.com/NixOS/nixpkgs/commit/697892036759f011d4fcb8dbddf75de53f52dfb6) | `` nixos/dendrite: add package option ``                                                         |
| [`91bc748a`](https://github.com/NixOS/nixpkgs/commit/91bc748a73e6b14f74e69af75c6701c664314029) | `` nixos/tests/matrix-continuwuity: add bartoostveen as a maintainer ``                          |
| [`fe3454e6`](https://github.com/NixOS/nixpkgs/commit/fe3454e664e7c550ad7eecbd51a34cc0b0195f0c) | `` nixos/tests/matrix-continuwuity: refactor to mautrix library ``                               |
| [`1b97280b`](https://github.com/NixOS/nixpkgs/commit/1b97280b9bc7190dd11547b403b749ca2d7d7548) | `` dendrite: set mainProgram ``                                                                  |
| [`ad3d9742`](https://github.com/NixOS/nixpkgs/commit/ad3d97426255abeb146261dbf423c1ff3a21b6d0) | `` matrix-continuwuity: 0.5.10 -> 26.6.1 ``                                                      |
| [`089b0058`](https://github.com/NixOS/nixpkgs/commit/089b0058af9a62d6eef53ab9b13f05a319cd6ff4) | `` vscode-extensions.anthropic.claude-code: 2.1.206 -> 2.1.207 ``                                |
| [`dff61847`](https://github.com/NixOS/nixpkgs/commit/dff61847ca0be92925623d18fdff9feb7bfe9e4a) | `` claude-code: 2.1.206 -> 2.1.207 ``                                                            |
| [`9dad28e4`](https://github.com/NixOS/nixpkgs/commit/9dad28e4d8beebe1a47dc93a04ad65efd9cbe48f) | `` tandoor-recipes: 2.6.9 -> 2.6.13 ``                                                           |
| [`f5616cc3`](https://github.com/NixOS/nixpkgs/commit/f5616cc38c3ec227efa85d9f7c9195837efab8c3) | `` telegram-desktop: work around ld64 hardening issue ``                                         |
| [`ca46b2bf`](https://github.com/NixOS/nixpkgs/commit/ca46b2bffc54ee30ddf433b57a7660127e151d86) | `` prow: 0-unstable-2026-07-02 -> 0-unstable-2026-07-09 ``                                       |
| [`2b4712cf`](https://github.com/NixOS/nixpkgs/commit/2b4712cf55d582b59de7b6cc4a49c300723de45c) | `` python3Packages.types-mysqlclient: 2.2.0.20250915 -> 2.2.0.20260508 ``                        |
| [`0125c384`](https://github.com/NixOS/nixpkgs/commit/0125c384a55ce6d6df59fd279edeaa787ff67bc6) | `` yabai: work around `ld64` hardening issue ``                                                  |
| [`5b5163e1`](https://github.com/NixOS/nixpkgs/commit/5b5163e1bd0d147c3cf2885a6606421c57d8afd6) | `` python3Packages.pylint-django: 2.7.0 -> 2.8.0 ``                                              |

*... and 331 more commits (truncated)*