### PR TITLE
chore(flake/nixpkgs): `18b9261c` -> `61b7c44c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -814,11 +814,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1784007870,
-        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`d80f324c`](https://github.com/NixOS/nixpkgs/commit/d80f324c322da056091e9823fa92571380f01991) | `` nixos/release-combined: tests.shadow moved to tests.shadow.login ``                |
| [`69721d35`](https://github.com/NixOS/nixpkgs/commit/69721d35948eb53e82d1a0ba7c53ebf9652c5e97) | `` terraform-providers.mongodb_mongodbatlas: 2.13.0 -> 2.14.0 ``                      |
| [`6138306a`](https://github.com/NixOS/nixpkgs/commit/6138306acc342aac05ee2cd3375469003dd6e56f) | `` dms-shell: 1.5.0 -> 1.5.2 ``                                                       |
| [`9b51f4f9`](https://github.com/NixOS/nixpkgs/commit/9b51f4f9f7851c0711bf7d0f270cf311d5ebd1d6) | `` kdePackages.kirigami-addons: 1.12.1 -> 1.13.0 ``                                   |
| [`61e2d9d5`](https://github.com/NixOS/nixpkgs/commit/61e2d9d5568092a1cdb12cabfe5ce5e0a42849d1) | `` python3Packages.aws-adfs: 2.12.1 -> 2.13.0 ``                                      |
| [`e8638ad0`](https://github.com/NixOS/nixpkgs/commit/e8638ad0b5c1ec70e110141ceec8c968e123babe) | `` python3Packages.nvchecker: 2.20 -> 2.21 ``                                         |
| [`0a215e1b`](https://github.com/NixOS/nixpkgs/commit/0a215e1b9edf18d5de4dd29c68561cd2e6807f25) | `` evcc: 0.311.1 -> 0.312.0 ``                                                        |
| [`da91c257`](https://github.com/NixOS/nixpkgs/commit/da91c257c29d16d299c721e086e6081ebbd6e480) | `` tdlib: 1.8.65 -> 1.8.66 ``                                                         |
| [`a16d0593`](https://github.com/NixOS/nixpkgs/commit/a16d05931dbdad7245e45674906c4a16d3e7b8af) | `` fittrackee: 0.11.2 -> 1.3.3 ``                                                     |
| [`a73b3784`](https://github.com/NixOS/nixpkgs/commit/a73b37840cc2d97bedd8f78411fab8daa10b1f5a) | `` python3Packages.periodiq: 0.13.0 -> 0.14.0 ``                                      |
| [`e44b628f`](https://github.com/NixOS/nixpkgs/commit/e44b628f92c414d4be04ea1c0d66f807997155f3) | `` python3Packages.flask-dramatiq: 0.6.0 -> 0.8.0 ``                                  |
| [`d83946a9`](https://github.com/NixOS/nixpkgs/commit/d83946a9eea65310a994032c78c77a2ef1aa0a6f) | `` forgejo: remove unused coreutils from nativeCheckInputs ``                         |
| [`64cd191c`](https://github.com/NixOS/nixpkgs/commit/64cd191c4fa39e00955c18eee9c76d6127003258) | `` terraform-providers.linode_linode: 3.14.1 -> 4.1.0 ``                              |
| [`d26e3830`](https://github.com/NixOS/nixpkgs/commit/d26e383033c4298d2fa870c40ae5a1a0ac8174b5) | `` sable-unwrapped: 1.19.4 -> 1.20.0 ``                                               |
| [`3b914e70`](https://github.com/NixOS/nixpkgs/commit/3b914e7044d4eb6342cfb11787fee368b20a27bc) | `` jsonschema-cli: 0.47.0 -> 0.48.0 ``                                                |
| [`3f8ce589`](https://github.com/NixOS/nixpkgs/commit/3f8ce5894508cc1b688f612930b1d5e2d0e16ec3) | `` terraform-providers.checkly_checkly: 1.25.0 -> 1.26.0 ``                           |
| [`5ae52c6f`](https://github.com/NixOS/nixpkgs/commit/5ae52c6fdec751544345ee70fd23c7a941ff1037) | `` antigravity-cli: 1.0.12 -> 1.1.4 ``                                                |
| [`beb90090`](https://github.com/NixOS/nixpkgs/commit/beb90090d4f85b507e1f723ac60d05dff5b1c950) | `` kiro-cli: 2.10.0 -> 2.13.0 ``                                                      |
| [`71fc9a14`](https://github.com/NixOS/nixpkgs/commit/71fc9a14f886342c584e9e6afac6a9222f5e4c28) | `` nzbhydra2: 8.8.5 -> 8.9.0 ``                                                       |
| [`d42e0f3b`](https://github.com/NixOS/nixpkgs/commit/d42e0f3b00c989f18c1417419d2c055ce0735d56) | `` emmylua-ls: 0.23.2 -> 0.24.0 ``                                                    |
| [`4feedf47`](https://github.com/NixOS/nixpkgs/commit/4feedf4759a8d0f2aca0993378aee871bbd2f078) | `` torrserver: 142 -> 142.1 ``                                                        |
| [`a148bdf6`](https://github.com/NixOS/nixpkgs/commit/a148bdf623f2260395d9565e7e9d61bf17d36ccf) | `` mcp-server-time: 2026.7.4 -> 2026.7.10 ``                                          |
| [`7eb5f481`](https://github.com/NixOS/nixpkgs/commit/7eb5f481468cdd1f3bf5a84b43b0c059ee2c3fac) | `` ci/github-script/bot: label llm-assisted PRs accordingly ``                        |
| [`0cf4096e`](https://github.com/NixOS/nixpkgs/commit/0cf4096e7449ca842652dda3bd915a84ebc8b1b2) | `` mcp-server-git: 2026.7.4 -> 2026.7.10 ``                                           |
| [`92ce29c5`](https://github.com/NixOS/nixpkgs/commit/92ce29c58df72f0b737ced02edd128b3da7c824c) | `` wayshot: add manpages ``                                                           |
| [`aca662a1`](https://github.com/NixOS/nixpkgs/commit/aca662a1f35cc41facf3c5177b17cbf4fad92573) | `` dua: 2.37.1 -> 2.38.0 ``                                                           |
| [`00627c1b`](https://github.com/NixOS/nixpkgs/commit/00627c1b9f5a279c077a9dfdcc5b79c8d135be29) | `` forgejo: 15.0.5 -> 16.0.0 ``                                                       |
| [`6e9b46bf`](https://github.com/NixOS/nixpkgs/commit/6e9b46bffbebcb1dcf552fade1766a56dae3bcc1) | `` victorialogs: 1.51.0 -> 1.52.0 ``                                                  |
| [`78e61f68`](https://github.com/NixOS/nixpkgs/commit/78e61f689fb0afadfa61d01e06696abf8346724e) | `` gram: fix darwin build ``                                                          |
| [`effc841c`](https://github.com/NixOS/nixpkgs/commit/effc841c801af18c8731f4ba3e772f21d0eb5bd9) | `` nixos/userborn: fix typo ``                                                        |
| [`4316a788`](https://github.com/NixOS/nixpkgs/commit/4316a78872acb678cf045cf318b1fd3472d1964f) | `` fnox: 1.30.0 -> 1.31.0 ``                                                          |
| [`aa1aa0b6`](https://github.com/NixOS/nixpkgs/commit/aa1aa0b6949113ce8b0f48af388d306e011e646b) | `` terraform-providers.scaleway_scaleway: 2.78.0 -> 2.79.0 ``                         |
| [`dc6bb626`](https://github.com/NixOS/nixpkgs/commit/dc6bb626a1b099b90444ca684942c63cfec7bd6c) | `` libmbd: 0.14.0 -> 0.14.1 ``                                                        |
| [`0824c31d`](https://github.com/NixOS/nixpkgs/commit/0824c31d31b29e7082c119525482a1bedd4cdd21) | `` libeufin: do not override patchPhase ``                                            |
| [`cd34e10e`](https://github.com/NixOS/nixpkgs/commit/cd34e10e84dcdac4a2b5a0ea4adc41e2c2642560) | `` recyclarr: 8.6.0 -> 8.7.0 ``                                                       |
| [`b423e510`](https://github.com/NixOS/nixpkgs/commit/b423e510f58e18f8c6f5c534717ca85cc0f8a440) | `` vscode-extensions.tsandall.opa: 0.23.0 -> 0.24.1 ``                                |
| [`e095f5e3`](https://github.com/NixOS/nixpkgs/commit/e095f5e38982e4d49abb9247e66733a05a94bfcf) | `` xournalpp: 1.3.5 -> 1.3.6 ``                                                       |
| [`2ad85046`](https://github.com/NixOS/nixpkgs/commit/2ad8504644ca6c3d50dbf1b4fa200c982020d2b0) | `` walker: 2.16.2 -> 2.17.0 ``                                                        |
| [`2c6a370a`](https://github.com/NixOS/nixpkgs/commit/2c6a370ad02f6c96d384133ceafc22a05fb8badb) | `` zerofs: 2.0.6 -> 2.0.10 ``                                                         |
| [`4a990168`](https://github.com/NixOS/nixpkgs/commit/4a9901681f4a38a2d75775d15bb4b130c1129e77) | `` cudatext: 1.234.6.0 -> 1.235.0.3 ``                                                |
| [`3f659ad1`](https://github.com/NixOS/nixpkgs/commit/3f659ad1617f7235f0279fb1772311553dec217d) | `` typst: 0.15.0 -> 0.15.1 ``                                                         |
| [`5b27903a`](https://github.com/NixOS/nixpkgs/commit/5b27903a7ba8b9af743b0603a40d4dceaec44826) | `` libreswan: 5.3.1 -> 5.3.2 ``                                                       |
| [`4cf8b9a7`](https://github.com/NixOS/nixpkgs/commit/4cf8b9a7c50c1be35ac9d02359a953d274486e9d) | `` osmo-hlr: 1.9.2 -> 1.9.3 ``                                                        |
| [`215b4e25`](https://github.com/NixOS/nixpkgs/commit/215b4e25939b7c32dfbc9f3c216d09d8d58def28) | `` rocketchat-desktop: 4.15.2 -> 4.15.6 ``                                            |
| [`2030f9e1`](https://github.com/NixOS/nixpkgs/commit/2030f9e1580da96591a24aba34bbcf07e893fe7c) | `` svxlink: 25.05.1 -> 26.05 ``                                                       |
| [`cbeb9495`](https://github.com/NixOS/nixpkgs/commit/cbeb94951ff1d30851fe4271844c09e8b2445c20) | `` wpprobe: 0.12.4 -> 0.12.5 ``                                                       |
| [`1ce5a0d6`](https://github.com/NixOS/nixpkgs/commit/1ce5a0d68801183d27c2edcdf329515c4d6aacde) | `` amnezia-vpn: 4.8.19.0 -> 4.8.21.0 ``                                               |
| [`1e32bbc5`](https://github.com/NixOS/nixpkgs/commit/1e32bbc52a8ea0f461778cd4ff28980ab180b834) | `` bruijn: 0-unstable-2026-07-05 -> 0-unstable-2026-07-16 ``                          |
| [`2036e426`](https://github.com/NixOS/nixpkgs/commit/2036e426ba98cc1590114f9b064cc3a8a24d7171) | `` python3Packages.discogs-client: 2.8 -> 2.9 ``                                      |
| [`a077c7d5`](https://github.com/NixOS/nixpkgs/commit/a077c7d5a2f1185c19f88f97ccb1eff618d02036) | `` ungoogled-chromium: 150.0.7871.124-1 -> 150.0.7871.128-1 ``                        |
| [`c571adae`](https://github.com/NixOS/nixpkgs/commit/c571adaefb071b8f9a08cbf1e7343153d1288019) | `` nixos/sshd: remove 'moduliFile' option, in favour of settings.ModuliFile ``        |
| [`631a2a5c`](https://github.com/NixOS/nixpkgs/commit/631a2a5cfd4701d50ec20975c0e70ae008983776) | `` terraform-providers.selectel_selectel: 8.2.1 -> 8.2.3 ``                           |
| [`aa8931bd`](https://github.com/NixOS/nixpkgs/commit/aa8931bdd5c85a90bd8d96af85b7a634a89fe7ea) | `` qownnotes: 26.7.3 -> 26.7.7 ``                                                     |
| [`ab3d0981`](https://github.com/NixOS/nixpkgs/commit/ab3d098139bec2061f370240fd75dffb2064c584) | `` dezoomify-rs: 2.16.0 -> 2.17.0 ``                                                  |
| [`1f3fb1a2`](https://github.com/NixOS/nixpkgs/commit/1f3fb1a2ba518419021f4ac58be20d7dffe94b69) | `` dotter: 0.13.4 -> 0.13.5 ``                                                        |
| [`e0299355`](https://github.com/NixOS/nixpkgs/commit/e0299355540a1bba97cbaa03bf2a22d58b88ece5) | `` flood: 4.14.2 -> 4.15.0 ``                                                         |
| [`8d766b34`](https://github.com/NixOS/nixpkgs/commit/8d766b34fc65ebb89e5a6febdc433b86ffa4dd2f) | `` terraform-providers.vultr_vultr: 2.31.2 -> 2.32.0 ``                               |
| [`4079c662`](https://github.com/NixOS/nixpkgs/commit/4079c662ce0baa053b3427c86b1315afb1c6c303) | `` razer-cli: 2.3.0 -> 2.3.1 ``                                                       |
| [`750770bc`](https://github.com/NixOS/nixpkgs/commit/750770bcfe61cc544ed2275af3c6c6974d05cc21) | `` openocd: use jimtcl 0.82 ``                                                        |
| [`71c1b60d`](https://github.com/NixOS/nixpkgs/commit/71c1b60da5986c855b8b225e92a50cd3aa858e77) | `` jimtcl: 0.82 -> 0.84 ``                                                            |
| [`4678fe9c`](https://github.com/NixOS/nixpkgs/commit/4678fe9cd8f389bfd3c4ad251d1a01db0f23b913) | `` hydralauncher: 4.0.4 -> 4.0.5 ``                                                   |
| [`50771fa1`](https://github.com/NixOS/nixpkgs/commit/50771fa1d96431971d1f8eeefef69ef2d9012e68) | `` direwolf-unstable: 1.8.1-unstable-2026-07-06 -> 1.8.1-unstable-2026-07-16 ``       |
| [`4724778e`](https://github.com/NixOS/nixpkgs/commit/4724778e8ead0833af15aaeffba3ca56db4ee5b3) | `` apidog: 2.8.36 -> 2.8.38 ``                                                        |
| [`abb7950c`](https://github.com/NixOS/nixpkgs/commit/abb7950c853e8b63935efcc2e0f7ae24bce61755) | `` hasciicam: 2.5.0 -> 2.6.0 ``                                                       |
| [`298dc41c`](https://github.com/NixOS/nixpkgs/commit/298dc41cc61685e46b5d14e7c9769a4763ecf4d7) | `` python3Packages.clarifai-grpc: 12.5.1 -> 12.6.0 ``                                 |
| [`dda0d2a2`](https://github.com/NixOS/nixpkgs/commit/dda0d2a27b98233a3803366b26bc0d4ba1f439a2) | `` see-cat: 0.9.2 -> 0.10.0 ``                                                        |
| [`7dbe7817`](https://github.com/NixOS/nixpkgs/commit/7dbe7817e4250fc1bfffc8f4c813ea4d788300cf) | `` dblab: 0.43.0 -> 0.44.1 ``                                                         |
| [`c17259da`](https://github.com/NixOS/nixpkgs/commit/c17259daaa38947c66c7d24a201ac8bb81c99945) | `` fricas: cleanup configurePhase ``                                                  |
| [`cfb1ce17`](https://github.com/NixOS/nixpkgs/commit/cfb1ce17c0bda0b5a9a53a19f6abacbcf6dab08b) | `` dolt: 2.1.11 -> 2.2.1 ``                                                           |
| [`2016d270`](https://github.com/NixOS/nixpkgs/commit/2016d2705d6428b57d8ee5ab54b89eccd4e56db8) | `` fricas: 1.3.12 -> 1.3.13 ``                                                        |
| [`42f25b4b`](https://github.com/NixOS/nixpkgs/commit/42f25b4b653b2ec198b3856db7fee9a3ccc8a1a5) | `` tailwindcss_4: 4.3.2 -> 4.3.3 ``                                                   |
| [`83c9ad52`](https://github.com/NixOS/nixpkgs/commit/83c9ad52ff6e9247b70da69634e691394a6d0485) | `` androidStudioPackages.canary: 2026.1.3.3 -> 2026.1.4.1 ``                          |
| [`0bf650c1`](https://github.com/NixOS/nixpkgs/commit/0bf650c1e8d1507f69e4eadc8e940b8c871f6d5f) | `` mcp-server-fetch: 2026.7.4 -> 2026.7.10 ``                                         |
| [`ca5bd428`](https://github.com/NixOS/nixpkgs/commit/ca5bd42822d1fb23931f774961d352864d10ed19) | `` ytdl-sub: 2026.06.23 -> 2026.07.16 ``                                              |
| [`8bc54dc0`](https://github.com/NixOS/nixpkgs/commit/8bc54dc05f57da1b69f03631dd655d6f71994b7f) | `` censor: 0.7.2 -> 0.8.0 ``                                                          |
| [`12c6e8c1`](https://github.com/NixOS/nixpkgs/commit/12c6e8c1c2384921c2e6e0385ea2a2d29a73ac09) | `` python3Packages.tencentcloud-sdk-python: 3.1.133 -> 3.1.135 ``                     |
| [`41c9ec1e`](https://github.com/NixOS/nixpkgs/commit/41c9ec1e3ecca43599a9779b6a3471e8cfe593e0) | `` python313Packages.iamdata: 0.1.202607151 -> 0.1.202607171 ``                       |
| [`16ed2b93`](https://github.com/NixOS/nixpkgs/commit/16ed2b9336e01dfb248ed0f70f4dcda0976c3735) | `` python3Packages.boschshcpy: 0.4.12 -> 0.6.2 ``                                     |
| [`d765b046`](https://github.com/NixOS/nixpkgs/commit/d765b04680dc10c0dbd59aa8d0944d6f9b05c5bf) | `` python313Packages.boschshcpy: 0.4.8 -> 0.4.12 ``                                   |
| [`d9eba364`](https://github.com/NixOS/nixpkgs/commit/d9eba364faacac8b832e5ac916d3852b5e5f6455) | `` cynthion: build gateware bitstreams and moondancer firmware ``                     |
| [`615937a2`](https://github.com/NixOS/nixpkgs/commit/615937a234bff4436d917d01bbb80ef98db23ba0) | `` luna-soc: fix CSR register field collection on Python 3.14 ``                      |
| [`e58e0e8c`](https://github.com/NixOS/nixpkgs/commit/e58e0e8cfb1aab48dcbcaa9bb288311c4d8ee79a) | `` rust: add riscv32-none target platform ``                                          |
| [`dc7e7baf`](https://github.com/NixOS/nixpkgs/commit/dc7e7baf4790f01c937204f8c96107624eeb64a4) | `` rtklib-ex: 2.5.0 -> 2.5.1 ``                                                       |
| [`8a69e6e0`](https://github.com/NixOS/nixpkgs/commit/8a69e6e08a08bc8f0b0f95c34c4459afc7e56c1a) | `` pkgsite: 0.2.0-unstable-2026-07-07 -> 0.3.0-unstable-2026-07-16 ``                 |
| [`474bfcef`](https://github.com/NixOS/nixpkgs/commit/474bfcef861584a919380be6a2f22a19e6807a96) | `` fake-gcs-server: 1.54.0 -> 1.55.0 ``                                               |
| [`b7e5c56a`](https://github.com/NixOS/nixpkgs/commit/b7e5c56a202f9b34918bce4763ca99e8429ea264) | `` acme-sh: 3.1.3 -> 3.1.4 ``                                                         |
| [`49b1862f`](https://github.com/NixOS/nixpkgs/commit/49b1862f30e37123c78ea927abf7970e1e5bfc07) | `` carapace-bridge: 1.6.1 -> 1.6.2 ``                                                 |
| [`750e2545`](https://github.com/NixOS/nixpkgs/commit/750e2545166964a74f702f7b4d110ceb3fd8b347) | `` bandcampsync: init at 0.8.0 ``                                                     |
| [`65c0f67b`](https://github.com/NixOS/nixpkgs/commit/65c0f67b10df487e87ce278a61a70aa6f0326d32) | `` vscode-extensions.anthropic.claude-code: 2.1.211 -> 2.1.212 ``                     |
| [`a5626b2f`](https://github.com/NixOS/nixpkgs/commit/a5626b2f1d48f195ab988e84e73ee2ad296bf6b7) | `` claude-code: 2.1.211 -> 2.1.212 ``                                                 |
| [`d4a04ddf`](https://github.com/NixOS/nixpkgs/commit/d4a04ddf5c440ea1ed859cc7719994c01caa76a1) | `` python3Packages.generic: use finalAttrs ``                                         |
| [`828c2776`](https://github.com/NixOS/nixpkgs/commit/828c277614edbb6e81cf1ccdcec847b1eb31396e) | `` autobrr: 1.81.0 -> 1.82.1 ``                                                       |
| [`eb6577f5`](https://github.com/NixOS/nixpkgs/commit/eb6577f5d5e988227ddf049b45a6964374ba19d5) | `` pvz-portable-unwrapped: 0.1.26 -> 0.1.27 ``                                        |
| [`5c485513`](https://github.com/NixOS/nixpkgs/commit/5c485513ee1d4bcfa7ecfd6564a17d3633afc7fa) | `` fresh-editor: 0.4.3 -> 0.4.4 ``                                                    |
| [`7b61c464`](https://github.com/NixOS/nixpkgs/commit/7b61c46426fe468a9b3b4d38ac912685c6251ea2) | `` grafana-alloy: 1.16.0 -> 1.17.1 ``                                                 |
| [`3de3f9ca`](https://github.com/NixOS/nixpkgs/commit/3de3f9caeeba550e7b51143193f9f1ea87e5431d) | `` fluxcd-operator: 0.54.0 -> 0.55.0 ``                                               |
| [`e6ab1a35`](https://github.com/NixOS/nixpkgs/commit/e6ab1a35dae78db38d01cdb74226b108756a8377) | `` tt-smi: 5.3.1 -> 6.0.0 ``                                                          |
| [`31252e5c`](https://github.com/NixOS/nixpkgs/commit/31252e5c081680bb4caa33082c0981659f90a9e5) | `` mpg123: move to by-name/ ``                                                        |
| [`a9fe53ff`](https://github.com/NixOS/nixpkgs/commit/a9fe53ff7228d4f7c8c91307f8f416de4404ed90) | `` tree-sitter-grammars.tree-sitter-elm: 5.9.2 -> 5.9.4 ``                            |
| [`bf13b635`](https://github.com/NixOS/nixpkgs/commit/bf13b635d62ab5c45b2a805baf141001f1924e93) | `` fluxcd: 2.9.1 -> 2.9.2 ``                                                          |
| [`424d39ac`](https://github.com/NixOS/nixpkgs/commit/424d39ac5625e5025852e94b131bcc5f34664e43) | `` redpanda-client: 26.1.12 -> 26.1.13 ``                                             |
| [`4dac83ea`](https://github.com/NixOS/nixpkgs/commit/4dac83eae3bb6ace8021afcc6d55d2775bd7737b) | `` pomerium-cli: 0.32.2 -> 0.33.0 ``                                                  |
| [`8236cf26`](https://github.com/NixOS/nixpkgs/commit/8236cf26cde7bf3638de8bb68f5cdf8d4c69e5eb) | `` python3Packages.glean-sdk: mark broken ``                                          |
| [`db547987`](https://github.com/NixOS/nixpkgs/commit/db5479873095f4d155aa2aeac720be87ff8d1593) | `` steam-unwrapped: 1.0.0.85 -> 1.0.0.87 ``                                           |
| [`a221e35f`](https://github.com/NixOS/nixpkgs/commit/a221e35fa8e1270b2a0a520d33b4d31f4cb50455) | `` pmtiles: 1.31.0 -> 1.31.1 ``                                                       |
| [`2d0d4abb`](https://github.com/NixOS/nixpkgs/commit/2d0d4abb1aea2125e78dd2ef44b4a3bfa1e99dfc) | `` libretro.beetle-pce-fast: 0-unstable-2026-07-03 -> 0-unstable-2026-07-10 ``        |
| [`cf40341c`](https://github.com/NixOS/nixpkgs/commit/cf40341cfab320a5ecee477acf7dedf405005bcd) | `` teehee: modernize slightly ``                                                      |
| [`29fc7971`](https://github.com/NixOS/nixpkgs/commit/29fc7971a446c8eef85b328796ddedc2420494bc) | `` google-chrome: 150.0.7871.124 -> 150.0.7871.128 ``                                 |
| [`bc98e604`](https://github.com/NixOS/nixpkgs/commit/bc98e6046d5817b41831d976adb0077165c1e43d) | `` models-dev: sdk-v0.0.5-unstable-2026-07-07 -> sdk-v0.0.5-unstable-2026-07-17 ``    |
| [`14448131`](https://github.com/NixOS/nixpkgs/commit/14448131882747fe76a797c6d5551227acb8135b) | `` broot: 1.57.0 -> 1.58.0 ``                                                         |
| [`1b0fdf09`](https://github.com/NixOS/nixpkgs/commit/1b0fdf096c357ea62bd53d14b711112aebb65724) | `` herdr: 0.7.3 -> 0.7.4 ``                                                           |
| [`132f3c43`](https://github.com/NixOS/nixpkgs/commit/132f3c43c3d02a30948ad656e15bb0bc35bd2527) | `` python3Packages.stopit: fix build ``                                               |
| [`6f278e15`](https://github.com/NixOS/nixpkgs/commit/6f278e1520cd4ebf1d3fe64bffcc5164c0f9b6fb) | `` python3Packages.sentry-sdk: 2.64.0 -> 2.66.0 ``                                    |
| [`5f7f60ba`](https://github.com/NixOS/nixpkgs/commit/5f7f60bad7ef0c06171a07be606089e057f73446) | `` python3Packages.pydantic-ai-slim: 2.8.0 -> 2.11.0 ``                               |
| [`901d83dc`](https://github.com/NixOS/nixpkgs/commit/901d83dcd72407ec343aa59567415cf277b5bad8) | `` python3Packages.pydantic-graph: 2.8.0 -> 2.11.0 ``                                 |
| [`5d33618f`](https://github.com/NixOS/nixpkgs/commit/5d33618f8a97f5562261e33443f335908e71e375) | `` python3Packages.gcsa: 2.6.0 -> 2.7.0 ``                                            |
| [`94a5ed62`](https://github.com/NixOS/nixpkgs/commit/94a5ed626668a4e102f0559dd5b2d32b89b082c6) | `` radare2: 6.1.4 -> 6.1.8 ``                                                         |
| [`aa90ff5c`](https://github.com/NixOS/nixpkgs/commit/aa90ff5c1f6515463f795da8c5d67279a7ae8315) | `` python3Packages.modbus-connection: 3.6.0 -> 3.7.0 ``                               |
| [`e97ff549`](https://github.com/NixOS/nixpkgs/commit/e97ff5490baa7c39f7cb8683791596e214c0375c) | `` blackfire: 2026.6.1 -> 2026.7.0 ``                                                 |
| [`2d22cda7`](https://github.com/NixOS/nixpkgs/commit/2d22cda774b6faf93f92b1c90bb89e3759f2fb51) | `` libphonenumber: 9.0.34 -> 9.0.35 ``                                                |
| [`2f0f7706`](https://github.com/NixOS/nixpkgs/commit/2f0f770617f9b33e42616f3867defcf9f6f08226) | `` python3Packages.vallox-websocket-api: 6.0.0 -> 6.1.0 ``                            |
| [`14ef7806`](https://github.com/NixOS/nixpkgs/commit/14ef780695b27cffa727de1a1860f264e3a178e8) | `` coc-rust-analyzer: 0-unstable-2026-07-01 -> 0-unstable-2026-07-14 ``               |
| [`86292d1b`](https://github.com/NixOS/nixpkgs/commit/86292d1b1adce9c4daf2959c661b1d2d106ed3f4) | `` chromium,chromedriver: 150.0.7871.124 -> 150.0.7871.128 ``                         |
| [`83db2e47`](https://github.com/NixOS/nixpkgs/commit/83db2e4722b6c4ecb791b3386c77a9bedefc42b9) | `` python3Packages.ocrmypdf: use finalAttrs ``                                        |
| [`9d14bb8f`](https://github.com/NixOS/nixpkgs/commit/9d14bb8ff82b091acf8f4155ff808035676db43a) | `` python3Packages.ocrmypdf: 17.8.0 -> 17.8.1 ``                                      |
| [`c4c199df`](https://github.com/NixOS/nixpkgs/commit/c4c199dfbb53bb8ec038c81630f7c1bc4342e0be) | `` clipnotify: fix version scheme ``                                                  |
| [`3368852e`](https://github.com/NixOS/nixpkgs/commit/3368852e7f4a906e6def25895319a3419f56c4d4) | `` doc: add NFS file systems documentation ``                                         |
| [`830113ef`](https://github.com/NixOS/nixpkgs/commit/830113efa8f4fe14a5363422474fb926f9db84ca) | `` mergiraf: 0.17.0 -> 0.18.0 ``                                                      |
| [`e85ee319`](https://github.com/NixOS/nixpkgs/commit/e85ee3197471a1fec6b4eb92c14d6cf400738f8b) | `` cc-token: fix version scheme ``                                                    |
| [`f33fb952`](https://github.com/NixOS/nixpkgs/commit/f33fb952cd6b0291150ad358221711b68da90cbe) | `` userborn: 0.5.0 -> 1.0.0 ``                                                        |
| [`ca4408c1`](https://github.com/NixOS/nixpkgs/commit/ca4408c11878746739f7d361122218569d9be67a) | `` Revert "nix-eval-jobs: 2.34.3 -> 2.35.0" ``                                        |
| [`7d016a42`](https://github.com/NixOS/nixpkgs/commit/7d016a42b8339f7e3843ab5b71b472656f37c42c) | `` aliyun-cli: 3.4.5 -> 3.4.7 ``                                                      |
| [`8408aabb`](https://github.com/NixOS/nixpkgs/commit/8408aabbfd4817203f1bf824c48d564c55ad1376) | `` python3Packages.amply: migrate to pyproject ``                                     |
| [`faded7ba`](https://github.com/NixOS/nixpkgs/commit/faded7ba04970a70f84a14d36099747ea88721b9) | `` vscode-extensions.saoudrizwan.claude-dev: 3.89.2 -> 4.0.8 ``                       |
| [`b6595a15`](https://github.com/NixOS/nixpkgs/commit/b6595a154173206ea04ecc8211b0eb1a45b8eeb5) | `` chkcrontab: inline with usage ``                                                   |
| [`630ad224`](https://github.com/NixOS/nixpkgs/commit/630ad2247768b3019568bd7439567a28f458f87b) | `` gdscript-formatter: 0.20.1 -> 0.21.0 ``                                            |
| [`9a9e2dc9`](https://github.com/NixOS/nixpkgs/commit/9a9e2dc9c575de2ac59de9166160bb13601ce6a5) | `` postgresqlPackages.timescaledb-apache: 2.28.2 -> 2.28.3 ``                         |
| [`2c4d8909`](https://github.com/NixOS/nixpkgs/commit/2c4d8909a933c8d8a8069c1268ca9eae721203a1) | `` shaarli: 0.16.1 -> 0.16.3 ``                                                       |
| [`62ced583`](https://github.com/NixOS/nixpkgs/commit/62ced583e53c569966b9132736b1b98c9f0ae3e8) | `` pipeweaver: 0.1.6 -> 0.1.9 ``                                                      |
| [`6c8de6f8`](https://github.com/NixOS/nixpkgs/commit/6c8de6f8b208257e05dd6a4a85f9190c54bfa2ec) | `` python3Packages.fastai: 2.8.6 -> 2.8.7 ``                                          |
| [`391c0a2c`](https://github.com/NixOS/nixpkgs/commit/391c0a2c09d0c8ae945287689e984a607c77e71f) | `` python3Packages.fasttransform: init at 0.0.2 ``                                    |
| [`5612eefc`](https://github.com/NixOS/nixpkgs/commit/5612eefc08d203a004ae748eea379301818f6a55) | `` python3Packages.plum-dispatch: init at 2.9.0 ``                                    |
| [`3a707e29`](https://github.com/NixOS/nixpkgs/commit/3a707e29d60d524e46fb1c3cae8cac45b9dc7a96) | `` glasgow: print error message in case of firmware mismatch ``                       |
| [`238fe5c7`](https://github.com/NixOS/nixpkgs/commit/238fe5c7da8da1d1ed43bcddea729fd83fb2b602) | `` python3Packages.manga-ocr: 0.1.14 -> 0.1.15 ``                                     |
| [`5ea8afe1`](https://github.com/NixOS/nixpkgs/commit/5ea8afe11a0311707f3c47f822ebe7a6760618ab) | `` buildkit: 0.31.1 -> 0.31.2 ``                                                      |
| [`6c47bd4d`](https://github.com/NixOS/nixpkgs/commit/6c47bd4d28b4d15c11a94c6598139bf487b1e816) | `` python3Packages.fastdownload: cleanup, fix ``                                      |
| [`d2e98592`](https://github.com/NixOS/nixpkgs/commit/d2e9859262bf98362e474a90724bf68b9858d8b1) | `` cog: 0.1.22 -> 0.1.23 ``                                                           |
| [`90b88cce`](https://github.com/NixOS/nixpkgs/commit/90b88cce0cde2cb755921f2aabd6765dd8cd0cdc) | `` minikube: Add withVfkit parameter ``                                               |
| [`b64d5151`](https://github.com/NixOS/nixpkgs/commit/b64d5151976f905a7465bab9ac6e27c2a35cfcc0) | `` minikube: Fix darwin build by adding LD_LIBRARY_PATH prefix only on Linux ``       |
| [`ffb5b4b0`](https://github.com/NixOS/nixpkgs/commit/ffb5b4b00089f53578e47d4030d8f62cf2960fdc) | `` firefox-devedition-unwrapped: 153.0b11 -> 153.0b13 ``                              |
| [`f4f8338f`](https://github.com/NixOS/nixpkgs/commit/f4f8338f0eed090c91b59755ddd1b6a8f8d965ad) | `` Revert "buildMozillaMach: backport BZ 2047651 patch for 153" ``                    |
| [`38de0900`](https://github.com/NixOS/nixpkgs/commit/38de0900df94ab0de033923d7359107403910b1e) | `` firefox-beta-unwrapped: 152.0b10 -> 153.0b13 ``                                    |
| [`06840591`](https://github.com/NixOS/nixpkgs/commit/06840591deb34431eb3a03e04773f4de195770db) | `` postgresqlPackages.pgsql-http: 1.7.1 -> 1.7.2 ``                                   |
| [`e97166c7`](https://github.com/NixOS/nixpkgs/commit/e97166c7b0913eaffd21e04ffb05af2402d6fb30) | `` python3Packages.stanza: 1.13.0 -> 1.14.0 ``                                        |
| [`7611b0cb`](https://github.com/NixOS/nixpkgs/commit/7611b0cb303dbf764062c8a86ec093762fcd06d6) | `` csharp-ls: 0.25.0 -> 0.26.0 ``                                                     |
| [`5422674d`](https://github.com/NixOS/nixpkgs/commit/5422674d2cf939f727e53d5a9df63276f819bb74) | `` minikube: add prefix PATH to wrapped minikube when building with qemu ``           |
| [`a12cc3fd`](https://github.com/NixOS/nixpkgs/commit/a12cc3fd0161d847897e3280830da9acb7077e00) | `` nu_scripts: 0-unstable-2026-07-02 -> 0-unstable-2026-07-15 ``                      |
| [`901e7310`](https://github.com/NixOS/nixpkgs/commit/901e731042584af2e97bb3b1804e863ea946ea57) | `` minikube: simplify installation of shell completion ``                             |
| [`24580f43`](https://github.com/NixOS/nixpkgs/commit/24580f4373665d329a7b5cac07e42931f7ca9abc) | `` minikube: Use recommened --replace-fail option with substituteInPlace ``           |
| [`3b9dc345`](https://github.com/NixOS/nixpkgs/commit/3b9dc345d637620cd137ec6c9adaf9444e828659) | `` nufmt: 0-unstable-2026-07-05 -> 0-unstable-2026-07-16 ``                           |
| [`ad43266f`](https://github.com/NixOS/nixpkgs/commit/ad43266fcade57132d0e74fe724703621299bc72) | `` home-assistant: update component packages ``                                       |
| [`0941abff`](https://github.com/NixOS/nixpkgs/commit/0941abff3ca68ff53127b8b776ec9716221fe218) | `` python3Packages.greencell-client: init at 1.0.3 ``                                 |
| [`2116c17d`](https://github.com/NixOS/nixpkgs/commit/2116c17d575c0aad22bcc2e874418ce8ed6d0526) | `` glooctl: 1.21.11 -> 1.21.12 ``                                                     |
| [`5d672bbb`](https://github.com/NixOS/nixpkgs/commit/5d672bbbc59ea31cfd4ea785011b13210c2982a0) | `` roon-server: 2.67.1661 -> 2.70.1671 ``                                             |
| [`ad3a37cc`](https://github.com/NixOS/nixpkgs/commit/ad3a37cccda253e26041b0252badaca4eee7c363) | `` istioctl: 1.30.2 -> 1.30.3 ``                                                      |
| [`1acf3b04`](https://github.com/NixOS/nixpkgs/commit/1acf3b049e97abdf6eee95340e44787382cd2aa7) | `` terraform-providers.huaweicloud_huaweicloud: 1.94.0 -> 1.95.0 ``                   |
| [`7812a646`](https://github.com/NixOS/nixpkgs/commit/7812a64698104d7f86d762307097e5e0329b1e44) | `` opencode{,-desktop}: 1.17.20 -> 1.18.3 ``                                          |
| [`0b3e905b`](https://github.com/NixOS/nixpkgs/commit/0b3e905bf9e89c314ade61cbb4915d9697c8b456) | `` martin: 1.10.1 → 1.12.0 ``                                                         |
| [`2fd66d40`](https://github.com/NixOS/nixpkgs/commit/2fd66d40c7a48c9d7bb92c756f27c39104e77fae) | `` vscode-extensions.svelte.svelte-vscode: 110.2.1 -> 110.3.0 ``                      |
| [`8fb92b0a`](https://github.com/NixOS/nixpkgs/commit/8fb92b0a611678a15fc0cb8cdc23f35e788bb3d9) | `` nuclei-templates: 10.4.5 -> 10.4.6 ``                                              |
| [`4048e0a6`](https://github.com/NixOS/nixpkgs/commit/4048e0a65a90a83bec6cea87b30e48c36e7e7a3b) | `` postgresqlPackages.pg_safeupdate: 1.6-unstable-2026-06-29 -> 1.7 ``                |
| [`8eba732e`](https://github.com/NixOS/nixpkgs/commit/8eba732ecaa51ffb4c9d935809dfcce144d908d7) | `` ocamlPackages.aeneas: 2026.07.01 -> 2026.07.16-bc2eb6f ``                          |
| [`5349cbc9`](https://github.com/NixOS/nixpkgs/commit/5349cbc9bb06a6e7fdf11a93daed79d58a22b5a2) | `` ocamlPackages.charon: 2026.07.01 -> 2026.07.16 ``                                  |
| [`0d685d49`](https://github.com/NixOS/nixpkgs/commit/0d685d4908d048190d51ba4a72b8f57b15e14343) | `` citrix-workspace: fix icaroot passthru ``                                          |
| [`eed21873`](https://github.com/NixOS/nixpkgs/commit/eed21873ad308522389e1c4944c0647592ae4fa8) | `` yashiki: add Br1ght0ne to maintainers ``                                           |
| [`1a74923e`](https://github.com/NixOS/nixpkgs/commit/1a74923ede6d804d7e6f5c27790465bf69aa3ce3) | `` yashiki: 0.14.0 -> 0.15.2 ``                                                       |
| [`8c480310`](https://github.com/NixOS/nixpkgs/commit/8c4803105f25eb444889863a6fefd579b89fd03e) | `` bomly: 0.16.1 -> 0.18.0 ``                                                         |
| [`c75351ac`](https://github.com/NixOS/nixpkgs/commit/c75351ac7958f70a8fa6ad251419fbade994e877) | `` zennotes-desktop: 2.13.3 -> 2.13.5 ``                                              |
| [`a468bacd`](https://github.com/NixOS/nixpkgs/commit/a468bacd7deccf0f8c5435221e6d5fccfb278aee) | `` kanarenshu: 0.1.1 -> 0.1.4 ``                                                      |
| [`c0ba1b68`](https://github.com/NixOS/nixpkgs/commit/c0ba1b6842ff3ead5fbd5998ca7d92df6608694f) | `` mcelog: 211 -> 212 ``                                                              |
| [`7d7f1a08`](https://github.com/NixOS/nixpkgs/commit/7d7f1a08ac7f30faf3060eb88d9a24d039154749) | `` par-lang: 0-unstable-2026-06-24 -> 0-unstable-2026-07-15 ``                        |
| [`7add644c`](https://github.com/NixOS/nixpkgs/commit/7add644c033afec1cb013f143b8c201fc7ecf653) | `` regal: 0.41.1 -> 0.42.0 ``                                                         |
| [`fee76ef0`](https://github.com/NixOS/nixpkgs/commit/fee76ef093078cb94cf9c37aa7de32f7536265f8) | `` jetbrains-toolbox: 3.6.1.85592 -> 3.6.2.85969 ``                                   |
| [`b4e645d4`](https://github.com/NixOS/nixpkgs/commit/b4e645d4937d1be79c3b00e2cb3c0b5e23b0e5c2) | `` libretro.stella: 0-unstable-2026-06-28 -> 0-unstable-2026-07-16 ``                 |
| [`4c2ba5f8`](https://github.com/NixOS/nixpkgs/commit/4c2ba5f85cb450346c020e8c05a73cbe7f9684fa) | `` spotatui: 0.40.1 -> 0.40.2 ``                                                      |
| [`631700ad`](https://github.com/NixOS/nixpkgs/commit/631700aded9b426f4e8807e86c8c1536c86f91c2) | `` python3Packages.elevenlabs: 2.56.0 -> 2.58.0 ``                                    |
| [`da563ef1`](https://github.com/NixOS/nixpkgs/commit/da563ef16172476bc6ef79a69b014640fb427ae0) | `` mcp-grafana: 0.17.1 -> 0.17.2 ``                                                   |
| [`2dc8ac25`](https://github.com/NixOS/nixpkgs/commit/2dc8ac259367fa3929412024b53570fc99054858) | `` python3Packages.inventree: fix dependencies ``                                     |
| [`ea0ab2ea`](https://github.com/NixOS/nixpkgs/commit/ea0ab2eac441daa211581c5b5e071975aebecf79) | `` autopush-rs: 1.82.1 -> 1.82.2 ``                                                   |
| [`146b1e27`](https://github.com/NixOS/nixpkgs/commit/146b1e2702c38ab8dcd4037952fd4b1479a212c4) | `` pnpm: 11.11.0 -> 11.13.1 ``                                                        |
| [`9d7f8062`](https://github.com/NixOS/nixpkgs/commit/9d7f8062fd1d8cba2d3758e88bbb668e38f4e3d1) | `` tutanota-desktop: 353.260630.0 -> 355.260710.0 ``                                  |
| [`799cd29f`](https://github.com/NixOS/nixpkgs/commit/799cd29f25eb0decfb941e95283aeb183fda251b) | `` argocd: 3.4.4 -> 3.4.5 ``                                                          |
| [`85a93bcb`](https://github.com/NixOS/nixpkgs/commit/85a93bcb9eb7c3e0c04b731af2b8f75656fcc4b3) | `` biome: 2.5.0 -> 2.5.4 ``                                                           |
| [`2a16da6f`](https://github.com/NixOS/nixpkgs/commit/2a16da6f0b24abab9aeb977a48111a5f9402baba) | `` mimir: remove adamcstephens as maintainer ``                                       |
| [`72f5048d`](https://github.com/NixOS/nixpkgs/commit/72f5048d567d34839d7d7cfa5baf451e58895af9) | `` python3Packages.paho-mqtt: use upstream patch for generating SSL certs ``          |
| [`d9ab107c`](https://github.com/NixOS/nixpkgs/commit/d9ab107c28c81fdf400b85bd351a06b6c50ee395) | `` mimir: 3.1.2 -> 3.1.3 ``                                                           |
| [`e4946acf`](https://github.com/NixOS/nixpkgs/commit/e4946acfec6bfe82b2a62e61776c60860f3b80c0) | `` elephant: 2.21.0 -> 2.22.0 ``                                                      |
| [`cb0155c3`](https://github.com/NixOS/nixpkgs/commit/cb0155c34e05c17d11911463666ea4ecb8de3367) | `` mas: add updateScript ``                                                           |
| [`c790223a`](https://github.com/NixOS/nixpkgs/commit/c790223a69627a1228408a0ca7fac106c87e724a) | `` pyfa: 2.67.0 -> 2.68.0 ``                                                          |
| [`2267e8a5`](https://github.com/NixOS/nixpkgs/commit/2267e8a541284ffc1b50f726aff07de67e3cde06) | `` sage: work around ipython and scipy regressions ``                                 |
| [`31ab8f0d`](https://github.com/NixOS/nixpkgs/commit/31ab8f0df3651f5a6a61c110bb7547d727e854f1) | `` owmods-gui: 0.15.6 -> 0.15.7 ``                                                    |
| [`0f41d748`](https://github.com/NixOS/nixpkgs/commit/0f41d748ea37ef58b948f1ac06094921f51d6c87) | `` herdr: add shell completions ``                                                    |
| [`0454542a`](https://github.com/NixOS/nixpkgs/commit/0454542a18d8945babf66f2ed4d2fb9bf37a9b37) | `` karate: 2.1.0 -> 2.1.1 ``                                                          |
| [`4596ab92`](https://github.com/NixOS/nixpkgs/commit/4596ab92394e69a5553387a7ba7fdd3ff2152ae4) | `` pi-coding-agent: 0.80.7 -> 0.80.8 ``                                               |
| [`0b3dea1c`](https://github.com/NixOS/nixpkgs/commit/0b3dea1c3f8a26f81837ef31db943445f464431e) | `` python3Packages.pysigma-backend-sqlite: 1.1.3 -> 1.2.0 ``                          |
| [`c8055bf4`](https://github.com/NixOS/nixpkgs/commit/c8055bf4329756debe449ef8cfaeefe1065fdbb8) | `` cutecosmic: 0.1-unstable-2026-03-25 -> 0.1-unstable-2026-07-11 ``                  |
| [`ed63bc54`](https://github.com/NixOS/nixpkgs/commit/ed63bc544bf85cf825326d794e8634945de1583f) | `` protonup-rs: 0.12.2 -> 0.14.0 ``                                                   |
| [`a2df4305`](https://github.com/NixOS/nixpkgs/commit/a2df430578412e2157e5729a03516a602972adfc) | `` python3Packages.aiosomecomfort: 0.0.37 -> 0.0.38 ``                                |
| [`7d51e81a`](https://github.com/NixOS/nixpkgs/commit/7d51e81aab159c2076b44b8362714a65c9135d0d) | `` rcp: 0.36.0 -> 0.37.0 ``                                                           |
| [`767e694c`](https://github.com/NixOS/nixpkgs/commit/767e694c18923bb94aed604aedc26f23a0a6f60b) | `` vscode-extensions.databricks.databricks: 2.12.1 -> 2.12.3 ``                       |
| [`45d3f8a5`](https://github.com/NixOS/nixpkgs/commit/45d3f8a556372563769f52efbb4e5753246a8816) | `` afew: use build-system, dependencies ``                                            |
| [`f6a85571`](https://github.com/NixOS/nixpkgs/commit/f6a8557194015f5152637b00d17232ccb302f60e) | `` afew: 4.0.0 -> 4.0.1 ``                                                            |
| [`ba84bc11`](https://github.com/NixOS/nixpkgs/commit/ba84bc11c4f0721bb8e874e9644e495dce883f65) | `` afew: 3.0.1 -> 4.0.0 ``                                                            |
| [`0e3b5005`](https://github.com/NixOS/nixpkgs/commit/0e3b50058626e27787422d241efcf75416aecd5d) | `` terraform-providers.temporalio_temporalcloud: 1.5.0 -> 1.6.0 ``                    |
| [`2dad175f`](https://github.com/NixOS/nixpkgs/commit/2dad175f41836b019ba34a40c8a762b214acc4d0) | `` vimPlugins.bitbake: 6.0.1 -> 6.0.2 ``                                              |
| [`1e213b72`](https://github.com/NixOS/nixpkgs/commit/1e213b72729fd03777973819836a3609c77eb2d3) | `` vimPlugins.command-t: 8.1 -> 8.2 ``                                                |
| [`75b92863`](https://github.com/NixOS/nixpkgs/commit/75b92863ae36bc61270180f585091aa9357887ce) | `` vimPlugins.typst-preview-nvim: 1.4.2-unstable -> 1.5.0 ``                          |
| [`bebc151d`](https://github.com/NixOS/nixpkgs/commit/bebc151d6a42cd3db4b76c81bde80eb010e520b1) | `` vimPlugins.vague-nvim: 2.1.3 -> 2.1.4 ``                                           |
| [`1832ac1a`](https://github.com/NixOS/nixpkgs/commit/1832ac1ae314de31e6783ae0047ce02de8f827be) | `` vimPlugins: update on 2026-07-16 ``                                                |
| [`e55ac21e`](https://github.com/NixOS/nixpkgs/commit/e55ac21e86f162fd4fd4a9130675902e11cf9397) | `` versitygw: re-enable tests ``                                                      |
| [`86ccc1be`](https://github.com/NixOS/nixpkgs/commit/86ccc1be5745f66a239f37a92817e71d7f1ecede) | `` piped: 0-unstable-2024-11-04 -> 0-unstable-2026-07-06 ``                           |
| [`53dbe095`](https://github.com/NixOS/nixpkgs/commit/53dbe095e4e30782b5cb2325d01fec34c6065784) | `` cue: 0.17.0 -> 0.17.1 ``                                                           |
| [`e45b4c30`](https://github.com/NixOS/nixpkgs/commit/e45b4c3064d70c5c82f93022a9f662a02478024e) | `` python3Packages.autopxd2: 3.2.2 -> 3.2.3 ``                                        |
| [`aea32a03`](https://github.com/NixOS/nixpkgs/commit/aea32a03a4928172b803256a694bd7a059894726) | `` python3Packages.general-sam: 1.0.3 -> 1.0.4.post0 ``                               |
| [`662c39e7`](https://github.com/NixOS/nixpkgs/commit/662c39e77671de4b84ef1840e0914429079f372a) | `` python3Packages.types-tabulate: 0.10.0.20260308 -> 0.10.0.20260508 ``              |
| [`40d47072`](https://github.com/NixOS/nixpkgs/commit/40d47072d410b4a14ac055c525e9a049fdb17768) | `` piped: use nix-update-script ``                                                    |
| [`f36d19c3`](https://github.com/NixOS/nixpkgs/commit/f36d19c3430adce08596a4dcea6d0433fa2ca1a6) | `` terraform-providers.sysdiglabs_sysdig: 3.8.2 -> 3.9.0 ``                           |
| [`7d0a2d95`](https://github.com/NixOS/nixpkgs/commit/7d0a2d954be797111acb2cde707ff44749faa3f2) | `` python3Packages.cometx: 3.6.6 -> 3.6.7 ``                                          |
| [`5c0ea6b2`](https://github.com/NixOS/nixpkgs/commit/5c0ea6b2d536f6e582c73abda4b7fd015c291a86) | `` python3Packages.beets: remove gstreamer test ``                                    |
| [`13df38b2`](https://github.com/NixOS/nixpkgs/commit/13df38b2190fb111fa73d42f9dd07b05e74e080f) | `` home-assistant-custom-components.llm_intents: 1.8.2 -> 1.8.3 ``                    |
| [`90791e4c`](https://github.com/NixOS/nixpkgs/commit/90791e4c643f5d15154389a5114055f9cb7d71f2) | `` supercell-wx: drop geographiclib single-output workaround ``                       |
| [`683e8fa0`](https://github.com/NixOS/nixpkgs/commit/683e8fa08bbd9e88785228618c6ea3deb62dc6c5) | `` geographiclib: fix multi-output CMake import prefix ``                             |
| [`206650be`](https://github.com/NixOS/nixpkgs/commit/206650be46b6e20ce5e730a25b62a04fa0d65d28) | `` python3Packages.beets: fix plugin dependencies ``                                  |
| [`bfbb7882`](https://github.com/NixOS/nixpkgs/commit/bfbb7882ca10e7c1282b49daeb186bc9badd3b9f) | `` python3Packages.beets: mark bpsync plugin deprecated ``                            |
| [`79835e40`](https://github.com/NixOS/nixpkgs/commit/79835e4005b43c1e944dcaf3f642eec41f2b9d35) | `` python3Packages.beets: add single-plugin passthru tests ``                         |
| [`c43f9cfc`](https://github.com/NixOS/nixpkgs/commit/c43f9cfcf9414cb21c33e54d6a571fe71b7f5231) | `` minikube: set libvirt to PATH to avoid PROVIDER_KVM2_NOT_FOUND error ``            |
| [`eb808e50`](https://github.com/NixOS/nixpkgs/commit/eb808e50bec53dc9526e2241f8e6a99b9f041bf3) | `` python3Packages.beets: use lib.pipe for plugins.all (readability) ``               |
| [`dfc90ede`](https://github.com/NixOS/nixpkgs/commit/dfc90edeb19d8292ac22609781e5506fb4d79880) | `` python3Packages.beets: add doCheck argument for easier overriding ``               |
| [`f73cda94`](https://github.com/NixOS/nixpkgs/commit/f73cda9494111cbe3cde23754ecac88e05355fc1) | `` terraform-providers.splunk-terraform_signalfx: 9.30.3 -> 9.33.0 ``                 |
| [`e8ddd49e`](https://github.com/NixOS/nixpkgs/commit/e8ddd49ea964d0f1c0caf400343985ebe771d4c1) | `` topgrade: 17.7.0 -> 17.8.0 ``                                                      |
| [`8e28c091`](https://github.com/NixOS/nixpkgs/commit/8e28c091025b9544569498648e8914182bdae84c) | `` jsign: 7.4 -> 7.5 ``                                                               |
| [`74548700`](https://github.com/NixOS/nixpkgs/commit/745487006e12262667d4acf568362df7c75296d4) | `` cargo-shear: 1.13.1 -> 1.13.2 ``                                                   |
| [`2add52cc`](https://github.com/NixOS/nixpkgs/commit/2add52cc3e44fbe3e760f9f429744ed33f3ea7c2) | `` maigret: 0.6.2 -> 0.6.3 ``                                                         |
| [`3068460c`](https://github.com/NixOS/nixpkgs/commit/3068460c4fd8a185b7a4c1d08235898476eb3225) | `` mautrix-telegram: fix crash and unbreak default-python build ``                    |
| [`745503aa`](https://github.com/NixOS/nixpkgs/commit/745503aa8803b33e17012ba211ac609f5541edbd) | `` vscode-extensions.danielsanmedium.dscodegpt: 3.23.1 -> 3.24.12 ``                  |
| [`13484259`](https://github.com/NixOS/nixpkgs/commit/13484259fde9e9fb743cdbdce584505a58332122) | `` coqPackages.stalmarck-tactic: enable compilation on master ``                      |
| [`4b1a16ac`](https://github.com/NixOS/nixpkgs/commit/4b1a16ac0bd10c4273c4b928ee4b8d306265a552) | `` nixos/vnstat: add NixOS test ``                                                    |
| [`6042a858`](https://github.com/NixOS/nixpkgs/commit/6042a858016a127d647586cf381f61bf6fcf35da) | `` libretro-shaders-slang: 0-unstable-2026-06-28 -> 0-unstable-2026-07-15 ``          |
| [`a4a3c6d2`](https://github.com/NixOS/nixpkgs/commit/a4a3c6d2dfa34cb40a1b6f626c3d376392104813) | `` libretro.snes9x: 0-unstable-2026-07-05 -> 0-unstable-2026-07-13 ``                 |
| [`c8e2ff06`](https://github.com/NixOS/nixpkgs/commit/c8e2ff06a7e2c5e94475d64105f7f019c53b1841) | `` music-assistant-desktop: 0.5.7 -> 0.5.9 ``                                         |
| [`f6cf3818`](https://github.com/NixOS/nixpkgs/commit/f6cf38182b0ec42e5e319081094b0b35ffa659c5) | `` python3Packages.amaranth: 0.5.8 -> 0.5.9 ``                                        |
| [`12814ca0`](https://github.com/NixOS/nixpkgs/commit/12814ca04809d0082b07bb5c1271c9f3563588bb) | `` nix-eval-jobs: 2.34.3 -> 2.35.0 ``                                                 |
| [`0a0efaad`](https://github.com/NixOS/nixpkgs/commit/0a0efaad01a06654169e7bdddc533478cdab95c4) | `` layerx: 1.5.2 -> 1.5.3 ``                                                          |
| [`b8e3d238`](https://github.com/NixOS/nixpkgs/commit/b8e3d23844a6c3019bc35ea60a00ab01441b917a) | `` tanka: 0.37.5 -> 0.38.0 ``                                                         |
| [`e365f12a`](https://github.com/NixOS/nixpkgs/commit/e365f12aca41d3d2af0ad79711243326436a41d5) | `` nix-unit: 2.34.2 -> 2.35.0 ``                                                      |
| [`56ef6c77`](https://github.com/NixOS/nixpkgs/commit/56ef6c77f4fae27ac66d55e64aa489d12ef13469) | `` cargo-llvm-cov: 0.8.5 -> 0.8.7 ``                                                  |
| [`432fe8d9`](https://github.com/NixOS/nixpkgs/commit/432fe8d9657ddb15186286a0ccd90b5668bb9252) | `` badger: 4.9.3 -> 4.9.4 ``                                                          |
| [`1fe86fe8`](https://github.com/NixOS/nixpkgs/commit/1fe86fe8067ac9218d46aaf85ce72178413d9b6b) | `` gomuks-web: 26.06 -> 26.07 ``                                                      |
| [`1cb22c69`](https://github.com/NixOS/nixpkgs/commit/1cb22c69681dca6a984743955fdbfd104ffeb6fc) | `` python3Packages.databricks-sdk: 0.119.0 -> 0.121.0 ``                              |
| [`6e8b58cd`](https://github.com/NixOS/nixpkgs/commit/6e8b58cddc8438dbb68f8e292aa556e828685072) | `` python3Packages.perplexityai: 0.39.0 -> 0.41.0 ``                                  |
| [`4bf136ff`](https://github.com/NixOS/nixpkgs/commit/4bf136ff556334774decc59b40021314ac988fc3) | `` luau-lsp: 1.68.1 -> 1.69.0 ``                                                      |
| [`4809a53a`](https://github.com/NixOS/nixpkgs/commit/4809a53a82a5005ea9b0a364c949fafe8682907f) | `` amnezia-vpn: fix missing system tray and window icons ``                           |
| [`cc04ca75`](https://github.com/NixOS/nixpkgs/commit/cc04ca75c2a61951e8246332512bd232d5449d3c) | `` nono: skip broken tests on darwin ``                                               |
| [`bf619da4`](https://github.com/NixOS/nixpkgs/commit/bf619da4fb5133ca7313a76a24530f52344a5ac9) | `` modrinth-app-unwrapped: 0.15.7 -> 0.15.11 ``                                       |
| [`5e670cae`](https://github.com/NixOS/nixpkgs/commit/5e670cae3538ed92bc426ab3ef73775b3bc2d5c6) | `` bant: 0.2.10 -> 0.3.0 ``                                                           |
| [`3c8b479c`](https://github.com/NixOS/nixpkgs/commit/3c8b479ce0f79121dbd922691ececc6d6cf7f140) | `` feishu-cli: 1.34.0 -> 1.35.0 ``                                                    |
| [`2b54d4d8`](https://github.com/NixOS/nixpkgs/commit/2b54d4d8564870790987867a2cdcca4e52d52a1f) | `` python3Packages.msgraph-core: 1.4.0 -> 1.5.1 ``                                    |
| [`edfa702a`](https://github.com/NixOS/nixpkgs/commit/edfa702a597cc638519e43ba597ea1b5cd0c125b) | `` rectangle: 0.96 -> 0.98 ``                                                         |
| [`abcb99b7`](https://github.com/NixOS/nixpkgs/commit/abcb99b715b6117f00d76f32afa5b61fe93756fb) | `` python3Packages.gto: 1.9.0 -> 1.10.1 ``                                            |
| [`642a5990`](https://github.com/NixOS/nixpkgs/commit/642a5990fa87e1983976c32999585a7a387514e0) | `` kubectl-gadget: 0.54.0 -> 0.54.1 ``                                                |
| [`ee8b23cf`](https://github.com/NixOS/nixpkgs/commit/ee8b23cf07c1d80f28656c20222d2c29aa44f06d) | `` vesktop: migrate from electron_40 to electron_42 ``                                |
| [`da0f8403`](https://github.com/NixOS/nixpkgs/commit/da0f840372ddcad083ab115c0ce06232b6ffa550) | `` python3Packages.xcaplib: 2.0.2-unstable-2026-01-23 -> 2.0.2-unstable-2026-07-09 `` |
| [`d5c86e51`](https://github.com/NixOS/nixpkgs/commit/d5c86e51d81e7c38e3bfc51b659bd20009c449ef) | `` troubadix: 26.4.6 -> 26.7.1 ``                                                     |
| [`6d3c620f`](https://github.com/NixOS/nixpkgs/commit/6d3c620fa6d2c55014a4f9b9b5d66a26b7c47a09) | `` nixos/vnstat: add hmenke as maintainer ``                                          |
| [`ec074b03`](https://github.com/NixOS/nixpkgs/commit/ec074b03336784bb5dc91bef6255e872a768ae7f) | `` vscode-extensions.yoshi47.selection-path-copier: 1.5.0 -> 1.6.0 ``                 |
| [`b6085fc0`](https://github.com/NixOS/nixpkgs/commit/b6085fc0204f47886b5f0dea0d8b1e519a5b747a) | `` nixos/vnstat: add RFC-42 settings ``                                               |
| [`3f72a0cb`](https://github.com/NixOS/nixpkgs/commit/3f72a0cb8cfa85c3007350a885f4236ba0705352) | `` lstk: 0.15.0 -> 0.17.0 ``                                                          |
| [`6212eaa0`](https://github.com/NixOS/nixpkgs/commit/6212eaa047ecbe9a52b35547b47b8392734dc0e0) | `` epson_202101w: init at 1.0.2 ``                                                    |
| [`f0eacaa7`](https://github.com/NixOS/nixpkgs/commit/f0eacaa7b5166bc988a2ba23882dda684d7c3804) | `` coqPackages.smtcoq: now depends on trakt ``                                        |
| [`ccfdda56`](https://github.com/NixOS/nixpkgs/commit/ccfdda5636e1aceed02046b3b053c4c49bd4cf97) | `` coqPackages.smtcoq: SMTCoq-2.2+8.19 -> SMTCoq-2.3+8.20 ``                          |
| [`f771f20b`](https://github.com/NixOS/nixpkgs/commit/f771f20b231bd72d17d17c5b8ad558bc30153ae5) | `` coqPackages.smtcoq: improve formatting ``                                          |
| [`e74588f8`](https://github.com/NixOS/nixpkgs/commit/e74588f83020182d282b568a72d437ff1d5c1574) | `` wireproxy: 1.1.2 -> 1.1.3 ``                                                       |
| [`2fdbe559`](https://github.com/NixOS/nixpkgs/commit/2fdbe55932e7d91002a1f5f346c7f9bbd30c9939) | `` python3Packages.oelint-parser: 8.11.5 -> 8.11.6 ``                                 |
| [`5d794a15`](https://github.com/NixOS/nixpkgs/commit/5d794a1546989d3d3f643de45bffd6a19702e59e) | `` glaze: 7.8.4 -> 7.9.0 ``                                                           |
| [`513f0c00`](https://github.com/NixOS/nixpkgs/commit/513f0c006e5fbe1070092009ba7a4228c7bbd86e) | `` turso-cli: 1.0.29 -> 1.0.30 ``                                                     |
| [`862c515c`](https://github.com/NixOS/nixpkgs/commit/862c515c13e6ef249c9368c48bebf56ee5f3f2c1) | `` python3Packages.snuggs: remove click & uneeded patch ``                            |
| [`b39eb8a2`](https://github.com/NixOS/nixpkgs/commit/b39eb8a2a594c58b8b5266f27bc44f4b4f95d13c) | `` nixos/rename: fix typo in ecryptfs option removal message ``                       |
| [`5dba23de`](https://github.com/NixOS/nixpkgs/commit/5dba23de0db904712c558dc584a509aadbda225e) | `` vscode-extensions.foam.foam-vscode: 0.44.1 -> 0.44.2 ``                            |
| [`15c4f513`](https://github.com/NixOS/nixpkgs/commit/15c4f513474374b85e8bdeda76d4113f22299f17) | `` zed-editor: 1.10.0 -> 1.11.3 ``                                                    |
| [`772e74b8`](https://github.com/NixOS/nixpkgs/commit/772e74b818d8f60e3554c9b1eebb44bf7708abf8) | `` qrupdate: 1.1.5 -> 1.2.0 ``                                                        |
| [`ce57f129`](https://github.com/NixOS/nixpkgs/commit/ce57f1294040b35214e54ec585268fdd2ee7519e) | `` doc/using: clarify security support status ``                                      |
| [`19ec1b17`](https://github.com/NixOS/nixpkgs/commit/19ec1b17bd15ae25de3589a1e049557cdf045c52) | `` fabric-ai: 1.4.455 -> 1.4.459 ``                                                   |
| [`5b94d397`](https://github.com/NixOS/nixpkgs/commit/5b94d39771b2eede9dfe235afa760848e7941ec5) | `` luaPackages.neotest: 5.19.0-1 -> 5.19.2-1 ``                                       |
| [`8aa7c3c5`](https://github.com/NixOS/nixpkgs/commit/8aa7c3c56dd221af48a4370a49c46d4c0c42bd02) | `` rundeck: 6.0.0 -> 6.0.1 ``                                                         |
| [`ecbc12c4`](https://github.com/NixOS/nixpkgs/commit/ecbc12c408a585d32e258af16253a49c36077b65) | `` luaPackages.luarocks-build-treesitter-parser: 6.0.2-1 -> 6.1.1-1 ``                |
| [`8b7b74c9`](https://github.com/NixOS/nixpkgs/commit/8b7b74c9cb17a6bfe7e5f218f37df3a3e632e763) | `` yaziPlugins.mediainfo: 0-unstable-2026-06-06 → 0-unstable-2026-07-13 ``            |
| [`b3fbdcfc`](https://github.com/NixOS/nixpkgs/commit/b3fbdcfcc0fc611dee52e89cefb3aae05ea894d5) | `` yaziPlugins.keep-preferences: 0-unstable-2026-05-25 → 0-unstable-2026-07-15 ``     |
| [`af555d53`](https://github.com/NixOS/nixpkgs/commit/af555d53e73e9686d4c13d52c6ff4d35126a98e0) | `` luaPackages.compat53: 0.15.0-1 -> 0.15.1-1 ``                                      |
| [`edca056e`](https://github.com/NixOS/nixpkgs/commit/edca056e2a681ec3112e361402142e973a9e6006) | `` yaziPlugins.gvfs: 0-unstable-2026-03-29 → 0-unstable-2026-07-13 ``                 |
| [`dbb2261b`](https://github.com/NixOS/nixpkgs/commit/dbb2261b641060fa5752446893cc1f35555986fc) | `` yaziPlugins.clipboard: 0-unstable-2026-05-22 → 0-unstable-2026-07-14 ``            |
| [`bed958b1`](https://github.com/NixOS/nixpkgs/commit/bed958b104e3271d01bd075535fa60b96b2c994d) | `` draupnir: add patch for package-lock.json ``                                       |
| [`8fca7c69`](https://github.com/NixOS/nixpkgs/commit/8fca7c698184db77869a41c40609cd9248836727) | `` libgcrypt: fix riscv64-linux build ``                                              |
| [`75610b07`](https://github.com/NixOS/nixpkgs/commit/75610b07a1830f82d70eb215e8f88a70166f6e4b) | `` litmusctl: 1.26.0 -> 1.27.0 ``                                                     |
| [`2b07bc1b`](https://github.com/NixOS/nixpkgs/commit/2b07bc1b847b6257feeb9d230fdb1487a025e0db) | `` tzf-rs: 1.3.3 -> 1.3.6 ``                                                          |
| [`2ab89ffc`](https://github.com/NixOS/nixpkgs/commit/2ab89ffc971a306411975baedf213e28eac70fd4) | `` kythe: 0.0.75 -> 0.0.76 ``                                                         |
| [`d71c01fe`](https://github.com/NixOS/nixpkgs/commit/d71c01fe3bc846b41e9e04462b70ad9a318603ea) | `` cni-plugin-flannel: 1.9.1-flannel1 -> 1.9.1-flannel2 ``                            |
| [`b38ad120`](https://github.com/NixOS/nixpkgs/commit/b38ad120704650cad8ea2339d4aec12d0c9bd972) | `` python3Packages.python-bsblan: 6.1.6 -> 6.1.7 ``                                   |
| [`c30dcbe4`](https://github.com/NixOS/nixpkgs/commit/c30dcbe477b362f7e1edbaeaa595e7cdbed4839a) | `` octavePackages.statistics: 1.8.3 -> 1.8.4 ``                                       |
| [`09be24a2`](https://github.com/NixOS/nixpkgs/commit/09be24a28271318d67fa85754e390178955d200d) | `` scdl: 3.0.6 -> 3.0.7 ``                                                            |
| [`25378654`](https://github.com/NixOS/nixpkgs/commit/25378654cd48b5276208a098cba7691470a110f4) | `` vscode-extensions.anthropic.claude-code: 2.1.210 -> 2.1.211 ``                     |
| [`e3ca059c`](https://github.com/NixOS/nixpkgs/commit/e3ca059c7f06bb6c0ef7012028dcd551fcd7921d) | `` claude-code: 2.1.210 -> 2.1.211 ``                                                 |
| [`94e565a3`](https://github.com/NixOS/nixpkgs/commit/94e565a31d646629b276a630b3d6ca15707e1abc) | `` sequoia-sq: add anish to maintainers ``                                            |
| [`f9640ca4`](https://github.com/NixOS/nixpkgs/commit/f9640ca49ddfd8b9d5e7eac60f263fe27a915e80) | `` sequoia-sq: add versionCheckHook ``                                                |
| [`adf9c9fe`](https://github.com/NixOS/nixpkgs/commit/adf9c9fe56cf0a4480a7b0b4ca294f8bbb2c2bd5) | `` sequoia-sq: enable structuredAttrs and strictDeps ``                               |
| [`da71f23b`](https://github.com/NixOS/nixpkgs/commit/da71f23be546b9a09cf370cc4abac87f945f740c) | `` sequoia-sq: write build assets to target dir ``                                    |
| [`dbac79ca`](https://github.com/NixOS/nixpkgs/commit/dbac79cad870862655d09c43dc8f9d167c9b1b5f) | `` sequoia-sq: 1.3.1 -> 1.4.0 ``                                                      |
| [`6b3e51df`](https://github.com/NixOS/nixpkgs/commit/6b3e51df76a977f1914eb1e384e1247ddf5da37a) | `` python3Packages.oelint-data: 1.5.9 -> 1.5.10 ``                                    |
| [`7221f0f2`](https://github.com/NixOS/nixpkgs/commit/7221f0f2a67df0158bd7520a30f32677356dc0f4) | `` parla: 0.6.6 -> 0.6.8 ``                                                           |
| [`702057b5`](https://github.com/NixOS/nixpkgs/commit/702057b5bfed7baa21c414ceb9c61672b1a1b8b2) | `` adslib: 0-unstable-2026-04-27 -> 113.0.34-1 ``                                     |
| [`ffb6fb0a`](https://github.com/NixOS/nixpkgs/commit/ffb6fb0a133b2d5c09ce40b62808628840d76008) | `` python3Packages.aioimmich: 0.16.1 -> 0.16.3 ``                                     |
| [`844d254b`](https://github.com/NixOS/nixpkgs/commit/844d254b632e1c9c1582b68807696c8d07c08377) | `` home-assistant-custom-components.eero: init at 1.8.1 ``                            |
| [`7df5dd5c`](https://github.com/NixOS/nixpkgs/commit/7df5dd5c46015001bc0a6553de129dc665afb587) | `` budget-tracker-tui: 1.4.0 -> 1.4.1 ``                                              |
| [`8f2a7d59`](https://github.com/NixOS/nixpkgs/commit/8f2a7d595ccbc55f888089556a02b87dfae2784e) | `` python3Packages.cucumber-tag-expressions: use finalAttrs ``                        |
| [`56578f40`](https://github.com/NixOS/nixpkgs/commit/56578f40d8868d91257faf9d40b33bf06fad3d16) | `` python3Packages.cucumber-tag-expressions: 9.1.0 -> 10.0.0 ``                       |
| [`173a569d`](https://github.com/NixOS/nixpkgs/commit/173a569dbf2a3ea2c865f59cd7c71347930f5405) | `` losange: 0.10.1 -> 0.10.2 ``                                                       |
| [`3dce8ff7`](https://github.com/NixOS/nixpkgs/commit/3dce8ff7830be100a37f88c7835e2bfd7b79588c) | `` mouser: 3.6.0 -> 3.7.0 ``                                                          |
| [`62ab41a7`](https://github.com/NixOS/nixpkgs/commit/62ab41a79dca976a0c1864f557b8a20c93733a7f) | `` python3Packages.cucumber-expressions: use finalAttrs ``                            |
| [`8c367592`](https://github.com/NixOS/nixpkgs/commit/8c36759238323e5dcdc15ba6f768e22f75ca09a3) | `` python3Packages.cucumber-expressions: 19.0.1 -> 20.0.0 ``                          |
| [`7e9e7179`](https://github.com/NixOS/nixpkgs/commit/7e9e7179fb90c6ed0d109900f42fd1338269e947) | `` python3Packages.coverage: 7.14.1 -> 7.15.2 ``                                      |
| [`866ade67`](https://github.com/NixOS/nixpkgs/commit/866ade6731ad00ccec3cf4a4475e31f185acdb0e) | `` roslyn-ls: 5.9.0-1.26314.1 -> 5.9.0-1.26319.6 ``                                   |
| [`42e33f88`](https://github.com/NixOS/nixpkgs/commit/42e33f8873ff790768ba1ad78ae61be5c12eafdd) | `` python3Packages.types-markdown: 3.10.2.20260211 -> 3.10.2.20260712 ``              |
| [`9ca2e133`](https://github.com/NixOS/nixpkgs/commit/9ca2e133f07c2541c0622b6afcf2237f2675ab01) | `` vscode-extensions.jnoortheen.nix-ide: 0.5.9 -> 0.5.10 ``                           |
| [`f440a349`](https://github.com/NixOS/nixpkgs/commit/f440a349a2fc9f1c94eb80d8022f6901ab9abe39) | `` termsvg: 0.10.0 -> 0.11.0 ``                                                       |
| [`725f0361`](https://github.com/NixOS/nixpkgs/commit/725f036116753bee0ad99c3fb3f938b718505554) | `` sshified: 1.2.6 -> 1.2.7 ``                                                        |
| [`527e9b10`](https://github.com/NixOS/nixpkgs/commit/527e9b1055d3e1e66395281bb21b206a36504aa2) | `` resterm: 0.44.6 -> 0.46.4 ``                                                       |
| [`9104e3f5`](https://github.com/NixOS/nixpkgs/commit/9104e3f5b69b0ea23778d1344af8c7a6753216de) | `` prometheus-redis-exporter: 1.86.0 -> 1.87.0 ``                                     |
| [`fb014235`](https://github.com/NixOS/nixpkgs/commit/fb0142357e305d6a361a77ef5018891ec8da8b5f) | `` mesa: 26.1.4 -> 26.1.5 ``                                                          |
| [`30c066ab`](https://github.com/NixOS/nixpkgs/commit/30c066ab2f3672bc31dccea69c920371e3e07e6c) | `` python3Packages.pyhelty: 0.2.0 -> 0.3.0 ``                                         |
| [`929e1a04`](https://github.com/NixOS/nixpkgs/commit/929e1a048e6cf646a955b43e321fa52ab470a0a3) | `` python3Packages.aiomelcloudhome: 0.1.9 -> 0.2.1 ``                                 |
| [`4486d950`](https://github.com/NixOS/nixpkgs/commit/4486d9505d9e767832470f2ff791ce8e10691b37) | `` automatic-timezoned: 2.0.126 -> 2.0.143 ``                                         |
| [`6a7227f2`](https://github.com/NixOS/nixpkgs/commit/6a7227f26ce9d9a29e0f8dd68fa2bf7c2a9cee59) | `` cloudflared: 2026.6.1 -> 2026.7.2 ``                                               |
| [`89550588`](https://github.com/NixOS/nixpkgs/commit/895505880493a9a4073da5c8df87a346df42bad2) | `` linuxPackages.xpadneo: 0.10.2 -> 0.10.4 ``                                         |
| [`e55b25ba`](https://github.com/NixOS/nixpkgs/commit/e55b25bac44b2852848d03a9c87a93f1cd19247f) | `` brave: 1.92.139 -> 1.92.140 ``                                                     |
| [`cfb5c7c7`](https://github.com/NixOS/nixpkgs/commit/cfb5c7c7d6da9f95b7e3e1c7e6953fcb23af56f1) | `` libretro.dolphin: 0-unstable-2026-06-28 -> 0-unstable-2026-07-12 ``                |
| [`0cbb0842`](https://github.com/NixOS/nixpkgs/commit/0cbb0842fd3bfcf5a45e33b00fe955a751c1a9dc) | `` julia-mono: 0.062 -> 0.63 ``                                                       |
| [`9f1699c4`](https://github.com/NixOS/nixpkgs/commit/9f1699c4467932c9d0e064d3f707b4386ccae629) | `` beeper: 4.2.957 -> 4.2.985 ``                                                      |
| [`b501cb18`](https://github.com/NixOS/nixpkgs/commit/b501cb180d8578ecba5aeb1f5d6ced62b2c2f836) | `` python3Packages.imgw-pib: 2.4.1 -> 2.4.3 ``                                        |

*... and 880 more commits (truncated)*