### PR TITLE
chore(flake/nixpkgs-stable): `fd146203` -> `597283ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -960,11 +960,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1784432872,
-        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`536eb89b`](https://github.com/NixOS/nixpkgs/commit/536eb89b10b57c06a85630fb24ad02c58217fde8) | `` piknik: adopt ``                                                                             |
| [`3737c99d`](https://github.com/NixOS/nixpkgs/commit/3737c99deb0dc142436a5ce5ec80d71bf5fab4a0) | `` linux_testing: 7.2-rc3 -> 7.2-rc4 ``                                                         |
| [`d0a1de9f`](https://github.com/NixOS/nixpkgs/commit/d0a1de9fa687d9a5a8ae61da611ce361c3eb3fc5) | `` openobserve: 0.50.3 -> 0.91.1 ``                                                             |
| [`bf1a8d26`](https://github.com/NixOS/nixpkgs/commit/bf1a8d26edf26f38e9f19d836ee23af81fe4b3ea) | `` google-chrome: 150.0.7871.181 -> 150.0.7871.186 ``                                           |
| [`32645543`](https://github.com/NixOS/nixpkgs/commit/3264554320ad721e3ab374f1d32107a658687d17) | `` dokuwiki: 2025-05-14b -> 2026-07-14a ``                                                      |
| [`7938951b`](https://github.com/NixOS/nixpkgs/commit/7938951b0d655d36988434aed4e2b7326ed5f651) | `` youtrack: 2026.2.17012 -> 2026.2.17765 ``                                                    |
| [`26e64d56`](https://github.com/NixOS/nixpkgs/commit/26e64d56722c16b5fd835a3560d8cf21ac181f50) | `` listmonk: fix hash after upstream tag was moved ``                                           |
| [`59aef628`](https://github.com/NixOS/nixpkgs/commit/59aef62837407e2386d525bb538aa15bcca7fcc1) | `` listmonk: 6.1.0 -> 6.2.0 ``                                                                  |
| [`0bb476f0`](https://github.com/NixOS/nixpkgs/commit/0bb476f0ec97902406e73e712e8688a09131e58e) | `` frankenphp: 1.12.4 -> 1.12.5 ``                                                              |
| [`46c7ec56`](https://github.com/NixOS/nixpkgs/commit/46c7ec561e37d648aec2f7f9e20571690efb465c) | `` mochi: 1.21.16 -> 1.21.17 ``                                                                 |
| [`6cb1bced`](https://github.com/NixOS/nixpkgs/commit/6cb1bced1257dd18e4e7a23b40225ef55a10c3db) | `` ungoogled-chromium: 150.0.7871.128-1 -> 150.0.7871.181-1 ``                                  |
| [`b0526a5d`](https://github.com/NixOS/nixpkgs/commit/b0526a5d67477aa9c66e41eb333c57ee59899b42) | `` exim: 4.99.4 -> 4.99.5 ``                                                                    |
| [`bff0a8a5`](https://github.com/NixOS/nixpkgs/commit/bff0a8a5f1122ef88c113eed52777d0735ad293a) | `` javaPackages.compiler.openjdk8: 8u502-b01 -> 8u502-b07 ``                                    |
| [`36ad1e80`](https://github.com/NixOS/nixpkgs/commit/36ad1e809a9f52f17eca573ff5a1a97d5c6aae92) | `` proton-pass-cli: Update license ``                                                           |
| [`20c259d1`](https://github.com/NixOS/nixpkgs/commit/20c259d10d07268e1815231be36c4bd1e4e19788) | `` perlPackages.NetDNS: 1.48 -> 1.56 ``                                                         |
| [`76f172ec`](https://github.com/NixOS/nixpkgs/commit/76f172ecbadb1baee0c88321c4f692becb221cbc) | `` matrix-authentication-service: 1.20.0 -> 1.21.0 ``                                           |
| [`af336bf1`](https://github.com/NixOS/nixpkgs/commit/af336bf182c5e335e41a48acd1ddf3d7f905f0b4) | `` markdown-code-runner: 0.5.1 -> 0.5.2 ``                                                      |
| [`81c5bc7d`](https://github.com/NixOS/nixpkgs/commit/81c5bc7d1632c320bd7a861f8379d7ce25f4abaf) | `` rustywind: 0.25.2 -> 0.26.0 ``                                                               |
| [`3a4d5daa`](https://github.com/NixOS/nixpkgs/commit/3a4d5daa0c8ce7058fa2c9bac7f22e0019f8d15f) | `` commitizen: 4.13.9 -> 4.16.4 ``                                                              |
| [`45767039`](https://github.com/NixOS/nixpkgs/commit/457670392bc69b63a7669e8f37547a1955a8755f) | `` docker: 29.6.1 -> 29.6.2 ``                                                                  |
| [`21c91a5c`](https://github.com/NixOS/nixpkgs/commit/21c91a5c169a300e5373af3463274f2d7b7dbb69) | `` python3Packages.osmnx: 2.1.0 -> 2.1.1 ``                                                     |
| [`9fe0f498`](https://github.com/NixOS/nixpkgs/commit/9fe0f498ed93d62029082ecc66327b3d6987243f) | `` gecode: 6.3.0 → 6.4.0 ``                                                                     |
| [`120495af`](https://github.com/NixOS/nixpkgs/commit/120495af75a24ddc35b6389cb4233dd2ae14a5e2) | `` minizinc: use default gecode ``                                                              |
| [`2fa7bc12`](https://github.com/NixOS/nixpkgs/commit/2fa7bc1276395a0e82d8b9860ae6d576dfff8a17) | `` gecode: 6.2.0 → 6.3.0 ``                                                                     |
| [`e99b6101`](https://github.com/NixOS/nixpkgs/commit/e99b61017ebc0499eafdf6b8e203f7a89c68d72c) | `` javaPackages.compiler.openjdk17: 17.0.20+2 -> 17.0.20+8 ``                                   |
| [`ad34ce57`](https://github.com/NixOS/nixpkgs/commit/ad34ce57400043da8565b79972f1e9dac7659ee9) | `` javaPackages.compiler.openjdk25: 25.0.4+1 -> 25.0.4+7 ``                                     |
| [`02ebdf83`](https://github.com/NixOS/nixpkgs/commit/02ebdf833907d9105f9a688a493eafce8a042ebf) | `` Revert "python3Packages.starsessions: 2.2.1 -> .2.2.0" ``                                    |
| [`5cf22903`](https://github.com/NixOS/nixpkgs/commit/5cf22903489f2cda3e0c6ee452d2fa045fa28ff2) | `` ziglint: init at 0.5.3 ``                                                                    |
| [`6d66618a`](https://github.com/NixOS/nixpkgs/commit/6d66618a0379516120c2dcfad49bd8f3efa00b17) | `` maintainers: add xqtc161 ``                                                                  |
| [`4c817537`](https://github.com/NixOS/nixpkgs/commit/4c8175371bbd427f1ec08fc96faf752f76155b15) | `` bat: fix escaping of shell settings values ``                                                |
| [`49c3f733`](https://github.com/NixOS/nixpkgs/commit/49c3f733f94cd70227e70666520e4badd20fa278) | `` nixos/resolved: apply transformations to keys within resolved section ``                     |
| [`d8613c00`](https://github.com/NixOS/nixpkgs/commit/d8613c000d30a78b53c983f297d0bf4c291199f6) | `` openbao: 2.6.0 -> 2.6.1 ``                                                                   |
| [`ff792929`](https://github.com/NixOS/nixpkgs/commit/ff79292932115ff9d35bd50b5fe88e8e65f3222f) | `` protozero: 1.8.1 -> 1.8.2 ``                                                                 |
| [`5bf2c70f`](https://github.com/NixOS/nixpkgs/commit/5bf2c70fc72bf8c30d4a87b9ac7233ce76969846) | `` libsolv: 0.7.37 -> 0.7.39 ``                                                                 |
| [`a7f19640`](https://github.com/NixOS/nixpkgs/commit/a7f19640365bf8f96db3bdfbcab83724355ad18c) | `` mapserver: 8.6.4 -> 8.6.5 ``                                                                 |
| [`69dacb3c`](https://github.com/NixOS/nixpkgs/commit/69dacb3c98ce84499c4ccea05164a3b66049ef16) | `` framework-tool-tui: 0.8.3 -> 0.8.4 ``                                                        |
| [`895060e5`](https://github.com/NixOS/nixpkgs/commit/895060e56dbd6ebed90528a5953e9491953b20c9) | `` coredns: 1.14.3 -> 1.14.6 ``                                                                 |
| [`4a11796a`](https://github.com/NixOS/nixpkgs/commit/4a11796a0b0f545c56f0dcfe59788ed1ed8bc93d) | `` jadx: 1.5.5 -> 1.5.6 ``                                                                      |
| [`88b9d66d`](https://github.com/NixOS/nixpkgs/commit/88b9d66d04b6611fbe7dc7ecf4b8ec9cecc8ea70) | `` perlPackages.YAMLSyck: 1.45 -> 1.47 ``                                                       |
| [`961d555f`](https://github.com/NixOS/nixpkgs/commit/961d555fa85f1ec25edc4549c12f8e907001b6a5) | `` chromium,chromedriver: 150.0.7871.128 -> 150.0.7871.181 ``                                   |
| [`b427576f`](https://github.com/NixOS/nixpkgs/commit/b427576fe206cf9116ccf8ac4a8e5f28e0df2afe) | `` dcmtk: patch CVE-2026-5663 ``                                                                |
| [`08d01437`](https://github.com/NixOS/nixpkgs/commit/08d0143788aab8ff976ea81cdce17ad0d4abdc15) | `` microsoft-edge: 150.0.4078.65 -> 150.0.4078.83 ``                                            |
| [`eca4de2d`](https://github.com/NixOS/nixpkgs/commit/eca4de2ddc3a6c8f64280f15970d38a884ff43d8) | `` flameshot: octou symlink attack fix ``                                                       |
| [`094d44eb`](https://github.com/NixOS/nixpkgs/commit/094d44ebb9dccba3eacf3294056b99c5dac87465) | `` gelly: 1.9.2 -> 1.9.4 ``                                                                     |
| [`f7cc71a5`](https://github.com/NixOS/nixpkgs/commit/f7cc71a5307c33e6cfb0d0d89bc27b34267803cc) | `` nezha: 2.2.10 -> 2.3.0 ``                                                                    |
| [`c066daa1`](https://github.com/NixOS/nixpkgs/commit/c066daa162bb9a58b9bbb816c2bed90217a13ce3) | `` ci/github-script/lint-commits: add more conventional commit prefixes ``                      |
| [`e820ddd4`](https://github.com/NixOS/nixpkgs/commit/e820ddd41705fefb3f01d91e7e5c2832453aff78) | `` gitlab: 18.11.6 -> 18.11.7 ``                                                                |
| [`d28866fa`](https://github.com/NixOS/nixpkgs/commit/d28866fa56e678ec1aa937ea3764286fcd4de7c5) | `` matrix-tuwunel: 1.8.1 -> 1.8.2 ``                                                            |
| [`0537c983`](https://github.com/NixOS/nixpkgs/commit/0537c9831bac64f4a6ba9129f8dc917e1389e110) | `` olivetin-3k: 3000.17.0 -> 3000.17.3 ``                                                       |
| [`f3f8098f`](https://github.com/NixOS/nixpkgs/commit/f3f8098f79a09a23994933dd05805855e7869948) | `` dn42-registry-wizard: 0.4.20 -> 0.4.21 ``                                                    |
| [`3ba81f43`](https://github.com/NixOS/nixpkgs/commit/3ba81f43e5f1d8405622c1c852fc6e8dc30150e6) | `` smithy-language-server: init at 0.9.0 ``                                                     |
| [`7525b56c`](https://github.com/NixOS/nixpkgs/commit/7525b56cc57a7c28adcdaebea49269b4c3746ae0) | `` maintainers: add yoquec ``                                                                   |
| [`a3a1a2ea`](https://github.com/NixOS/nixpkgs/commit/a3a1a2ea5e7bf88514c694414035066b7d172bcc) | `` draupnir: add patch for package-lock.json ``                                                 |
| [`97fbb30f`](https://github.com/NixOS/nixpkgs/commit/97fbb30fdb5ae6afea48b88018ae154a29a57eca) | `` knot-resolver_5: 5.7.6 -> 5.7.7 (security!) ``                                               |
| [`4e57c4cd`](https://github.com/NixOS/nixpkgs/commit/4e57c4cd018cc6eb95bbbc8fc8b9e6eb6b69531b) | `` knot-resolver_6: 6.4.0 -> 6.4.1 (security!) ``                                               |
| [`320731fe`](https://github.com/NixOS/nixpkgs/commit/320731fe2d262114f00a0a252cc7c1e69229abc0) | `` stremio-linux-shell: 1.1.2 -> 1.1.3 ``                                                       |
| [`71735a66`](https://github.com/NixOS/nixpkgs/commit/71735a664ad282c18278327245c526f35432fb76) | `` aonsoku: 0.14.0 -> 0.15.0 ``                                                                 |
| [`3573bc1e`](https://github.com/NixOS/nixpkgs/commit/3573bc1ef25a8b0fa6625e11e05a9cb0e5d0bad6) | `` gdal: fix cross-compilation ``                                                               |
| [`fdb1e02e`](https://github.com/NixOS/nixpkgs/commit/fdb1e02ef9f18d1fc6933370f2eb3efb594b5bc8) | `` freecad: 1.1 fix sheetmetal workbench addon ``                                               |
| [`c41e3bce`](https://github.com/NixOS/nixpkgs/commit/c41e3bced564ad42e64dbbf5c9b9bb71131dd238) | `` monero-gui: 0.18.5.0 -> 0.18.5.2 ``                                                          |
| [`499c1950`](https://github.com/NixOS/nixpkgs/commit/499c1950859c4427c5ca373df0be7405e7e5ea9a) | `` monero-cli: 0.18.5.0 -> 0.18.5.1 ``                                                          |
| [`f77ce833`](https://github.com/NixOS/nixpkgs/commit/f77ce833c552f8bcccedd89dca7769984744b757) | `` randomx: 1.2.1 -> 1.2.2 ``                                                                   |
| [`a7007c08`](https://github.com/NixOS/nixpkgs/commit/a7007c088a6a30a9af11440e1bde3b6838d78bd7) | `` anytype: fix build that may not be deterministic ``                                          |
| [`fe05ef35`](https://github.com/NixOS/nixpkgs/commit/fe05ef35c2bc91b83168053cdd68384599f2aa19) | `` clickhouse: preserve VERSION_REVISION from the source tree ``                                |
| [`c3ecdc1a`](https://github.com/NixOS/nixpkgs/commit/c3ecdc1a5be5ebd3c79c339c3c05df262e50d13e) | `` pipeweaver: 0.1.6 -> 0.1.9 ``                                                                |
| [`9d11041a`](https://github.com/NixOS/nixpkgs/commit/9d11041ab1d314cfbab70383ff7777548b6cc94c) | `` zoom-us: 7.0.0.1666 -> 7.0.5.3034 ``                                                         |
| [`a0223b43`](https://github.com/NixOS/nixpkgs/commit/a0223b4329def9034da8a39ce0d2e37dac5ac39d) | `` google-chrome: 150.0.7871.128 -> 150.0.7871.181 ``                                           |
| [`8b89f1d0`](https://github.com/NixOS/nixpkgs/commit/8b89f1d0b0ca7515726a0bd8e9067cc6b7afc251) | `` workflows: Node 24 is now the default ``                                                     |
| [`33cb0933`](https://github.com/NixOS/nixpkgs/commit/33cb0933be0caab124686af631f8526455342e9d) | `` nixos/flarum: add initialAdminPasswordFile and databasePasswordFile options ``               |
| [`42378549`](https://github.com/NixOS/nixpkgs/commit/423785494573380658a5fbf17575bcdfc4480131) | `` mautrix-whatsapp: 26.06 -> 26.07 ``                                                          |
| [`89acd0d6`](https://github.com/NixOS/nixpkgs/commit/89acd0d6bc9ab54e12e550bec9967ac7da9f8c22) | `` mautrix-signal: 26.06 -> 26.07 ``                                                            |
| [`536eb89b`](https://github.com/NixOS/nixpkgs/commit/536eb89b10b57c06a85630fb24ad02c58217fde8) | `` piknik: adopt ``                                                                             |
| [`3737c99d`](https://github.com/NixOS/nixpkgs/commit/3737c99deb0dc142436a5ce5ec80d71bf5fab4a0) | `` linux_testing: 7.2-rc3 -> 7.2-rc4 ``                                                         |
| [`d0a1de9f`](https://github.com/NixOS/nixpkgs/commit/d0a1de9fa687d9a5a8ae61da611ce361c3eb3fc5) | `` openobserve: 0.50.3 -> 0.91.1 ``                                                             |
| [`bf1a8d26`](https://github.com/NixOS/nixpkgs/commit/bf1a8d26edf26f38e9f19d836ee23af81fe4b3ea) | `` google-chrome: 150.0.7871.181 -> 150.0.7871.186 ``                                           |
| [`32645543`](https://github.com/NixOS/nixpkgs/commit/3264554320ad721e3ab374f1d32107a658687d17) | `` dokuwiki: 2025-05-14b -> 2026-07-14a ``                                                      |
| [`7938951b`](https://github.com/NixOS/nixpkgs/commit/7938951b0d655d36988434aed4e2b7326ed5f651) | `` youtrack: 2026.2.17012 -> 2026.2.17765 ``                                                    |
| [`26e64d56`](https://github.com/NixOS/nixpkgs/commit/26e64d56722c16b5fd835a3560d8cf21ac181f50) | `` listmonk: fix hash after upstream tag was moved ``                                           |
| [`59aef628`](https://github.com/NixOS/nixpkgs/commit/59aef62837407e2386d525bb538aa15bcca7fcc1) | `` listmonk: 6.1.0 -> 6.2.0 ``                                                                  |
| [`0bb476f0`](https://github.com/NixOS/nixpkgs/commit/0bb476f0ec97902406e73e712e8688a09131e58e) | `` frankenphp: 1.12.4 -> 1.12.5 ``                                                              |
| [`46c7ec56`](https://github.com/NixOS/nixpkgs/commit/46c7ec561e37d648aec2f7f9e20571690efb465c) | `` mochi: 1.21.16 -> 1.21.17 ``                                                                 |
| [`6cb1bced`](https://github.com/NixOS/nixpkgs/commit/6cb1bced1257dd18e4e7a23b40225ef55a10c3db) | `` ungoogled-chromium: 150.0.7871.128-1 -> 150.0.7871.181-1 ``                                  |
| [`b0526a5d`](https://github.com/NixOS/nixpkgs/commit/b0526a5d67477aa9c66e41eb333c57ee59899b42) | `` exim: 4.99.4 -> 4.99.5 ``                                                                    |
| [`bff0a8a5`](https://github.com/NixOS/nixpkgs/commit/bff0a8a5f1122ef88c113eed52777d0735ad293a) | `` javaPackages.compiler.openjdk8: 8u502-b01 -> 8u502-b07 ``                                    |
| [`36ad1e80`](https://github.com/NixOS/nixpkgs/commit/36ad1e809a9f52f17eca573ff5a1a97d5c6aae92) | `` proton-pass-cli: Update license ``                                                           |
| [`20c259d1`](https://github.com/NixOS/nixpkgs/commit/20c259d10d07268e1815231be36c4bd1e4e19788) | `` perlPackages.NetDNS: 1.48 -> 1.56 ``                                                         |
| [`76f172ec`](https://github.com/NixOS/nixpkgs/commit/76f172ecbadb1baee0c88321c4f692becb221cbc) | `` matrix-authentication-service: 1.20.0 -> 1.21.0 ``                                           |
| [`af336bf1`](https://github.com/NixOS/nixpkgs/commit/af336bf182c5e335e41a48acd1ddf3d7f905f0b4) | `` markdown-code-runner: 0.5.1 -> 0.5.2 ``                                                      |
| [`81c5bc7d`](https://github.com/NixOS/nixpkgs/commit/81c5bc7d1632c320bd7a861f8379d7ce25f4abaf) | `` rustywind: 0.25.2 -> 0.26.0 ``                                                               |
| [`3a4d5daa`](https://github.com/NixOS/nixpkgs/commit/3a4d5daa0c8ce7058fa2c9bac7f22e0019f8d15f) | `` commitizen: 4.13.9 -> 4.16.4 ``                                                              |
| [`45767039`](https://github.com/NixOS/nixpkgs/commit/457670392bc69b63a7669e8f37547a1955a8755f) | `` docker: 29.6.1 -> 29.6.2 ``                                                                  |
| [`21c91a5c`](https://github.com/NixOS/nixpkgs/commit/21c91a5c169a300e5373af3463274f2d7b7dbb69) | `` python3Packages.osmnx: 2.1.0 -> 2.1.1 ``                                                     |
| [`9fe0f498`](https://github.com/NixOS/nixpkgs/commit/9fe0f498ed93d62029082ecc66327b3d6987243f) | `` gecode: 6.3.0 → 6.4.0 ``                                                                     |
| [`120495af`](https://github.com/NixOS/nixpkgs/commit/120495af75a24ddc35b6389cb4233dd2ae14a5e2) | `` minizinc: use default gecode ``                                                              |
| [`2fa7bc12`](https://github.com/NixOS/nixpkgs/commit/2fa7bc1276395a0e82d8b9860ae6d576dfff8a17) | `` gecode: 6.2.0 → 6.3.0 ``                                                                     |
| [`e99b6101`](https://github.com/NixOS/nixpkgs/commit/e99b61017ebc0499eafdf6b8e203f7a89c68d72c) | `` javaPackages.compiler.openjdk17: 17.0.20+2 -> 17.0.20+8 ``                                   |
| [`ad34ce57`](https://github.com/NixOS/nixpkgs/commit/ad34ce57400043da8565b79972f1e9dac7659ee9) | `` javaPackages.compiler.openjdk25: 25.0.4+1 -> 25.0.4+7 ``                                     |
| [`02ebdf83`](https://github.com/NixOS/nixpkgs/commit/02ebdf833907d9105f9a688a493eafce8a042ebf) | `` Revert "python3Packages.starsessions: 2.2.1 -> .2.2.0" ``                                    |
| [`5cf22903`](https://github.com/NixOS/nixpkgs/commit/5cf22903489f2cda3e0c6ee452d2fa045fa28ff2) | `` ziglint: init at 0.5.3 ``                                                                    |
| [`6d66618a`](https://github.com/NixOS/nixpkgs/commit/6d66618a0379516120c2dcfad49bd8f3efa00b17) | `` maintainers: add xqtc161 ``                                                                  |
| [`4c817537`](https://github.com/NixOS/nixpkgs/commit/4c8175371bbd427f1ec08fc96faf752f76155b15) | `` bat: fix escaping of shell settings values ``                                                |
| [`49c3f733`](https://github.com/NixOS/nixpkgs/commit/49c3f733f94cd70227e70666520e4badd20fa278) | `` nixos/resolved: apply transformations to keys within resolved section ``                     |
| [`d8613c00`](https://github.com/NixOS/nixpkgs/commit/d8613c000d30a78b53c983f297d0bf4c291199f6) | `` openbao: 2.6.0 -> 2.6.1 ``                                                                   |
| [`ff792929`](https://github.com/NixOS/nixpkgs/commit/ff79292932115ff9d35bd50b5fe88e8e65f3222f) | `` protozero: 1.8.1 -> 1.8.2 ``                                                                 |
| [`5bf2c70f`](https://github.com/NixOS/nixpkgs/commit/5bf2c70fc72bf8c30d4a87b9ac7233ce76969846) | `` libsolv: 0.7.37 -> 0.7.39 ``                                                                 |
| [`a7f19640`](https://github.com/NixOS/nixpkgs/commit/a7f19640365bf8f96db3bdfbcab83724355ad18c) | `` mapserver: 8.6.4 -> 8.6.5 ``                                                                 |
| [`69dacb3c`](https://github.com/NixOS/nixpkgs/commit/69dacb3c98ce84499c4ccea05164a3b66049ef16) | `` framework-tool-tui: 0.8.3 -> 0.8.4 ``                                                        |
| [`895060e5`](https://github.com/NixOS/nixpkgs/commit/895060e56dbd6ebed90528a5953e9491953b20c9) | `` coredns: 1.14.3 -> 1.14.6 ``                                                                 |
| [`4a11796a`](https://github.com/NixOS/nixpkgs/commit/4a11796a0b0f545c56f0dcfe59788ed1ed8bc93d) | `` jadx: 1.5.5 -> 1.5.6 ``                                                                      |
| [`88b9d66d`](https://github.com/NixOS/nixpkgs/commit/88b9d66d04b6611fbe7dc7ecf4b8ec9cecc8ea70) | `` perlPackages.YAMLSyck: 1.45 -> 1.47 ``                                                       |
| [`961d555f`](https://github.com/NixOS/nixpkgs/commit/961d555fa85f1ec25edc4549c12f8e907001b6a5) | `` chromium,chromedriver: 150.0.7871.128 -> 150.0.7871.181 ``                                   |
| [`b427576f`](https://github.com/NixOS/nixpkgs/commit/b427576fe206cf9116ccf8ac4a8e5f28e0df2afe) | `` dcmtk: patch CVE-2026-5663 ``                                                                |
| [`08d01437`](https://github.com/NixOS/nixpkgs/commit/08d0143788aab8ff976ea81cdce17ad0d4abdc15) | `` microsoft-edge: 150.0.4078.65 -> 150.0.4078.83 ``                                            |
| [`eca4de2d`](https://github.com/NixOS/nixpkgs/commit/eca4de2ddc3a6c8f64280f15970d38a884ff43d8) | `` flameshot: octou symlink attack fix ``                                                       |
| [`094d44eb`](https://github.com/NixOS/nixpkgs/commit/094d44ebb9dccba3eacf3294056b99c5dac87465) | `` gelly: 1.9.2 -> 1.9.4 ``                                                                     |
| [`f7cc71a5`](https://github.com/NixOS/nixpkgs/commit/f7cc71a5307c33e6cfb0d0d89bc27b34267803cc) | `` nezha: 2.2.10 -> 2.3.0 ``                                                                    |
| [`c066daa1`](https://github.com/NixOS/nixpkgs/commit/c066daa162bb9a58b9bbb816c2bed90217a13ce3) | `` ci/github-script/lint-commits: add more conventional commit prefixes ``                      |
| [`e820ddd4`](https://github.com/NixOS/nixpkgs/commit/e820ddd41705fefb3f01d91e7e5c2832453aff78) | `` gitlab: 18.11.6 -> 18.11.7 ``                                                                |
| [`d28866fa`](https://github.com/NixOS/nixpkgs/commit/d28866fa56e678ec1aa937ea3764286fcd4de7c5) | `` matrix-tuwunel: 1.8.1 -> 1.8.2 ``                                                            |
| [`0537c983`](https://github.com/NixOS/nixpkgs/commit/0537c9831bac64f4a6ba9129f8dc917e1389e110) | `` olivetin-3k: 3000.17.0 -> 3000.17.3 ``                                                       |
| [`f3f8098f`](https://github.com/NixOS/nixpkgs/commit/f3f8098f79a09a23994933dd05805855e7869948) | `` dn42-registry-wizard: 0.4.20 -> 0.4.21 ``                                                    |
| [`3ba81f43`](https://github.com/NixOS/nixpkgs/commit/3ba81f43e5f1d8405622c1c852fc6e8dc30150e6) | `` smithy-language-server: init at 0.9.0 ``                                                     |
| [`7525b56c`](https://github.com/NixOS/nixpkgs/commit/7525b56cc57a7c28adcdaebea49269b4c3746ae0) | `` maintainers: add yoquec ``                                                                   |
| [`a3a1a2ea`](https://github.com/NixOS/nixpkgs/commit/a3a1a2ea5e7bf88514c694414035066b7d172bcc) | `` draupnir: add patch for package-lock.json ``                                                 |
| [`97fbb30f`](https://github.com/NixOS/nixpkgs/commit/97fbb30fdb5ae6afea48b88018ae154a29a57eca) | `` knot-resolver_5: 5.7.6 -> 5.7.7 (security!) ``                                               |
| [`4e57c4cd`](https://github.com/NixOS/nixpkgs/commit/4e57c4cd018cc6eb95bbbc8fc8b9e6eb6b69531b) | `` knot-resolver_6: 6.4.0 -> 6.4.1 (security!) ``                                               |
| [`320731fe`](https://github.com/NixOS/nixpkgs/commit/320731fe2d262114f00a0a252cc7c1e69229abc0) | `` stremio-linux-shell: 1.1.2 -> 1.1.3 ``                                                       |
| [`71735a66`](https://github.com/NixOS/nixpkgs/commit/71735a664ad282c18278327245c526f35432fb76) | `` aonsoku: 0.14.0 -> 0.15.0 ``                                                                 |
| [`3573bc1e`](https://github.com/NixOS/nixpkgs/commit/3573bc1ef25a8b0fa6625e11e05a9cb0e5d0bad6) | `` gdal: fix cross-compilation ``                                                               |
| [`fdb1e02e`](https://github.com/NixOS/nixpkgs/commit/fdb1e02ef9f18d1fc6933370f2eb3efb594b5bc8) | `` freecad: 1.1 fix sheetmetal workbench addon ``                                               |
| [`c41e3bce`](https://github.com/NixOS/nixpkgs/commit/c41e3bced564ad42e64dbbf5c9b9bb71131dd238) | `` monero-gui: 0.18.5.0 -> 0.18.5.2 ``                                                          |
| [`499c1950`](https://github.com/NixOS/nixpkgs/commit/499c1950859c4427c5ca373df0be7405e7e5ea9a) | `` monero-cli: 0.18.5.0 -> 0.18.5.1 ``                                                          |
| [`f77ce833`](https://github.com/NixOS/nixpkgs/commit/f77ce833c552f8bcccedd89dca7769984744b757) | `` randomx: 1.2.1 -> 1.2.2 ``                                                                   |
| [`a7007c08`](https://github.com/NixOS/nixpkgs/commit/a7007c088a6a30a9af11440e1bde3b6838d78bd7) | `` anytype: fix build that may not be deterministic ``                                          |
| [`fe05ef35`](https://github.com/NixOS/nixpkgs/commit/fe05ef35c2bc91b83168053cdd68384599f2aa19) | `` clickhouse: preserve VERSION_REVISION from the source tree ``                                |
| [`c3ecdc1a`](https://github.com/NixOS/nixpkgs/commit/c3ecdc1a5be5ebd3c79c339c3c05df262e50d13e) | `` pipeweaver: 0.1.6 -> 0.1.9 ``                                                                |
| [`9d11041a`](https://github.com/NixOS/nixpkgs/commit/9d11041ab1d314cfbab70383ff7777548b6cc94c) | `` zoom-us: 7.0.0.1666 -> 7.0.5.3034 ``                                                         |
| [`a0223b43`](https://github.com/NixOS/nixpkgs/commit/a0223b4329def9034da8a39ce0d2e37dac5ac39d) | `` google-chrome: 150.0.7871.128 -> 150.0.7871.181 ``                                           |
| [`8b89f1d0`](https://github.com/NixOS/nixpkgs/commit/8b89f1d0b0ca7515726a0bd8e9067cc6b7afc251) | `` workflows: Node 24 is now the default ``                                                     |
| [`33cb0933`](https://github.com/NixOS/nixpkgs/commit/33cb0933be0caab124686af631f8526455342e9d) | `` nixos/flarum: add initialAdminPasswordFile and databasePasswordFile options ``               |
| [`42378549`](https://github.com/NixOS/nixpkgs/commit/423785494573380658a5fbf17575bcdfc4480131) | `` mautrix-whatsapp: 26.06 -> 26.07 ``                                                          |
| [`89acd0d6`](https://github.com/NixOS/nixpkgs/commit/89acd0d6bc9ab54e12e550bec9967ac7da9f8c22) | `` mautrix-signal: 26.06 -> 26.07 ``                                                            |
| [`de36f40b`](https://github.com/NixOS/nixpkgs/commit/de36f40b00bb740078e1ad658e0bdee34ee34557) | `` libsignal-ffi: 0.94.4 -> 0.97.2 ``                                                           |
| [`d26c694f`](https://github.com/NixOS/nixpkgs/commit/d26c694f54ac642d212706bb28d171bf8f68a5c5) | `` nextcloudPackages: add diagramming app ``                                                    |
| [`5a6212bc`](https://github.com/NixOS/nixpkgs/commit/5a6212bcd1693fb73a9725efda3a2ac4703fbced) | `` nextcloudPackages: update apps ``                                                            |
| [`39a02d6c`](https://github.com/NixOS/nixpkgs/commit/39a02d6cc871f870ff89c1157d390a364e1555b6) | `` sc-controller: 0.5.5 -> 0.6.2 ``                                                             |
| [`0ed2d45f`](https://github.com/NixOS/nixpkgs/commit/0ed2d45f65d824132ff41b87c8cdf32544d3f202) | `` teleport_17: 17.7.25 -> 17.7.26 ``                                                           |
| [`ee1585f7`](https://github.com/NixOS/nixpkgs/commit/ee1585f719ec7646f32a7e845335d42c8401c602) | `` teleport_18: 18.9.2 -> 18.10.0 ``                                                            |
| [`336967c7`](https://github.com/NixOS/nixpkgs/commit/336967c7135251ada0d9d41b3fdebaa334c647f6) | `` vikunja: 2.3.0 -> 2.4.0 ``                                                                   |
| [`436f3e18`](https://github.com/NixOS/nixpkgs/commit/436f3e18a5e0e5a78dece3ecf874e84466f01367) | `` dump_syms: 2.3.7 -> 2.3.8 ``                                                                 |
| [`83d4e9f0`](https://github.com/NixOS/nixpkgs/commit/83d4e9f0307708110698d93ebff3f1941a72667f) | `` rocqPackages.mathcomp: 2.5.0 -> 2.6.0 ``                                                     |
| [`ca0e82d5`](https://github.com/NixOS/nixpkgs/commit/ca0e82d5fc795c0aed3fa64f28948acd1b4249a4) | `` victoriametrics: 1.146.0 -> 1.148.0 ``                                                       |
| [`494d1760`](https://github.com/NixOS/nixpkgs/commit/494d1760400ff6acf18089f5362adc14cda8d945) | `` ocamlPackages.lrgrep: init at 0.9 ``                                                         |
| [`487abbad`](https://github.com/NixOS/nixpkgs/commit/487abbad423e2e2bfb83183ebc492c9405a9fae5) | `` ocamlPackages.cmon: init at 0.2 ``                                                           |
| [`35ed2cb3`](https://github.com/NixOS/nixpkgs/commit/35ed2cb3c0bd67f315700493f139d3e58c64dd25) | `` ocamlPackages.grenier: init at 0.16 ``                                                       |
| [`4ab44691`](https://github.com/NixOS/nixpkgs/commit/4ab44691a50f66a366485ab84e85483849eb3e8a) | `` forgejo: 16.0.0 -> 16.0.1 ``                                                                 |
| [`373399a1`](https://github.com/NixOS/nixpkgs/commit/373399a17c7f4d23ef1a98b9dae298816335d5b0) | `` mullvad-browser: 15.0.18 -> 15.0.19 ``                                                       |
| [`a5fc5da5`](https://github.com/NixOS/nixpkgs/commit/a5fc5da57805d751b7e99a7c4de48868e7ae2fdc) | `` tor-browser: 15.0.18 -> 15.0.19 ``                                                           |
| [`ae1c2dac`](https://github.com/NixOS/nixpkgs/commit/ae1c2dacc73640506d7f12185b1f389fac1ef34b) | `` spamassassin: set __darwinAllowLocalNetworking ``                                            |
| [`f77e272e`](https://github.com/NixOS/nixpkgs/commit/f77e272ea59d506f3cba285a6aa5e922889a12af) | `` github-copilot-cli: 1.0.26 -> 1.0.61 ``                                                      |
| [`2a360743`](https://github.com/NixOS/nixpkgs/commit/2a3607437f7e5e771c215e4cd19ec980983bb6af) | `` syslogng: 4.11.0 -> 4.12.0 ``                                                                |
| [`b766517d`](https://github.com/NixOS/nixpkgs/commit/b766517d8a0f96796953ba3d14e28a163da8c687) | `` sumo: 1.27.0 -> 1.27.1 ``                                                                    |
| [`38b434b9`](https://github.com/NixOS/nixpkgs/commit/38b434b974e2513acc0d2504d9ff3f136dfd68cd) | `` [backport release-26.05] v2rayn: add andrewzah as maintainer ``                              |
| [`8ab3a080`](https://github.com/NixOS/nixpkgs/commit/8ab3a0801ef34bcac5a643e8bb02b033cc321680) | `` nixos/syncthing: fix unix socket curl address ``                                             |
| [`ff3574c8`](https://github.com/NixOS/nixpkgs/commit/ff3574c816eefa896d6fd9172243771d21f38da5) | `` ramalama: wrap all deps when withPodman==false, except podman ``                             |
| [`6f375af0`](https://github.com/NixOS/nixpkgs/commit/6f375af028e1ff6204ae38f4e1d61ed877ee0a0e) | `` godot: 4.7-stable -> 4.7.1-stable ``                                                         |
| [`a5d3bb2e`](https://github.com/NixOS/nixpkgs/commit/a5d3bb2ef7715c29dca6c8d135b8a3dbedcb6209) | `` pdfding: fix package version ``                                                              |
| [`99132c26`](https://github.com/NixOS/nixpkgs/commit/99132c26d6471c3470e77f1dfb6cba625d56c59f) | `` pdfding: fix build ``                                                                        |
| [`322cf143`](https://github.com/NixOS/nixpkgs/commit/322cf1433a76d89b9bd62f266634ae07512c0ea5) | `` weechat: 4.9.3 -> 4.9.4 ``                                                                   |
| [`0bf03652`](https://github.com/NixOS/nixpkgs/commit/0bf03652613cc17968a28c3131b00189907fc3f0) | `` pgdog: 0.1.48 -> 0.1.49 ``                                                                   |
| [`df8b4214`](https://github.com/NixOS/nixpkgs/commit/df8b4214c2890ff160e5c3303a7acb9e5f1d1254) | `` firefox: fix flaky dylib check due to SIGPIPE race ``                                        |
| [`934fb091`](https://github.com/NixOS/nixpkgs/commit/934fb091968f94135fd1464075c3fc1adb5aa9a1) | `` vivaldi-ffmpeg-codecs: update from vivaldi 8.1.4087.48 update-ffmpeg ``                      |
| [`d309af78`](https://github.com/NixOS/nixpkgs/commit/d309af784a6fe05d13db53104c557d44132baf76) | `` texlive.bin.pygmentex: use standard bin container instead of buildPythonApplication ``       |
| [`61a08c7a`](https://github.com/NixOS/nixpkgs/commit/61a08c7acda6e5bd8db4c73d807fb593a4b6decf) | `` doc: on overriding and excluding packages from TeX Live collections ``                       |
| [`b1055053`](https://github.com/NixOS/nixpkgs/commit/b10550535935895d0149636de0df94c6f0eff15c) | `` radicle-httpd: 0.25.0 -> 0.26.0 ``                                                           |
| [`78725bba`](https://github.com/NixOS/nixpkgs/commit/78725bba99072edafef6eaf2ffbaa2664a17a4bc) | `` radicle-explorer: decouple src from radicle-httpd ``                                         |
| [`43df1595`](https://github.com/NixOS/nixpkgs/commit/43df15958a3146b218f2b977b36fb525d8452c4d) | `` fractal: 14 -> 14.1 ``                                                                       |
| [`f81dc01b`](https://github.com/NixOS/nixpkgs/commit/f81dc01baccffd06f97052900c8ed411ee94f6f9) | `` rocmPackages.aotriton: disable verbose logs for ninja install ``                             |
| [`d1324d3c`](https://github.com/NixOS/nixpkgs/commit/d1324d3cab590ff54f49860edf9b75a89e083703) | `` dotnetCorePackages.sdk_11_0: 11.0.100-preview.5.26302.115 -> 11.0.100-preview.6.26359.118 `` |
| [`91715632`](https://github.com/NixOS/nixpkgs/commit/91715632db52585642e6e606dbed19bd4768a1cd) | `` dotnetCorePackages.sdk_10_0: 10.0.301 -> 10.0.302 ``                                         |
| [`47567ea1`](https://github.com/NixOS/nixpkgs/commit/47567ea10150a2defec11e3991ad9b8b1df49150) | `` dotnetCorePackages.sdk_9_0: 9.0.315 -> 9.0.316 ``                                            |
| [`4808e07d`](https://github.com/NixOS/nixpkgs/commit/4808e07d9cd874a3a42460d84b46f0871ea5b08c) | `` dotnetCorePackages.sdk_8_0: 8.0.422 -> 8.0.423 ``                                            |
| [`b069627e`](https://github.com/NixOS/nixpkgs/commit/b069627edb56ac1ac99d7fe940e93f8d2f0ffd9f) | `` coinmp: adopt ``                                                                             |
| [`e4289e41`](https://github.com/NixOS/nixpkgs/commit/e4289e41dd4c3c5daeec7c6ec3835c74bd74d208) | `` gmp: adopt ``                                                                                |
| [`ef7bdd60`](https://github.com/NixOS/nixpkgs/commit/ef7bdd602ef9189cb478fc8eba11eece67dab85a) | `` _4ti2: adopt ``                                                                              |
| [`2eee74e7`](https://github.com/NixOS/nixpkgs/commit/2eee74e790327661eff3db8450ada640d313d49a) | `` knot-dns: 3.5.5 -> 3.5.6 ``                                                                  |
| [`76709bbb`](https://github.com/NixOS/nixpkgs/commit/76709bbb1a8301510965fa6334afd16e774dd9dc) | `` netbox_4_5: 4.5.9 -> 4.5.10 ``                                                               |
| [`1f20939d`](https://github.com/NixOS/nixpkgs/commit/1f20939dc5d6a620dda7c1be92b6baf4975f19fb) | `` firefox-esr-153-unwrapped: init at 153.0esr ``                                               |
| [`7908f9af`](https://github.com/NixOS/nixpkgs/commit/7908f9af236cff84d7bcf46d54282ff78dc2abba) | `` firefox-esr-140-unwrapped: 140.12.0esr -> 140.13.0esr ``                                     |
| [`2a977b45`](https://github.com/NixOS/nixpkgs/commit/2a977b452c48c461a3da33c437d912dad9a72b08) | `` firefox-bin-unwrapped: 152.0.6 -> 153.0 ``                                                   |
| [`2e6938e0`](https://github.com/NixOS/nixpkgs/commit/2e6938e0105337d546ff436a8dffcd4361972c02) | `` firefox-unwrapped: 152.0.6 -> 153.0 ``                                                       |
| [`efda42ae`](https://github.com/NixOS/nixpkgs/commit/efda42ae727c2a0b5be3fb7e00f7db95e08299e8) | `` buildMozillaMach: revert apple-sdk 26.5 on 153.0 and newer ``                                |
| [`c4f76a57`](https://github.com/NixOS/nixpkgs/commit/c4f76a571317ee1f349113ce6cd133f67e6bd1a7) | `` mdns-scanner: 0.27.4 -> 0.27.5 ``                                                            |
| [`1f161da4`](https://github.com/NixOS/nixpkgs/commit/1f161da44f13f579bcaec70902a32688aea2da19) | `` nixos/tabbyapi: sync options with upstream ``                                                |
| [`235a75c4`](https://github.com/NixOS/nixpkgs/commit/235a75c4af31f41cdcc2a4cab5aa4791a753bbed) | `` tabbyapi: 0-unstable-2026-06-27 -> 0-unstable-2026-07-18 ``                                  |
| [`8dae28f3`](https://github.com/NixOS/nixpkgs/commit/8dae28f36c7296d6cb4ea29afc03b881122b037f) | `` python3Packages.exllamav3: 0.0.43 -> 1.1.0 ``                                                |
| [`4ff38198`](https://github.com/NixOS/nixpkgs/commit/4ff38198b478c7c2486a932e8564f6b365855c56) | `` perlPackages.TemplateToolkit: 3.101 -> 3.106 ``                                              |
| [`a6be8090`](https://github.com/NixOS/nixpkgs/commit/a6be8090117f1c8fbc96e8e0f4a64981691ef837) | `` bbot: 2.7.2 -> 2.8.6 ``                                                                      |