### PR TITLE
chore(flake/home-manager-stable): `4ce19022` -> `d4fd2466`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -735,11 +735,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784350909,
-        "narHash": "sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE+KzCrM=",
+        "lastModified": 1785119570,
+        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4ce190229c73d44536caa7072f6308fb2d8feeb3",
+        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`d4fd2466`](https://github.com/nix-community/home-manager/commit/d4fd24667c8cbef124bb70a20380cab75ec8474d) | `` ci: bump actions/labeler from 6 to 7 ``            |
| [`7a64d002`](https://github.com/nix-community/home-manager/commit/7a64d00231ce5fafa407f34591c7683283471b7a) | `` flake: bump nixpkgs from `293d6ab` to `b3fe958` `` |