### PR TITLE
chore(flake/home-manager): `46010800` -> `39411a8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784351324,
-        "narHash": "sha256-By+kuRJZRqs2TuXgtR8vJ8cTKWXw33YG/Yollu5cO1U=",
+        "lastModified": 1784407317,
+        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "460108009ca1ff69ca2ff19079ca2c838d6e3080",
+        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`39411a8e`](https://github.com/nix-community/home-manager/commit/39411a8e12a5526d992e65bc7e3dc9a4414d6713) | `` syncthing: use localhost authority for unix-socket REST calls `` |