### PR TITLE
chore(flake/home-manager): `079a3b5d` -> `0c486d2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784913159,
-        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
+        "lastModified": 1785158503,
+        "narHash": "sha256-vEhDKc9JYVGH5CO4nbfqIZmsWiDKLPFReYK6emsFK5U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
+        "rev": "0c486d2b21bb1e4d0e5a11e374deb51587267387",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`0c486d2b`](https://github.com/nix-community/home-manager/commit/0c486d2b21bb1e4d0e5a11e374deb51587267387) | `` Translate using Weblate (Turkish) ``                           |
| [`e83dffa8`](https://github.com/nix-community/home-manager/commit/e83dffa86cccb6237fe194d4eeb47f41557749d1) | `` ci: bump actions/labeler from 6 to 7 ``                        |
| [`6c957965`](https://github.com/nix-community/home-manager/commit/6c957965dbd445deac9a1320753b5cc16f5c1075) | `` wlsunset: make duration optional with manual sunrise/sunset `` |