### PR TITLE
chore(opencode): update overlay to v1.18.3

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -27,13 +27,13 @@
 }:
 opencode.overrideAttrs (
   _finalAttrs: prevAttrs: rec {
-    version = "1.18.2";
+    version = "1.18.3";
 
     src = fetchFromGitHub {
       owner = "anomalyco";
       repo = "opencode";
       tag = "v${version}";
-      hash = "sha256-dtokh2AJCnrp07jtx+0vOYjQzfxNA+3pajIFFNYuI24=";
+      hash = "sha256-Wdkzms59oHw3M/Em2RH7BPhZME8AtLmtNFSnsUxO1V4=";
     };
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {


### PR DESCRIPTION
Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled OpenCode version to 1.18.3.
  * Refreshed the associated source metadata for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->