### PR TITLE
feat(apps): brave as default app

### DIFF
--- a/features/desktop/environments/modules/xdg-mime-common.nix
+++ b/features/desktop/environments/modules/xdg-mime-common.nix
@@ -19,11 +19,11 @@ _: {
       "image/jxl" = [ "org.gnome.gThumb.desktop" ];
 
       # Web browser - Firefox
-      "text/html" = [ "firefox.desktop" ];
-      "x-scheme-handler/http" = [ "firefox.desktop" ];
-      "x-scheme-handler/https" = [ "firefox.desktop" ];
-      "x-scheme-handler/about" = [ "firefox.desktop" ];
-      "x-scheme-handler/unknown" = [ "firefox.desktop" ];
+      "text/html" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/http" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/https" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/about" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/unknown" = [ "brave-browser.desktop" ];
     };
 
     defaultApplications = {
@@ -44,11 +44,11 @@ _: {
       "image/jxl" = [ "org.gnome.gThumb.desktop" ];
 
       # Web browser - Firefox
-      "text/html" = [ "firefox.desktop" ];
-      "x-scheme-handler/http" = [ "firefox.desktop" ];
-      "x-scheme-handler/https" = [ "firefox.desktop" ];
-      "x-scheme-handler/about" = [ "firefox.desktop" ];
-      "x-scheme-handler/unknown" = [ "firefox.desktop" ];
+      "text/html" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/http" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/https" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/about" = [ "brave-browser.desktop" ];
+      "x-scheme-handler/unknown" = [ "brave-browser.desktop" ];
     };
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated default web browsing associations to use Brave Browser for HTML files and HTTP, HTTPS, about, and unknown links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->