### PR TITLE
chore(flake/freminal): `978cee99` -> `cb4ff646`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1785041531,
-        "narHash": "sha256-wiL76nu2S6QEVYvoUzyYlcO0fo9sQ57l5XeRdVkHzac=",
+        "lastModified": 1785165134,
+        "narHash": "sha256-YwxUlzXYxqp1iSXVz6iajvLJ1ZVuA4LXpFBhdQZTHgc=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "978cee99e4490d2572c9ad4964e3683443498d75",
+        "rev": "cb4ff646b1c518f16d289fc37c0cfc80b0f7f886",
         "type": "github"
       },
       "original": {
@@ -540,11 +540,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -1085,11 +1085,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1784120854,
-        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1784275620,
-        "narHash": "sha256-vk/LLBBfr2c25A0IpvSqGbzqDtybWUnxO4YsiSCeWeg=",
+        "lastModified": 1784881447,
+        "narHash": "sha256-LX+JOSlg0xD7e03/K8hiZxG4T2dHVtapYo7lVbr9LU0=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "50bd447e1d3206ea63716ef6c77ac0deba9f0276",
+        "rev": "ff4b38d25952a7b818f3b2e0edc749bf6c11b371",
         "type": "github"
       },
       "original": {
@@ -1309,11 +1309,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1784265529,
-        "narHash": "sha256-ohQQiPOngux8ofsrSlloHCMDhRMvocXqJiG8uH45Q5k=",
+        "lastModified": 1784870759,
+        "narHash": "sha256-ZaS89rj5u6pygXKDRfCzPMGm7isJxLsSeIAR5EaSyu8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "068175006cfb69d5b541a140ed93e361488c9e53",
+        "rev": "471286a5fadc690e2408ad854eb32325f5e74da7",
         "type": "github"
       },
       "original": {
@@ -1330,11 +1330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784438913,
-        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
+        "lastModified": 1785131767,
+        "narHash": "sha256-VNbQv2P0zgaNh96mT4LrnX7hdXgiC5nBH+uvyrrVX7U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
+        "rev": "c67ce00525464a710971351c183ce67acb6ca827",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`b1a904dd`](https://github.com/fredsystems/freminal/commit/b1a904dd7f71d834fd8d19bc6c696065b4b6b965) | `` fix: invalidate merge_cache on scrollback-capacity drain (#405) ``          |
| [`3cc0137f`](https://github.com/fredsystems/freminal/commit/3cc0137facd080c287ad91c64f8b62d06cde07ee) | `` chore(flake): update flakes ``                                              |
| [`27db267c`](https://github.com/fredsystems/freminal/commit/27db267cdde3b66206f5d050faebf70dc8d20333) | `` chore(version): 0.12.0-beta.6 ``                                            |
| [`78d2c573`](https://github.com/fredsystems/freminal/commit/78d2c573a1aee0353506e9d41712b8ab39b7b6ea) | `` fix: chrome emoji fallback must skip color-only fonts ``                    |
| [`3908de5b`](https://github.com/fredsystems/freminal/commit/3908de5b7f9de5d20508e109462294cbac8fed14) | `` fix: 453 -- suppress queued raw keys during a pane-border drag ``           |
| [`95a9182b`](https://github.com/fredsystems/freminal/commit/95a9182bfc3d5f1fc4c59e7de216cb1cf70e71ae) | `` fix: 453 -- stop pane-divider drag from painting phantom selection ``       |
| [`e5bafe12`](https://github.com/fredsystems/freminal/commit/e5bafe127c9df41e1cef8b881867e144226c4551) | `` fix: 431 -- always use bundled emoji font, remove system ranking ``         |
| [`df546ab4`](https://github.com/fredsystems/freminal/commit/df546ab46d7c9f01ae1fefb54055b921809b0c59) | `` chore(deps): update taiki-e/install-action action to v2.85.2 ``             |
| [`3b418676`](https://github.com/fredsystems/freminal/commit/3b4186766149802ae3d69ef7fec11332d05c9d3f) | `` fix: 433 -- show notification icon via inline image-data bytes ``           |
| [`dc6f849a`](https://github.com/fredsystems/freminal/commit/dc6f849ac0a163242f43c94adfc490c40f80ce3e) | `` docs: 433 -- add freminal-toast-options skill (slice 4) ``                  |
| [`67b3a824`](https://github.com/fredsystems/freminal/commit/67b3a8245abe1a82868550d020edd2908ce962c7) | `` feat: 433 -- toast visual redesign (neutral fill, border, no glow) ``       |
| [`ad0b7fa3`](https://github.com/fredsystems/freminal/commit/ad0b7fa3ed24dff453c34eacdef9375b9ecd2023) | `` feat: 433 -- attach freminal app icon to desktop notifications (slice 3) `` |
| [`5c382d0d`](https://github.com/fredsystems/freminal/commit/5c382d0db7efb82ef4ec9930d0c02dc65d41fcca) | `` fix: 433 -- address PR #451 CodeRabbit review (slice 2) ``                  |
| [`aa5b0f80`](https://github.com/fredsystems/freminal/commit/aa5b0f80675c111237e7f4fdb2c234f7037f0c94) | `` feat: 433 -- per-scope toast positioning (slice 2) ``                       |