### PR TITLE
chore(flake/nixpkgs-stable): `8eeec934` -> `293d6abe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1784011430,
-        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`67d1202e`](https://github.com/NixOS/nixpkgs/commit/67d1202e08b911e8fba51b953c06a9e359f1e69f) | `` picgo: 2.5.3 -> 3.0.0 ``                                                                 |
| [`e5516fa8`](https://github.com/NixOS/nixpkgs/commit/e5516fa86d4c19d0e3d8ff1a959e2bcf9fe904bb) | `` pmtiles: 1.31.0 -> 1.31.1 ``                                                             |
| [`732688fa`](https://github.com/NixOS/nixpkgs/commit/732688fab6a83172548eccf05ec78877b42f8225) | `` signal-cli: 0.14.5 -> 0.14.6 ``                                                          |
| [`f72f4f8d`](https://github.com/NixOS/nixpkgs/commit/f72f4f8d4d9c17f3ed2cdf13e9edd17c8726c9e6) | `` signal-cli: Add update script ``                                                         |
| [`d4f04901`](https://github.com/NixOS/nixpkgs/commit/d4f04901e121276ae92805fa3a1f2844014f925b) | `` pmtiles: 1.30.3 -> 1.31.0 ``                                                             |
| [`c8194b59`](https://github.com/NixOS/nixpkgs/commit/c8194b592d70e107b392f4a45658829b66a6113c) | `` blackfire: 2026.6.1 -> 2026.7.0 ``                                                       |
| [`d1532e33`](https://github.com/NixOS/nixpkgs/commit/d1532e33d1e702d8265be713c30a8822d726ed7f) | `` netbird: fix GUI application's XDG desktop file ``                                       |
| [`2f7be540`](https://github.com/NixOS/nixpkgs/commit/2f7be540540aeaea847b4f8e95a316e9cc2ea402) | `` chromium,chromedriver: 150.0.7871.124 -> 150.0.7871.128 ``                               |
| [`aaab4a0e`](https://github.com/NixOS/nixpkgs/commit/aaab4a0e9665fb5e998ebaa7c9920d4081deb837) | `` pmtiles: 1.30.0 → 1.30.3 ``                                                              |
| [`5691aad3`](https://github.com/NixOS/nixpkgs/commit/5691aad368e34d077c52359a1146bda39e1d1831) | `` google-chrome: 150.0.7871.124 -> 150.0.7871.128 ``                                       |
| [`bf5919b4`](https://github.com/NixOS/nixpkgs/commit/bf5919b4d3044cabc70481b00de4a042152d1ce2) | `` python3Packages.paho-mqtt: use upstream patch for generating SSL certs ``                |
| [`7b2a1f3d`](https://github.com/NixOS/nixpkgs/commit/7b2a1f3d825e03533fd6a019324508332e6b8317) | `` rundeck: 6.0.0 -> 6.0.1 ``                                                               |
| [`d826c939`](https://github.com/NixOS/nixpkgs/commit/d826c9399cebd315061e43bdc8f65b508b0b216e) | `` absolute: init at 0.3 ``                                                                 |
| [`4326f508`](https://github.com/NixOS/nixpkgs/commit/4326f5086b9185711b619efcae95a94318ad8705) | `` ocamlPackages.libabsolute: init at 0.3 ``                                                |
| [`31d0f341`](https://github.com/NixOS/nixpkgs/commit/31d0f341b8b48f37a33b8234853ad6c51bc188b0) | `` ocamlPackages.picasso: init at 0.4 ``                                                    |
| [`4b95f7ae`](https://github.com/NixOS/nixpkgs/commit/4b95f7aeac0552b22f331ca8e052eba7dcc14abd) | `` ocamlPackages.apronext: init at 1.0.4 ``                                                 |
| [`97c430d0`](https://github.com/NixOS/nixpkgs/commit/97c430d0b152431fb287fc988cc197b23f5845dc) | `` ocamlPackages.apron: fix propagated inputs ``                                            |
| [`bf21e0e6`](https://github.com/NixOS/nixpkgs/commit/bf21e0e63357c8d38fc34e792aacae9323a90e3e) | `` cargo-shear: 1.13.1 -> 1.13.2 ``                                                         |
| [`ec4f4bf2`](https://github.com/NixOS/nixpkgs/commit/ec4f4bf2c8dea4fe24237fd14a6b4803dfc02d6a) | `` nix-unit: 2.34.0 -> 2.34.2 ``                                                            |
| [`57501c99`](https://github.com/NixOS/nixpkgs/commit/57501c9972e23089e3862943befd968361b808ce) | `` python3Packages.dogpile-cache: update disabled tests for darwin ``                       |
| [`bf982dd1`](https://github.com/NixOS/nixpkgs/commit/bf982dd1e2e83d4c82b1d764d4db7ea699f90ece) | `` gomuks-web: 26.06 -> 26.07 ``                                                            |
| [`539ad5a4`](https://github.com/NixOS/nixpkgs/commit/539ad5a43f5c50f7b6cfc85c09df65aef0a4299c) | `` gomuks-web: remove `libheif` patches ``                                                  |
| [`b6eb7f5a`](https://github.com/NixOS/nixpkgs/commit/b6eb7f5a8b0d11231d7adc7f5ffa601b6c8c830b) | `` gomuks-web: 26.05 -> 26.06 ``                                                            |
| [`c964ee92`](https://github.com/NixOS/nixpkgs/commit/c964ee92bfe2ab646b4a004c4ee17b234991567d) | `` gdal: fix build with poppler 26.06 ``                                                    |
| [`a613a3f6`](https://github.com/NixOS/nixpkgs/commit/a613a3f6560e66503d8519bbc792d819dd9e5bf7) | `` appium-inspector: 2026.2.1 -> 2026.5.1 ``                                                |
| [`4a5c9860`](https://github.com/NixOS/nixpkgs/commit/4a5c9860f5d26eb147929f2a1e4940a693ac3bd1) | `` appium-inspector: let update script automatically update electron version ``             |
| [`595a9d07`](https://github.com/NixOS/nixpkgs/commit/595a9d070dcf81804e105377e630681f7cacb6b2) | `` ocamlPackages.ocsigen-toolkit: 4.2.0 → 4.3.0 ``                                          |
| [`026aee51`](https://github.com/NixOS/nixpkgs/commit/026aee5150de2ce5f31bf42b11ddb22e39a978b0) | `` outline: 1.8.1 -> 1.9.1 ``                                                               |
| [`6b0823ee`](https://github.com/NixOS/nixpkgs/commit/6b0823ee0ec357a312817f8578d9546cadfe6736) | `` outline: fix updateScript ``                                                             |
| [`7f3381ce`](https://github.com/NixOS/nixpkgs/commit/7f3381ce1823aa65cc09400887cdef5bee70483e) | `` dovecot: Fix building with Lua ``                                                        |
| [`b920851e`](https://github.com/NixOS/nixpkgs/commit/b920851ee8ec5aefff495628f2ac7f929c9c5c7a) | `` luaPackages.json: Init at 0.1.2 ``                                                       |
| [`780f6631`](https://github.com/NixOS/nixpkgs/commit/780f6631f37eea608471761cb4b2a65744d9e5b4) | `` nginxStable: 1.30.3 -> 1.30.4 ``                                                         |
| [`235ce217`](https://github.com/NixOS/nixpkgs/commit/235ce217a8be9b2c74c3cbe49412856829052e1c) | `` nginxMainline: 1.31.2 -> 1.31.3 ``                                                       |
| [`f1565f62`](https://github.com/NixOS/nixpkgs/commit/f1565f623ac02c43514e8e8dde6461a50c03d342) | `` mesa: 26.1.4 -> 26.1.5 ``                                                                |
| [`8bcf0630`](https://github.com/NixOS/nixpkgs/commit/8bcf0630a65bfef2b6f78f4d2448b11acee8b5d3) | `` remark42: 1.15.0 -> 1.16.4 ``                                                            |
| [`27a724e7`](https://github.com/NixOS/nixpkgs/commit/27a724e7e6e366cb93ea905996d89313a8bb4660) | `` remark42: switch to pnpm_9 ``                                                            |
| [`9c24429f`](https://github.com/NixOS/nixpkgs/commit/9c24429f50a481cc8da0ad996c7b74fa3b849ee0) | `` librewolf-unwrapped: 152.0.5-1 -> 152.0.6-1 ``                                           |
| [`73cd3df9`](https://github.com/NixOS/nixpkgs/commit/73cd3df9a250d4d15ea130e2180db37473121b6c) | `` vicinae: 0.22.3 -> 0.23.1 ``                                                             |
| [`7a097208`](https://github.com/NixOS/nixpkgs/commit/7a097208bd734c9d9b8a48ed6cdd47ccfe76c878) | `` ungoogled-chromium: 150.0.7871.114-1 -> 150.0.7871.124-1 ``                              |
| [`e551145d`](https://github.com/NixOS/nixpkgs/commit/e551145d97d810065f9d38265f1c642834242e18) | `` python3Packages.httplib2: 0.31.1 -> 0.32.0 ``                                            |
| [`66237861`](https://github.com/NixOS/nixpkgs/commit/662378614ee0d2cc92c977fc0b07e55b75bcd71f) | `` dgraph: 25.3.3 -> 25.3.8 ``                                                              |
| [`4fd15d69`](https://github.com/NixOS/nixpkgs/commit/4fd15d695a7fdd81589fc2d5398c8b506c82902e) | `` linuxKernel.kernels.linux_zen: 7.1.2 -> 7.1.3 ``                                         |
| [`241c0a7e`](https://github.com/NixOS/nixpkgs/commit/241c0a7e6a1ec7d2084d99105bdc3e7fa89842e4) | `` perlPackages.CryptOpenSSLX509: 1.915 -> 2.1.3 ``                                         |
| [`907ca17f`](https://github.com/NixOS/nixpkgs/commit/907ca17fcdc0310164922cd16c7dceda03b38fec) | `` wivrn: 26.6.1 -> 26.6.2 ``                                                               |
| [`f1ba17f3`](https://github.com/NixOS/nixpkgs/commit/f1ba17f34db384f000d8f21ecf013748f246b184) | `` forgejo: 15.0.4 -> 15.0.5 ``                                                             |
| [`b77af21c`](https://github.com/NixOS/nixpkgs/commit/b77af21c318e29d6af25218894a9b58d2f186676) | `` flytectl.tests: fix the eval ``                                                          |
| [`be694493`](https://github.com/NixOS/nixpkgs/commit/be694493f481f8b63689724d9f9e08537a46b1ac) | `` ttl: add herbetom as maintainer ``                                                       |
| [`75228a29`](https://github.com/NixOS/nixpkgs/commit/75228a29e4998881b85cbe68fe7a30cebb21a49b) | `` ttl: disable update check ``                                                             |
| [`7d797725`](https://github.com/NixOS/nixpkgs/commit/7d7977259195d96d653a5eba15a4b031becff961) | `` ttl: 0.19.1 -> 0.21.0 ``                                                                 |
| [`d3b3cf52`](https://github.com/NixOS/nixpkgs/commit/d3b3cf523e000a55f8be048d987a49c155efd320) | `` switch-to-configuration-ng: Die less ``                                                  |
| [`61d5ebc7`](https://github.com/NixOS/nixpkgs/commit/61d5ebc7c430b02e83f39a5e01ac2a7c1611b2f3) | `` firefly-iii-data-importer: 2.3.2 -> 2.3.4 ``                                             |
| [`4514f903`](https://github.com/NixOS/nixpkgs/commit/4514f9030c2b3b6d6208b5ab385f3857ee4982d2) | `` radarr: 6.2.1.10461 -> 6.3.0.10514 ``                                                    |
| [`9fa65ff4`](https://github.com/NixOS/nixpkgs/commit/9fa65ff4c1dda6bd5fb6eadc0174f34d76fe2b18) | `` gotenberg: 8.33.0 -> 8.34.0 ``                                                           |
| [`ece01617`](https://github.com/NixOS/nixpkgs/commit/ece016172bff5783450c34470c5176a3e2340f2f) | `` element-desktop: 1.12.22 -> 1.12.23 ``                                                   |
| [`47bd1ef0`](https://github.com/NixOS/nixpkgs/commit/47bd1ef046426341c37b4dc37844147d672fae49) | `` phpExtensions.blackfire: 2026.5.0 -> 2026.7.0 ``                                         |
| [`93393a17`](https://github.com/NixOS/nixpkgs/commit/93393a1701c327cd32a403d6b042dc918ce318d1) | `` gotenberg: 8.32.0 -> 8.33.0 ``                                                           |
| [`63a46917`](https://github.com/NixOS/nixpkgs/commit/63a469176c7a75d6c6025ac87a224f62ecfbb2c9) | `` gajim: 2.4.7 -> 2.4.7.1 ``                                                               |
| [`de79f2d1`](https://github.com/NixOS/nixpkgs/commit/de79f2d1aee15168c155d63273b4a89e070908de) | `` gajim: add changelog ``                                                                  |
| [`51159f3f`](https://github.com/NixOS/nixpkgs/commit/51159f3fda8a3672af61fe4a327c8141af24ef95) | `` keycloak: 26.6.4 -> 26.7.0 ``                                                            |
| [`ec09cf3c`](https://github.com/NixOS/nixpkgs/commit/ec09cf3cb3f06d05eba207f5691ef29024326922) | `` gajim: 2.4.6 → 2.4.7 ``                                                                  |
| [`3371c67c`](https://github.com/NixOS/nixpkgs/commit/3371c67cfb836ef494b4bed5540f3a97546682f0) | `` pam_ssh_agent_auth: fix runtime error on aarch64 ``                                      |
| [`dc1b7433`](https://github.com/NixOS/nixpkgs/commit/dc1b74336895c362b47eacbdea8813f6e6fa9983) | `` vikunja: Set version metadata at build time ``                                           |
| [`034023ca`](https://github.com/NixOS/nixpkgs/commit/034023ca7f0c158b6bdd02434d00064b97209981) | `` chromium,chromedriver: 150.0.7871.114 -> 150.0.7871.124 ``                               |
| [`ca53f072`](https://github.com/NixOS/nixpkgs/commit/ca53f0727b28f293590dc9084a1255a8c0d46db4) | `` powerdns-admin: fix oidc auth ``                                                         |
| [`e8df3a01`](https://github.com/NixOS/nixpkgs/commit/e8df3a0142c456f7c9fb8bc05bee8952b4243e0d) | `` powerdns-admin: fix reset password ``                                                    |
| [`1ffa2d1d`](https://github.com/NixOS/nixpkgs/commit/1ffa2d1d4c331c30658a9f4db0c653488ee3aeb6) | `` google-chrome: 150.0.7871.114 -> 150.0.7871.124 ``                                       |
| [`f7351ca8`](https://github.com/NixOS/nixpkgs/commit/f7351ca8a5e14ffc53c2803e880f00d973a4925e) | `` esphome: use paho-mqtt_1 ``                                                              |
| [`86ba3a75`](https://github.com/NixOS/nixpkgs/commit/86ba3a75189ff6aad926cc57dddbb5c9a13e5bba) | `` python3Packages.paho-mqtt_1: init at 1.6.1 ``                                            |
| [`076003e3`](https://github.com/NixOS/nixpkgs/commit/076003e33b24598c1ac356d01df3f979a09ea891) | `` python3Packages.paho-mqtt: regenerate certificates for tests ``                          |
| [`2ee1e3a3`](https://github.com/NixOS/nixpkgs/commit/2ee1e3a33d4fbdaad9536b4b31650e30823ee646) | `` navidrome: 0.63.1 -> 0.63.2 ``                                                           |
| [`dfaf107e`](https://github.com/NixOS/nixpkgs/commit/dfaf107e8e74e609121ec1a2cbe4c56ae368b1b4) | `` tor-browser: 15.0.17 -> 15.0.18 ``                                                       |
| [`8ee1d106`](https://github.com/NixOS/nixpkgs/commit/8ee1d106efb5fcf330b0b1a17fb26c2b86b3ec6d) | `` mullvad-browser: 15.0.16 -> 15.0.18 ``                                                   |
| [`4fbb919a`](https://github.com/NixOS/nixpkgs/commit/4fbb919a47d1e18ff9aba9ada62c4535ef3ddc5d) | `` rura: init at 1.3.0 ``                                                                   |
| [`3a379a70`](https://github.com/NixOS/nixpkgs/commit/3a379a70a0857c4057ae040a22d9b6af03224fe4) | `` matrix-appservice-irc: use nodejs-slim_22 ``                                             |
| [`3e103dd7`](https://github.com/NixOS/nixpkgs/commit/3e103dd73fb5bc9b9cb5eeaccb4ba5a068507384) | `` pihole-web: 6.5.1 -> 6.6 ``                                                              |
| [`b5ab975f`](https://github.com/NixOS/nixpkgs/commit/b5ab975f836dbf1c9a0dbd9f197fae6353dbd658) | `` osquery: 5.23.0 -> 5.23.1 ``                                                             |
| [`1c743472`](https://github.com/NixOS/nixpkgs/commit/1c74347238d12849f8ec423f46f6e26bc46ad184) | `` python3Packages.jq: skip another test that relies on exact jq error text ``              |
| [`d0f26909`](https://github.com/NixOS/nixpkgs/commit/d0f26909927ad3070bab6e3ce13f1f53402581e0) | `` bookstack: 26.05.1 -> 26.05.2 ``                                                         |
| [`4565806c`](https://github.com/NixOS/nixpkgs/commit/4565806cec79c2e186c1e61331648e23ff00225f) | `` navidromePlugins.discord-rich-presence: 1.0.0 -> 2.0.0 ``                                |
| [`9ed5a62d`](https://github.com/NixOS/nixpkgs/commit/9ed5a62d5bedd229b7772002b9db8b2210123752) | `` matrix-authentication-service: 1.17.0 -> 1.20.0 ``                                       |
| [`c27db374`](https://github.com/NixOS/nixpkgs/commit/c27db374bc0540a3d5f4ca23f096cd9529080d75) | `` incus-lts: 7.0.0 -> 7.0.1 ``                                                             |
| [`d774ac19`](https://github.com/NixOS/nixpkgs/commit/d774ac19255e8a1192acb123634d6a3558389b6d) | `` eww: 0.6.0-unstable-2026-03-05 -> 0.6.0-unstable-2026-07-05 ``                           |
| [`fefecf55`](https://github.com/NixOS/nixpkgs/commit/fefecf5577f239a4bebe81bc53d089430cb8ea60) | `` rage: 0.11.2 -> 0.11.4 ``                                                                |
| [`98bebb5c`](https://github.com/NixOS/nixpkgs/commit/98bebb5c596420c1c23d62e81d9f2f8fe70f87ac) | `` python3Packages.numexpr: relax thread limit hook ``                                      |
| [`97ae4a44`](https://github.com/NixOS/nixpkgs/commit/97ae4a44584b3bad92748b186030e8f6b696b115) | `` Revert "kdePackages.calligra: fix build with poppler 26.04.0" ``                         |
| [`b23b487e`](https://github.com/NixOS/nixpkgs/commit/b23b487eb51c978c9f7c081f967adb0ec5050254) | `` firefox-bin-unwrapped: 152.0.5 -> 152.0.6 ``                                             |
| [`f4a45d9b`](https://github.com/NixOS/nixpkgs/commit/f4a45d9b87c0263d8b370b18cc1d4ffaf869b4cd) | `` firefox-unwrapped: 152.0.5 -> 152.0.6 ``                                                 |
| [`7b096537`](https://github.com/NixOS/nixpkgs/commit/7b096537afb97e911a57ec1ac5b209973c65ebc3) | `` pijul: 1.0.0-beta.14 -> 1.0.0-beta.18 ``                                                 |
| [`98e65564`](https://github.com/NixOS/nixpkgs/commit/98e6556475a7583dcfeae869d9cece498636a33a) | `` pihole-web: 6.5 -> 6.5.1 ``                                                              |
| [`7c75d87a`](https://github.com/NixOS/nixpkgs/commit/7c75d87a6ad80099822273972c0af8a69553c5ea) | `` onlyoffice-documentserver: use icu78 ``                                                  |
| [`c4a6a889`](https://github.com/NixOS/nixpkgs/commit/c4a6a8897c9b138e224198b3246a57e1fcb86c31) | `` llama-cpp: do not overwrite the actual llama cli ``                                      |
| [`2da9dbf9`](https://github.com/NixOS/nixpkgs/commit/2da9dbf95924b4f056161f5f41c56c99a67b7dd2) | `` flytectl: init at 0.9.8 ``                                                               |
| [`745fe474`](https://github.com/NixOS/nixpkgs/commit/745fe474da3be4f8eff25c2bd5d2ceff77b874b8) | `` maintainers: add mcuste ``                                                               |
| [`d21bbd7f`](https://github.com/NixOS/nixpkgs/commit/d21bbd7ff334dd7a71edcf89f7af22037e1f92b3) | `` python3Packages.oslo-i18n: update ignored tests ``                                       |
| [`67453c9a`](https://github.com/NixOS/nixpkgs/commit/67453c9a73bf2a359836c1ab22bacbd083f0a9a9) | `` poppler: fix build with Clang ``                                                         |
| [`dc6bed02`](https://github.com/NixOS/nixpkgs/commit/dc6bed02031c778f6f5d69f2ce2b22f7970578d9) | `` stremio-linux-shell: 1.1.1 -> 1.1.2 ``                                                   |
| [`8bacb3d5`](https://github.com/NixOS/nixpkgs/commit/8bacb3d548460959dd31a97afebe188165b9c06e) | `` stremio-linux-shell: add fazzi to maintainers ``                                         |
| [`985cd6a3`](https://github.com/NixOS/nixpkgs/commit/985cd6a3bab557f17579deec5356ef06e3a24272) | `` stremio-linux-shell: install more files to match upstream packaging ``                   |
| [`f2d9d941`](https://github.com/NixOS/nixpkgs/commit/f2d9d941741d88481a97bf9cbbb6ea958c53a5f0) | `` stremio-linux-shell: 1.0.2 -> 1.1.1 ``                                                   |
| [`7ab5695c`](https://github.com/NixOS/nixpkgs/commit/7ab5695c91a071c190bfc0ea8cf3344677c1124c) | `` stremio-linux-shell: fix update script ``                                                |
| [`8762ee21`](https://github.com/NixOS/nixpkgs/commit/8762ee217b3669e0e9151a4423afbd846689d90e) | `` rauthy: 0.35.2 -> 0.36.0 ``                                                              |
| [`6aeaf306`](https://github.com/NixOS/nixpkgs/commit/6aeaf306ff3a6378ad3a8ce1dffe7d44cebbe879) | `` komikku: 50.8.0 -> 50.9.0 ``                                                             |
| [`95a4cb1e`](https://github.com/NixOS/nixpkgs/commit/95a4cb1ee20dc5e675ae5562196039a60b8f25f2) | `` qemu: 10.2.2 -> 10.2.4 ``                                                                |
| [`d30dd5ab`](https://github.com/NixOS/nixpkgs/commit/d30dd5abf00053a48fd1d2876fe261eab746bc37) | `` pihole-ftl: 6.6.2 -> 6.7 ``                                                              |
| [`c25f3b46`](https://github.com/NixOS/nixpkgs/commit/c25f3b460d29b3b8bc84dce000db2c0f76f7cb46) | `` gelly: 1.9.0 -> 1.9.2 ``                                                                 |
| [`0aa0defa`](https://github.com/NixOS/nixpkgs/commit/0aa0defae79489c590f0718bb3ffe146f8cc0c2d) | `` python3Packages.pyarrow: skip the same tests as on nixpkgs master ``                     |
| [`23cdb14b`](https://github.com/NixOS/nixpkgs/commit/23cdb14b43332c9f8390c65d189195d8c8e50474) | `` python3Packages.cfn-lint: disable failing tests ``                                       |
| [`f30599e8`](https://github.com/NixOS/nixpkgs/commit/f30599e817e4f2251e7e3b0d61c7a86610020ce6) | `` technitium-dns-server: 15.2.0 -> 15.3.0 ``                                               |
| [`7ff775da`](https://github.com/NixOS/nixpkgs/commit/7ff775da1e8162e32d99172bcda4a4caaf35b3c1) | `` microsoft-edge: 149.0.4022.98 -> 150.0.4078.65 ``                                        |
| [`e23b6da0`](https://github.com/NixOS/nixpkgs/commit/e23b6da0a78a3285450bdefc9faf888efe777cd1) | `` picocom: add myself as maintainer ``                                                     |
| [`8bbc131c`](https://github.com/NixOS/nixpkgs/commit/8bbc131cc0b9fb402cac14737ea87a31d2d4804d) | `` discourse: Fix icu library mismatch in mini_racer ``                                     |
| [`5c672c14`](https://github.com/NixOS/nixpkgs/commit/5c672c1409daa03f29e0141391068e755edfeb64) | `` cargo-auditable: disable `test_bare_linker` ``                                           |
| [`1ac3397e`](https://github.com/NixOS/nixpkgs/commit/1ac3397e8bba38bd5fd69cb805b458a3e86778e7) | `` daed: 1.0.0 -> 1.27.0, add maintainer ``                                                 |
| [`4ce2e622`](https://github.com/NixOS/nixpkgs/commit/4ce2e6224a681a49ee2fcb12fb3bdd78a2339acb) | `` mate-power-manager: Fix backlight-helper polkit popup ``                                 |
| [`25eed016`](https://github.com/NixOS/nixpkgs/commit/25eed016bd7cf0ecb2add01409d9f8da8548113f) | `` wealthfolio: 3.4.0 -> 3.5.2 ``                                                           |
| [`c1d849f2`](https://github.com/NixOS/nixpkgs/commit/c1d849f2ba68ae6dfdd97a8ca0e8ddce077d2127) | `` tabby-agent: adopt ``                                                                    |
| [`44f533e1`](https://github.com/NixOS/nixpkgs/commit/44f533e1c90b8806edb7184d6b229d39535ea54e) | `` tabby-agent: modernize ``                                                                |
| [`c3a60b23`](https://github.com/NixOS/nixpkgs/commit/c3a60b23b0f499700d72306baa2e8ad1ffd20f02) | `` tabby-agent: 0.31.2 -> 0.32.0 ``                                                         |
| [`872221df`](https://github.com/NixOS/nixpkgs/commit/872221df17cb136b82cdfd7deede513b2a74e062) | `` tabby-agent: migrate to pnpm 11 and fetcherVersion 4 ``                                  |
| [`4678bf61`](https://github.com/NixOS/nixpkgs/commit/4678bf612e5a32386c6133d74e5aee8594972be7) | `` sketchybar-app-font: migrate to pnpm_11 ``                                               |
| [`624a3dd7`](https://github.com/NixOS/nixpkgs/commit/624a3dd764274ceea9db49436dcf81496cfbf117) | `` porn-vault: update pnpm to 10 ``                                                         |
| [`c20473d6`](https://github.com/NixOS/nixpkgs/commit/c20473d6d078cc284713cf24a6f200d7773e1932) | `` piped: use pnpm 10 ``                                                                    |
| [`0ca30a8c`](https://github.com/NixOS/nixpkgs/commit/0ca30a8cc2f667f8af6fe6c509891e8fcf9149ec) | `` meshtastic-web: pnpm_9 -> pnpm_10 ``                                                     |
| [`2106b453`](https://github.com/NixOS/nixpkgs/commit/2106b453be81460bbcbd80fc40646b8ad2b99c7f) | `` flood: pnpm_9 -> pnpm_10 ``                                                              |
| [`f258253e`](https://github.com/NixOS/nixpkgs/commit/f258253ed7731141000a87809cfe14acd8ffff8d) | `` autoprefixer: adopt ``                                                                   |
| [`eb3cb64c`](https://github.com/NixOS/nixpkgs/commit/eb3cb64cd494b7e8dda01b9c93a8c7a88342e07c) | `` autoprefixer: modernize ``                                                               |
| [`e1eed562`](https://github.com/NixOS/nixpkgs/commit/e1eed562dc9b2324d08d0769caa471d01c753b2c) | `` autoprefixer: 10.4.24 -> 10.5.0 ``                                                       |
| [`f841ce07`](https://github.com/NixOS/nixpkgs/commit/f841ce07fda76bc872f245915c9e6c6c0bf18e21) | `` autoprefixer: migrate to pnpm 10 and fetcherVersion 4 ``                                 |
| [`1c848485`](https://github.com/NixOS/nixpkgs/commit/1c848485fb57553c993c7a2b8f041bd81b55ae82) | `` firezone-gui-client: 1.5.1 -> 1.5.2 ``                                                   |
| [`654c6037`](https://github.com/NixOS/nixpkgs/commit/654c60378515b42ab55af3b7f3643e9b6ad02065) | `` synchrony: 2.4.5 -> 2.4.6, use pnpm 11 ``                                                |
| [`3d09ac02`](https://github.com/NixOS/nixpkgs/commit/3d09ac02c54ba53baa7aa46425a625fc15d0a93b) | `` wire-desktop: fix eval on unsupported systems ``                                         |
| [`4a196670`](https://github.com/NixOS/nixpkgs/commit/4a19667063680e21636730f4e46a507a293c8b54) | `` webkitgtk_6_0: 2.52.4 → 2.52.5 ``                                                        |
| [`c6ef05be`](https://github.com/NixOS/nixpkgs/commit/c6ef05be1fc77d030581e9ab172ceec53213fa50) | `` ddev: 1.25.2 -> 1.25.3 ``                                                                |
| [`3c346ab7`](https://github.com/NixOS/nixpkgs/commit/3c346ab7a49047837071634ba59c9b24d479742f) | `` treewide: add checkPhaseThreadLimitHook to more things used in parallel checks ``        |
| [`58f1bfd8`](https://github.com/NixOS/nixpkgs/commit/58f1bfd8f7f9ab0d438ed6ce8b5c82fd0ec0479b) | `` treewide: openmpCheckPhaseHook -> checkPhaseThreadLimitHook ``                           |
| [`e6f3eb4a`](https://github.com/NixOS/nixpkgs/commit/e6f3eb4a09c4beb15f5504371c2378bcee0918eb) | `` checkPhaseThreadLimitHook: rename from openmpCheckPhaseHook, set more thread env vars `` |
| [`70ef897c`](https://github.com/NixOS/nixpkgs/commit/70ef897c8364bfdf5a69368e427d4e0217ff7e53) | `` pijul: 1.0.0-beta.11 -> 1.0.0-beta.14 ``                                                 |
| [`67d1202e`](https://github.com/NixOS/nixpkgs/commit/67d1202e08b911e8fba51b953c06a9e359f1e69f) | `` picgo: 2.5.3 -> 3.0.0 ``                                                                 |
| [`e5516fa8`](https://github.com/NixOS/nixpkgs/commit/e5516fa86d4c19d0e3d8ff1a959e2bcf9fe904bb) | `` pmtiles: 1.31.0 -> 1.31.1 ``                                                             |
| [`732688fa`](https://github.com/NixOS/nixpkgs/commit/732688fab6a83172548eccf05ec78877b42f8225) | `` signal-cli: 0.14.5 -> 0.14.6 ``                                                          |
| [`f72f4f8d`](https://github.com/NixOS/nixpkgs/commit/f72f4f8d4d9c17f3ed2cdf13e9edd17c8726c9e6) | `` signal-cli: Add update script ``                                                         |
| [`d4f04901`](https://github.com/NixOS/nixpkgs/commit/d4f04901e121276ae92805fa3a1f2844014f925b) | `` pmtiles: 1.30.3 -> 1.31.0 ``                                                             |
| [`c8194b59`](https://github.com/NixOS/nixpkgs/commit/c8194b592d70e107b392f4a45658829b66a6113c) | `` blackfire: 2026.6.1 -> 2026.7.0 ``                                                       |
| [`d1532e33`](https://github.com/NixOS/nixpkgs/commit/d1532e33d1e702d8265be713c30a8822d726ed7f) | `` netbird: fix GUI application's XDG desktop file ``                                       |
| [`2f7be540`](https://github.com/NixOS/nixpkgs/commit/2f7be540540aeaea847b4f8e95a316e9cc2ea402) | `` chromium,chromedriver: 150.0.7871.124 -> 150.0.7871.128 ``                               |
| [`aaab4a0e`](https://github.com/NixOS/nixpkgs/commit/aaab4a0e9665fb5e998ebaa7c9920d4081deb837) | `` pmtiles: 1.30.0 → 1.30.3 ``                                                              |
| [`5691aad3`](https://github.com/NixOS/nixpkgs/commit/5691aad368e34d077c52359a1146bda39e1d1831) | `` google-chrome: 150.0.7871.124 -> 150.0.7871.128 ``                                       |
| [`bf5919b4`](https://github.com/NixOS/nixpkgs/commit/bf5919b4d3044cabc70481b00de4a042152d1ce2) | `` python3Packages.paho-mqtt: use upstream patch for generating SSL certs ``                |
| [`7b2a1f3d`](https://github.com/NixOS/nixpkgs/commit/7b2a1f3d825e03533fd6a019324508332e6b8317) | `` rundeck: 6.0.0 -> 6.0.1 ``                                                               |
| [`d826c939`](https://github.com/NixOS/nixpkgs/commit/d826c9399cebd315061e43bdc8f65b508b0b216e) | `` absolute: init at 0.3 ``                                                                 |
| [`4326f508`](https://github.com/NixOS/nixpkgs/commit/4326f5086b9185711b619efcae95a94318ad8705) | `` ocamlPackages.libabsolute: init at 0.3 ``                                                |
| [`31d0f341`](https://github.com/NixOS/nixpkgs/commit/31d0f341b8b48f37a33b8234853ad6c51bc188b0) | `` ocamlPackages.picasso: init at 0.4 ``                                                    |
| [`4b95f7ae`](https://github.com/NixOS/nixpkgs/commit/4b95f7aeac0552b22f331ca8e052eba7dcc14abd) | `` ocamlPackages.apronext: init at 1.0.4 ``                                                 |
| [`97c430d0`](https://github.com/NixOS/nixpkgs/commit/97c430d0b152431fb287fc988cc197b23f5845dc) | `` ocamlPackages.apron: fix propagated inputs ``                                            |
| [`bf21e0e6`](https://github.com/NixOS/nixpkgs/commit/bf21e0e63357c8d38fc34e792aacae9323a90e3e) | `` cargo-shear: 1.13.1 -> 1.13.2 ``                                                         |
| [`ec4f4bf2`](https://github.com/NixOS/nixpkgs/commit/ec4f4bf2c8dea4fe24237fd14a6b4803dfc02d6a) | `` nix-unit: 2.34.0 -> 2.34.2 ``                                                            |
| [`57501c99`](https://github.com/NixOS/nixpkgs/commit/57501c9972e23089e3862943befd968361b808ce) | `` python3Packages.dogpile-cache: update disabled tests for darwin ``                       |
| [`bf982dd1`](https://github.com/NixOS/nixpkgs/commit/bf982dd1e2e83d4c82b1d764d4db7ea699f90ece) | `` gomuks-web: 26.06 -> 26.07 ``                                                            |
| [`539ad5a4`](https://github.com/NixOS/nixpkgs/commit/539ad5a43f5c50f7b6cfc85c09df65aef0a4299c) | `` gomuks-web: remove `libheif` patches ``                                                  |
| [`b6eb7f5a`](https://github.com/NixOS/nixpkgs/commit/b6eb7f5a8b0d11231d7adc7f5ffa601b6c8c830b) | `` gomuks-web: 26.05 -> 26.06 ``                                                            |
| [`c964ee92`](https://github.com/NixOS/nixpkgs/commit/c964ee92bfe2ab646b4a004c4ee17b234991567d) | `` gdal: fix build with poppler 26.06 ``                                                    |
| [`a613a3f6`](https://github.com/NixOS/nixpkgs/commit/a613a3f6560e66503d8519bbc792d819dd9e5bf7) | `` appium-inspector: 2026.2.1 -> 2026.5.1 ``                                                |
| [`4a5c9860`](https://github.com/NixOS/nixpkgs/commit/4a5c9860f5d26eb147929f2a1e4940a693ac3bd1) | `` appium-inspector: let update script automatically update electron version ``             |
| [`595a9d07`](https://github.com/NixOS/nixpkgs/commit/595a9d070dcf81804e105377e630681f7cacb6b2) | `` ocamlPackages.ocsigen-toolkit: 4.2.0 → 4.3.0 ``                                          |
| [`026aee51`](https://github.com/NixOS/nixpkgs/commit/026aee5150de2ce5f31bf42b11ddb22e39a978b0) | `` outline: 1.8.1 -> 1.9.1 ``                                                               |
| [`6b0823ee`](https://github.com/NixOS/nixpkgs/commit/6b0823ee0ec357a312817f8578d9546cadfe6736) | `` outline: fix updateScript ``                                                             |
| [`7f3381ce`](https://github.com/NixOS/nixpkgs/commit/7f3381ce1823aa65cc09400887cdef5bee70483e) | `` dovecot: Fix building with Lua ``                                                        |
| [`b920851e`](https://github.com/NixOS/nixpkgs/commit/b920851ee8ec5aefff495628f2ac7f929c9c5c7a) | `` luaPackages.json: Init at 0.1.2 ``                                                       |
| [`780f6631`](https://github.com/NixOS/nixpkgs/commit/780f6631f37eea608471761cb4b2a65744d9e5b4) | `` nginxStable: 1.30.3 -> 1.30.4 ``                                                         |
| [`235ce217`](https://github.com/NixOS/nixpkgs/commit/235ce217a8be9b2c74c3cbe49412856829052e1c) | `` nginxMainline: 1.31.2 -> 1.31.3 ``                                                       |
| [`f1565f62`](https://github.com/NixOS/nixpkgs/commit/f1565f623ac02c43514e8e8dde6461a50c03d342) | `` mesa: 26.1.4 -> 26.1.5 ``                                                                |
| [`8bcf0630`](https://github.com/NixOS/nixpkgs/commit/8bcf0630a65bfef2b6f78f4d2448b11acee8b5d3) | `` remark42: 1.15.0 -> 1.16.4 ``                                                            |
| [`27a724e7`](https://github.com/NixOS/nixpkgs/commit/27a724e7e6e366cb93ea905996d89313a8bb4660) | `` remark42: switch to pnpm_9 ``                                                            |
| [`9c24429f`](https://github.com/NixOS/nixpkgs/commit/9c24429f50a481cc8da0ad996c7b74fa3b849ee0) | `` librewolf-unwrapped: 152.0.5-1 -> 152.0.6-1 ``                                           |
| [`73cd3df9`](https://github.com/NixOS/nixpkgs/commit/73cd3df9a250d4d15ea130e2180db37473121b6c) | `` vicinae: 0.22.3 -> 0.23.1 ``                                                             |
| [`7a097208`](https://github.com/NixOS/nixpkgs/commit/7a097208bd734c9d9b8a48ed6cdd47ccfe76c878) | `` ungoogled-chromium: 150.0.7871.114-1 -> 150.0.7871.124-1 ``                              |
| [`e551145d`](https://github.com/NixOS/nixpkgs/commit/e551145d97d810065f9d38265f1c642834242e18) | `` python3Packages.httplib2: 0.31.1 -> 0.32.0 ``                                            |
| [`66237861`](https://github.com/NixOS/nixpkgs/commit/662378614ee0d2cc92c977fc0b07e55b75bcd71f) | `` dgraph: 25.3.3 -> 25.3.8 ``                                                              |
| [`4fd15d69`](https://github.com/NixOS/nixpkgs/commit/4fd15d695a7fdd81589fc2d5398c8b506c82902e) | `` linuxKernel.kernels.linux_zen: 7.1.2 -> 7.1.3 ``                                         |
| [`241c0a7e`](https://github.com/NixOS/nixpkgs/commit/241c0a7e6a1ec7d2084d99105bdc3e7fa89842e4) | `` perlPackages.CryptOpenSSLX509: 1.915 -> 2.1.3 ``                                         |
| [`907ca17f`](https://github.com/NixOS/nixpkgs/commit/907ca17fcdc0310164922cd16c7dceda03b38fec) | `` wivrn: 26.6.1 -> 26.6.2 ``                                                               |
| [`f1ba17f3`](https://github.com/NixOS/nixpkgs/commit/f1ba17f34db384f000d8f21ecf013748f246b184) | `` forgejo: 15.0.4 -> 15.0.5 ``                                                             |
| [`b77af21c`](https://github.com/NixOS/nixpkgs/commit/b77af21c318e29d6af25218894a9b58d2f186676) | `` flytectl.tests: fix the eval ``                                                          |
| [`be694493`](https://github.com/NixOS/nixpkgs/commit/be694493f481f8b63689724d9f9e08537a46b1ac) | `` ttl: add herbetom as maintainer ``                                                       |
| [`75228a29`](https://github.com/NixOS/nixpkgs/commit/75228a29e4998881b85cbe68fe7a30cebb21a49b) | `` ttl: disable update check ``                                                             |
| [`7d797725`](https://github.com/NixOS/nixpkgs/commit/7d7977259195d96d653a5eba15a4b031becff961) | `` ttl: 0.19.1 -> 0.21.0 ``                                                                 |
| [`d3b3cf52`](https://github.com/NixOS/nixpkgs/commit/d3b3cf523e000a55f8be048d987a49c155efd320) | `` switch-to-configuration-ng: Die less ``                                                  |
| [`61d5ebc7`](https://github.com/NixOS/nixpkgs/commit/61d5ebc7c430b02e83f39a5e01ac2a7c1611b2f3) | `` firefly-iii-data-importer: 2.3.2 -> 2.3.4 ``                                             |
| [`4514f903`](https://github.com/NixOS/nixpkgs/commit/4514f9030c2b3b6d6208b5ab385f3857ee4982d2) | `` radarr: 6.2.1.10461 -> 6.3.0.10514 ``                                                    |
| [`9fa65ff4`](https://github.com/NixOS/nixpkgs/commit/9fa65ff4c1dda6bd5fb6eadc0174f34d76fe2b18) | `` gotenberg: 8.33.0 -> 8.34.0 ``                                                           |
| [`ece01617`](https://github.com/NixOS/nixpkgs/commit/ece016172bff5783450c34470c5176a3e2340f2f) | `` element-desktop: 1.12.22 -> 1.12.23 ``                                                   |
| [`47bd1ef0`](https://github.com/NixOS/nixpkgs/commit/47bd1ef046426341c37b4dc37844147d672fae49) | `` phpExtensions.blackfire: 2026.5.0 -> 2026.7.0 ``                                         |
| [`93393a17`](https://github.com/NixOS/nixpkgs/commit/93393a1701c327cd32a403d6b042dc918ce318d1) | `` gotenberg: 8.32.0 -> 8.33.0 ``                                                           |
| [`63a46917`](https://github.com/NixOS/nixpkgs/commit/63a469176c7a75d6c6025ac87a224f62ecfbb2c9) | `` gajim: 2.4.7 -> 2.4.7.1 ``                                                               |
| [`de79f2d1`](https://github.com/NixOS/nixpkgs/commit/de79f2d1aee15168c155d63273b4a89e070908de) | `` gajim: add changelog ``                                                                  |
| [`51159f3f`](https://github.com/NixOS/nixpkgs/commit/51159f3fda8a3672af61fe4a327c8141af24ef95) | `` keycloak: 26.6.4 -> 26.7.0 ``                                                            |
| [`ec09cf3c`](https://github.com/NixOS/nixpkgs/commit/ec09cf3cb3f06d05eba207f5691ef29024326922) | `` gajim: 2.4.6 → 2.4.7 ``                                                                  |
| [`3371c67c`](https://github.com/NixOS/nixpkgs/commit/3371c67cfb836ef494b4bed5540f3a97546682f0) | `` pam_ssh_agent_auth: fix runtime error on aarch64 ``                                      |
| [`dc1b7433`](https://github.com/NixOS/nixpkgs/commit/dc1b74336895c362b47eacbdea8813f6e6fa9983) | `` vikunja: Set version metadata at build time ``                                           |
| [`034023ca`](https://github.com/NixOS/nixpkgs/commit/034023ca7f0c158b6bdd02434d00064b97209981) | `` chromium,chromedriver: 150.0.7871.114 -> 150.0.7871.124 ``                               |
| [`ca53f072`](https://github.com/NixOS/nixpkgs/commit/ca53f0727b28f293590dc9084a1255a8c0d46db4) | `` powerdns-admin: fix oidc auth ``                                                         |
| [`e8df3a01`](https://github.com/NixOS/nixpkgs/commit/e8df3a0142c456f7c9fb8bc05bee8952b4243e0d) | `` powerdns-admin: fix reset password ``                                                    |
| [`1ffa2d1d`](https://github.com/NixOS/nixpkgs/commit/1ffa2d1d4c331c30658a9f4db0c653488ee3aeb6) | `` google-chrome: 150.0.7871.114 -> 150.0.7871.124 ``                                       |
| [`f7351ca8`](https://github.com/NixOS/nixpkgs/commit/f7351ca8a5e14ffc53c2803e880f00d973a4925e) | `` esphome: use paho-mqtt_1 ``                                                              |
| [`86ba3a75`](https://github.com/NixOS/nixpkgs/commit/86ba3a75189ff6aad926cc57dddbb5c9a13e5bba) | `` python3Packages.paho-mqtt_1: init at 1.6.1 ``                                            |
| [`076003e3`](https://github.com/NixOS/nixpkgs/commit/076003e33b24598c1ac356d01df3f979a09ea891) | `` python3Packages.paho-mqtt: regenerate certificates for tests ``                          |
| [`2ee1e3a3`](https://github.com/NixOS/nixpkgs/commit/2ee1e3a33d4fbdaad9536b4b31650e30823ee646) | `` navidrome: 0.63.1 -> 0.63.2 ``                                                           |
| [`dfaf107e`](https://github.com/NixOS/nixpkgs/commit/dfaf107e8e74e609121ec1a2cbe4c56ae368b1b4) | `` tor-browser: 15.0.17 -> 15.0.18 ``                                                       |
| [`8ee1d106`](https://github.com/NixOS/nixpkgs/commit/8ee1d106efb5fcf330b0b1a17fb26c2b86b3ec6d) | `` mullvad-browser: 15.0.16 -> 15.0.18 ``                                                   |
| [`4fbb919a`](https://github.com/NixOS/nixpkgs/commit/4fbb919a47d1e18ff9aba9ada62c4535ef3ddc5d) | `` rura: init at 1.3.0 ``                                                                   |
| [`3a379a70`](https://github.com/NixOS/nixpkgs/commit/3a379a70a0857c4057ae040a22d9b6af03224fe4) | `` matrix-appservice-irc: use nodejs-slim_22 ``                                             |
| [`3e103dd7`](https://github.com/NixOS/nixpkgs/commit/3e103dd73fb5bc9b9cb5eeaccb4ba5a068507384) | `` pihole-web: 6.5.1 -> 6.6 ``                                                              |
| [`b5ab975f`](https://github.com/NixOS/nixpkgs/commit/b5ab975f836dbf1c9a0dbd9f197fae6353dbd658) | `` osquery: 5.23.0 -> 5.23.1 ``                                                             |
| [`1c743472`](https://github.com/NixOS/nixpkgs/commit/1c74347238d12849f8ec423f46f6e26bc46ad184) | `` python3Packages.jq: skip another test that relies on exact jq error text ``              |
| [`d0f26909`](https://github.com/NixOS/nixpkgs/commit/d0f26909927ad3070bab6e3ce13f1f53402581e0) | `` bookstack: 26.05.1 -> 26.05.2 ``                                                         |
| [`4565806c`](https://github.com/NixOS/nixpkgs/commit/4565806cec79c2e186c1e61331648e23ff00225f) | `` navidromePlugins.discord-rich-presence: 1.0.0 -> 2.0.0 ``                                |
| [`9ed5a62d`](https://github.com/NixOS/nixpkgs/commit/9ed5a62d5bedd229b7772002b9db8b2210123752) | `` matrix-authentication-service: 1.17.0 -> 1.20.0 ``                                       |
| [`c27db374`](https://github.com/NixOS/nixpkgs/commit/c27db374bc0540a3d5f4ca23f096cd9529080d75) | `` incus-lts: 7.0.0 -> 7.0.1 ``                                                             |
| [`d774ac19`](https://github.com/NixOS/nixpkgs/commit/d774ac19255e8a1192acb123634d6a3558389b6d) | `` eww: 0.6.0-unstable-2026-03-05 -> 0.6.0-unstable-2026-07-05 ``                           |
| [`fefecf55`](https://github.com/NixOS/nixpkgs/commit/fefecf5577f239a4bebe81bc53d089430cb8ea60) | `` rage: 0.11.2 -> 0.11.4 ``                                                                |
| [`98bebb5c`](https://github.com/NixOS/nixpkgs/commit/98bebb5c596420c1c23d62e81d9f2f8fe70f87ac) | `` python3Packages.numexpr: relax thread limit hook ``                                      |
| [`97ae4a44`](https://github.com/NixOS/nixpkgs/commit/97ae4a44584b3bad92748b186030e8f6b696b115) | `` Revert "kdePackages.calligra: fix build with poppler 26.04.0" ``                         |
| [`b23b487e`](https://github.com/NixOS/nixpkgs/commit/b23b487eb51c978c9f7c081f967adb0ec5050254) | `` firefox-bin-unwrapped: 152.0.5 -> 152.0.6 ``                                             |
| [`f4a45d9b`](https://github.com/NixOS/nixpkgs/commit/f4a45d9b87c0263d8b370b18cc1d4ffaf869b4cd) | `` firefox-unwrapped: 152.0.5 -> 152.0.6 ``                                                 |
| [`7b096537`](https://github.com/NixOS/nixpkgs/commit/7b096537afb97e911a57ec1ac5b209973c65ebc3) | `` pijul: 1.0.0-beta.14 -> 1.0.0-beta.18 ``                                                 |
| [`98e65564`](https://github.com/NixOS/nixpkgs/commit/98e6556475a7583dcfeae869d9cece498636a33a) | `` pihole-web: 6.5 -> 6.5.1 ``                                                              |
| [`7c75d87a`](https://github.com/NixOS/nixpkgs/commit/7c75d87a6ad80099822273972c0af8a69553c5ea) | `` onlyoffice-documentserver: use icu78 ``                                                  |
| [`c4a6a889`](https://github.com/NixOS/nixpkgs/commit/c4a6a8897c9b138e224198b3246a57e1fcb86c31) | `` llama-cpp: do not overwrite the actual llama cli ``                                      |
| [`2da9dbf9`](https://github.com/NixOS/nixpkgs/commit/2da9dbf95924b4f056161f5f41c56c99a67b7dd2) | `` flytectl: init at 0.9.8 ``                                                               |
| [`745fe474`](https://github.com/NixOS/nixpkgs/commit/745fe474da3be4f8eff25c2bd5d2ceff77b874b8) | `` maintainers: add mcuste ``                                                               |
| [`d21bbd7f`](https://github.com/NixOS/nixpkgs/commit/d21bbd7ff334dd7a71edcf89f7af22037e1f92b3) | `` python3Packages.oslo-i18n: update ignored tests ``                                       |
| [`67453c9a`](https://github.com/NixOS/nixpkgs/commit/67453c9a73bf2a359836c1ab22bacbd083f0a9a9) | `` poppler: fix build with Clang ``                                                         |
| [`dc6bed02`](https://github.com/NixOS/nixpkgs/commit/dc6bed02031c778f6f5d69f2ce2b22f7970578d9) | `` stremio-linux-shell: 1.1.1 -> 1.1.2 ``                                                   |
| [`8bacb3d5`](https://github.com/NixOS/nixpkgs/commit/8bacb3d548460959dd31a97afebe188165b9c06e) | `` stremio-linux-shell: add fazzi to maintainers ``                                         |
| [`985cd6a3`](https://github.com/NixOS/nixpkgs/commit/985cd6a3bab557f17579deec5356ef06e3a24272) | `` stremio-linux-shell: install more files to match upstream packaging ``                   |
| [`f2d9d941`](https://github.com/NixOS/nixpkgs/commit/f2d9d941741d88481a97bf9cbbb6ea958c53a5f0) | `` stremio-linux-shell: 1.0.2 -> 1.1.1 ``                                                   |
| [`7ab5695c`](https://github.com/NixOS/nixpkgs/commit/7ab5695c91a071c190bfc0ea8cf3344677c1124c) | `` stremio-linux-shell: fix update script ``                                                |
| [`8762ee21`](https://github.com/NixOS/nixpkgs/commit/8762ee217b3669e0e9151a4423afbd846689d90e) | `` rauthy: 0.35.2 -> 0.36.0 ``                                                              |
| [`6aeaf306`](https://github.com/NixOS/nixpkgs/commit/6aeaf306ff3a6378ad3a8ce1dffe7d44cebbe879) | `` komikku: 50.8.0 -> 50.9.0 ``                                                             |
| [`95a4cb1e`](https://github.com/NixOS/nixpkgs/commit/95a4cb1ee20dc5e675ae5562196039a60b8f25f2) | `` qemu: 10.2.2 -> 10.2.4 ``                                                                |
| [`d30dd5ab`](https://github.com/NixOS/nixpkgs/commit/d30dd5abf00053a48fd1d2876fe261eab746bc37) | `` pihole-ftl: 6.6.2 -> 6.7 ``                                                              |
| [`c25f3b46`](https://github.com/NixOS/nixpkgs/commit/c25f3b460d29b3b8bc84dce000db2c0f76f7cb46) | `` gelly: 1.9.0 -> 1.9.2 ``                                                                 |
| [`0aa0defa`](https://github.com/NixOS/nixpkgs/commit/0aa0defae79489c590f0718bb3ffe146f8cc0c2d) | `` python3Packages.pyarrow: skip the same tests as on nixpkgs master ``                     |
| [`23cdb14b`](https://github.com/NixOS/nixpkgs/commit/23cdb14b43332c9f8390c65d189195d8c8e50474) | `` python3Packages.cfn-lint: disable failing tests ``                                       |
| [`f30599e8`](https://github.com/NixOS/nixpkgs/commit/f30599e817e4f2251e7e3b0d61c7a86610020ce6) | `` technitium-dns-server: 15.2.0 -> 15.3.0 ``                                               |
| [`7ff775da`](https://github.com/NixOS/nixpkgs/commit/7ff775da1e8162e32d99172bcda4a4caaf35b3c1) | `` microsoft-edge: 149.0.4022.98 -> 150.0.4078.65 ``                                        |
| [`e23b6da0`](https://github.com/NixOS/nixpkgs/commit/e23b6da0a78a3285450bdefc9faf888efe777cd1) | `` picocom: add myself as maintainer ``                                                     |
| [`8bbc131c`](https://github.com/NixOS/nixpkgs/commit/8bbc131cc0b9fb402cac14737ea87a31d2d4804d) | `` discourse: Fix icu library mismatch in mini_racer ``                                     |
| [`5c672c14`](https://github.com/NixOS/nixpkgs/commit/5c672c1409daa03f29e0141391068e755edfeb64) | `` cargo-auditable: disable `test_bare_linker` ``                                           |
| [`1ac3397e`](https://github.com/NixOS/nixpkgs/commit/1ac3397e8bba38bd5fd69cb805b458a3e86778e7) | `` daed: 1.0.0 -> 1.27.0, add maintainer ``                                                 |
| [`4ce2e622`](https://github.com/NixOS/nixpkgs/commit/4ce2e6224a681a49ee2fcb12fb3bdd78a2339acb) | `` mate-power-manager: Fix backlight-helper polkit popup ``                                 |
| [`25eed016`](https://github.com/NixOS/nixpkgs/commit/25eed016bd7cf0ecb2add01409d9f8da8548113f) | `` wealthfolio: 3.4.0 -> 3.5.2 ``                                                           |
| [`c1d849f2`](https://github.com/NixOS/nixpkgs/commit/c1d849f2ba68ae6dfdd97a8ca0e8ddce077d2127) | `` tabby-agent: adopt ``                                                                    |
| [`44f533e1`](https://github.com/NixOS/nixpkgs/commit/44f533e1c90b8806edb7184d6b229d39535ea54e) | `` tabby-agent: modernize ``                                                                |
| [`c3a60b23`](https://github.com/NixOS/nixpkgs/commit/c3a60b23b0f499700d72306baa2e8ad1ffd20f02) | `` tabby-agent: 0.31.2 -> 0.32.0 ``                                                         |
| [`872221df`](https://github.com/NixOS/nixpkgs/commit/872221df17cb136b82cdfd7deede513b2a74e062) | `` tabby-agent: migrate to pnpm 11 and fetcherVersion 4 ``                                  |
| [`4678bf61`](https://github.com/NixOS/nixpkgs/commit/4678bf612e5a32386c6133d74e5aee8594972be7) | `` sketchybar-app-font: migrate to pnpm_11 ``                                               |
| [`624a3dd7`](https://github.com/NixOS/nixpkgs/commit/624a3dd764274ceea9db49436dcf81496cfbf117) | `` porn-vault: update pnpm to 10 ``                                                         |
| [`c20473d6`](https://github.com/NixOS/nixpkgs/commit/c20473d6d078cc284713cf24a6f200d7773e1932) | `` piped: use pnpm 10 ``                                                                    |
| [`0ca30a8c`](https://github.com/NixOS/nixpkgs/commit/0ca30a8cc2f667f8af6fe6c509891e8fcf9149ec) | `` meshtastic-web: pnpm_9 -> pnpm_10 ``                                                     |
| [`2106b453`](https://github.com/NixOS/nixpkgs/commit/2106b453be81460bbcbd80fc40646b8ad2b99c7f) | `` flood: pnpm_9 -> pnpm_10 ``                                                              |
| [`f258253e`](https://github.com/NixOS/nixpkgs/commit/f258253ed7731141000a87809cfe14acd8ffff8d) | `` autoprefixer: adopt ``                                                                   |
| [`eb3cb64c`](https://github.com/NixOS/nixpkgs/commit/eb3cb64cd494b7e8dda01b9c93a8c7a88342e07c) | `` autoprefixer: modernize ``                                                               |
| [`e1eed562`](https://github.com/NixOS/nixpkgs/commit/e1eed562dc9b2324d08d0769caa471d01c753b2c) | `` autoprefixer: 10.4.24 -> 10.5.0 ``                                                       |
| [`f841ce07`](https://github.com/NixOS/nixpkgs/commit/f841ce07fda76bc872f245915c9e6c6c0bf18e21) | `` autoprefixer: migrate to pnpm 10 and fetcherVersion 4 ``                                 |
| [`1c848485`](https://github.com/NixOS/nixpkgs/commit/1c848485fb57553c993c7a2b8f041bd81b55ae82) | `` firezone-gui-client: 1.5.1 -> 1.5.2 ``                                                   |
| [`654c6037`](https://github.com/NixOS/nixpkgs/commit/654c60378515b42ab55af3b7f3643e9b6ad02065) | `` synchrony: 2.4.5 -> 2.4.6, use pnpm 11 ``                                                |