### PR TITLE
fix(degoog): fix degoog so it works again

### DIFF
--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -76,6 +76,8 @@ in
     firewall = {
       allowedTCPPorts = [
         80
+        6379
+        5432
       ];
       allowedUDPPorts = [ 53 ];
     };
@@ -625,6 +627,10 @@ in
         environment = {
           PUID = "1000";
           PGID = "1000";
+          DEGOOG_SETTINGS_PASSWORDS = "fred";
+          DEGOOG_PUBLIC_INSTANCE = "false";
+          DEGOOG_VALKEY_URL = "redis://192.168.31.20:6379";
+          DEGOOG_POSTGRES = "postgresql://degoog:changeme@192.168.31.20:5432/degoog";
         };
 
         ports = [
@@ -633,6 +639,47 @@ in
 
         volumes = [
           "/opt/adsb/degoog:/app/data"
+        ];
+      }
+
+      {
+        name = "degoog-valkey";
+        image = "valkey/valkey:8-alpine";
+
+        restart = "always";
+
+        ports = [
+          "6379:6379"
+        ];
+
+        # 0.10.0 entrypoint starts as root, chowns /app/data, then drops
+        # to PUID/PGID.  Do NOT pass --user; let the entrypoint handle it.
+        environment = {
+          PUID = "1000";
+          PGID = "1000";
+        };
+      }
+
+      {
+        name = "degoog-postgres";
+        image = "postgres:17-alpine";
+
+        restart = "always";
+
+        ports = [
+          "5432:5432"
+        ];
+
+        environment = {
+          PUID = "70";
+          PGID = "70";
+          POSTGRES_DB = "degoog";
+          POSTGRES_USER = "degoog";
+          POSTGRES_PASSWORD = "changeme";
+        };
+
+        volumes = [
+          "/opt/adsb/postgres-data:/var/lib/postgresql/data"
         ];
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DeGooG’s Valkey and PostgreSQL services.
  * Enabled network access for the supporting services on ports 6379 and 5432.
  * Configured persistent PostgreSQL storage for improved data retention.
  * Added DeGooG connection settings, password configuration, and public-instance mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->