### PR TITLE
chore(flake/freminal): `c9d41ef2` -> `5660875b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784521295,
-        "narHash": "sha256-pPrDuLZdWlkDC6wlNeHGPXMvzaRvmJQOh6e6Tsqr2U0=",
+        "lastModified": 1784593281,
+        "narHash": "sha256-CZjJLsHdUV4j0JRtYGxahm7G2sVfspVhtO7D+4BZn0Q=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "c9d41ef20f0410cb32ca500900a5d4638efbf204",
+        "rev": "5660875b0d867d703194ba83934633b1a5930677",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`dc8eb1f3`](https://github.com/fredsystems/freminal/commit/dc8eb1f39ac53149665ebdf2ebd74d2191a50068) | `` chore: harden --raw-pty export in sequence_decoder.py ``                       |
| [`58978eee`](https://github.com/fredsystems/freminal/commit/58978eeee24823b92c22399f00a4c12701ad2d10) | `` chore: add --raw-pty export mode to sequence_decoder.py ``                     |
| [`b0d591ba`](https://github.com/fredsystems/freminal/commit/b0d591ba2e7b989fc94f04e7eaa7c76a2fb22e1e) | `` fix: no BCE on line-feed/scroll-created rows (extra blank line on resize) ``   |
| [`3a676c02`](https://github.com/fredsystems/freminal/commit/3a676c02f61bc6a04af980f0799b06509e9063f7) | `` test: 119 -- address CodeRabbit review on PR #419 ``                           |
| [`e946084d`](https://github.com/fredsystems/freminal/commit/e946084d1b592023479adf2e83adb1a54248a9d3) | `` chore(version): 0.12.0-beta.3 ``                                               |
| [`fd625e07`](https://github.com/fredsystems/freminal/commit/fd625e0786460709b6e1eb711feb5fa9b91640ca) | `` docs: 119 -- mark Task 119 (Scrollback Compression) pending merge ``           |
| [`7f7954fe`](https://github.com/fredsystems/freminal/commit/7f7954fe81ef80879e95e579718dc2f23afa0423) | `` perf: 119.6 -- compression benchmarks + idle-budget tuning ``                  |
| [`475479b2`](https://github.com/fredsystems/freminal/commit/475479b2c65c81c0639a26553cc98e5666f5946a) | `` perf: 119.5 -- idle-driven scrollback compression on the PTY thread ``         |
| [`58833f0b`](https://github.com/fredsystems/freminal/commit/58833f0b1998480bdd760400b201ecce5dee4f90) | `` perf: 119.4 -- compress cold scrollback blocks with decompress-on-read ``      |
| [`0c9d6201`](https://github.com/fredsystems/freminal/commit/0c9d6201aa8ec57d20defc1c239100ef17260100) | `` perf: 119.2 + 119.3 -- LZ4 compressed-block type + CompactRow serialization `` |