### PR TITLE
chore(flake/home-manager): `a45a7c45` -> `46010800`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783963347,
-        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
+        "lastModified": 1784351324,
+        "narHash": "sha256-By+kuRJZRqs2TuXgtR8vJ8cTKWXw33YG/Yollu5cO1U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
+        "rev": "460108009ca1ff69ca2ff19079ca2c838d6e3080",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`46010800`](https://github.com/nix-community/home-manager/commit/460108009ca1ff69ca2ff19079ca2c838d6e3080) | `` herdr: Automatically reload config ``                    |
| [`18f90473`](https://github.com/nix-community/home-manager/commit/18f90473407ac9a919e0b108fbd5da3d347dd9ff) | `` navi: update url for config file docs ``                 |
| [`c71e83ef`](https://github.com/nix-community/home-manager/commit/c71e83ef50cddf0ba8528347beaf26094453594e) | `` maintainers: update all-maintainers.nix ``               |
| [`165228b0`](https://github.com/nix-community/home-manager/commit/165228b0efefc3e635e5174020c40ea64271dc25) | `` launchd: restore gui domain defaults ``                  |
| [`6dc9e081`](https://github.com/nix-community/home-manager/commit/6dc9e081ba2afc8c3b81ccddcb895f786155b292) | `` docs: fix cross-page links broken by mdbook migration `` |