### PR TITLE
chore(flake/nixvim): `07180a08` -> `f316e949`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1008,11 +1008,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1783915482,
-        "narHash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50=",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {
@@ -1186,11 +1186,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1784057377,
-        "narHash": "sha256-yycNej5//EsRbV10moBoh+/63vXEwZD1ZFEiRm6C9rQ=",
+        "lastModified": 1784814601,
+        "narHash": "sha256-T32JXjZ7kIbhBn8/Har171yGg6IBdl97cxAWameqZDE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "07180a087e4a00720dc0731cbcd8dec796974381",
+        "rev": "f316e949e0ed9df0e1e0bf645c6dce721d4e230e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message             |
| ----------------------------------------------------------------------------------------------------- | ------------------- |
| [`f316e949`](https://github.com/nix-community/nixvim/commit/f316e949e0ed9df0e1e0bf645c6dce721d4e230e) | `` flake: Update `` |
| [`85d64907`](https://github.com/nix-community/nixvim/commit/85d64907a9c132ecf2e8ebe46d0ad842381516ec) | `` flake: Update `` |