### PR TITLE
chore(flake/home-manager): `041a999e` -> `079a3b5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784725727,
-        "narHash": "sha256-J5+C9wsO0lhDyUalQzfplDbRjyHDYeEH5+9sdyXtwa8=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "041a999e8c1c5b731913855909e68d30ca69b8e0",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`079a3b5d`](https://github.com/nix-community/home-manager/commit/079a3b5d1aa6a719920a51316253b7d6dd22738d) | `` sshAuthSock: for Zsh, initialize in .zprofile and .zshenv ``  |
| [`40d502fa`](https://github.com/nix-community/home-manager/commit/40d502faf202bbd7a0b3df90d5830acc23b71c6e) | `` sshAuthSock: indent initialization code ``                    |
| [`32de400b`](https://github.com/nix-community/home-manager/commit/32de400b6ac9f43042bca706f4a64f6ad08117e8) | `` direnv: fix nushell integration failing to unset variables `` |
| [`3b0e6bbd`](https://github.com/nix-community/home-manager/commit/3b0e6bbd65869af1beadf5963a99befc179d209f) | `` modules: partially apply `.nix` suffix check ``               |
| [`cbfe6732`](https://github.com/nix-community/home-manager/commit/cbfe6732716e1f46cd158431f34d0ea8b5512108) | `` modules: stop filtering files starting with _ ``              |