### PR TITLE
chore(flake/nixvim): `f316e949` -> `48409beb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1186,11 +1186,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1784814601,
-        "narHash": "sha256-T32JXjZ7kIbhBn8/Har171yGg6IBdl97cxAWameqZDE=",
+        "lastModified": 1785001306,
+        "narHash": "sha256-xWqmquUtqKXLeDZ1oQUO+rV4sjA9TShIJhLL8M5Bozo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f316e949e0ed9df0e1e0bf645c6dce721d4e230e",
+        "rev": "48409beb41e8e28b64e8160ca82d8a93fb628963",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`48409beb`](https://github.com/nix-community/nixvim/commit/48409beb41e8e28b64e8160ca82d8a93fb628963) | `` maintainers: update generated/all-maintainers.nix `` |
| [`fdd3386b`](https://github.com/nix-community/nixvim/commit/fdd3386b85d7c2596a880266f5a09b3495af4a59) | `` maintainers: update Fovir's GitHub username ``       |