### PR TITLE
chore(flake/niri): `e824ba4f` -> `97ef5e8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -759,11 +759,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1784573996,
-        "narHash": "sha256-DtURW6dNmnTdD/lFxN3ej34qFka5zwfi94k1t+fcQYU=",
+        "lastModified": 1784690641,
+        "narHash": "sha256-C0rHH09hHNRmZ38AE7j3i5ppkjMdzKqKiL1jx/ZyFHU=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "e824ba4f9bc2049ab80846e5d70a03f6249065c3",
+        "rev": "97ef5e8d03a13fe5f801398f8eed0aa8007b8a0b",
         "type": "github"
       },
       "original": {
@@ -1799,11 +1799,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1783895132,
-        "narHash": "sha256-Dl0Gvrig3EpE962hzF3ETPhUztlfuRhcmlpd8ioHN54=",
+        "lastModified": 1784679892,
+        "narHash": "sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "a2b5c635d8c8c99b286967658d0d177044887eb8",
+        "rev": "8d135d3b2854b30fd01ea6cd6c27e523dd50a839",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`97ef5e8d`](https://github.com/epireyn/niri-flake/commit/97ef5e8d03a13fe5f801398f8eed0aa8007b8a0b) | `` Update flake.lock `` |