### PR TITLE
chore(flake/niri): `97ef5e8d` -> `13ea2229`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -759,11 +759,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1784690641,
-        "narHash": "sha256-C0rHH09hHNRmZ38AE7j3i5ppkjMdzKqKiL1jx/ZyFHU=",
+        "lastModified": 1784970463,
+        "narHash": "sha256-DZAPpKpsb4HbsVFIRN1hgC3AV3L7g+np8QyyfSI+sJ4=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "97ef5e8d03a13fe5f801398f8eed0aa8007b8a0b",
+        "rev": "13ea222907ca78d5d55312ce2d9e460d369b3ca1",
         "type": "github"
       },
       "original": {
@@ -944,11 +944,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1784432872,
-        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {
@@ -1149,11 +1149,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                 |
| --------------------------------------------------------------------------------------------------- | ----------------------- |
| [`13ea2229`](https://github.com/epireyn/niri-flake/commit/13ea222907ca78d5d55312ce2d9e460d369b3ca1) | `` Update flake.lock `` |
| [`4d3cadc4`](https://github.com/epireyn/niri-flake/commit/4d3cadc456266491d3fe1e80cfb640d55a8039d8) | `` Update flake.lock `` |
| [`763eea97`](https://github.com/epireyn/niri-flake/commit/763eea9750cda05a118a05cee71158f29e3f3c85) | `` Update flake.lock `` |