### PR TITLE
chore(flake/freminal): `0abc8b5d` -> `64dc3fcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784072532,
-        "narHash": "sha256-fZGSS9Amm1xnGXBrDyXEGV31hg3Kwt+4y//2lSc2kIU=",
+        "lastModified": 1784443719,
+        "narHash": "sha256-8d+mS1/LcGaIqtzuzz+Xt3WeL/Lvk5ah5dgdELdTSRQ=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "0abc8b5d77bf08eb0165f81f13d6b1d2be88d5d7",
+        "rev": "64dc3fcf5eda075e48e83c0bec4e128e7cb51ec8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`61d05089`](https://github.com/fredsystems/freminal/commit/61d05089e2ab4e91ab5a216d5e4e643f6a7a6cf5) | `` fix: wire cursor.shape/cursor.blink config into actual cursor rendering (#406) ``  |
| [`91e37651`](https://github.com/fredsystems/freminal/commit/91e37651d261447e117b8cc5b7852e3cb3964b00) | `` fix: settings window orphaned and app fails to quit on owner close (#401) ``       |
| [`5ea8e585`](https://github.com/fredsystems/freminal/commit/5ea8e58557605c0623e9cb8109e12d1250e7a8c9) | `` chore(version): 0.12.0-beta.1 ``                                                   |
| [`164cbde5`](https://github.com/fredsystems/freminal/commit/164cbde558171f2e9f9951cbb758dea5ffb8a84a) | `` chore(deps): update taiki-e/install-action action to v2.83.4 ``                    |
| [`f9d92f36`](https://github.com/fredsystems/freminal/commit/f9d92f360784b4e6811373a0270adace700a2f48) | `` chore(deps): update serde ``                                                       |
| [`fbb877dc`](https://github.com/fredsystems/freminal/commit/fbb877dcf07e2d2a36984f5325b2c89411c5b071) | `` chore(deps): update rust crate swash to v0.2.10 ``                                 |
| [`4cf2cf98`](https://github.com/fredsystems/freminal/commit/4cf2cf984812c940dea8b6a7178ba9eead2cf491) | `` chore(deps): update rust crate regex to v1.13.1 ``                                 |
| [`d87b3f07`](https://github.com/fredsystems/freminal/commit/d87b3f075c353c5562c6b97979486967d07f506b) | `` chore(deps): update rust crate futures to v0.3.33 ``                               |
| [`e74cd301`](https://github.com/fredsystems/freminal/commit/e74cd30171151fc3f013f0061009e21484085238) | `` chore(deps): update rust crate clap to v4.6.2 ``                                   |
| [`9bda46d7`](https://github.com/fredsystems/freminal/commit/9bda46d7073506df58d821aced407d87413e8af3) | `` chore(deps): update rust crate bitflags to v2.13.1 ``                              |
| [`f1c6cbe3`](https://github.com/fredsystems/freminal/commit/f1c6cbe3fcbd76dae85c1ad19415189920db5c91) | `` chore(deps): update error handling ``                                              |
| [`f4d42105`](https://github.com/fredsystems/freminal/commit/f4d421054d997ccd0075a152f40ba67e24f2cb88) | `` chore(deps): update dependency rust to v1.97.1 ``                                  |
| [`ef033cfb`](https://github.com/fredsystems/freminal/commit/ef033cfb2909deba533503af7d9c4911f3142367) | `` chore(deps): update dtolnay/rust-toolchain digest ``                               |
| [`6494aab2`](https://github.com/fredsystems/freminal/commit/6494aab241828faa46fc0fb43c50ab73abb19b01) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 2a0be24 `` |