### PR TITLE
chore(flake/freminal): `2e8c6ca7` -> `147bfb97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784682414,
-        "narHash": "sha256-JPvJGoIVhL9m6ryaKrIbbTqrsByL1ZDrL1dAyiC0vfk=",
+        "lastModified": 1784745309,
+        "narHash": "sha256-P6NNVf5grHCu+RNFFOkQOT/VK4rJ4ESm5mSJ88ZxSAA=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "2e8c6ca7c645771d3aa2ce3ce7bb8472aa3ad2dd",
+        "rev": "147bfb9736c7b91cff66a09220f44ede50629138",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`a6732e2f`](https://github.com/fredsystems/freminal/commit/a6732e2f97657925fb2427ef79871a0a505a0733) | `` fix: address review feedback on #439 (bounded drain, floor SoT, doc) ``                        |
| [`ce99c47c`](https://github.com/fredsystems/freminal/commit/ce99c47c1146b1680d1e39d7c8aaccd91121dcb2) | `` perf: collapse idle over-repaint in the PTY->snapshot->render pipeline (#439) ``               |
| [`d81c0523`](https://github.com/fredsystems/freminal/commit/d81c0523d59047f64f9410a05afb3337156c5d1f) | `` chore: bump version 0.12.0-beta.4 -> 0.12.0-beta.5 ``                                          |
| [`7e6e4d24`](https://github.com/fredsystems/freminal/commit/7e6e4d249e94b9c0f888f13aab8194cd6d2e5ad0) | `` test: 436.9 -- 436.8 follow-up coverage (drag-latch sequences + interactive-at wrapper) ``     |
| [`2bde8315`](https://github.com/fredsystems/freminal/commit/2bde8315e8dfaf6102eb201781cd15bd32171c1c) | `` fix: reinsert orphaned PerWindowState on no-active-pane early return (CLEANUP-436-A) ``        |
| [`e84b68fd`](https://github.com/fredsystems/freminal/commit/e84b68fd978940337dc2c588e52a7d6386706037) | `` perf: 436.8 -- region-aware pointer chrome gate (mouse-over-terminal no longer forces Full) `` |
| [`c7b289d2`](https://github.com/fredsystems/freminal/commit/c7b289d239c9d1d17e5e2a4514423fe026b5d1f4) | `` test: 436.7 -- overlays, multi-window isolation, settings-never-replay, warm-up ``             |
| [`0fcb5e7e`](https://github.com/fredsystems/freminal/commit/0fcb5e7eb795e4a1e426f43e7566851394e91216) | `` docs: add egui-stack upgrade-assumptions reference + skill + Renovate guard ``                 |
| [`5cbf3fd6`](https://github.com/fredsystems/freminal/commit/5cbf3fd6e029dd992600c7334b7b9612ebf281a4) | `` perf: 436.6 -- #435/#436 compose (chrome change forces Full) + exact-pin egui stack ``         |
| [`8c680104`](https://github.com/fredsystems/freminal/commit/8c68010404d892923f294a42ff4c888eda2302fc) | `` test: 436.5 -- verify band GL callbacks stay contiguous/ordered across the split ``            |
| [`c28bc078`](https://github.com/fredsystems/freminal/commit/c28bc0782cbd8f98e7855b593cc4e7797ac01470) | `` perf: 436.4c -- font-atlas-resize self-heal for cached chrome (§5.2) ``                        |
| [`457c13ae`](https://github.com/fredsystems/freminal/commit/457c13aeafc1fa09e2f2045cecfe120a2f680701) | `` perf: 436.4b -- chrome REPLAY goes live (skip chrome re-record/tessellate when static) ``      |
| [`93572dda`](https://github.com/fredsystems/freminal/commit/93572dda97ddae33107ebd68befa57814b573c0f) | `` refactor: 436.4a -- split run_frame paint into head/band/tail (byte-identical) ``              |
| [`80154ab6`](https://github.com/fredsystems/freminal/commit/80154ab66555d9716aaa6a5fc16276fb94347a50) | `` feat: 436.3 -- ChromeDamage signal + self-dismissal settle rule (no consumer yet) ``           |
| [`47b10a29`](https://github.com/fredsystems/freminal/commit/47b10a2927ea8b011e379099b2c5f6f7d4a6bc82) | `` refactor: 436.2b -- extract frame-damage decision into pure decide_frame_damage ``             |
| [`ac7b0e79`](https://github.com/fredsystems/freminal/commit/ac7b0e799a40616edb2c5f055845b3aecfc1c25a) | `` perf: 436.2a -- extract terminal-band egui shapes via background-layer index range ``          |
| [`6d6604d0`](https://github.com/fredsystems/freminal/commit/6d6604d0a3414f49f4f0e5ba6047d3059cd6eeca) | `` perf: 436.1 -- add chrome_frame_record bench measuring run_ui+tessellate cost ``               |