### PR TITLE
chore(flake/nixpkgs-stable): `293d6abe` -> `fd146203`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1784280462,
-        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`60237948`](https://github.com/NixOS/nixpkgs/commit/602379489c5fd59e218de5a64dbc64fb7a2abb17) | `` unityhub: 3.18.3 -> 3.19.1 ``                                                                                  |
| [`08aabd98`](https://github.com/NixOS/nixpkgs/commit/08aabd98a7c1cdd3c7c441fa199849fd0f2758db) | `` river{,-classic}: mark aarch64-linux as a badPlatform ``                                                       |
| [`698fd859`](https://github.com/NixOS/nixpkgs/commit/698fd8591433dd9d75df43a542d6aa62adcfa818) | `` python3Package.albumentations: fix build ``                                                                    |
| [`839049de`](https://github.com/NixOS/nixpkgs/commit/839049de1b0f0285daeb724e3fc7923a6ae4620d) | `` python3Package.albucore: fix build ``                                                                          |
| [`c5f2316d`](https://github.com/NixOS/nixpkgs/commit/c5f2316d084154fff0d63fa0b4030694742e8e82) | `` .github: Bump cachix/install-nix-action from 31.10.7 to 31.11.0 ``                                             |
| [`0ac82a60`](https://github.com/NixOS/nixpkgs/commit/0ac82a609cbe1cedb017e994f9436ff5c77bad86) | `` linux_6_12: 6.12.95 -> 6.12.96 ``                                                                              |
| [`414d5060`](https://github.com/NixOS/nixpkgs/commit/414d5060ef22f0b284f778dc68c0d0226b650f7f) | `` linux_6_18: 6.18.38 -> 6.18.39 ``                                                                              |
| [`4986cdc0`](https://github.com/NixOS/nixpkgs/commit/4986cdc09d289f8e78a6af5753e8e1237c431811) | `` linux_7_1: 7.1.3 -> 7.1.4 ``                                                                                   |
| [`01aa4051`](https://github.com/NixOS/nixpkgs/commit/01aa4051a482037b1bf5aae6cec846db8c42e79e) | `` thunar: 4.20.8 -> 4.20.9 ``                                                                                    |
| [`4fde01ec`](https://github.com/NixOS/nixpkgs/commit/4fde01ec781a89f51964f9eed2fc8f07322f3659) | `` mawk: fix `passthru.tests`, relax hardening options ``                                                         |
| [`597ad40f`](https://github.com/NixOS/nixpkgs/commit/597ad40f1206472be8823406acdf51bf24cb2899) | `` python315: 3.15.0b4 -> 3.15.0b5 ``                                                                             |
| [`cedf4027`](https://github.com/NixOS/nixpkgs/commit/cedf4027c9c7a558e29f8d233673b98cd0dac1ef) | `` nss_latest: 3.125 -> 3.126 ``                                                                                  |
| [`27c10d85`](https://github.com/NixOS/nixpkgs/commit/27c10d856bb802ad98762f6375419035c799f0a7) | `` wt: add required libraries to RPATH ``                                                                         |
| [`b70b5e07`](https://github.com/NixOS/nixpkgs/commit/b70b5e0797dc134add91aecbbeb77ea32a207f4b) | `` lms: 3.74.0 -> 3.78.0 ``                                                                                       |
| [`19ace67d`](https://github.com/NixOS/nixpkgs/commit/19ace67d0dfbd87e6bca4f16ebe2430e73a2b55a) | `` qpwgraph: 1.0.2 -> 1.0.3 ``                                                                                    |
| [`f4dcbecb`](https://github.com/NixOS/nixpkgs/commit/f4dcbecbcf9d9e9dea9fc38ab5fa5c38f385049c) | `` qpwgraph: 1.0.1 -> 1.0.2 ``                                                                                    |
| [`37bb3411`](https://github.com/NixOS/nixpkgs/commit/37bb3411e7b9ea34fde14b9e5802c751a9ed59b3) | `` shaka-packager: 3.8.0 -> 3.9.2 ``                                                                              |
| [`aa4ca6e2`](https://github.com/NixOS/nixpkgs/commit/aa4ca6e2afab01eb81fb62ffc0d32743747247db) | `` rocketchat-desktop: 4.15.2 -> 4.15.6 ``                                                                        |
| [`6b3bfd92`](https://github.com/NixOS/nixpkgs/commit/6b3bfd929386396a002f6b337d0892e16eaa3159) | `` nixosTests/stardust-xr-{atmosphere,flatland}: init ``                                                          |
| [`70ab1a36`](https://github.com/NixOS/nixpkgs/commit/70ab1a36bb474b424ee06282600a6c53627a757f) | `` wayland-colorbar: init at 0.1.1 ``                                                                             |
| [`701bb33a`](https://github.com/NixOS/nixpkgs/commit/701bb33a737da6a72cf5eee656309c5de43a5239) | `` nixosTests/monado: add xrgears test ``                                                                         |
| [`61c5290f`](https://github.com/NixOS/nixpkgs/commit/61c5290f677c71b93cf34cda8a51715052cc7cbb) | `` stardust-xr-protostar: 0-unstable-2024-12-29 -> 0.51.1 ``                                                      |
| [`fccaf196`](https://github.com/NixOS/nixpkgs/commit/fccaf196207758d62186a00a57484d9ad63e5dae) | `` stardust-xr-gravity: 0-unstable-2024-12-29 -> 0.51.1 ``                                                        |
| [`d2d58a58`](https://github.com/NixOS/nixpkgs/commit/d2d58a58da3c2a1d78f075ff2781c0e4f7e5915a) | `` stardust-xr-flatland: 0-unstable-2024-04-13 -> 0.51.1 ``                                                       |
| [`090b2beb`](https://github.com/NixOS/nixpkgs/commit/090b2beb19d02a03c850d085cb89eb3b399b04f4) | `` stardust-xr-atmosphere: 0-unstable-2024-08-22 -> 0.51.1 ``                                                     |
| [`530e8b73`](https://github.com/NixOS/nixpkgs/commit/530e8b73141c6288a99e014c18018e7a1d72fe8e) | `` stardust-xr-*: enable strictDeps and __structuredAttrs where not already enabled ``                            |
| [`41b9cd13`](https://github.com/NixOS/nixpkgs/commit/41b9cd13408b957c82c9864724c0386aa5706c90) | `` stardust-xr-*: update updateScript to point at stable ``                                                       |
| [`9ac0ff28`](https://github.com/NixOS/nixpkgs/commit/9ac0ff28b2439cc975d4b128f1c24428001ea37b) | `` stardust-xr-*: set platforms to unix, not linux ``                                                             |
| [`5f719ccd`](https://github.com/NixOS/nixpkgs/commit/5f719ccd39b9053110f4fd40c808d3e8ccecc37f) | `` stardust-xr-non-spatial-input: init at 0.51.1 ``                                                               |
| [`926f0324`](https://github.com/NixOS/nixpkgs/commit/926f03242e4d7a8c1dadae9aeba297b4da431b46) | `` stardust-xr-server: 0.44.1 -> 0.51.1 ``                                                                        |
| [`8099b3f7`](https://github.com/NixOS/nixpkgs/commit/8099b3f7d77e24226c0bbf19fcc66d0af6f20428) | `` maintainers/team-list: add stardust-xr team; stardust-xr-*: make use of stardust-xr team for maintainers ``    |
| [`cc82cc82`](https://github.com/NixOS/nixpkgs/commit/cc82cc8246d2b05638b1385a7938d45712244879) | `` stardust-xr-{kiara, magnetar, phobetor, sphereland}: drop ``                                                   |
| [`67b5fde3`](https://github.com/NixOS/nixpkgs/commit/67b5fde37b9a3427c86ebbe87b9c8d12e8244f17) | `` ci/github-script/bot: label llm-assisted PRs accordingly ``                                                    |
| [`5f21d928`](https://github.com/NixOS/nixpkgs/commit/5f21d9285d348fddcb530d8ec07a4f99642d9eaa) | `` forgejo: remove unused coreutils from nativeCheckInputs ``                                                     |
| [`af8029e2`](https://github.com/NixOS/nixpkgs/commit/af8029e22e7c541d1e5debbe5ac350de942fb539) | `` evcc: 0.311.1 -> 0.312.0 ``                                                                                    |
| [`10ab364c`](https://github.com/NixOS/nixpkgs/commit/10ab364ce79627279ae5e30d393931559049213e) | `` pyfa: 2.67.0 -> 2.68.0 ``                                                                                      |
| [`edeb8f16`](https://github.com/NixOS/nixpkgs/commit/edeb8f16cf2dfa4ffcd1f410ab3fc5189e720ee8) | `` pnpm: 11.11.0 -> 11.13.1 ``                                                                                    |
| [`4c5619a8`](https://github.com/NixOS/nixpkgs/commit/4c5619a8f5f607062d60983366167fded3c5b7e8) | `` firefox-devedition-unwrapped: 153.0b11 -> 153.0b13 ``                                                          |
| [`37dde0b0`](https://github.com/NixOS/nixpkgs/commit/37dde0b03909bc46ae021e2334e68e499a45b0dc) | `` firefox-beta-unwrapped: 152.0b10 -> 153.0b13 ``                                                                |
| [`22f721aa`](https://github.com/NixOS/nixpkgs/commit/22f721aab2b3008cc27d244a28d0d5e347d22411) | `` firefox-devedition-unwrapped: 152.0b8 -> 153.0b11 ``                                                           |
| [`9aae9020`](https://github.com/NixOS/nixpkgs/commit/9aae9020bc22c2ede7ed225f1d22744a9cff66e2) | `` firefox-devedition-unwrapped: 152.0b1 -> 152.0b8 ``                                                            |
| [`bccb92a3`](https://github.com/NixOS/nixpkgs/commit/bccb92a3da0970949555e40f37d30e6879278f63) | `` xla: require big-parallel feature ``                                                                           |
| [`943cba13`](https://github.com/NixOS/nixpkgs/commit/943cba13ab39593375ac3451d7568aa0bc3bdc38) | `` forgejo: 15.0.5 -> 16.0.0 ``                                                                                   |
| [`db1a4410`](https://github.com/NixOS/nixpkgs/commit/db1a44108a126696413cd38eb181b44ab3488f63) | `` vesktop: migrate from electron_40 to electron_42 ``                                                            |
| [`cb1f36ca`](https://github.com/NixOS/nixpkgs/commit/cb1f36ca4380fcb1e8c692a6a0152b4907ea8aa9) | `` victorialogs: 1.51.0 -> 1.52.0 ``                                                                              |
| [`f86737b8`](https://github.com/NixOS/nixpkgs/commit/f86737b89aaac04dc23c39ef9f8bef218d20a2b0) | `` mediawiki: 1.45.3 -> 1.45.4 ``                                                                                 |
| [`ad8a24e0`](https://github.com/NixOS/nixpkgs/commit/ad8a24e08a3a91af85205b51792d625a17a238b7) | `` repomix: 1.14.0 -> 1.15.0 ``                                                                                   |
| [`eefd7ae5`](https://github.com/NixOS/nixpkgs/commit/eefd7ae567dcb890dbe9710aeba079a3b271ec28) | `` rancher: 2.14.1 -> 2.14.2 ``                                                                                   |
| [`0ccdb899`](https://github.com/NixOS/nixpkgs/commit/0ccdb8998a58b2203e9de49ccd2bde5a27998512) | `` shaarli: 0.16.1 -> 0.16.3 ``                                                                                   |
| [`9d49f128`](https://github.com/NixOS/nixpkgs/commit/9d49f1281474cf578aba150355aa3439e05aabb7) | `` freeipmi: 1.6.17 -> 1.6.18 ``                                                                                  |
| [`3ba5baa4`](https://github.com/NixOS/nixpkgs/commit/3ba5baa4d694a7bf40b1a8fe87cbeea484a89aa6) | `` libreswan: 5.3.1 -> 5.3.2 ``                                                                                   |
| [`b7356750`](https://github.com/NixOS/nixpkgs/commit/b7356750866a9122dafe7abfaeac46cfed6607ce) | `` Revert "nixosTests/zfs: replace direct bootctl call with switch-to-configuration invocation" ``                |
| [`123fbdc9`](https://github.com/NixOS/nixpkgs/commit/123fbdc90070920635b2aa3e7a31fdf9970fce7a) | `` zfs: remove patch ``                                                                                           |
| [`b524bd96`](https://github.com/NixOS/nixpkgs/commit/b524bd96d9ffaf04a4312f18b9d773192ff6b96c) | `` zfs_2_4: 2.4.2 -> 2.4.3 ``                                                                                     |
| [`ec560ff4`](https://github.com/NixOS/nixpkgs/commit/ec560ff469946eb2959c827b46e2331b1a56bb73) | `` zfs_2_3: 2.3.7 -> 2.3.8 ``                                                                                     |
| [`e3759cac`](https://github.com/NixOS/nixpkgs/commit/e3759cac343b1f508613ac53554475e0871e7d5d) | `` ungoogled-chromium: 150.0.7871.124-1 -> 150.0.7871.128-1 ``                                                    |
| [`c0170845`](https://github.com/NixOS/nixpkgs/commit/c01708459919f3a00c91288361538d1d45a7645d) | `` python3Packages.beets-filetote: 1.3.5 -> 1.3.6 ``                                                              |
| [`7b2b8435`](https://github.com/NixOS/nixpkgs/commit/7b2b8435a19b0ea20c788015a2388f02cea19d89) | `` python3Packages.beets-filetote: add returntoreality as maintainer ``                                           |
| [`f205a6cd`](https://github.com/NixOS/nixpkgs/commit/f205a6cd40967d1bbe17398bda2b7ff5e1743f54) | `` python3Packages.beets-filetote: 1.1.1 -> 1.3.5 ``                                                              |
| [`b7e3f7a7`](https://github.com/NixOS/nixpkgs/commit/b7e3f7a70b3f9302b1f0e233e5e067aec855222c) | `` python3Packages.beets-alternatives: fix tests with upstream patch ``                                           |
| [`e1d267aa`](https://github.com/NixOS/nixpkgs/commit/e1d267aa7565c3f0f1bfcf808685df5344690171) | `` python3Packages.beets-filetote: remove unused pytest argument ``                                               |
| [`e3129d22`](https://github.com/NixOS/nixpkgs/commit/e3129d220797985ec8a0df23805ff0acc8da17d9) | `` python3Packages.beets: 2.11.0 -> 2.12.0 ``                                                                     |
| [`05e8b39f`](https://github.com/NixOS/nixpkgs/commit/05e8b39f7691ea070fdd35434b720327466de49a) | `` python3Packages.beets: remove gstreamer test ``                                                                |
| [`636ded8b`](https://github.com/NixOS/nixpkgs/commit/636ded8bf3733e7e426078529bb198f6ac2febfe) | `` python3Packages.beets: fix plugin dependencies ``                                                              |
| [`f9ff7e7a`](https://github.com/NixOS/nixpkgs/commit/f9ff7e7a12bedd3ff2fb5010623ba817ece72f38) | `` python3Packages.beets: mark bpsync plugin deprecated ``                                                        |
| [`f58d893c`](https://github.com/NixOS/nixpkgs/commit/f58d893cb6bb64c6b498bd0aae3df1221a65a72a) | `` python3Packages.beets: add single-plugin passthru tests ``                                                     |
| [`43d096e5`](https://github.com/NixOS/nixpkgs/commit/43d096e5545aa3e4590ed3c92401469cf20c824d) | `` python3Packages.beets: use lib.pipe for plugins.all (readability) ``                                           |
| [`ce95e82d`](https://github.com/NixOS/nixpkgs/commit/ce95e82d193db33d28ed8ab32ed5d1bf30052695) | `` python3Packages.beets: add doCheck argument for easier overriding ``                                           |
| [`a0350896`](https://github.com/NixOS/nixpkgs/commit/a0350896a1c6e8679cf95d036228ad8f33e3bbfe) | `` python3Packages.beets: add staticdev as maintainer ``                                                          |
| [`2318eb69`](https://github.com/NixOS/nixpkgs/commit/2318eb6960a0f62cd0c037acaf32d170d3d10254) | `` radare2: 6.1.4 -> 6.1.8 ``                                                                                     |
| [`f7b759a8`](https://github.com/NixOS/nixpkgs/commit/f7b759a80e65adc0eb12935d7700bab66a4e4ff5) | `` nixos/tack: init ``                                                                                            |
| [`71a601cf`](https://github.com/NixOS/nixpkgs/commit/71a601cfc5a2faa3124f1001af18494619fc63ee) | `` tack: init at 1.0.0 ``                                                                                         |
| [`78ee5ed2`](https://github.com/NixOS/nixpkgs/commit/78ee5ed2d29e3ca43bdc4ff6bb1815cad92ae942) | `` freerdp: 3.27.1 -> 3.29.0 ``                                                                                   |
| [`46e0d6b0`](https://github.com/NixOS/nixpkgs/commit/46e0d6b0a5e68aa8acfdc536205e2be40ab07f16) | `` cyrus-imapd: 3.12.2 -> 3.12.3 ``                                                                               |
| [`88cb4940`](https://github.com/NixOS/nixpkgs/commit/88cb49400303b09a3fc6e155197daea1fa5a9e73) | `` ioquake3: fix riscv cross-compilation ``                                                                       |
| [`65653a25`](https://github.com/NixOS/nixpkgs/commit/65653a257d7ca0d2f13cbfc0c4267588db5cf19c) | `` libgcrypt: fix riscv64-linux build ``                                                                          |
| [`8a9214a0`](https://github.com/NixOS/nixpkgs/commit/8a9214a0c4615f26d734f2d1d0a462b5a9725331) | `` mimir: remove adamcstephens as maintainer ``                                                                   |
| [`fa324fd4`](https://github.com/NixOS/nixpkgs/commit/fa324fd46d73b0bef461db6f0418cd3da5fa936c) | `` mimir: 3.0.7 -> 3.0.8 ``                                                                                       |
| [`f9b4be71`](https://github.com/NixOS/nixpkgs/commit/f9b4be71163c692f91325d3f9a6649d2c2c61bf8) | `` perlPackages.JavaScriptMinifierXS: 0.15 -> 0.16 ``                                                             |
| [`82cc7453`](https://github.com/NixOS/nixpkgs/commit/82cc745378dc9064945b1bc23f45111d88492690) | `` rocketchat-desktop: 4.15.0 -> 4.15.2 ``                                                                        |
| [`b073e8ef`](https://github.com/NixOS/nixpkgs/commit/b073e8efbe3a8c0c9a2d94d1feef56d8fb67c365) | `` rocketchat-desktop: 4.14.1 -> 4.15.0 ``                                                                        |
| [`083bc21d`](https://github.com/NixOS/nixpkgs/commit/083bc21dff03bacd6ccbe59105d7ecf7c7256465) | `` wordpress_*: add bartoostveen as a maintainer ``                                                               |
| [`fa88ad0f`](https://github.com/NixOS/nixpkgs/commit/fa88ad0f4d13ad8538bdad17f52aa1b6cf177b29) | `` wordpress_*: modernize ``                                                                                      |
| [`978d5adc`](https://github.com/NixOS/nixpkgs/commit/978d5adc583fcd7ea4717e2ee8d0bbdb8a2308cf) | `` wordpressPackages: update plugins and themes ``                                                                |
| [`ea14c61e`](https://github.com/NixOS/nixpkgs/commit/ea14c61e2b1c36722ac66a9d5d471e22c2f44238) | `` wordpress_7_0: init at 7.0 ``                                                                                  |
| [`d7a7c725`](https://github.com/NixOS/nixpkgs/commit/d7a7c725eef502b54c2471ec03632a7fb3ca6804) | `` electron_40-bin: mark as insecure ``                                                                           |
| [`f9f5ac25`](https://github.com/NixOS/nixpkgs/commit/f9f5ac259a85e639eb939414920297bb4256975a) | `` electron-source.electron_40: remove ``                                                                         |
| [`31a0c572`](https://github.com/NixOS/nixpkgs/commit/31a0c5721a2c8d43f860b6d639bc6260288f2c68) | `` opencode: add x86_64-darwin support ``                                                                         |
| [`ce9342a2`](https://github.com/NixOS/nixpkgs/commit/ce9342a2531e3f501c6bf291ced9c3f1cf9b6cce) | `` nixos/incus: fix incus containers being wrongly restarted on package update whilst softDaemonRestart is set `` |
| [`fb40fd5f`](https://github.com/NixOS/nixpkgs/commit/fb40fd5f644a3fee4cd5949063215f35c7a63971) | `` archisteamfarm: 6.3.6.0 -> 6.3.6.1 ``                                                                          |
| [`78943072`](https://github.com/NixOS/nixpkgs/commit/78943072fd551f55e7b070eeafde113550baed76) | `` prosody: 13.0.3 -> 13.0.6 ``                                                                                   |