### PR TITLE
chore(flake/niri): `61efc39e` -> `e824ba4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -629,11 +629,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1784488715,
-        "narHash": "sha256-r1fBgFQIWIfkD+oSW0A95syhs9EDhdNmsYoH5iC3a+w=",
+        "lastModified": 1784573996,
+        "narHash": "sha256-DtURW6dNmnTdD/lFxN3ej34qFka5zwfi94k1t+fcQYU=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "61efc39e76d3d3aa89bbbfcf84b75655909c443f",
+        "rev": "e824ba4f9bc2049ab80846e5d70a03f6249065c3",
         "type": "github"
       },
       "original": {
@@ -662,11 +662,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1784456420,
-        "narHash": "sha256-38yvDuO09V/GG19oJO+B5nn38NhvvZEWKRGFE4WPUi4=",
+        "lastModified": 1784570726,
+        "narHash": "sha256-9EMn69JBcFWFgUM7f0VBAX+jBby5b9H3M59U75+5yI4=",
         "owner": "niri-wm",
         "repo": "niri",
-        "rev": "f036de655d309edc13fef545a3809330796cbe83",
+        "rev": "7f26c3ee804fb6ed458ef7fb0e3c794f14e0b3bc",
         "type": "github"
       },
       "original": {
@@ -971,11 +971,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`e824ba4f`](https://github.com/epireyn/niri-flake/commit/e824ba4f9bc2049ab80846e5d70a03f6249065c3) | `` Update flake.lock `` |
| [`2b8b91c7`](https://github.com/epireyn/niri-flake/commit/2b8b91c74002172d076121b2fc349b795f478318) | `` Update flake.lock `` |