### PR TITLE
chore(flake/home-manager): `deeb6b7e` -> `041a999e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784588016,
-        "narHash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg=",
+        "lastModified": 1784725727,
+        "narHash": "sha256-J5+C9wsO0lhDyUalQzfplDbRjyHDYeEH5+9sdyXtwa8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
+        "rev": "041a999e8c1c5b731913855909e68d30ca69b8e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`041a999e`](https://github.com/nix-community/home-manager/commit/041a999e8c1c5b731913855909e68d30ca69b8e0) | `` modules/misc/ssh-auth-sock: correct nushell init ``                               |
| [`6d8d6156`](https://github.com/nix-community/home-manager/commit/6d8d61567802997f9ec3086b2a837e3ef31fac16) | `` herdr: Use the binary outside Nix to reload the config when `package` is unset `` |
| [`abba1081`](https://github.com/nix-community/home-manager/commit/abba1081f5d6e3bf6b0c53644f26ff209888e988) | `` rclone: add nfsmount mount type ``                                                |
| [`a2a9fec5`](https://github.com/nix-community/home-manager/commit/a2a9fec5723ce8ca8daf4268d068783cf120dbba) | `` senpai: use correct config directory on darwin systems ``                         |