### PR TITLE
chore(opencode): update overlay to v1.18.2

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -27,13 +27,13 @@
 }:
 opencode.overrideAttrs (
   _finalAttrs: prevAttrs: rec {
-    version = "1.18.1";
+    version = "1.18.2";
 
     src = fetchFromGitHub {
       owner = "anomalyco";
       repo = "opencode";
       tag = "v${version}";
-      hash = "sha256-ESKM2u46KQI5wq736D2RTd8IZH2SdOKtGUCDnMJQGVc=";
+      hash = "sha256-dtokh2AJCnrp07jtx+0vOYjQzfxNA+3pajIFFNYuI24=";
     };
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {


### PR DESCRIPTION
Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the packaged OpenCode release to version 1.18.2.
  * Aligned the source package with the corresponding upstream release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->