### PR TITLE
chore(flake/home-manager): `3139deb8` -> `deeb6b7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784489491,
-        "narHash": "sha256-j9maqjx1T8+ljAVntAdSI5hSGCm77QNZz64JF1rJNu0=",
+        "lastModified": 1784588016,
+        "narHash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3139deb8cafbe73b39b24451255b2fdd3426077e",
+        "rev": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`deeb6b7e`](https://github.com/nix-community/home-manager/commit/deeb6b7eb7e0c44ae1819c051ce175bd92a85100) | `` files: fix unintended subshell expansion ``                    |
| [`cbcbd8b0`](https://github.com/nix-community/home-manager/commit/cbcbd8b043a666b0c7566d8d80f6d772fce0568d) | `` kanshi: Fix scale example values from int to float ``          |
| [`7e2199f4`](https://github.com/nix-community/home-manager/commit/7e2199f4bc76f96e557d35ac84523852dc67e302) | `` rclone: set `programs.fuse.enable` to fix integration tests `` |
| [`56ccab89`](https://github.com/nix-community/home-manager/commit/56ccab89189f63dcd14a3f5710c8d3577d81f22a) | `` programs.claude-code: avoid watching the Nix store ``          |
| [`a02190ed`](https://github.com/nix-community/home-manager/commit/a02190edf9a79d8da191da75eced1ce1ae5e2408) | `` wlsunset: add duration option ``                               |
| [`411408f5`](https://github.com/nix-community/home-manager/commit/411408f523b59d6c781d9f8176ce749c4f0d5aa3) | `` lib/file-type: partially apply hasPrefix and removePrefix ``   |
| [`7834e3fb`](https://github.com/nix-community/home-manager/commit/7834e3fb36a685e0cea0290312b4d200d06649ef) | `` Translate using Weblate (Chinese (Simplified Han script)) ``   |
| [`7d7a2566`](https://github.com/nix-community/home-manager/commit/7d7a2566f6578f82ee478c8fdf6da1737eba3197) | `` Translate using Weblate (Italian) ``                           |
| [`e3dea8e4`](https://github.com/nix-community/home-manager/commit/e3dea8e4792b09a6c0eb5836b0284ad05b1acba0) | `` tirith: zsh initExtra -> initContent ``                        |