### PR TITLE
chore(flake/freminal): `147bfb97` -> `b15c6e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784745309,
-        "narHash": "sha256-P6NNVf5grHCu+RNFFOkQOT/VK4rJ4ESm5mSJ88ZxSAA=",
+        "lastModified": 1784992758,
+        "narHash": "sha256-N8kE9i9HwaToyzxgMtknJX30GafeSgDLQ8d1FsKmlZ0=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "147bfb9736c7b91cff66a09220f44ede50629138",
+        "rev": "b15c6e696bf79c92a1f12f676bbfb66245cf82d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`812d2f7d`](https://github.com/fredsystems/freminal/commit/812d2f7d453d6662659a71dead01657f2435f71b) | `` chore(deps): update taiki-e/install-action action to v2.85.0 ``                   |
| [`c604a847`](https://github.com/fredsystems/freminal/commit/c604a847eba04cb6ab93be80a28b14ebde2129d2) | `` chore(deps): update rust crate libc to v0.2.189 ``                                |
| [`a59a37a0`](https://github.com/fredsystems/freminal/commit/a59a37a0840a46c4414542a4613301e70e6e8ae8) | `` chore(deps): update rust crate clap to v4.6.4 ``                                  |
| [`f300a0da`](https://github.com/fredsystems/freminal/commit/f300a0da6d948b1955a9e2f648a024f0512d57af) | `` fix: 432 -- append cursor quad when no reserved tail exists (review follow-up) `` |
| [`c76ae8d1`](https://github.com/fredsystems/freminal/commit/c76ae8d17485504970aa62e608b000f6006ea5c4) | `` fix: 432 -- stop cursor blink from corrupting selection highlight ``              |
| [`59599566`](https://github.com/fredsystems/freminal/commit/59599566240dcc2e0dc6349c94092885c7d43701) | `` fix: stop visual bell flash from getting stuck on background/inactive panes ``    |