### PR TITLE
chore(flake/freminal): `64dc3fcf` -> `c9d41ef2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     "cargo-bundle-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1780169337,
-        "narHash": "sha256-jYSYR430gKJDcKKu+Kmc3VzpuQBvU80ydNRvJBTeFec=",
+        "lastModified": 1784488347,
+        "narHash": "sha256-u5xy+orq+GetQe9C7pZDjzKPK5y15+gzghUoMjTGO2w=",
         "owner": "burtonageo",
         "repo": "cargo-bundle",
-        "rev": "739f92c37c789b5511a448a389cbc76fcebd99df",
+        "rev": "dfb855b5205c08b08aeb0cab9e1cee6c12df1ce0",
         "type": "github"
       },
       "original": {
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784443719,
-        "narHash": "sha256-8d+mS1/LcGaIqtzuzz+Xt3WeL/Lvk5ah5dgdELdTSRQ=",
+        "lastModified": 1784521295,
+        "narHash": "sha256-pPrDuLZdWlkDC6wlNeHGPXMvzaRvmJQOh6e6Tsqr2U0=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "64dc3fcf5eda075e48e83c0bec4e128e7cb51ec8",
+        "rev": "c9d41ef20f0410cb32ca500900a5d4638efbf204",
         "type": "github"
       },
       "original": {
@@ -907,11 +907,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -1041,11 +1041,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1783875506,
-        "narHash": "sha256-Hx7uYdd6XyBohpAyIJwzjsJrUsY9ucOpzxoGMV+AYsI=",
+        "lastModified": 1784275620,
+        "narHash": "sha256-vk/LLBBfr2c25A0IpvSqGbzqDtybWUnxO4YsiSCeWeg=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "7ffbe4d244ef810e871ff616988753131c9595e8",
+        "rev": "50bd447e1d3206ea63716ef6c77ac0deba9f0276",
         "type": "github"
       },
       "original": {
@@ -1129,11 +1129,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1783834461,
-        "narHash": "sha256-FCmrs1StAghJDKfqy56KM96KZtxpYzgeq6zM3QO8wjA=",
+        "lastModified": 1784265529,
+        "narHash": "sha256-ohQQiPOngux8ofsrSlloHCMDhRMvocXqJiG8uH45Q5k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a286e5b998e852297a403786f063fb2c9fe7f57a",
+        "rev": "068175006cfb69d5b541a140ed93e361488c9e53",
         "type": "github"
       },
       "original": {
@@ -1150,11 +1150,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783921439,
-        "narHash": "sha256-DsSIQSRMrLOz40LrGZ03sp2RlJ9sz3wKpd8XPTOzXnw=",
+        "lastModified": 1784438913,
+        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e013376c32a8fcf07ddb6ec71739552bc118b7bd",
+        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`c9d41ef2`](https://github.com/fredsystems/freminal/commit/c9d41ef20f0410cb32ca500900a5d4638efbf204) | `` fix(pty/tests): nixos sandbox ``                                                          |
| [`71b3790a`](https://github.com/fredsystems/freminal/commit/71b3790aa7fa6d83986e4408519894a0ef822eb7) | `` Revert "fix(pty/tests): nixos sandbox" ``                                                 |
| [`e52a9afd`](https://github.com/fredsystems/freminal/commit/e52a9afd7492e672b43a7a8bafd0e7e742044378) | `` fix(pty/tests): nixos sandbox ``                                                          |
| [`9c20b562`](https://github.com/fredsystems/freminal/commit/9c20b5627e60cb62e936d41bb7c5fb335e0ba049) | `` fix: clear stashed snapshot cache on scroll/extra-row change (#405) ``                    |
| [`b5dde413`](https://github.com/fredsystems/freminal/commit/b5dde413a228e6e887b8656f218a3db0822a7058) | `` feat: center glyphs vertically via configurable font.line_height ``                       |
| [`0e3d6a5f`](https://github.com/fredsystems/freminal/commit/0e3d6a5f5b0865a4f70c01814aa32723ee09d142) | `` test: add partial-dirty (1-of-N rows) benchmarks (#405) ``                                |
| [`9e6226e5`](https://github.com/fredsystems/freminal/commit/9e6226e5535e41a96d7ebf924e587422894696f8) | `` perf: preserve per-buffer snapshot cache across alt/primary switch (#405) ``              |
| [`5ff39868`](https://github.com/fredsystems/freminal/commit/5ff39868176f3f3b7f69e7662b750bf6b21d4102) | `` perf: event-driven echo-off detection to remove idle-CPU poll (#405) ``                   |
| [`091b7883`](https://github.com/fredsystems/freminal/commit/091b78836e5b07f4ddf48eff72d3adf2f4708045) | `` chore(cargo/flake): update flake, cargo bundle lock, and cargo deps ``                    |
| [`9642677a`](https://github.com/fredsystems/freminal/commit/9642677a0b5dcca84486e709629bc459f456a39b) | `` fix: harden glyph atlas, box-drawing, and fallback rendering; add procedural powerline `` |
| [`bb086e49`](https://github.com/fredsystems/freminal/commit/bb086e49049820a0a626efb6bd913fb89519cda4) | `` fix: don't register CBDT bundled emoji into the egui chrome font stack ``                 |
| [`2b5ac177`](https://github.com/fredsystems/freminal/commit/2b5ac1778120533dd49fd3cfd0d0fe26a007dc84) | `` docs: add upstream copyright notice to Noto Color Emoji license ``                        |
| [`3df8d697`](https://github.com/fredsystems/freminal/commit/3df8d697e26d8fa73af8b38362eb1b81eb2f9dbc) | `` fix: normalize fallback-face glyphs into the primary cell (#411) ``                       |
| [`0ac16036`](https://github.com/fredsystems/freminal/commit/0ac1603621767128a3a3bf1f46d1c75506d840c3) | `` feat: bundle Noto Color Emoji + capability-based emoji discovery (#402) ``                |
| [`30d0fc78`](https://github.com/fredsystems/freminal/commit/30d0fc78ed366bc954be4e643634292d978efa4e) | `` feat: procedural box-drawing and block-element rendering (#410) ``                        |
| [`1fe7ddc2`](https://github.com/fredsystems/freminal/commit/1fe7ddc2d35ee1917580a55f0871382417cf4b93) | `` fix: rasterize glyphs at the font ppem, not the cell height ``                            |
| [`a48a6d91`](https://github.com/fredsystems/freminal/commit/a48a6d911f509069fcb3a91d442f9daaf312f564) | `` fix: derive cell height from ascent+descent, gate win-metrics on Nerd fonts (#403) ``     |