### PR TITLE
chore(flake/freminal): `b15c6e69` -> `978cee99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784992758,
-        "narHash": "sha256-N8kE9i9HwaToyzxgMtknJX30GafeSgDLQ8d1FsKmlZ0=",
+        "lastModified": 1785041531,
+        "narHash": "sha256-wiL76nu2S6QEVYvoUzyYlcO0fo9sQ57l5XeRdVkHzac=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "b15c6e696bf79c92a1f12f676bbfb66245cf82d3",
+        "rev": "978cee99e4490d2572c9ad4964e3683443498d75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`be90e9fe`](https://github.com/fredsystems/freminal/commit/be90e9feed9b82c146090466252e633bb404e0e3) | `` fix: 433 -- address PR #450 review (frame damage, docs, dedup) ``           |
| [`d9744a8d`](https://github.com/fredsystems/freminal/commit/d9744a8d95bd0b14d225cef7f998c36cbe972024) | `` feat: 433 -- freminal-derived toasts + resize overlay ``                    |
| [`fb89bb3a`](https://github.com/fredsystems/freminal/commit/fb89bb3a71b6f504018e76d746a0ebe50fd0abce) | `` fix: 433 -- surface routing_info deprecation warning at startup ``          |
| [`504fbcf3`](https://github.com/fredsystems/freminal/commit/504fbcf364ccccdad5fba1a3aa0519933a528360) | `` refactor: 433 -- per-source notification routing model ``                   |
| [`32b8c1dc`](https://github.com/fredsystems/freminal/commit/32b8c1dc7bdb9e36f1e08fd5775af2bcfb352d18) | `` fix: 433 -- address PR #448 review (toast text overflow, hit-test scope) `` |
| [`f3fd451d`](https://github.com/fredsystems/freminal/commit/f3fd451d7e869fc1fd62202773de19fcdcd45f83) | `` feat: 433 -- fully-owned GL toast renderer ``                               |