### PR TITLE
chore(flake/nixpkgs): `61b7c44c` -> `241313f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -814,11 +814,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`f7ebebed`](https://github.com/NixOS/nixpkgs/commit/f7ebebed87250a40e83b612a21626613c1d45829) | `` casync: drop fuse support ``                                                                                   |
| [`74f1e0fd`](https://github.com/NixOS/nixpkgs/commit/74f1e0fd88ab1fdbf858d6ba2107cbf3ca82892b) | `` maintainers: remove lumi ``                                                                                    |
| [`60b3b829`](https://github.com/NixOS/nixpkgs/commit/60b3b829befc8ee348d1bbe7feab3da17de0b02d) | `` python3Packages.flask-static-digest: init at 0.4.1 ``                                                          |
| [`cf53f066`](https://github.com/NixOS/nixpkgs/commit/cf53f06606924cd9109e8890b27a257fa442058f) | `` prometheus-node-exporter: 1.12.0 -> 1.12.1 ``                                                                  |
| [`6ca435f1`](https://github.com/NixOS/nixpkgs/commit/6ca435f1c65c32eff8fd991142a70fb2424cf4dc) | `` phoenixd: 0.8.0 -> 0.9.0 ``                                                                                    |
| [`76c59399`](https://github.com/NixOS/nixpkgs/commit/76c59399edad6cdcaef372451e8bfd5ad8e0fd4a) | `` python3Packages.meld3: drop ``                                                                                 |
| [`74b37d77`](https://github.com/NixOS/nixpkgs/commit/74b37d77b750308a43f5059e1d681810e352aaab) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.11.4 -> 4.11.5 ``                              |
| [`304f5ed0`](https://github.com/NixOS/nixpkgs/commit/304f5ed0bedd0e71014f78e158528400405c33aa) | `` confy-tui: init at 3.0.0 ``                                                                                    |
| [`148342b2`](https://github.com/NixOS/nixpkgs/commit/148342b2232aa0eb14c6151d77ae5aac2654cff1) | `` maintainers: add phluxjr ``                                                                                    |
| [`2a7f6f66`](https://github.com/NixOS/nixpkgs/commit/2a7f6f66bdfcc1a0e24273e4e8baf2f9650d0b7d) | `` home-assistant-custom-components.cable_modem_monitor: 3.14.0-beta.13 -> 3.14.0-beta.14 ``                      |
| [`bdca419f`](https://github.com/NixOS/nixpkgs/commit/bdca419f3819f2fdc66dae70c825fbb428555a45) | `` home-assistant-custom-components.smarthq: 1.2.2 -> 1.2.3 ``                                                    |
| [`a11b7d5c`](https://github.com/NixOS/nixpkgs/commit/a11b7d5ce8a5b7b8b6cd43e81c82e1eadc3bc03f) | `` oci-cli: 3.89.1 -> 3.89.2 ``                                                                                   |
| [`58fee7f4`](https://github.com/NixOS/nixpkgs/commit/58fee7f4f7524452cf0a04153c66c0b77b0dab40) | `` eww: remove rustc bootstrap ``                                                                                 |
| [`3435825c`](https://github.com/NixOS/nixpkgs/commit/3435825c66ec487a9a2f727dce41627766dea07a) | `` timelimit: adopt ``                                                                                            |
| [`e0ad052d`](https://github.com/NixOS/nixpkgs/commit/e0ad052d15ee915a6a5e1d25b8f383293048feb9) | `` unimap: adopt ``                                                                                               |
| [`83d207ac`](https://github.com/NixOS/nixpkgs/commit/83d207ac9fceb26f2a3e2aea050537a10cfada4f) | `` tml: adopt ``                                                                                                  |
| [`b88fa503`](https://github.com/NixOS/nixpkgs/commit/b88fa50389ce93fe12f22a455367a3918b7bf5d0) | `` nixos/tabbyapi: sync options with upstream ``                                                                  |
| [`5507f97c`](https://github.com/NixOS/nixpkgs/commit/5507f97c7fa0b4d93e75d4831a3eab6666424163) | `` python3Packages.exllamav2: drop ``                                                                             |
| [`f54df095`](https://github.com/NixOS/nixpkgs/commit/f54df095479861765490319b51041fdb11ea8ae5) | `` archon-lite: 9.3.172 -> 9.4.36 ``                                                                              |
| [`ae9dcf6e`](https://github.com/NixOS/nixpkgs/commit/ae9dcf6e3c334a54cb89ed56e4bc9fee2695fdb7) | `` tabbyapi: 0-unstable-2026-06-27 -> 0-unstable-2026-07-18 ``                                                    |
| [`dfdf079c`](https://github.com/NixOS/nixpkgs/commit/dfdf079ccd8114467b7d0894757e57edc945fcad) | `` python3Packages.exllamav3: 0.0.43 -> 1.1.0 ``                                                                  |
| [`aff80617`](https://github.com/NixOS/nixpkgs/commit/aff80617db77df43ca189f01beab29b77a8526df) | `` feishin: 1.13.0 -> 1.15.0 ``                                                                                   |
| [`6fe80390`](https://github.com/NixOS/nixpkgs/commit/6fe8039026234040655ee3e49d225d74ff4d0377) | `` betteralign: 0.14.0 -> 0.14.2 ``                                                                               |
| [`f9e65543`](https://github.com/NixOS/nixpkgs/commit/f9e655431c89f743773aa1c98a07ea8bf1b8488b) | `` libretro.beetle-psx: 0-unstable-2026-07-11 -> 0-unstable-2026-07-18 ``                                         |
| [`99491ba6`](https://github.com/NixOS/nixpkgs/commit/99491ba6e1e2acbcb0be1f79db43ea9f5972ba5c) | `` livekit-cli: 2.17.0 -> 2.18.0 ``                                                                               |
| [`8ed12904`](https://github.com/NixOS/nixpkgs/commit/8ed12904eb0127ff55e9a1e355ef9c7e8c254f45) | `` cudatext: 1.235.0.3 -> 1.235.1.0 ``                                                                            |
| [`14f41176`](https://github.com/NixOS/nixpkgs/commit/14f411767f98a4c8b1d3b89a90ee9f675c3605b3) | `` snips-sh: 0.10.1 -> 0.11.0 ``                                                                                  |
| [`4add5411`](https://github.com/NixOS/nixpkgs/commit/4add54119e13fc28400956015caebc06dd692aff) | `` veilid: 0.5.6 -> 0.5.7 ``                                                                                      |
| [`067e9a0c`](https://github.com/NixOS/nixpkgs/commit/067e9a0c535c7d65759a9096e9892253e3213fc4) | `` warp-terminal: 0.2026.07.08.17.54.stable_02 -> 0.2026.07.15.08.55.stable_01 ``                                 |
| [`8ed5a1e5`](https://github.com/NixOS/nixpkgs/commit/8ed5a1e5cb4f8c0b3adab02aaf4bb58bfabb4e76) | `` pocketbase: 0.39.6 -> 0.39.8 ``                                                                                |
| [`e222c7dc`](https://github.com/NixOS/nixpkgs/commit/e222c7dcf1345077b2cdb789003e8c48080ff157) | `` python3Packages.pymvglive: drop ``                                                                             |
| [`3709bda3`](https://github.com/NixOS/nixpkgs/commit/3709bda38e09b4748c1ccf6558d06a527223cdfb) | `` mplayer: move to by-name ``                                                                                    |
| [`83ee6c36`](https://github.com/NixOS/nixpkgs/commit/83ee6c36f50e950662885f56959a40fb0be452b5) | `` oxfmt: 0.58.0 -> 0.59.0 ``                                                                                     |
| [`2efeb439`](https://github.com/NixOS/nixpkgs/commit/2efeb439e287f9a402d6693d6a1534a651ae6387) | `` fpart: 1.7.0 -> 1.7.1 ``                                                                                       |
| [`bcd6e4df`](https://github.com/NixOS/nixpkgs/commit/bcd6e4df6d70dbeffbe68398de1132400790ca76) | `` just: 1.56.0 -> 1.57.0 ``                                                                                      |
| [`61e8bd31`](https://github.com/NixOS/nixpkgs/commit/61e8bd315ee6fad5cf8ba526e9ae9b82ecb39c47) | `` serie: 0.8.0 -> 0.8.1 ``                                                                                       |
| [`f4c30622`](https://github.com/NixOS/nixpkgs/commit/f4c30622bab7c3fe59da1a8843c380478d42a912) | `` glauth: 2.5.0 -> 2.5.1 ``                                                                                      |
| [`6bd35e25`](https://github.com/NixOS/nixpkgs/commit/6bd35e253519c52e14b2761a47cb9c5e6698b1eb) | `` zennotes-desktop: 2.13.5 -> 2.14.0 ``                                                                          |
| [`4c54c8b8`](https://github.com/NixOS/nixpkgs/commit/4c54c8b8794c7a32970827d34d61974464a03bcf) | `` invidious: patch CVE-2026-58447 ``                                                                             |
| [`2d2bc51a`](https://github.com/NixOS/nixpkgs/commit/2d2bc51aa1f8da07cae5f718db3ff0ab80d3a112) | `` forgejo-cli: 0.5.0 -> 0.6.0 ``                                                                                 |
| [`9b4a3051`](https://github.com/NixOS/nixpkgs/commit/9b4a30518c502d96bae0f43b2fa3d1053461ba1d) | `` statix: 0.5.8-unstable-2026-07-10 -> 0.5.8-unstable-2026-07-17 ``                                              |
| [`5083fec2`](https://github.com/NixOS/nixpkgs/commit/5083fec268f90eb50424159a2efba68926cb481c) | `` knossosnet: 1.3.8 -> 1.3.9 ``                                                                                  |
| [`a3310ba2`](https://github.com/NixOS/nixpkgs/commit/a3310ba26845b99ffc625947f20844101e53d4d6) | `` nak: 0.20.0 -> 0.20.1 ``                                                                                       |
| [`0943d5cb`](https://github.com/NixOS/nixpkgs/commit/0943d5cbff6148c9ec942f2bf0b1edba5d7367e1) | `` edhm-ui: 3.0.69 -> 3.0.70 ``                                                                                   |
| [`5e2d6f7d`](https://github.com/NixOS/nixpkgs/commit/5e2d6f7dc07e64a6ca33a654f168dc6f2aa2749a) | `` python3Packages.cppheaderparser: use finalAttrs and dependencies ``                                            |
| [`40868bfd`](https://github.com/NixOS/nixpkgs/commit/40868bfdf4e4b60f2a82c11aa3e50c1c3c5098f6) | `` xdg-desktop-portal-hyprland: 1.3.12 -> 1.4.0 ``                                                                |
| [`4e592b97`](https://github.com/NixOS/nixpkgs/commit/4e592b9705b75ff33cb464bbddef2da525a268a4) | `` aquamarine: 0.12.1 -> 0.13.0 ``                                                                                |
| [`39aab9af`](https://github.com/NixOS/nixpkgs/commit/39aab9af3b04abfad7912f91d6bbb67f4734dc62) | `` multica-cli: 0.3.43 -> 0.4.4 ``                                                                                |
| [`80f00642`](https://github.com/NixOS/nixpkgs/commit/80f00642e0cad742c1a855634ee7337919e9ddab) | `` nezha-theme-user: 2.4.0 -> 2.4.2 ``                                                                            |
| [`21b7e3b7`](https://github.com/NixOS/nixpkgs/commit/21b7e3b7ad8e344e8e2702d45c5669c092180d37) | `` runme: 3.17.1 -> 3.17.2 ``                                                                                     |
| [`f382dbba`](https://github.com/NixOS/nixpkgs/commit/f382dbba9c009e28e5eff1dd16a105ac96a64f10) | `` vscodium: Drop armv7l-linux and x86_64-darwin from update script ``                                            |
| [`697d2eca`](https://github.com/NixOS/nixpkgs/commit/697d2eca3346fef51776f4c6090b860942ec39f6) | `` pedantix: init at 1.0.0 ``                                                                                     |
| [`d3a530e5`](https://github.com/NixOS/nixpkgs/commit/d3a530e577e77ee8b930e13d2c0dc10c7669a176) | `` home-assistant-custom-components.frigidaire: 0.1.30 -> 0.1.31 ``                                               |
| [`de27704f`](https://github.com/NixOS/nixpkgs/commit/de27704fc5c79f864b7a7f0674e7ad5c63221664) | `` stamp: add missing glib-networking dependency ``                                                               |
| [`2e67fe9a`](https://github.com/NixOS/nixpkgs/commit/2e67fe9a22edc9ace25075903bd59b7c68528488) | `` qemu: disable `brlttySupport` on darwin by default ``                                                          |
| [`aef3427e`](https://github.com/NixOS/nixpkgs/commit/aef3427eef4b92c18c099489d0591ee80448c675) | `` pakku: 1.3.3 -> 1.5.0 ``                                                                                       |
| [`9cd5226f`](https://github.com/NixOS/nixpkgs/commit/9cd5226f034a5b91b0224053557db55fdda453d4) | `` home-assistant-custom-components.localtuya: 2025.11.0 -> 2026.7.0 ``                                           |
| [`f317110a`](https://github.com/NixOS/nixpkgs/commit/f317110a52f27f205cb2bee5ee5683a3d70ad14f) | `` flyctl: 0.4.69 -> 0.4.71 ``                                                                                    |
| [`d2e3cbf2`](https://github.com/NixOS/nixpkgs/commit/d2e3cbf2757bf60d21129239663ceb892f1ee3fc) | `` lockbook-desktop: 26.7.4 -> 26.7.16 ``                                                                         |
| [`1721a4af`](https://github.com/NixOS/nixpkgs/commit/1721a4af200e5b6ddd6819814bb45ce44187950e) | `` python3Packages.nixpkgs-pytools: use finalAttrs and dependencies ``                                            |
| [`c1c721d1`](https://github.com/NixOS/nixpkgs/commit/c1c721d10d3d96250408ec8791884447dc9d15e3) | `` jackett: 0.24.2200 -> 0.24.2237 ``                                                                             |
| [`2ae80aff`](https://github.com/NixOS/nixpkgs/commit/2ae80affee2abc3dad4a0a8c3f44d46b94d151ee) | `` python3Packages.fireworks-ai: 1.2.0-alpha.71 -> 1.2.0 ``                                                       |
| [`6db9adcb`](https://github.com/NixOS/nixpkgs/commit/6db9adcbc4ca2c7ae59a249ac6656378459b11f7) | `` code-cursor: 3.11.19 -> 3.12.17 ``                                                                             |
| [`8cf30075`](https://github.com/NixOS/nixpkgs/commit/8cf30075e773b06a4e18f0cf6005c6ec5982e19e) | `` python3Packages.ttkbootstrap: 1.20.4 -> 2.0.0 ``                                                               |
| [`3e2eaba6`](https://github.com/NixOS/nixpkgs/commit/3e2eaba6037a02edee74c77024fe45c9b4b2e479) | `` limine: 12.4.2 -> 12.5.0 ``                                                                                    |
| [`43769ddc`](https://github.com/NixOS/nixpkgs/commit/43769ddc856292fb01651d07c2c3623e555817fb) | `` kin-openapi: 0.141.0 -> 0.142.0 ``                                                                             |
| [`09598d76`](https://github.com/NixOS/nixpkgs/commit/09598d769ece497fd0d60c91ca74fbbdb218d80a) | `` python3Packages.whirlpool-sixth-sense: 1.2.0 -> 1.3.1 ``                                                       |
| [`578aa1f6`](https://github.com/NixOS/nixpkgs/commit/578aa1f69ab934dfdb29772c639d08216466e808) | `` python3Packages.asyncwhois: migrate to finalAttrs ``                                                           |
| [`4050db98`](https://github.com/NixOS/nixpkgs/commit/4050db98fead6a61a551bc98338dbb28831db8f5) | `` vimPlugins.fff-nvim: 0.9.6 -> 0.10.0 ``                                                                        |
| [`30c32092`](https://github.com/NixOS/nixpkgs/commit/30c32092dc09e48d0a9c7ac525a356193e816dbc) | `` python3Packages.pyskyqhub: modernize ``                                                                        |
| [`9fabc663`](https://github.com/NixOS/nixpkgs/commit/9fabc663866174ff821f40ab80aee2346c761ad4) | `` python3Packages.rns: 1.3.8 -> 1.3.9 ``                                                                         |
| [`1fa9124c`](https://github.com/NixOS/nixpkgs/commit/1fa9124cb72bc67997f2c7325ca9192e8fac8dd5) | `` vimPlugins.canola-nvim: init at 0.1.0-1 ``                                                                     |
| [`517aa7e8`](https://github.com/NixOS/nixpkgs/commit/517aa7e8632da8e420419b25f56ad6f0fcb07a3b) | `` luaPackages.canola-nvim: init at 0.1.0-1 ``                                                                    |
| [`caebed74`](https://github.com/NixOS/nixpkgs/commit/caebed747d67b58865b0fc43a01181f0a73414cc) | `` libretro.fbneo: 0-unstable-2026-06-22 -> 0-unstable-2026-07-19 ``                                              |
| [`7d414b04`](https://github.com/NixOS/nixpkgs/commit/7d414b046bfc07faa9ae32055359ff988e3942f7) | `` python313Packages.iamdata: 0.1.202607181 -> 0.1.202607191 ``                                                   |
| [`7209554a`](https://github.com/NixOS/nixpkgs/commit/7209554a8248a330bbd2ed4495fabee54118bb4b) | `` diskwatch: 0.1.2 -> 0.1.3 ``                                                                                   |
| [`904aebb3`](https://github.com/NixOS/nixpkgs/commit/904aebb35628ba087126a05adc8526148d21a08b) | `` reqable: 3.2.3 -> 3.2.10 ``                                                                                    |
| [`82a23a5a`](https://github.com/NixOS/nixpkgs/commit/82a23a5af08a22149784c807ef499aa4a4ef157b) | `` libretro.mame: 0-unstable-2026-06-16 -> 0-unstable-2026-07-18 ``                                               |
| [`44045f69`](https://github.com/NixOS/nixpkgs/commit/44045f695f796857463c01c41d458085b531be1d) | `` ggml: 0.16.0 -> 0.17.0 ``                                                                                      |
| [`f303f458`](https://github.com/NixOS/nixpkgs/commit/f303f4588127b74344346015ac9ba6a7e0a74589) | `` checkstyle: 13.7.0 -> 13.8.0 ``                                                                                |
| [`88b832f0`](https://github.com/NixOS/nixpkgs/commit/88b832f0c4d6e2273e0a525541dc84d73e9caad3) | `` usage: 3.5.4 -> 3.5.5 ``                                                                                       |
| [`e3c72c88`](https://github.com/NixOS/nixpkgs/commit/e3c72c88d3112ea78be9226a7938d6c2be4ce7e1) | `` ghostfolio: 3.22.0 -> 3.29.0 ``                                                                                |
| [`39425bc3`](https://github.com/NixOS/nixpkgs/commit/39425bc3e82422198b3d46d98e6edbff00082110) | `` unityhub: 3.19.1 -> 3.19.5 ``                                                                                  |
| [`e97ec58a`](https://github.com/NixOS/nixpkgs/commit/e97ec58af3a54e09d941a2bf9e3858baec0620fc) | `` python3Packages.hier-config: 3.6.1 -> 3.6.2 ``                                                                 |
| [`f3788960`](https://github.com/NixOS/nixpkgs/commit/f3788960676799887599bbc0b779b4d576d5bac2) | `` syswatch: 0.7.3 -> 0.7.5 ``                                                                                    |
| [`83f439aa`](https://github.com/NixOS/nixpkgs/commit/83f439aa801e67aa59b0627ac51468f0e69880cf) | `` super-productivity: 18.13.1 -> 18.15.1 ``                                                                      |
| [`6e2c517f`](https://github.com/NixOS/nixpkgs/commit/6e2c517f77e6f993eed77d2753eb7a993f3465f4) | `` perfect_dark: fix hash ``                                                                                      |
| [`eec82c42`](https://github.com/NixOS/nixpkgs/commit/eec82c426d2607ad67a7878085bb417fb004ce81) | `` piliplus: 2.0.9.2 -> 2.1.0 ``                                                                                  |
| [`246189d4`](https://github.com/NixOS/nixpkgs/commit/246189d433c783c12440e1df45e7f7dd2b058e43) | `` nixos/tests/immichframe: add jfly as maintainer ``                                                             |
| [`97451cd2`](https://github.com/NixOS/nixpkgs/commit/97451cd267c458520a2d112eda5cf253100068d2) | `` nixos/redmine: Drop pidfile ``                                                                                 |
| [`b320e385`](https://github.com/NixOS/nixpkgs/commit/b320e3850887526aabfd4e0c0f9362cadede3dc7) | `` python3Packages.caido-sdk-client: enable tests ``                                                              |
| [`17a44472`](https://github.com/NixOS/nixpkgs/commit/17a444725cb0ef9d84958c0e2e2b67e4d1f9314e) | `` wezterm: 0-unstable-2026-07-07 -> 0-unstable-2026-07-16 ``                                                     |
| [`5c8bac09`](https://github.com/NixOS/nixpkgs/commit/5c8bac0971dd2895c0989b3b8c3392e812b54e39) | `` expat: make version easily overridable ``                                                                      |
| [`401b914c`](https://github.com/NixOS/nixpkgs/commit/401b914c7dcce29097a3ca9f89684bc17c6ab98f) | `` photoprism: add ipetkov as maintainer ``                                                                       |
| [`372c1220`](https://github.com/NixOS/nixpkgs/commit/372c122028bb44864eff9576f52fe30b14a46f68) | `` maintainers: add ipetkov ``                                                                                    |
| [`19a52e1c`](https://github.com/NixOS/nixpkgs/commit/19a52e1c29c23f34d4e71dadcd83616a1ad63859) | `` river{,-classic}: mark aarch64-linux as a badPlatform ``                                                       |
| [`c0d12a58`](https://github.com/NixOS/nixpkgs/commit/c0d12a58b4a662aeec7e86fe6a8456ef471ad601) | `` antimatter-dimensions: 0-unstable-2025-11-20 -> 0-unstable-2026-07-17 ``                                       |
| [`1dc5ce08`](https://github.com/NixOS/nixpkgs/commit/1dc5ce0862b7b389f20bddb8e5dfd56febfa91b4) | `` oxigraph: add videl to maintainers ``                                                                          |
| [`345d2059`](https://github.com/NixOS/nixpkgs/commit/345d2059b5b4018de84c6f11b2d1f1049632ef95) | `` _7zz: 26.0.1 -> 26.0.2 ``                                                                                      |
| [`2dcb86fc`](https://github.com/NixOS/nixpkgs/commit/2dcb86fc30fd7a7239d0aeae32b863138d26d6df) | `` _7zz-rar: move to pkgs/by-name ``                                                                              |
| [`3160431a`](https://github.com/NixOS/nixpkgs/commit/3160431a467c11234eb5f924365f7750fd6d6cae) | `` onlyoffice-documentserver: update nodejs ``                                                                    |
| [`5f95b141`](https://github.com/NixOS/nixpkgs/commit/5f95b141b41b70a6042d47a25128cd41aaa49303) | `` bitrise: 2.40.7 -> 2.42.0 ``                                                                                   |
| [`c7ecb223`](https://github.com/NixOS/nixpkgs/commit/c7ecb223b4f5cca0ee098c026d0ec08209264abf) | `` kitty-themes: 0-unstable-2026-06-29 -> 0-unstable-2026-07-10 ``                                                |
| [`ce2a87c5`](https://github.com/NixOS/nixpkgs/commit/ce2a87c5c70c432b95399a6d87009ce3b4f7ea3d) | `` hyprlock: 0.9.5 -> 0.9.6 ``                                                                                    |
| [`ab1881b7`](https://github.com/NixOS/nixpkgs/commit/ab1881b74ab9e694dd6ff2662c2c98cfde601b29) | `` freerdp: 3.29.0 -> 3.30.0 ``                                                                                   |
| [`65f3a040`](https://github.com/NixOS/nixpkgs/commit/65f3a0405d4094e3b5952b179b42eaa66aeb09ad) | `` python3Packages.pyskyqhub: use finalAttrs ``                                                                   |
| [`2b905eab`](https://github.com/NixOS/nixpkgs/commit/2b905eab3bb4307ecfa18c6a00b218ae3454f4eb) | `` python3Packages.pyskyqhub: migrate to pyproject ``                                                             |
| [`ae9f29da`](https://github.com/NixOS/nixpkgs/commit/ae9f29da4f2e0b80316f1ae3a5ab733b3bf7acd0) | `` python3Packages.pyskyqremote: use finalAttrs ``                                                                |
| [`523ee6cd`](https://github.com/NixOS/nixpkgs/commit/523ee6cd697c854bd7854f7cf3fef444f2c7cff7) | `` python3Packages.pyskyqremote: migrate to pyproject ``                                                          |
| [`9ad186f4`](https://github.com/NixOS/nixpkgs/commit/9ad186f4bc448aa7839e00ea3a27a98d515864d5) | `` python3Packages.pysmappee: use finalAttrs ``                                                                   |
| [`8cd6028f`](https://github.com/NixOS/nixpkgs/commit/8cd6028f2b81137760286cda28bcc101e33ca4d0) | `` python3Packages.pysmappee: migrate to pyproject ``                                                             |
| [`927370f4`](https://github.com/NixOS/nixpkgs/commit/927370f46c8e9e9306863e77382a25403321f7d2) | `` wifite2: migrate to pyproject ``                                                                               |
| [`924a1d29`](https://github.com/NixOS/nixpkgs/commit/924a1d291f86dd949b7eb1056e3427af8d061e03) | `` python3Packages.aiogram: 3.29.1 -> 3.30.0 ``                                                                   |
| [`81a49953`](https://github.com/NixOS/nixpkgs/commit/81a49953b532f89d9d99c1b542ffcf28357c5ad5) | `` gpu-screen-recorder: fix hardcoded binary in service ``                                                        |
| [`a57fe35f`](https://github.com/NixOS/nixpkgs/commit/a57fe35f0e8bd968c0909aa8efb99e48ffa7c598) | `` python3Packages.pydantic-ai-slim: 2.11.0 -> 2.13.0 ``                                                          |
| [`7538f703`](https://github.com/NixOS/nixpkgs/commit/7538f703ec1cb2b4869f41ee9a16495584c9effe) | `` python3Packages.pydantic-graph: 2.11.0 -> 2.13.0 ``                                                            |
| [`af7b6e6e`](https://github.com/NixOS/nixpkgs/commit/af7b6e6e83b25f5b656ec05911f5de2529710e58) | `` python3Packages.skops: Disable tests throwing a deprecation warning ``                                         |
| [`c96e374b`](https://github.com/NixOS/nixpkgs/commit/c96e374bf01d0871758450269dc711318c2adf66) | `` htop: 3.5.1 -> 3.5.2 ``                                                                                        |
| [`8e0c38fd`](https://github.com/NixOS/nixpkgs/commit/8e0c38fd0e08e7d4f5d343151e09b5e3f0c4a5ab) | `` yokadi: use finalAttrs ``                                                                                      |
| [`593f8e0b`](https://github.com/NixOS/nixpkgs/commit/593f8e0bde12c3d822f95d9682e26d9254566a7e) | `` yokadi: migrate to pyproject ``                                                                                |
| [`45ba7823`](https://github.com/NixOS/nixpkgs/commit/45ba78238273fdfd1f565c978f3b616504314f28) | `` terraform-providers.newrelic_newrelic: 3.94.3 -> 3.95.2 ``                                                     |
| [`d542ef40`](https://github.com/NixOS/nixpkgs/commit/d542ef406161bcc79b9a4bc2c38ecc496c8958d4) | `` delta: fix cross compilation ``                                                                                |
| [`294f0e82`](https://github.com/NixOS/nixpkgs/commit/294f0e828afed2bcc3671f222a549eb600e81321) | `` freescout: 1.8.229 -> 1.8.230 ``                                                                               |
| [`205455cc`](https://github.com/NixOS/nixpkgs/commit/205455cc7c6dc7e344639fc6822f5a7fdceb8922) | `` mitm6: migrate to finalAttrs ``                                                                                |
| [`4cc36782`](https://github.com/NixOS/nixpkgs/commit/4cc3678229e16beb215aa4bc36b52373af5bcaef) | `` endless-sky: 0.11.1 -> 0.11.2 ``                                                                               |
| [`ed0971ca`](https://github.com/NixOS/nixpkgs/commit/ed0971ca1df2df2141633ddbecff8e01396a9e53) | `` bfetch: fix version ``                                                                                         |
| [`19bc4320`](https://github.com/NixOS/nixpkgs/commit/19bc43209b2e2dd25ddf5be5c706c5b8701cab38) | `` postfix-tlspol: 1.11.0 -> 1.12.1 ``                                                                            |
| [`3ea33d85`](https://github.com/NixOS/nixpkgs/commit/3ea33d855253089dc58e26880d7db45da37dde22) | `` forgejo-runner: 12.13.0 -> 12.13.1 ``                                                                          |
| [`4c06da3c`](https://github.com/NixOS/nixpkgs/commit/4c06da3cb826720116e4cd82cf9e8b4e02441246) | `` pnpm: 11.13.1 -> 11.15.0 ``                                                                                    |
| [`176a4e9b`](https://github.com/NixOS/nixpkgs/commit/176a4e9bc335431cf70d005bf42667fe0cd7f52e) | `` upiano: adopt ``                                                                                               |
| [`1479900d`](https://github.com/NixOS/nixpkgs/commit/1479900db1556f16523cff90d0eeeba7d0178e30) | `` vscode-with-extensions: respect macos package bundle's CFBundleExecutable value when generating the wrapper `` |
| [`1f17084b`](https://github.com/NixOS/nixpkgs/commit/1f17084b7b2ceeb823f75f6f43e41cda57d09694) | `` watchexec: fix build on darwin by linking with lld ``                                                          |
| [`22e2b137`](https://github.com/NixOS/nixpkgs/commit/22e2b13770c1ef4d395d247c8c0efca799fe54af) | `` vivaldi: 8.1.4087.48 -> 8.1.4087.55 ``                                                                         |
| [`388430c8`](https://github.com/NixOS/nixpkgs/commit/388430c8ea121968d43d1db0785b3a1692e97add) | `` plasma-panel-colorizer: ensure gdbus works as a fallback ``                                                    |
| [`484463f0`](https://github.com/NixOS/nixpkgs/commit/484463f024cbeabfb2d09444dc70e735abd63cfc) | `` plasma-panel-colorizer: fix presets not being listed ``                                                        |
| [`131ead25`](https://github.com/NixOS/nixpkgs/commit/131ead25f89e3b4fa4bbc40f8c6b09b4f2f187a7) | `` photoprism: pin tensorflow to python313 ``                                                                     |
| [`12590903`](https://github.com/NixOS/nixpkgs/commit/12590903438dfcabf8dbe284f8815713d89e5ce0) | `` doc2dash: init at 3.1.0 ``                                                                                     |
| [`a3330995`](https://github.com/NixOS/nixpkgs/commit/a3330995c39eb0f3b1a8d319be768211a455f477) | `` heynote: 2.9.0 -> 2.9.1 ``                                                                                     |
| [`79d59b52`](https://github.com/NixOS/nixpkgs/commit/79d59b5216952bcea28a8590f68aca1376197321) | `` server-box: 1.0.1450 -> 1.0.1466 ``                                                                            |
| [`43948b27`](https://github.com/NixOS/nixpkgs/commit/43948b27dd74f4fdc492fec37ea9ed2bf36d482d) | `` seanime: 3.9.1 -> 3.10.1 ``                                                                                    |
| [`abe27d4a`](https://github.com/NixOS/nixpkgs/commit/abe27d4ab3b54601f4a801d1ed9a163f8d80c4bb) | `` linux_6_12: 6.12.95 -> 6.12.96 ``                                                                              |
| [`613e8a3e`](https://github.com/NixOS/nixpkgs/commit/613e8a3e5b47aeee6018ab9ba5a46fb86e3fe71c) | `` linux_6_18: 6.18.38 -> 6.18.39 ``                                                                              |
| [`7c9fdc4a`](https://github.com/NixOS/nixpkgs/commit/7c9fdc4a9f7306cc76e0e8bbcd7f569d08286ed4) | `` linux_7_1: 7.1.3 -> 7.1.4 ``                                                                                   |
| [`07064227`](https://github.com/NixOS/nixpkgs/commit/070642272b4a1ed7dc80ce9dcf8f0fa18751d8f8) | `` zepp-simulator: 2.0.2 -> 2.1.1 ``                                                                              |
| [`3bf09c94`](https://github.com/NixOS/nixpkgs/commit/3bf09c94e654b1ce1dd8f028f348dda93d80e2c1) | `` principia: 2026.07.09 -> 2026.07.15 ``                                                                         |
| [`4b444848`](https://github.com/NixOS/nixpkgs/commit/4b4448482a3cdc82e05ca94da71966d004fe43b1) | `` python3Packages.ghrepo-stats: migrate to finalAttrs ``                                                         |
| [`1c6d35a8`](https://github.com/NixOS/nixpkgs/commit/1c6d35a8b6804a1bd7d32cfff81e37fcc264460d) | `` python3Packages.types-docutils: migrate to finalAttrs ``                                                       |
| [`eb2c482d`](https://github.com/NixOS/nixpkgs/commit/eb2c482d21d417832d185aeab79b4e28b75d5970) | `` altus: 5.8.0 -> 5.8.1 ``                                                                                       |
| [`16ba0c80`](https://github.com/NixOS/nixpkgs/commit/16ba0c80ab393eb18fbf818e95e5c22dc2e73d43) | `` thunar: 4.20.8 -> 4.20.9 ``                                                                                    |
| [`bff275df`](https://github.com/NixOS/nixpkgs/commit/bff275dfcb3c66bb47f817163b315a5bbb3fa633) | `` python3Packages.wandb: 0.28.0 -> 0.28.1 ``                                                                     |
| [`e36c0d30`](https://github.com/NixOS/nixpkgs/commit/e36c0d30bc4411440a6709bd7c5a57e5372c6002) | `` fzf: 0.74.0 -> 0.74.1 ``                                                                                       |
| [`b82c79fb`](https://github.com/NixOS/nixpkgs/commit/b82c79fbfd30cdaa044c28fee5b33925fb08e400) | `` spotify: (darwin) 1.2.92.147 -> 1.2.94.583 ``                                                                  |
| [`ba6feaa0`](https://github.com/NixOS/nixpkgs/commit/ba6feaa09b248e7aa06ccbedcd2edc6a6031ae51) | `` python315: 3.15.0b4 -> 3.15.0b5 ``                                                                             |
| [`6aa4fe83`](https://github.com/NixOS/nixpkgs/commit/6aa4fe83665bef13a0f068bd83e3bcd2f12f6737) | `` spotify: (linux) 1.2.90.451.gb094aab0 -> 1.2.92.147.g5b8f9367 ``                                               |
| [`0df8d818`](https://github.com/NixOS/nixpkgs/commit/0df8d818864e5b83f527ad24d6025320247e590c) | `` sview: 26_02 -> 26.07 ``                                                                                       |
| [`d05cbdbe`](https://github.com/NixOS/nixpkgs/commit/d05cbdbea987b3770f95ebf16cd661cad16ce702) | `` librime-octagram: 0-unstable-2024-11-18 -> 0-unstable-2026-07-11 ``                                            |
| [`72c11962`](https://github.com/NixOS/nixpkgs/commit/72c11962e37b5e217e53359ebb81935b56f0cc6b) | `` dotenvx: 2.3.2 -> 2.14.0 ``                                                                                    |
| [`92347536`](https://github.com/NixOS/nixpkgs/commit/923475366873cab99520ca6771ddc5dcd1a06a17) | `` incus-ui-canonical: 0.21.4 -> 0.21.5 ``                                                                        |
| [`123f62d4`](https://github.com/NixOS/nixpkgs/commit/123f62d444bede31cc87da885910f140a611a752) | `` tombi: 1.2.1 -> 1.2.2 ``                                                                                       |
| [`b778befd`](https://github.com/NixOS/nixpkgs/commit/b778befd7903e2aa773bcae474831b3130931c6c) | `` nextvi: 6.1 -> 7.0 ``                                                                                          |
| [`0e4ee45f`](https://github.com/NixOS/nixpkgs/commit/0e4ee45fc18bba8c6caffb56678e91c7dc7a4955) | `` rembg: 2.0.76 -> 2.0.77 ``                                                                                     |
| [`d650a370`](https://github.com/NixOS/nixpkgs/commit/d650a370d308866dbb5eaa7b8179516ac60a56a1) | `` chirpstack-gateway-bridge: 4.1.1 -> 4.1.2 ``                                                                   |
| [`293154fe`](https://github.com/NixOS/nixpkgs/commit/293154fec099e723e7b634997fadd865c6a0da7c) | `` terraform-providers.auth0_auth0: 1.52.0 -> 1.53.0 ``                                                           |
| [`e4cbebe1`](https://github.com/NixOS/nixpkgs/commit/e4cbebe13878a8ad1c5d4344a708a925170cd83c) | `` python3Packages.nixpkgs-pytools: migrate to pyproject ``                                                       |
| [`5b257825`](https://github.com/NixOS/nixpkgs/commit/5b257825e2e52a74761ee83d26cd47febf2ee41b) | `` remnote: 1.26.30 -> 1.26.32 ``                                                                                 |
| [`3d84ca9f`](https://github.com/NixOS/nixpkgs/commit/3d84ca9f158aff970ab8aa5dbbf6ac2d16460365) | `` python3Packages.textnets: fix strict dependency pinning ``                                                     |
| [`5068e82c`](https://github.com/NixOS/nixpkgs/commit/5068e82cf54a3cdeb7e7197621d5caf7e31cc4b7) | `` python3Packages.types-decorator: 5.2.0.20260519 -> 5.2.0.20260712 ``                                           |
| [`ae83ba71`](https://github.com/NixOS/nixpkgs/commit/ae83ba71d42556c38312ebc3382f88f385abfe78) | `` pass-secret-service: 0-unstable-2023-12-16 -> 0-unstable-2026-07-15 ``                                         |
| [`d324d23e`](https://github.com/NixOS/nixpkgs/commit/d324d23e3faa04a36af9e1c41fececae4fc445dc) | `` python3Packages.cppheaderparser: migrate to pyproject ``                                                       |
| [`c7b5f297`](https://github.com/NixOS/nixpkgs/commit/c7b5f297f29bec825406a6e73c66b8825be5e8ce) | `` terraform-providers.vmware_vcd: 3.14.1 -> 3.14.2 ``                                                            |
| [`52dac2ea`](https://github.com/NixOS/nixpkgs/commit/52dac2eaee65bd400ce1690b9832cf3a11f1df7d) | `` firebase-tools: 15.22.4 -> 15.24.0 ``                                                                          |
| [`d2e8e28e`](https://github.com/NixOS/nixpkgs/commit/d2e8e28e4083ab97f1de9296b1d128fb15ab5751) | `` snyk: 1.1306.0 -> 1.1306.1 ``                                                                                  |
| [`3e2f3181`](https://github.com/NixOS/nixpkgs/commit/3e2f3181fac5561f82ce2b762f8c03014fe19eea) | `` python3Packages.modbus-connection: 3.7.0 -> 3.8.1 ``                                                           |
| [`ce97a57b`](https://github.com/NixOS/nixpkgs/commit/ce97a57bbbe8f6d269f62b2cd5e1c4534fb10951) | `` python3Packages.ghrepo-stats: remove outdated patch of beautifulsoup4 requires ``                              |
| [`9718bbdd`](https://github.com/NixOS/nixpkgs/commit/9718bbddd9f80c9ca101fa2f2c924c74d54a60f3) | `` python3Packages.ghrepo-stats: migrate to pyproject ``                                                          |
| [`5342f797`](https://github.com/NixOS/nixpkgs/commit/5342f797d6dad6e40284e1eb22383a1035d39aab) | `` nixos/stalwart: Fix broken Stalwart documentation link in configuration ``                                     |
| [`f0caeb8a`](https://github.com/NixOS/nixpkgs/commit/f0caeb8a635766fadc152e9234577f58f11521ab) | `` _1password-gui: 8.12.26 -> 8.12.28 ``                                                                          |
| [`eae70df6`](https://github.com/NixOS/nixpkgs/commit/eae70df6d7b37c98f7e9fefe0c14efb8de61de3f) | `` python3Packages.types-docutils: 0.22.3.20260518 -> 0.22.3.20260712 ``                                          |
| [`3bf09b22`](https://github.com/NixOS/nixpkgs/commit/3bf09b228355fef9e6955a8a8af342e5b0554420) | `` mitm6: fix build failure ``                                                                                    |
| [`101f6fa2`](https://github.com/NixOS/nixpkgs/commit/101f6fa23f6e2ae98fb8fb6856baa43527cceafe) | `` go-httpbin: 2.23.1 -> 2.24.0 ``                                                                                |
| [`d10b6270`](https://github.com/NixOS/nixpkgs/commit/d10b62701bfb450e7c65eb4861df7bf872ad5750) | `` quantlib: 1.42.1 -> 1.43 ``                                                                                    |
| [`c00f6004`](https://github.com/NixOS/nixpkgs/commit/c00f6004ac8f64c844a3e93fb13d74dd5cf31db5) | `` vacuum-go: 0.29.9 -> 0.29.10 ``                                                                                |
| [`a98c685b`](https://github.com/NixOS/nixpkgs/commit/a98c685b182fceb34cac75c95e27690b5a9e6086) | `` doc/style.css: add dark mode to sidebar ``                                                                     |
| [`76ac2a2a`](https://github.com/NixOS/nixpkgs/commit/76ac2a2a9e3398e032dd17cdc75fd20c3dbd3f84) | `` python3Packages.azure-containerregistry: drop deprecated msrestazure dependency ``                             |
| [`207cd2e3`](https://github.com/NixOS/nixpkgs/commit/207cd2e3765cb95728c5c2969eab8964bc8a578c) | `` python3Packages.agentic-threat-hunting-framework: 0.13.0 -> 0.16.0 ``                                          |
| [`651d8485`](https://github.com/NixOS/nixpkgs/commit/651d84852a915b20016eadc4d6a93aa8c5ac4fb0) | `` terraform-providers.grafana_grafana: 4.40.1 -> 4.41.0 ``                                                       |
| [`e6eb0f88`](https://github.com/NixOS/nixpkgs/commit/e6eb0f8830033856a2f258bc72e4979791d24e06) | `` doc/style.css: fix .nav-sidebar class selector ``                                                              |
| [`bdf67c98`](https://github.com/NixOS/nixpkgs/commit/bdf67c98eb4f84ec58e9213bb3b87fac24805567) | `` nss_latest: 3.125 -> 3.126 ``                                                                                  |
| [`f512cfaa`](https://github.com/NixOS/nixpkgs/commit/f512cfaac66eec2b91440a0da2715c2653787464) | `` colima: add docker dependency to fix error when starting with default container runtime ``                     |
| [`939ae480`](https://github.com/NixOS/nixpkgs/commit/939ae48020c4500f149000d7dc3d17c0cd848bfb) | `` terraform-providers.exoscale_exoscale: 0.69.3 -> 0.70.0 ``                                                     |
| [`501995e9`](https://github.com/NixOS/nixpkgs/commit/501995e9fe930934bde0d9522403f0df047e441c) | `` python3Packages.cmdline: modernize ``                                                                          |
| [`8023aeef`](https://github.com/NixOS/nixpkgs/commit/8023aeef2136238722aac81015a1f90830a74ae7) | `` python3Packages.cmdline: migrate to pyproject ``                                                               |
| [`aa630e7f`](https://github.com/NixOS/nixpkgs/commit/aa630e7f14c8e98a819e9f38f0ca6f6c4a19eb93) | `` mawk: fix `passthru.tests`, relax hardening options ``                                                         |
| [`f8d55c59`](https://github.com/NixOS/nixpkgs/commit/f8d55c597ce543a15fd072221be1b00ae1012b30) | `` vscode-extensions.anthropic.claude-code: 2.1.212 -> 2.1.214 ``                                                 |
| [`46ff6453`](https://github.com/NixOS/nixpkgs/commit/46ff6453436c67166ccb6e3434bba9bf671fdcf9) | `` claude-code: 2.1.212 -> 2.1.214 ``                                                                             |
| [`3906c00f`](https://github.com/NixOS/nixpkgs/commit/3906c00fcad20a40ea3fee12d829efb784166013) | `` python3Packages.aioghost: 0.4.18 -> 0.4.19 ``                                                                  |
| [`7f8801c2`](https://github.com/NixOS/nixpkgs/commit/7f8801c2089052fc5e8cc51f08b5b771f9229706) | `` kodiPackages.arteplussept: 1.4.4 -> 1.5.2 ``                                                                   |
| [`0eed29cb`](https://github.com/NixOS/nixpkgs/commit/0eed29cb51eb0f2045500763329753618387854a) | `` pangolin-cli: 0.13.0 -> 0.14.0 ``                                                                              |
| [`feffe087`](https://github.com/NixOS/nixpkgs/commit/feffe087324be2e993ff19b2925ef02312aacb2f) | `` vscode: 1.127.0 -> 1.129.1 ``                                                                                  |
| [`7d7b6a9d`](https://github.com/NixOS/nixpkgs/commit/7d7b6a9d48739346a4078c6c7e50463b0f217991) | `` qui: 1.22.0 -> 1.23.0 ``                                                                                       |
| [`2d273957`](https://github.com/NixOS/nixpkgs/commit/2d273957e9bc8e79f5c594e71628c29fe7492d2c) | `` terraform-providers.hashicorp_awscc: 1.92.0 -> 1.93.0 ``                                                       |
| [`7081d51a`](https://github.com/NixOS/nixpkgs/commit/7081d51a0ac5aa803c7a5c894f13c88b17c9aa3a) | `` python313Packages.iamdata: 0.1.202607171 -> 0.1.202607181 ``                                                   |
| [`e035286f`](https://github.com/NixOS/nixpkgs/commit/e035286f2b44fb850026db698648ec560f55f745) | `` mopidy: use setuptools_80 at runtime ``                                                                        |
| [`526b782e`](https://github.com/NixOS/nixpkgs/commit/526b782e83be94b3b25db3f86d3b5a272e5e9282) | `` cursor-cli: 0-unstable-2026-06-26 -> 0-unstable-2026-07-16 ``                                                  |
| [`d00af7f4`](https://github.com/NixOS/nixpkgs/commit/d00af7f4ef2e3981667d6918a111bcf39a74329b) | `` matrix-alertmanager-receiver: 2026.7.8 -> 2026.7.15 ``                                                         |
| [`6d5278a1`](https://github.com/NixOS/nixpkgs/commit/6d5278a1c17375bffe009d3ea4386f7b11e2fd79) | `` gallery-dl: 1.32.5 -> 1.32.6 ``                                                                                |
| [`591d68f5`](https://github.com/NixOS/nixpkgs/commit/591d68f5f025e344b1876b4cf69db20b561dfd8f) | `` androidStudioPackages.beta: 2026.1.2.9 -> 2026.1.3.5 ``                                                        |
| [`a061ef25`](https://github.com/NixOS/nixpkgs/commit/a061ef25d51f773363e87335b9162e07d9a48129) | `` air: 1.65.3 -> 1.66.0 ``                                                                                       |
| [`2d4b8d15`](https://github.com/NixOS/nixpkgs/commit/2d4b8d15e100f05fd7a9b0f9e96af0823a840237) | `` vunnel: 0.62.1 -> 0.63.0 ``                                                                                    |
| [`e67eb0e8`](https://github.com/NixOS/nixpkgs/commit/e67eb0e8a10f9e72f8456ed7fb2cb63b9db87a28) | `` lenspect: 1.0.5 -> 1.0.6 ``                                                                                    |
| [`436cc938`](https://github.com/NixOS/nixpkgs/commit/436cc938aaa564bb6a2d87e54aef7cd4f3be32b6) | `` tombi: 1.2.0 -> 1.2.1 ``                                                                                       |
| [`bf551011`](https://github.com/NixOS/nixpkgs/commit/bf551011a96fc43b553392d2a5ba6c1754a798f9) | `` postsrsd: 2.2.7 -> 2.3.0 ``                                                                                    |
| [`7acc0de5`](https://github.com/NixOS/nixpkgs/commit/7acc0de55cd5efb2ccc831e4cd1e41dcbb71a0fb) | `` writefreely: 0.16.0 -> 0.17.0 ``                                                                               |
| [`78e1d77f`](https://github.com/NixOS/nixpkgs/commit/78e1d77fbdeedc5f7448cb6628740e78ed13edcb) | `` sonoscli: 0.3.3 -> 0.3.4 ``                                                                                    |
| [`3da812be`](https://github.com/NixOS/nixpkgs/commit/3da812be24579a873a29955828c2fcf067f1bfae) | `` python3Packages.meshtastic: 2.7.10 -> 2.7.11 ``                                                                |
| [`8a9d8cf6`](https://github.com/NixOS/nixpkgs/commit/8a9d8cf6d0072dbd57ccf99785645fd3f5b44aa7) | `` sage: scope the ntl threads disablement to darwin ``                                                           |
| [`25fb57e9`](https://github.com/NixOS/nixpkgs/commit/25fb57e937e54849721d8bc3b8b89cfa08346078) | `` sage: disable ntl threading on all platforms ``                                                                |
| [`0e70c127`](https://github.com/NixOS/nixpkgs/commit/0e70c1279d86d56452a3ae01c5c0fdfec164b6c5) | `` diffoscope: 324 -> 325 ``                                                                                      |
| [`e045839a`](https://github.com/NixOS/nixpkgs/commit/e045839a0405088a97b3dff50537bb0ed6be4a56) | `` tsgolint: 0.24.0 -> 0.25.0 ``                                                                                  |
| [`da661659`](https://github.com/NixOS/nixpkgs/commit/da66165917b16ef31bbf992652a2a945a7df6f86) | `` kiesel: 0.2.0 -> 0.3.0 ``                                                                                      |
| [`a3aa0f75`](https://github.com/NixOS/nixpkgs/commit/a3aa0f75458a9c293c9625c4be756ea0a771497c) | `` lefthook: add nightconcept as maintainer ``                                                                    |
| [`81637cf6`](https://github.com/NixOS/nixpkgs/commit/81637cf6116e535c305350e1e71cb42f73b122a6) | `` maintainers: add nightconcept ``                                                                               |
| [`2f166600`](https://github.com/NixOS/nixpkgs/commit/2f1666002cc49043e81d38f6bbefa71473fd9506) | `` telegram-desktop: add cmark-gfm to buildInputs ``                                                              |
| [`7a1e0884`](https://github.com/NixOS/nixpkgs/commit/7a1e08848272dd812f13545fcf12fa6f7cfd3066) | `` telegram-desktop: drop clang from nativeBuildInputs ``                                                         |
| [`31bb89d4`](https://github.com/NixOS/nixpkgs/commit/31bb89d4aba477a3a55f9729a7acc0942ad6d3c7) | `` telegram-desktop: 7.0.1 -> 7.0.2 ``                                                                            |
| [`55936684`](https://github.com/NixOS/nixpkgs/commit/5593668485bc49182c814d702916344a48a1ffa5) | `` telegram-desktop: 6.9.3 -> 7.0.1 ``                                                                            |
| [`0f203968`](https://github.com/NixOS/nixpkgs/commit/0f203968a8e7ee1da357d9fe4e4b316c45ae21cd) | `` openmeters: 1.10.0 -> 1.11.0 ``                                                                                |
| [`d928f9e1`](https://github.com/NixOS/nixpkgs/commit/d928f9e179d5199946babc049e36e40fa9e05e5e) | `` brave: 1.92.140 -> 1.92.141 ``                                                                                 |
| [`3b2d7e43`](https://github.com/NixOS/nixpkgs/commit/3b2d7e437ca5371427ac102da3784e87a4c882a6) | `` python3Packages.yaswfp: fix version scheme ``                                                                  |
| [`16a712dc`](https://github.com/NixOS/nixpkgs/commit/16a712dcb56e8ca33f230ca45d94f3207d103ab6) | `` libretro.ppsspp: 0-unstable-2026-07-08 -> 0-unstable-2026-07-16 ``                                             |
| [`6c274a62`](https://github.com/NixOS/nixpkgs/commit/6c274a62bed5efa6737655e4bff45c2933901031) | `` smithy-language-server: init at 0.9.0 ``                                                                       |
| [`aa45ab19`](https://github.com/NixOS/nixpkgs/commit/aa45ab19e0acc616fbed3f93d63afac5d129d499) | `` maintainers: add yoquec ``                                                                                     |
| [`4dcf6869`](https://github.com/NixOS/nixpkgs/commit/4dcf68690a7281fdf43c06e42c9206a5917f6865) | `` python3Packages.ansi2image: 0.1.5 -> 0.1.6 ``                                                                  |
| [`af7a24dc`](https://github.com/NixOS/nixpkgs/commit/af7a24dcf160de65b2c05f7da5c74292f95a8088) | `` turso: 0.6.1 -> 0.7.0 ``                                                                                       |
| [`ff792c64`](https://github.com/NixOS/nixpkgs/commit/ff792c649ad4bae57f033a518155594ac87e2919) | `` ollama: 0.32.0 -> 0.32.1 ``                                                                                    |
| [`1c790e2b`](https://github.com/NixOS/nixpkgs/commit/1c790e2b42ba4819cc0d59bfaecc77d331b98182) | `` shaka-packager: 3.8.0 -> 3.9.2 ``                                                                              |
| [`0d161896`](https://github.com/NixOS/nixpkgs/commit/0d161896ee31515709e849b0f1509398de9a70e2) | `` music-assistant: 2.9.8 -> 2.9.9 ``                                                                             |
| [`29a3063e`](https://github.com/NixOS/nixpkgs/commit/29a3063e3bf16cae8e438b3b5df5b141d747b858) | `` pyinfra: Add robsliwi as maintainer ``                                                                         |
| [`5126e8ac`](https://github.com/NixOS/nixpkgs/commit/5126e8acb30a344fdad27174c3414da73d8a7da2) | `` pyinfra: Fix build by relaxing dependencies ``                                                                 |
| [`1228b953`](https://github.com/NixOS/nixpkgs/commit/1228b953c8c9306ba21699cdc41def104551d55b) | `` wordpress_6_8: 6.8.5 -> 6.8.6 ``                                                                               |
| [`9c0d4b89`](https://github.com/NixOS/nixpkgs/commit/9c0d4b89712bb5734925cb377aae3aa6b0df8fad) | `` wordpress_6_9: 6.9.4 -> 6.9.5 ``                                                                               |
| [`41b3e453`](https://github.com/NixOS/nixpkgs/commit/41b3e45366acbe2d5ac9fad8379908625677d3db) | `` wordpress_7_0: 7.0.1 -> 7.0.2 ``                                                                               |
| [`b241cd97`](https://github.com/NixOS/nixpkgs/commit/b241cd9701a3a8fdd7c46de7af7294db1cab3d4a) | `` routedns: 0.1.223 -> 0.1.225 ``                                                                                |
| [`231806b4`](https://github.com/NixOS/nixpkgs/commit/231806b47a694bb67bc2d90c5c6f98556200aace) | `` parla: 0.6.8 -> 0.7.0 ``                                                                                       |
| [`76854ca2`](https://github.com/NixOS/nixpkgs/commit/76854ca2f7bd289d2f242be58643b30cce888d6f) | `` python3Packages.scverse-misc: 0.1.1 -> 0.1.2 ``                                                                |
| [`8e5b21a4`](https://github.com/NixOS/nixpkgs/commit/8e5b21a402f802df5b72bacf3da4f6f6ddb35ddd) | `` packetry: add desktop entry and icon ``                                                                        |
| [`ca057dba`](https://github.com/NixOS/nixpkgs/commit/ca057dba98949dc09c29ca2e190742f633e804f4) | `` searxng: 0-unstable-2026-07-08 -> 0-unstable-2026-07-17 ``                                                     |
| [`e6e7bc84`](https://github.com/NixOS/nixpkgs/commit/e6e7bc8460857edc97491a23fa820f35a1197026) | `` python3Packages.asyncwhois: 1.1.12 -> 1.1.13 ``                                                                |
| [`5f258de0`](https://github.com/NixOS/nixpkgs/commit/5f258de0c5ebc44b7742f8f0918bf52581249fa1) | `` pdf-mcp: init at 1.21.0 ``                                                                                     |
| [`7c34f21b`](https://github.com/NixOS/nixpkgs/commit/7c34f21bb13c9f1d918ba3c41aa5b086e376b39c) | `` pi-coding-agent: 0.80.8 -> 0.80.10 ``                                                                          |
| [`44b9146a`](https://github.com/NixOS/nixpkgs/commit/44b9146a578aaa1cb71c81a821dad2550b25b3a2) | `` nushell: 0.114.0 -> 0.114.1 ``                                                                                 |
| [`e7627a8b`](https://github.com/NixOS/nixpkgs/commit/e7627a8b7fbff69b4c1570104c4dc94519481e78) | `` llama-cpp: 9925 -> 10063 ``                                                                                    |
| [`7edccb9a`](https://github.com/NixOS/nixpkgs/commit/7edccb9a5404cf11e3465f9af6d24718372481be) | `` aube: 1.27.0 -> 1.29.1 ``                                                                                      |
| [`397ac923`](https://github.com/NixOS/nixpkgs/commit/397ac92324423e77a2ebaedf59550c71e0fff2bd) | `` hydrus: 675 -> 679 ``                                                                                          |
| [`39e10a4c`](https://github.com/NixOS/nixpkgs/commit/39e10a4c38d5daca5d0967425db8a8e01fbb55cc) | `` python3Packages.tagoio-sdk: 5.1.2 -> 5.1.3 ``                                                                  |
| [`62d47f4a`](https://github.com/NixOS/nixpkgs/commit/62d47f4abba26ce0e5eafbe7a8cbf3a8055d9d63) | `` rapidraw: set updateScript ``                                                                                  |
| [`8800c893`](https://github.com/NixOS/nixpkgs/commit/8800c8933faa73ff3c4a1638deeb7e79b56009d2) | `` rapidraw: 1.5.8 -> 1.5.9 ``                                                                                    |
| [`55f82a3c`](https://github.com/NixOS/nixpkgs/commit/55f82a3cd9c0e59aa71e17a205e90dfafbe98093) | `` melos: 8.2.0 -> 8.2.2 ``                                                                                       |
| [`8366add8`](https://github.com/NixOS/nixpkgs/commit/8366add81dbe65ddd63f62e344b63e1f0b67dc2f) | `` tootik: add versionCheckHook and update script ``                                                              |
| [`0c265dd5`](https://github.com/NixOS/nixpkgs/commit/0c265dd595304f406d78d27d3697b7ca5d1f7b18) | `` nixosTests.optee: adjust ram and kernel offsets, explicitly load optee kernel module ``                        |
| [`a0e3766f`](https://github.com/NixOS/nixpkgs/commit/a0e3766f7ba1bc43171dec55d24b4fecf7032201) | `` tinyauth: 5.0.7 -> 5.1.1 ``                                                                                    |
| [`4e4e5a40`](https://github.com/NixOS/nixpkgs/commit/4e4e5a407f186c4fd693c9aea6123c6c9660b8ea) | `` lammps-mpi: fix build with correct mpi arguments ``                                                            |
| [`4087fb31`](https://github.com/NixOS/nixpkgs/commit/4087fb315eee0ba69a97175b5b4c686964e3c272) | `` lammps: add `extraNativeBuildInputs` and remove cuda ``                                                        |
| [`43386962`](https://github.com/NixOS/nixpkgs/commit/433869625a90cf1743361e48b5f62ac52cee6dd2) | `` lammps: remove deprecated MPIIO package not related to mpi ``                                                  |
| [`942be243`](https://github.com/NixOS/nixpkgs/commit/942be243bdc278c07a1474fe9282e9d8fa99e828) | `` .github: Bump cachix/install-nix-action from 31.10.7 to 31.11.0 ``                                             |
| [`399818be`](https://github.com/NixOS/nixpkgs/commit/399818be8520776965d1b4973aa78999f948d861) | `` technitium-dns-server{,-library}: add update script ``                                                         |
| [`a83fbfb6`](https://github.com/NixOS/nixpkgs/commit/a83fbfb6d9a312c697d1cf4c62d54bcbc577104b) | `` lubelogger: 1.6.8 -> 1.7.0 ``                                                                                  |
| [`c636aab3`](https://github.com/NixOS/nixpkgs/commit/c636aab378b3b55acba6e03929f60c36e4e297db) | `` electron-{bin,chromedriver}: drop x86_64-darwin support ``                                                     |
| [`ad7bfe94`](https://github.com/NixOS/nixpkgs/commit/ad7bfe94610b4ddaf060c51a015a916c983e3d97) | `` electron-chromedriver_43: init at 43.1.0 ``                                                                    |
| [`aa8118cd`](https://github.com/NixOS/nixpkgs/commit/aa8118cd09bc4b4d886025263d945db6b6655371) | `` electron_43-bin: init at 43.1.0 ``                                                                             |
| [`45072646`](https://github.com/NixOS/nixpkgs/commit/450726460d9334ab8bc856f40231b9b177f96f22) | `` electron-source.electron_43: init at 43.1.0 ``                                                                 |
| [`f4cc6e94`](https://github.com/NixOS/nixpkgs/commit/f4cc6e9411d9727be96691abbd971bc65dde5058) | `` gclient2nix: update depot-tools ``                                                                             |
| [`c6eb78ba`](https://github.com/NixOS/nixpkgs/commit/c6eb78bad219df56465dff8ade35dd2c4829df17) | `` gclient2nix: update, fix for electron_43 ``                                                                    |
| [`10b28492`](https://github.com/NixOS/nixpkgs/commit/10b28492606683683ff04160239c5f1ab0e4a869) | `` opentrack: 2026.1.0-unstable-2026-07-09 -> 2026.1.0-unstable-2026-07-14 ``                                     |
| [`05d3bb3a`](https://github.com/NixOS/nixpkgs/commit/05d3bb3a5be28e7be5404b5c3e556c9957be08d5) | `` protonup-ng: migrate from format to pyproject and use finalAttrs ``                                            |
| [`5f1f3c16`](https://github.com/NixOS/nixpkgs/commit/5f1f3c16636d8cad25bcde442e797d4174efe75a) | `` python3Packages.std-uritemplate: 2.0.11 -> 2.0.12 ``                                                           |
| [`7452b6fd`](https://github.com/NixOS/nixpkgs/commit/7452b6fd8be21c92ddd5bcd5e7cb06bd982affdd) | `` freecad: remove thumbnailer absolute path patch ``                                                             |
| [`31d10912`](https://github.com/NixOS/nixpkgs/commit/31d109128a24e1ae0022716f936e24ec267721ba) | `` modal: init at 1.5.2 ``                                                                                        |
| [`c01eef67`](https://github.com/NixOS/nixpkgs/commit/c01eef6756fd6e8601349af92713f0d8650eb810) | `` python3Packages.modal: 1.4.2 -> 1.5.2, modernize ``                                                            |
| [`e7f38358`](https://github.com/NixOS/nixpkgs/commit/e7f383589d9ce08c063925c88a0a08b64695364c) | `` netatalk: 4.5.0 -> 4.5.1 ``                                                                                    |
| [`625075aa`](https://github.com/NixOS/nixpkgs/commit/625075aa79e622d3f45f23b4f38263eaea7a65e0) | `` lumen: 2.31.0 -> 2.32.0 ``                                                                                     |
| [`cfdbc6e7`](https://github.com/NixOS/nixpkgs/commit/cfdbc6e79c98b7695372aac89693b337dfdabacd) | `` gerrit: 3.13.6 -> 3.14.2 ``                                                                                    |
| [`b9679938`](https://github.com/NixOS/nixpkgs/commit/b9679938b12364b506e1199a22b9e4770fddadb7) | `` python3Packages.inject: 5.4.1 -> 5.5.0 ``                                                                      |
| [`8d58ce5b`](https://github.com/NixOS/nixpkgs/commit/8d58ce5b337053bd0e7fd1c617c15edbe156448f) | `` tflint: 0.61.0 -> 0.63.1 ``                                                                                    |
| [`80c5335a`](https://github.com/NixOS/nixpkgs/commit/80c5335a98028db57cb0a44d11312b2527c9e146) | `` sidplayfp: Fix linking on Darwin ``                                                                            |
| [`3be9b656`](https://github.com/NixOS/nixpkgs/commit/3be9b65683ae7c4af07bef44275882e1661a2921) | `` firefox-esr: build on 32-bit ``                                                                                |
| [`b1ce1197`](https://github.com/NixOS/nixpkgs/commit/b1ce11974edf272d4a644de44b5229c1c5ee515a) | `` firefox: disable PGO on 32-bit ``                                                                              |
| [`db56115a`](https://github.com/NixOS/nixpkgs/commit/db56115a4bd94f89e5afb6129caffbbdb6811ec1) | `` tootik: 0.20.2 → 0.23.3 ``                                                                                     |
| [`87c6ada7`](https://github.com/NixOS/nixpkgs/commit/87c6ada7503662cf22c278e5d87b232bda474676) | `` golink: 1.0.0 -> 1.0.0-unstable-2026-07-03 ``                                                                  |
| [`e433f0b1`](https://github.com/NixOS/nixpkgs/commit/e433f0b122ac2a10c2f272641bedd1c5c735f09a) | `` ruff: 0.15.21 -> 0.15.22 ``                                                                                    |
| [`02be3bb6`](https://github.com/NixOS/nixpkgs/commit/02be3bb663ae0c29196c3627fa3030668eb94186) | `` chirpstack-mqtt-forwarder: 4.5.1 -> 4.6.0 ``                                                                   |
| [`fc182eec`](https://github.com/NixOS/nixpkgs/commit/fc182eeca8e64efffee808dd0736b53a4f7e0a14) | `` pkgs/nixos-render-docs: add auto-highlight toc ``                                                              |
| [`c9347500`](https://github.com/NixOS/nixpkgs/commit/c9347500b2ff6ebeb265a8fa0fb781da684b817d) | `` mautrix-meta: 26.06 -> 26.07 ``                                                                                |
| [`13032a10`](https://github.com/NixOS/nixpkgs/commit/13032a107d47723d6bd0115ca634f014570c0a75) | `` mautrix-slack: 26.06 -> 26.07 ``                                                                               |
| [`b79b555f`](https://github.com/NixOS/nixpkgs/commit/b79b555f448a2d02f9dfec7185bd24aff4d453fe) | `` mautrix-signal: 26.06 -> 26.07 ``                                                                              |
| [`d89a0f65`](https://github.com/NixOS/nixpkgs/commit/d89a0f65d02ca6eb9fc7dee6f54ad15d23ded9aa) | `` libsignal-ffi: 0.94.4 -> 0.97.2 ``                                                                             |
| [`a060b9d5`](https://github.com/NixOS/nixpkgs/commit/a060b9d5b3e2f699fd8486cc4e90da09a3493ff5) | `` mautrix-whatsapp: 26.06 -> 26.07 ``                                                                            |
| [`e4a00a49`](https://github.com/NixOS/nixpkgs/commit/e4a00a49f83e6b86c5de00eaeb98dc294108adf1) | `` ty: 0.0.59 -> 0.0.60 ``                                                                                        |
| [`1cad2710`](https://github.com/NixOS/nixpkgs/commit/1cad271033e2c5768ca7e3c217425d6e82d03315) | `` clickhouse-cpp: init at 2.6.2 ``                                                                               |
| [`c470a974`](https://github.com/NixOS/nixpkgs/commit/c470a974e723b54de8c4cc87fa4301a3ffbf6554) | `` endless-sky: add missing `libxext` & `libsm` deps ``                                                           |
| [`4294f68c`](https://github.com/NixOS/nixpkgs/commit/4294f68c7f0212316a15168a7dc08f5ed8fc0bc0) | `` qidi-studio: 2.07.01.57 -> 2.07.02.10 ``                                                                       |
| [`dffa348a`](https://github.com/NixOS/nixpkgs/commit/dffa348a1d39306ad2e633bd689af77a0b17ffed) | `` firefly-iii: 6.6.3 -> 6.6.6 ``                                                                                 |

*... and 99 more commits (truncated)*