### PR TITLE
chore(opencode): update overlay to v1.18.4

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -27,18 +27,18 @@
 }:
 opencode.overrideAttrs (
   _finalAttrs: prevAttrs: rec {
-    version = "1.18.3";
+    version = "1.18.4";
 
     src = fetchFromGitHub {
       owner = "anomalyco";
       repo = "opencode";
       tag = "v${version}";
-      hash = "sha256-Wdkzms59oHw3M/Em2RH7BPhZME8AtLmtNFSnsUxO1V4=";
+      hash = "sha256-tGMO5JktINO8kXAHFQftn+JCrzwvpmNipTa8V0aIfNI=";
     };
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {
       inherit version src;
-      outputHash = "sha256-1NUtprMH8GnSUqQ+mHQSC+JLU7lwzHe6XXYHe129WmE=";
+      outputHash = "sha256-jMZSDlqNObSmWJZ0Xn0IwfYC2+mBbRYorfgD5Y2sHWs=";
     });
   }
 )


### PR DESCRIPTION
Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled OpenCode package to version 1.18.4.
  * Refreshed packaged source and dependency data for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->