### PR TITLE
chore(flake/nixpkgs-stable): `569d5785` -> `8eeec934`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1783856661,
-        "narHash": "sha256-ZGP04e+Q6WyQJGA9ZvI5CL6+heGQldbAG9U1T9NGvmU=",
+        "lastModified": 1784011430,
+        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "569d578509928497eddc3fdbf94a799027050be4",
+        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| [`c27e7c20`](https://github.com/NixOS/nixpkgs/commit/c27e7c209138b58d0886b50991f6f02bce34c60a) | `` drawy: correct licenses ``                                                                                       |
| [`bce7f844`](https://github.com/NixOS/nixpkgs/commit/bce7f844638f9d124d0326cfb21e8bfc8c758cf7) | `` drawy: shorten buildInput calls ``                                                                               |
| [`47c4a34c`](https://github.com/NixOS/nixpkgs/commit/47c4a34c64055f084e011ff003a4a4569c354f1e) | `` drawy: enable __structuredAttrs ``                                                                               |
| [`10eee203`](https://github.com/NixOS/nixpkgs/commit/10eee203893d3456a5946c39a9a81ecfb571a8ea) | `` drawy: 1.0.0 -> 1.0.1 ``                                                                                         |
| [`519433d1`](https://github.com/NixOS/nixpkgs/commit/519433d13f0e611c772061fc329e7104487f091f) | `` wasm-bindgen-cli_0_2_126: init ``                                                                                |
| [`1c1652e6`](https://github.com/NixOS/nixpkgs/commit/1c1652e674d8f6f26e0dd0771a1c9f82b26f7b33) | `` maintainers/github-teams.json: Automated sync ``                                                                 |
| [`1ec7d6fc`](https://github.com/NixOS/nixpkgs/commit/1ec7d6fce49efbaebb94305e3eaf052ae82f90fb) | `` codechecker: remove withInfer (not backported) ``                                                                |
| [`f9cee623`](https://github.com/NixOS/nixpkgs/commit/f9cee623cf939bfbd8e8438d51331c2677cefe10) | `` codechecker: 6.24.0 -> 6.28.0 ``                                                                                 |
| [`1fee7ff6`](https://github.com/NixOS/nixpkgs/commit/1fee7ff69fceacd96f35c837b7f071c8860e0f83) | `` maintainers: add kacper-uminski ``                                                                               |
| [`a4b474cd`](https://github.com/NixOS/nixpkgs/commit/a4b474cd27358f4f558af9853ade5fd2e99fc8ea) | `` xfr: 0.9.20 -> 0.9.21 ``                                                                                         |
| [`eb9cbb7c`](https://github.com/NixOS/nixpkgs/commit/eb9cbb7cbb0f20083212067defb25a46ec6fe738) | `` pgdog: 0.1.47 -> 0.1.48 ``                                                                                       |
| [`237c44d0`](https://github.com/NixOS/nixpkgs/commit/237c44d09f80d1c8cb386ab2e30f2d8853797734) | `` satysfi: fix the ipaexfont is not bundled properly ``                                                            |
| [`6e82dfb9`](https://github.com/NixOS/nixpkgs/commit/6e82dfb9319c84eb6af12f849d91ce1d6fc9205b) | `` kermit: fix build with GCC 14+ ``                                                                                |
| [`c3ac4c7e`](https://github.com/NixOS/nixpkgs/commit/c3ac4c7e539fd61fcb3ba4966bc8e09721348739) | `` hmcl: 3.15.2 -> 3.15.3 ``                                                                                        |
| [`347767da`](https://github.com/NixOS/nixpkgs/commit/347767dac9572a208fb453066a7234edc5748915) | `` ntfy-sh: 2.25.0 -> 2.26.0 ``                                                                                     |
| [`61481b9f`](https://github.com/NixOS/nixpkgs/commit/61481b9f7a2c3b420eec75e6225db90c1e136cff) | `` ntfy-sh: 2.24.0 -> 2.25.0 ``                                                                                     |
| [`217669db`](https://github.com/NixOS/nixpkgs/commit/217669db09ae21a4a78fe5bbba9d42db237daccd) | `` ntfy-sh: 2.23.0 -> 2.24.0 ``                                                                                     |
| [`308b3851`](https://github.com/NixOS/nixpkgs/commit/308b3851ef821dddd55b984750feef81388a8351) | `` matrix-tuwunel: 1.8.0 -> 1.8.1 ``                                                                                |
| [`06b30598`](https://github.com/NixOS/nixpkgs/commit/06b3059860eae3cee4a38a5327edabb11f153482) | `` linux_testing: 7.2-rc2 -> 7.2-rc3 ``                                                                             |
| [`e03643dc`](https://github.com/NixOS/nixpkgs/commit/e03643dc84b6080948fb1d0225a26a0f2e762f6c) | `` llvmPackages_git: 23.0.0-unstable-2026-07-05 -> 23.0.0-unstable-2026-07-12 ``                                    |
| [`d3ffc4e1`](https://github.com/NixOS/nixpkgs/commit/d3ffc4e1e0bc06a569fadb424cee14dce70f62e5) | `` jenkins: 2.555.3 -> 2.568.1 ``                                                                                   |
| [`e2ef1c5f`](https://github.com/NixOS/nixpkgs/commit/e2ef1c5fdcad2569380416278d8b674b6b9d9bc2) | `` backrest: 1.13.0 -> 1.14.1 ``                                                                                    |
| [`bbf70644`](https://github.com/NixOS/nixpkgs/commit/bbf7064487d66aba408c54fe080c17f3c986b830) | `` wxwidgets_3_3: 3.3.2 -> 3.3.3.1 ``                                                                               |
| [`2dc077ba`](https://github.com/NixOS/nixpkgs/commit/2dc077ba959cfd84cf0ce52bc9d49251258da220) | `` wxwidgets_3_2: 3.2.9 -> 3.2.11 ``                                                                                |
| [`d92b5d2a`](https://github.com/NixOS/nixpkgs/commit/d92b5d2a16fd0a811242f82615a68bcf8a8028a0) | `` nixos/emacs: don't restartIfChanged ``                                                                           |
| [`52dccd6f`](https://github.com/NixOS/nixpkgs/commit/52dccd6f70d4ff344d507a22c0f6460db2006a3a) | `` searchix: 0.4.8 -> 0.4.9 ``                                                                                      |
| [`8de8bc9d`](https://github.com/NixOS/nixpkgs/commit/8de8bc9d3380e57df344047f2e5373052ac6180f) | `` osu-lazer: 2026.624.0 -> 2026.711.0 ``                                                                           |
| [`5802ede4`](https://github.com/NixOS/nixpkgs/commit/5802ede461510f3deb4a484ece3a9b7803b69acc) | `` osu-lazer-bin: 2026.624.0 -> 2026.711.0 ``                                                                       |
| [`d67fd7bd`](https://github.com/NixOS/nixpkgs/commit/d67fd7bdfd6793e4b6f5f807c6f4c1f3f9f624ba) | `` privatebin: 2.0.4 -> 2.0.5 ``                                                                                    |
| [`e21ffd08`](https://github.com/NixOS/nixpkgs/commit/e21ffd080f57433bdba3736f9b04bfc7a8264d01) | `` python3Packages.vllm: add more known vulnerabilities ``                                                          |
| [`04bb332a`](https://github.com/NixOS/nixpkgs/commit/04bb332a3365b10f8a64303a5406490af35765c0) | `` python3Packages.litellm: 1.83.14 -> 1.86.0 ``                                                                    |
| [`f3c5338d`](https://github.com/NixOS/nixpkgs/commit/f3c5338d8812ed80e1dacc0e7447d94b696a85f7) | `` openllm: mark insecure ``                                                                                        |
| [`6da50c1b`](https://github.com/NixOS/nixpkgs/commit/6da50c1bb2a05259e15413ca132564064680d2c5) | `` python3Packages.bentoml: mark insecure ``                                                                        |
| [`5d820c54`](https://github.com/NixOS/nixpkgs/commit/5d820c54a1e55e21ffb63075ce5b4c357fdd5b79) | `` fastmail-desktop: 1.3.0 -> 1.4.0 ``                                                                              |
| [`e87d0ca1`](https://github.com/NixOS/nixpkgs/commit/e87d0ca108f94b0d178cc0c03108c1ce6f264764) | `` tandoor-recipes: 2.6.9 -> 2.6.13 ``                                                                              |
| [`c60691af`](https://github.com/NixOS/nixpkgs/commit/c60691afdc92f588a5dfa5f28a4c4136f49d0e76) | `` gittuf: add anish as maintainer ``                                                                               |
| [`4d8d1279`](https://github.com/NixOS/nixpkgs/commit/4d8d1279e284dfba199839ce1b6f24a83b8193b2) | `` gittuf: add versionCheckHook and update script ``                                                                |
| [`64d7f12b`](https://github.com/NixOS/nixpkgs/commit/64d7f12bd564f759ee043f1759473c610199c3e7) | `` gittuf: modernize ``                                                                                             |
| [`1f862753`](https://github.com/NixOS/nixpkgs/commit/1f862753854b5fbbc82988eb4278f19f9403f0f2) | `` gittuf: 0.12.0 -> 0.15.0 ``                                                                                      |
| [`785805e7`](https://github.com/NixOS/nixpkgs/commit/785805e713e6a7ec72b1fdab81367e69acc81806) | `` gittuf: remove stale sandbox gendoc binary ``                                                                    |
| [`941c3b28`](https://github.com/NixOS/nixpkgs/commit/941c3b285f55971419ab1fdbf23476eb6e98e87a) | `` zotero: 9.0.5 -> 9.0.6 ``                                                                                        |
| [`bba87362`](https://github.com/NixOS/nixpkgs/commit/bba87362a316e95c87fecd2747a68841e7159410) | `` zotero: sign .app bundle on darwin ``                                                                            |
| [`0976ddb4`](https://github.com/NixOS/nixpkgs/commit/0976ddb447486f808afa74987f36baa58594cba4) | `` zotero: change all instances of targetPlatform to hostPlatform ``                                                |
| [`ee1759ce`](https://github.com/NixOS/nixpkgs/commit/ee1759ce730c66a55b3fdbddc38cda6ef707ce4d) | `` python3Packages.sqlalchemy_1_3: create new event loop if not exists ``                                           |
| [`14ebd607`](https://github.com/NixOS/nixpkgs/commit/14ebd6072e006e4836071acb95485bd89745ae07) | `` zotero: 9.0.4 -> 9.0.5 ``                                                                                        |
| [`11d90917`](https://github.com/NixOS/nixpkgs/commit/11d90917a8d6e681287532c111123b843cad6283) | `` lakefs: 1.79.0 -> 1.83.0 ``                                                                                      |
| [`ef84b103`](https://github.com/NixOS/nixpkgs/commit/ef84b10306ce613e63ee42fd3c2a171f0a72d97b) | `` space-station-14-launcher: 0.39.0 -> 0.39.1 ``                                                                   |
| [`9e480764`](https://github.com/NixOS/nixpkgs/commit/9e480764f4de4a5e2f4521e70094d66fbc6bde03) | `` space-station-14-launcher: add nix-update-script ``                                                              |
| [`7df1e472`](https://github.com/NixOS/nixpkgs/commit/7df1e472e1c68c706a43145cb64f9737e1baae95) | `` adw-bluetooth: 1.1.0 -> 1.1.2 ``                                                                                 |
| [`73c1d663`](https://github.com/NixOS/nixpkgs/commit/73c1d663f14bbbeb254626f9dbddf8975ed89a23) | `` dino: migrate to by-name ``                                                                                      |
| [`7a92ffff`](https://github.com/NixOS/nixpkgs/commit/7a92ffff174c2f8ed0556feebf76d130d9d4b11b) | `` alcom: install app icon ``                                                                                       |
| [`0bbc7e22`](https://github.com/NixOS/nixpkgs/commit/0bbc7e226edb42464d60fd98acaf1a2e73c3b258) | `` alcom: 1.1.6 -> 1.1.8 ``                                                                                         |
| [`4f8d225a`](https://github.com/NixOS/nixpkgs/commit/4f8d225a6620ece114452ce5652c5999095b7f4e) | `` syncyomi: migrate to pnpm 10 and fetcherVersion 4 ``                                                             |
| [`e0675ea6`](https://github.com/NixOS/nixpkgs/commit/e0675ea65a80e2da0da95b03ed06566d18a78326) | `` siyuan: switch to pnpm_10 ``                                                                                     |
| [`69e8611e`](https://github.com/NixOS/nixpkgs/commit/69e8611e5daf48a2ac64eff1a1106df7e07dd62a) | `` siyuan: refactor ``                                                                                              |
| [`5714ed34`](https://github.com/NixOS/nixpkgs/commit/5714ed3403a9a7d676edcf2fd096e71a57575669) | `` siyuan: support darwin ``                                                                                        |
| [`c69e8838`](https://github.com/NixOS/nixpkgs/commit/c69e8838a97e0e3f4f53dab354bcd4ab9b42b2d1) | `` prettier: use pnpm_10 ``                                                                                         |
| [`c06272c3`](https://github.com/NixOS/nixpkgs/commit/c06272c31e5d5af00faa68dd06542977832d0c18) | `` lessc: 4.6.3 -> 4.6.6 ``                                                                                         |
| [`de367be3`](https://github.com/NixOS/nixpkgs/commit/de367be335941dec29ac2dc2d1a4bded9cf385b3) | `` brave: 1.92.134 -> 1.92.139 ``                                                                                   |
| [`27947eff`](https://github.com/NixOS/nixpkgs/commit/27947effdb47e57fd069bc982de595d800909160) | `` whichllm: 0.5.13 -> 0.5.15 ``                                                                                    |
| [`6d6e693f`](https://github.com/NixOS/nixpkgs/commit/6d6e693fdef3db9c4fd57a0f6a3122cad4a28a76) | `` whichllm: 0.5.12 -> 0.5.13 ``                                                                                    |
| [`56d953ab`](https://github.com/NixOS/nixpkgs/commit/56d953ab53fc90500a347695eb6f801745abf93f) | `` discord: expose stageModules to allow overriding ``                                                              |
| [`5e12356d`](https://github.com/NixOS/nixpkgs/commit/5e12356d7fe027e0b17510d4060ccdc35322a82b) | `` beamPackages.hex: 2.5.0 -> 2.5.1 ``                                                                              |
| [`b795f19c`](https://github.com/NixOS/nixpkgs/commit/b795f19cc202593f301f9ec66d180882b07bbe23) | `` kyverno: 1.18.1 -> 1.18.2 ``                                                                                     |
| [`5c49d5ba`](https://github.com/NixOS/nixpkgs/commit/5c49d5ba690f5cfd12e52e6d434ee51bb97466e2) | `` python3Packages.gradio-client: add sans-reverse-dependencies passthru ``                                         |
| [`682c7e52`](https://github.com/NixOS/nixpkgs/commit/682c7e5254ff687270a9e26a2f216b438d9224e5) | `` python3Packages.gradio: 6.19.0 -> 6.20.0 ``                                                                      |
| [`7a4a50e7`](https://github.com/NixOS/nixpkgs/commit/7a4a50e7a909d724365bd75b33362dd5c87b1633) | `` python3Packages.gradio: 6.9.0 -> 6.19.0 ``                                                                       |
| [`427090d4`](https://github.com/NixOS/nixpkgs/commit/427090d4d31013b1952975438b2dc31e381b4c22) | `` python3Packages.gradio: add matplotlib ``                                                                        |
| [`92387b86`](https://github.com/NixOS/nixpkgs/commit/92387b86a5fb4dc460ad8486635d5a11b72f4cad) | `` apache-airflow: 3.2.2 -> 3.3.0 ``                                                                                |
| [`6c021b64`](https://github.com/NixOS/nixpkgs/commit/6c021b640970e33e58cb16d1ef54c6acd3d93be1) | `` apache-airflow: switch to finalAttrs, inline let binding ``                                                      |
| [`05df0b2f`](https://github.com/NixOS/nixpkgs/commit/05df0b2f400d0e3a962735b83a6a763edf8490cc) | `` pocket-casts: 0.12.1 -> 0.13.0 ``                                                                                |
| [`f16579bf`](https://github.com/NixOS/nixpkgs/commit/f16579bfa51038a4642e85d8b7c1da99614c69bc) | `` python3Packages.protego: 0.6.1 -> 0.6.2 ``                                                                       |
| [`d08d491e`](https://github.com/NixOS/nixpkgs/commit/d08d491e5f4ab10b9ac8f2f087fa2ef2e8503896) | `` dovecot: add mysql-config dependency ``                                                                          |
| [`4680b356`](https://github.com/NixOS/nixpkgs/commit/4680b35662fe53adf79ba87b6802737925d037f7) | `` opencolorio: 2.5.1 -> 2.5.2 ``                                                                                   |
| [`cea6e19d`](https://github.com/NixOS/nixpkgs/commit/cea6e19df9c59f0c42d2821244c80e8e62b19378) | `` nixos/swap: trigger device readiness ``                                                                          |
| [`79ed1b7b`](https://github.com/NixOS/nixpkgs/commit/79ed1b7bd1bc1bfae8f96f98e78bd4aeae6360f4) | `` nixos/swap: detect whether swap is a device ``                                                                   |
| [`3ad1669f`](https://github.com/NixOS/nixpkgs/commit/3ad1669f33859ed00aec9277ff473f60ade3845c) | `` nixos/llama-swap: remove ProcSubset pid limitation from service config for new performance monitoring feature `` |