### PR TITLE
chore(flake/freminal): `5660875b` -> `2e8c6ca7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784593281,
-        "narHash": "sha256-CZjJLsHdUV4j0JRtYGxahm7G2sVfspVhtO7D+4BZn0Q=",
+        "lastModified": 1784682414,
+        "narHash": "sha256-JPvJGoIVhL9m6ryaKrIbbTqrsByL1ZDrL1dAyiC0vfk=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "5660875b0d867d703194ba83934633b1a5930677",
+        "rev": "2e8c6ca7c645771d3aa2ce3ce7bb8472aa3ad2dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`2e8c6ca7`](https://github.com/fredsystems/freminal/commit/2e8c6ca7c645771d3aa2ce3ce7bb8472aa3ad2dd) | `` chore(version): 0.12.0-beta.4 ``                                                                 |
| [`6969224c`](https://github.com/fredsystems/freminal/commit/6969224cfa58945a36de92cc1624a8513c3ccaf2) | `` fix: silence clippy::unused_self on the Apple supports_partial_present stub ``                   |
| [`1a43d309`](https://github.com/fredsystems/freminal/commit/1a43d3095533b6edf8584b174eea145a1572fd31) | `` fix: compile EGL partial-present only on EGL backends; log present path ``                       |
| [`b68c90e3`](https://github.com/fredsystems/freminal/commit/b68c90e30408684de006d49661fbb5b7b1e08725) | `` fix: tighten cursor-only damage gate after review (#435) ``                                      |
| [`f300bfbc`](https://github.com/fredsystems/freminal/commit/f300bfbcedaff9485471340fef9a6968f51946e5) | `` chore(deps): update determinatesystems/determinate-nix-action digest to d966783 ``               |
| [`c8707b74`](https://github.com/fredsystems/freminal/commit/c8707b7432cab296d94a27240d59baf6b9981660) | `` fix: show cursor immediately on pane/tab activation ``                                           |
| [`28a22a8b`](https://github.com/fredsystems/freminal/commit/28a22a8bf4ed9f9df9d2b7de2ac8f0e31dd0807b) | `` perf: damage-aware present for cursor-only frames (#435) ``                                      |
| [`ca6237d0`](https://github.com/fredsystems/freminal/commit/ca6237d0b40e7711bcc6a0dc6ec0026a60a07b83) | `` test: cover update_pixels_per_point cache clear; refresh crossframe bench doc (#430) ``          |
| [`9cb127d4`](https://github.com/fredsystems/freminal/commit/9cb127d43816fced1fd37bee56ffd772249ad057) | `` test: time partial-dirty shaping without FontManager teardown (#430) ``                          |
| [`7b6739a4`](https://github.com/fredsystems/freminal/commit/7b6739a497af0c0a5c3bc8838feebda608985271) | `` test: assert glyph positions in shaping identity test; document script-key equivalence (#430) `` |
| [`49c15379`](https://github.com/fredsystems/freminal/commit/49c15379f3cc492dab58d28446ab412d844e9cd9) | `` refactor: hold font bytes behind a single Arc<[u8]> (#430) ``                                    |
| [`a05bc2ef`](https://github.com/fredsystems/freminal/commit/a05bc2ef546feb181dabedc50ca7c799cbce56b2) | `` test: shaping output-identity + cache reuse/invalidation tests (#430) ``                         |
| [`e7554fde`](https://github.com/fredsystems/freminal/commit/e7554fde89b895f0f4ca30bc4e7228d52c1fcb9b) | `` perf: cache rustybuzz Face and ShapePlan, shape_with_plan (#430) ``                              |
| [`b74116cf`](https://github.com/fredsystems/freminal/commit/b74116cf4967ce5c068ab184f76d705acd028aed) | `` refactor: store font bytes as Arc<[u8]> for shareable ownership (#430) ``                        |
| [`a4198602`](https://github.com/fredsystems/freminal/commit/a4198602353ba9075680b50982b019ef7785d44d) | `` test: add cross-frame shaping benchmark (#430) ``                                                |
| [`0bbf2dc4`](https://github.com/fredsystems/freminal/commit/0bbf2dc414de088069ec2aadbdef0fac1bf3a435) | `` docs: 121-C.1 — correct stale Arc-flatten doc (CodeRabbit PR #429) ``                            |
| [`d2c00ee3`](https://github.com/fredsystems/freminal/commit/d2c00ee395683ab3d8673e4f1557e4dd2671fd48) | `` docs: 121-C.5 — refresh freminal-bench-table skill catalog (#405) ``                             |
| [`a28abd3e`](https://github.com/fredsystems/freminal/commit/a28abd3e9cf602448df52d6c3c286e743ba594e2) | `` build: add [profile.profiling] for symbol-rich flamegraphs (#405) ``                             |
| [`71786308`](https://github.com/fredsystems/freminal/commit/71786308931a81b14b1a99636206516b052d2d62) | `` test: 121-C.3/C.4 — instanced partial-dirty + alt-screen e2e benches (#405) ``                   |
| [`850dd186`](https://github.com/fredsystems/freminal/commit/850dd186346223ceef2db1f0cb46e25bce911fbb) | `` perf: 121-C.1 — incremental buffer flatten merge (#405 Part C) ``                                |
| [`7cdf665b`](https://github.com/fredsystems/freminal/commit/7cdf665b57b1c6c62bd5c51eabe303dfd305458f) | `` chore(deps): update actions/checkout digest to 3d3c42e ``                                        |
| [`063d3c02`](https://github.com/fredsystems/freminal/commit/063d3c02be60be6ab54f8163b19b11cb5d827e08) | `` chore(flake): add cargo msrv to dev ``                                                           |
| [`953c1403`](https://github.com/fredsystems/freminal/commit/953c1403cd2ad36fc2c1dc62e0fc233a7b26cdc7) | `` chore(deps): update cargo versions ``                                                            |
| [`fb19a9b9`](https://github.com/fredsystems/freminal/commit/fb19a9b97f8e3c738c4751801b50e5abe137a962) | `` fix: detect URLs whose scheme is itself split by a wrap (CodeRabbit PR #426) ``                  |
| [`0b3ee71f`](https://github.com/fredsystems/freminal/commit/0b3ee71f7e5d433d15083098ba948fb0377347c5) | `` fix: detect wrapped plain-text URLs in full across soft-wrap boundaries (#418) ``                |
| [`8d825340`](https://github.com/fredsystems/freminal/commit/8d825340b038e1ebde76500184266cb46a335eaa) | `` chore(deps): update taiki-e/install-action action to v2.84.0 ``                                  |
| [`6f1fcbdc`](https://github.com/fredsystems/freminal/commit/6f1fcbdccc9d510e86b86a5bc2590c9d1dfdd4e0) | `` chore(deps): update rust crate libc to v0.2.187 ``                                               |
| [`9dead37b`](https://github.com/fredsystems/freminal/commit/9dead37b52e25dcf79ee8eb9161acfb2c82497de) | `` chore(deps): update rust crate clap to v4.6.3 ``                                                 |
| [`09ecf6f7`](https://github.com/fredsystems/freminal/commit/09ecf6f796369bf5efc09bf9aa89d8eb40a8ad0f) | `` chore(deps): update actions/checkout action to v7.0.1 ``                                         |