### PR TITLE
chore(flake/niri): `cb2b70a7` -> `80945d7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -629,11 +629,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1784046451,
-        "narHash": "sha256-To9gdRLJbyPzcBI3nwYsu7VsQkTXyNjLbslPxu7V/oo=",
+        "lastModified": 1784381900,
+        "narHash": "sha256-D6fU+A+XZk1gYMUuRP2VV6htZwFyW05kcwLTpG3as60=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "cb2b70a7902c1deac4dbe514e934a0efabe13f7a",
+        "rev": "80945d7b1212033814fdb0cc5d9f8b505a7b027f",
         "type": "github"
       },
       "original": {
@@ -766,11 +766,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1784011430,
-        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {
@@ -971,11 +971,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1784007870,
-        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`80945d7b`](https://github.com/epireyn/niri-flake/commit/80945d7b1212033814fdb0cc5d9f8b505a7b027f) | `` Update flake.lock `` |
| [`97ea28a9`](https://github.com/epireyn/niri-flake/commit/97ea28a9329536aab0cb8a8136ea894d72cefa43) | `` Update flake.lock `` |
| [`a5e3bdee`](https://github.com/epireyn/niri-flake/commit/a5e3bdee5d4becb540014ba6887ccff100c321c1) | `` Update flake.lock `` |
| [`8e9e8e67`](https://github.com/epireyn/niri-flake/commit/8e9e8e676fb26de496b4e815aab04874a13efb15) | `` Update flake.lock `` |