### PR TITLE
fix(monitoring): convert roaming daytona laptop to push-based monitoring

### DIFF
--- a/hosts/linux/daytona/configuration.nix
+++ b/hosts/linux/daytona/configuration.nix
@@ -37,6 +37,7 @@
   networking = {
     hostName = "Daytona";
     networkmanager.wifi.scanRandMacAddress = false;
+    firewall.allowedTCPPorts = [ 12345 ];
   };
 
   system.activationScripts.sddm-hyprland-config = ''
@@ -47,6 +48,91 @@
   '';
 
   services = {
+    alloy = {
+      enable = true;
+      configPath = pkgs.writeText "daytona.alloy" ''
+        // Journal source: tail systemd journal and emit Loki entries.
+        loki.source.journal "journal" {
+          path          = "/var/log/journal"
+          forward_to    = [loki.write.default.receiver]
+          relabel_rules = loki.relabel.journal.rules
+          labels        = {
+            job      = "journal",
+            hostname = "Daytona",
+            host     = "Daytona",
+          }
+        }
+
+        // Relabel journal metadata into stable Loki labels.
+        loki.relabel "journal" {
+          forward_to = []
+
+          rule {
+            source_labels = ["__journal__systemd_unit"]
+            target_label  = "unit"
+          }
+          rule {
+            source_labels = ["__journal__container_name"]
+            target_label  = "container"
+          }
+          rule {
+            source_labels = ["__journal__container_id"]
+            target_label  = "container_id"
+          }
+        }
+
+        // Push logs to the central Loki master.
+        loki.write "default" {
+          endpoint {
+            url       = "http://192.168.31.20:5678/loki/api/v1/push"
+            tenant_id = "default"
+          }
+        }
+
+        // Scrape local node_exporter
+        prometheus.scrape "node_exporter" {
+          targets = [
+            {"__address__" = "localhost:9100"},
+          ]
+          forward_to = [prometheus.relabel.node_exporter.receiver]
+          scrape_interval = "15s"
+        }
+
+        // Ensure proper labels for metrics
+        prometheus.relabel "node_exporter" {
+          forward_to = [prometheus.remote_write.default.receiver]
+
+          rule {
+            target_label = "hostname"
+            replacement  = "Daytona"
+          }
+          rule {
+            target_label = "role"
+            replacement  = "desktop"
+          }
+          rule {
+            target_label = "exporter"
+            replacement  = "node"
+          }
+          rule {
+            target_label = "job"
+            replacement  = "node"
+          }
+          rule {
+            target_label = "instance"
+            replacement  = "Daytona.local:9100"
+          }
+        }
+
+        // Push metrics to central Prometheus master
+        prometheus.remote_write "default" {
+          endpoint {
+            url = "http://192.168.31.20:9090/api/v1/write"
+          }
+        }
+      '';
+    };
+
     displayManager = {
       defaultSession = "hyprland";
       sddm = {

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -10,7 +10,7 @@
 }:
 let
   agentHosts = agentNodes;
-  desktopHosts = desktopNodes;
+  desktopHosts = builtins.filter (h: h != "Daytona") desktopNodes;
 
 in
 {
@@ -132,6 +132,7 @@ in
       extraFlags = [
         "--storage.tsdb.retention.time=90d"
         "--web.enable-admin-api"
+        "--web.enable-remote-write-receiver"
       ];
 
       globalConfig = {


### PR DESCRIPTION
Daytona is a laptop that connects over VPN, breaking the mDNS broadcasts (`daytona.local`) that Prometheus uses to scrape its `node_exporter` metrics. Because it's a roaming device without a stable IP, Prometheus's pull model doesn't work well here.

This drops Daytona from the central Prometheus scrape map and enables Prometheus's `remote_write` receiver. Daytona now runs a local Grafana Alloy agent that scrapes its own `node_exporter` and tails the systemd journal, pushing both logs and metrics directly to the central server's stable internal IP (`192.168.31.20`) over the VPN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized log collection and forwarding from Daytona.
  * Added system and node metrics collection with remote delivery to monitoring services.
  * Enabled Prometheus to receive remote-written metrics.
  * Opened TCP port 12345 for incoming connections.

* **Bug Fixes**
  * Excluded Daytona from the desktop monitoring target list to avoid incorrect target selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->