### PR TITLE
chore(flake/darwin): `d5bd9cd7` -> `b4cccbd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783395956,
-        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "lastModified": 1784362797,
+        "narHash": "sha256-EP9b9b+OXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "rev": "b4cccbd4bc299c1f71ae185b79c3cf99aa82805c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                    |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`1543ae08`](https://github.com/nix-darwin/nix-darwin/commit/1543ae0852863bfb5a2f58010b502f122993cef0) | `` darwin-rebuild: add flake options to zsh completions `` |
| [`deadc720`](https://github.com/nix-darwin/nix-darwin/commit/deadc7204ccc1d881a6776c17f988b687327ce8f) | `` mas: add module for Mac App Store management ``         |