### PR TITLE
chore(flake/colmena): `e5eda626` -> `e82594c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1784448989,
-        "narHash": "sha256-XC0OkWCiTM91msCp0o7zfM+iBv06mLlCzFxkP8vf+ac=",
+        "lastModified": 1785163180,
+        "narHash": "sha256-S1VWYFaaTkf4KH5HajutUFFMZft1oPhoo9pCqYF/HL8=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "e5eda626e459f7043868fd2e3b3bf8ce0d1992e6",
+        "rev": "e82594c22942c78f12baa4f0af81a92d324860d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`c4db1492`](https://github.com/nix-community/colmena/commit/c4db1492957424836925fe617031bd4a6fb3fbb1) | `` ci: bump actions/checkout from 7.0.0 to 7.0.1 in the actions group `` |
| [`5e1ae752`](https://github.com/nix-community/colmena/commit/5e1ae7522e67398ad5e832e0926ceca74ac9d223) | `` cargo: bump the cargo group with 10 updates ``                        |
| [`761397cf`](https://github.com/nix-community/colmena/commit/761397cfb758ec142259205b84068ed7437b8d0e) | `` .git-blame-ignore-revs: add treewide `nix fmt` run ``                 |
| [`4de1f38b`](https://github.com/nix-community/colmena/commit/4de1f38bb444cfd760a5c15ce347764c3141168b) | `` treewide: run nix fmt ``                                              |
| [`4538faa4`](https://github.com/nix-community/colmena/commit/4538faa4b2b09ac040b33f9e7314d4f8a7ce41ef) | `` ci: migrate checks ``                                                 |
| [`f8689754`](https://github.com/nix-community/colmena/commit/f8689754fc9b1557e3402da216d4d324e1cad838) | `` formatter: init ``                                                    |