### PR TITLE
chore(flake/nixpkgs-stable): `597283ad` -> `8623c4c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -960,11 +960,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1784856561,
-        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
+        "lastModified": 1785104993,
+        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
+        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`3f10436d`](https://github.com/NixOS/nixpkgs/commit/3f10436d3f19de3bf13367c3b225787245e9b1f3) | `` tomcat9: 9.0.118 -> 9.0.120 ``                                                      |
| [`390848e3`](https://github.com/NixOS/nixpkgs/commit/390848e31fd8f4f5314742fee5d39b3b5ca3bf50) | `` tomcat: 11.0.22 -> 11.0.24 ``                                                       |
| [`df5791d7`](https://github.com/NixOS/nixpkgs/commit/df5791d7134efe4d7fbc816746310b6445b8cc5e) | `` shell: cleanup 26.05 x86_64-darwin special case ``                                  |
| [`6fb1cea5`](https://github.com/NixOS/nixpkgs/commit/6fb1cea5e884e4c5db3548272182da02056243a3) | `` kubelogin-oidc: 1.36.2 -> 1.36.3 ``                                                 |
| [`77b540c8`](https://github.com/NixOS/nixpkgs/commit/77b540c8b9aa362738aca07bd6bff30867e13203) | `` google-chrome: add aarch64-linux support ``                                         |
| [`594178c0`](https://github.com/NixOS/nixpkgs/commit/594178c0caa56de22f59276afaa05f36d6d04234) | `` factorio: 2.0.76 -> 2.0.77, factorio-experimental: 2.0.76 -> 2.1.7 ``               |
| [`50f27f27`](https://github.com/NixOS/nixpkgs/commit/50f27f272d79cc3bd7b4d4697f57a416f40d723f) | `` osu-lazer: 2026.711.0 -> 2026.726.0 ``                                              |
| [`6db33887`](https://github.com/NixOS/nixpkgs/commit/6db33887865696145077dfd8e805f001be480ff4) | `` osu-lazer-bin: 2026.711.0 -> 2026.726.0 ``                                          |
| [`145fb034`](https://github.com/NixOS/nixpkgs/commit/145fb034e9e7b68735d2339f2da6257419b775dc) | `` komikku: 50.9.0 -> 50.10.0 ``                                                       |
| [`7ca40965`](https://github.com/NixOS/nixpkgs/commit/7ca40965e93b3accd2ef1348a59fa4b6d2a1899d) | `` signal-desktop: 8.15.0 -> 8.18.0 ``                                                 |
| [`e21a3725`](https://github.com/NixOS/nixpkgs/commit/e21a3725cb37af9915694e97f08dd6610d050fea) | `` nextcloud34: 34.0.1 -> 34.0.2 ``                                                    |
| [`49e8f6bc`](https://github.com/NixOS/nixpkgs/commit/49e8f6bcf4f1307f2997a80b2ca36de69e080874) | `` nextcloud33: 33.0.6 -> 33.0.7 ``                                                    |
| [`42f5a1dc`](https://github.com/NixOS/nixpkgs/commit/42f5a1dc5464a579ed53ba8dc774663f7fca3b9b) | `` nextcloud32: 32.0.12 -> 32.0.13 ``                                                  |
| [`48d9627b`](https://github.com/NixOS/nixpkgs/commit/48d9627b600af33d3c122d34b2136a35b279c53c) | `` nextcloud34Packages: update ``                                                      |
| [`08bcc4b7`](https://github.com/NixOS/nixpkgs/commit/08bcc4b7446e7286c72c500d8b08c9638d2ad61e) | `` nextcloud33Packages: update ``                                                      |
| [`8ab73548`](https://github.com/NixOS/nixpkgs/commit/8ab73548d2466c5aa0cdfd499ea490eecd578fb5) | `` nextcloud32Packages: update ``                                                      |
| [`cf20d82a`](https://github.com/NixOS/nixpkgs/commit/cf20d82a50ef592986e3f3cb1083360990c2eb88) | `` linux_xanmod_latest: 7.1.4 -> 7.1.5 ``                                              |
| [`bfd502ec`](https://github.com/NixOS/nixpkgs/commit/bfd502ecf7017e77bca74b62e1d375c64cfc45b1) | `` linux_xanmod: 6.18.39 -> 6.18.40 ``                                                 |
| [`e105dec3`](https://github.com/NixOS/nixpkgs/commit/e105dec306caa1f397a3724430a3f303402322c8) | `` telegram-bot-api: 10.1 -> 10.2 ``                                                   |
| [`5f9ab4dd`](https://github.com/NixOS/nixpkgs/commit/5f9ab4dd736783c5d05ecd39ba9829b6c4792f76) | `` tailscale: fix vendorHash ``                                                        |
| [`3f7f268b`](https://github.com/NixOS/nixpkgs/commit/3f7f268b6fe5de272fa859f6bd5cd363339ca708) | `` dbeaver-bin: 26.0.5 -> 26.1.3 ``                                                    |
| [`531ae260`](https://github.com/NixOS/nixpkgs/commit/531ae260c470b39cd79b8c6161d9592c37d060bf) | `` miniflux: 2.3.2 -> 2.3.3 ``                                                         |
| [`82cac00d`](https://github.com/NixOS/nixpkgs/commit/82cac00dcf615bcd298725eb39a1ba3bb7f35949) | `` hedgedoc: 1.11.0 -> 1.11.1 ``                                                       |
| [`70252347`](https://github.com/NixOS/nixpkgs/commit/70252347da9884ca491335357e85f6389d9948cb) | `` blueprint-compiler: set strictDeps ``                                               |
| [`37de201d`](https://github.com/NixOS/nixpkgs/commit/37de201dc6c401d7dc6d0836157133b912a16f15) | `` wayle: 0.6.0 -> 0.7.0 ``                                                            |
| [`800c6e4c`](https://github.com/NixOS/nixpkgs/commit/800c6e4cdf262eb4f43660f47aac6638734df3a9) | `` telegram-bot-api: 9.2 -> 10.1 ``                                                    |
| [`1b6b982c`](https://github.com/NixOS/nixpkgs/commit/1b6b982c719cc16ef79c9764cd5e5f502304211f) | `` cargo-shear: 1.13.2 -> 1.13.3 ``                                                    |
| [`32242b25`](https://github.com/NixOS/nixpkgs/commit/32242b254c12da9bebf3498c3103225b1d9267eb) | `` quarkdown: init at 1.6.1 ``                                                         |
| [`ebcf76cb`](https://github.com/NixOS/nixpkgs/commit/ebcf76cbfc86ca6983e796c5013b8b25fabec0bf) | `` pnpm: 11.16.0 -> 11.17.0 ``                                                         |
| [`76ae6706`](https://github.com/NixOS/nixpkgs/commit/76ae6706efaa714531560a704037d12f1f826b3f) | `` docker: avoid setting empty path segments into PATH ``                              |
| [`b264ff26`](https://github.com/NixOS/nixpkgs/commit/b264ff267597d56ee69e22dca53939532afb2adb) | `` zellij: avoid putting empty path segment into PATH when `extraPackages` is empty `` |
| [`090973a5`](https://github.com/NixOS/nixpkgs/commit/090973a56206a47b475357ed2db76a30217efecf) | `` gotosocial: fix cross-compilation on RISCV ``                                       |
| [`dbbeb6e5`](https://github.com/NixOS/nixpkgs/commit/dbbeb6e54a61cacb9ff2edee3305351331342526) | `` linuxKernel.kernels.linux_zen: 7.1.3 -> 7.1.4 ``                                    |
| [`debb45f5`](https://github.com/NixOS/nixpkgs/commit/debb45f5199bbf0f5502cf17550a1d9a4ef22fb3) | `` ollama: 0.32.1 -> 0.32.3 ``                                                         |
| [`017b30a2`](https://github.com/NixOS/nixpkgs/commit/017b30a2ce226105558467645fcda9b47189a88b) | `` ollama: add update.sh which also updates llamaCppSrc ``                             |
| [`8646b7be`](https://github.com/NixOS/nixpkgs/commit/8646b7be863e7bd7d7fc519be006edf6c758a51a) | `` ollama: 0.32.0 -> 0.32.1 ``                                                         |
| [`6de310b4`](https://github.com/NixOS/nixpkgs/commit/6de310b4fe11f9e23a4f71ec85023ca5a49fe429) | `` ollama: 0.31.2 -> 0.32.0 ``                                                         |
| [`2c199f83`](https://github.com/NixOS/nixpkgs/commit/2c199f838ed774af78129e7c4af618ff4b2d1f39) | `` ollama-cpu: 0.31.1 -> 0.31.2 ``                                                     |
| [`a7e6ee74`](https://github.com/NixOS/nixpkgs/commit/a7e6ee745230397218b5f64aea93590389fdd49a) | `` ollama: 0.30.7 -> 0.31.1 ``                                                         |
| [`d50cddd6`](https://github.com/NixOS/nixpkgs/commit/d50cddd6351cfd712c9fd991964cf1cb85ce797a) | `` ollama: mark cross as broken, fix cmake invocation ``                               |
| [`2630ab85`](https://github.com/NixOS/nixpkgs/commit/2630ab852af46765c3ca88d66b04bdb9dfebcb1b) | `` ollama-cpu: 0.30.6 -> 0.30.7 ``                                                     |
| [`78917f53`](https://github.com/NixOS/nixpkgs/commit/78917f536485ca31aa3dcf551b928110d9c6e977) | `` openasar: 0-unstable-2026-07-12 -> 0-unstable-2026-07-24 ``                         |
| [`a00e214c`](https://github.com/NixOS/nixpkgs/commit/a00e214c37d1c90573cce56f5cc294840fe74177) | `` openasar: 0-unstable-2026-06-04 -> 0-unstable-2026-07-12 ``                         |
| [`f34f2a2c`](https://github.com/NixOS/nixpkgs/commit/f34f2a2c5c4e4ff60a209eccc99e20788f499c8f) | `` openasar: 0-unstable-2026-05-08 -> 0-unstable-2026-06-04 ``                         |
| [`f282aa7d`](https://github.com/NixOS/nixpkgs/commit/f282aa7d941eff950d4c94627854cea3201560a1) | `` traefik: 3.7.6 -> 3.7.8 ``                                                          |
| [`9955bc1f`](https://github.com/NixOS/nixpkgs/commit/9955bc1ffb1362468c79cbfb1d8724f8a8718894) | `` pdns-recursor: 5.4.3 -> 5.4.4 ``                                                    |
| [`a8480862`](https://github.com/NixOS/nixpkgs/commit/a84808624c0f4ed7c7f657d9680bcb6d1ceb73d2) | `` nixos/regreet: fix docs for `services.greetd` config ``                             |
| [`4782c4b5`](https://github.com/NixOS/nixpkgs/commit/4782c4b58f0ce7a0b456e5c7ff01294cb944636e) | `` ci/pinned: update ``                                                                |
| [`c1d7bcf7`](https://github.com/NixOS/nixpkgs/commit/c1d7bcf74ce06544af15a72c395d4dfb1749e690) | `` switch-to-configuration-ng: /etc/os-release should not be required ``               |
| [`eb3a2330`](https://github.com/NixOS/nixpkgs/commit/eb3a233057c4179c372bd81be099eed6226a0409) | `` ci/pinned: bump nixpkgs ``                                                          |
| [`4ad8bf26`](https://github.com/NixOS/nixpkgs/commit/4ad8bf26d4891875d610e965ac1b6d4ff9752f68) | `` tailscale: 1.98.8 -> 1.98.9 ``                                                      |
| [`ce51e604`](https://github.com/NixOS/nixpkgs/commit/ce51e604be8b521a36661d28810d72e78f4a72fe) | `` shell: pin a Nixpkgs that supports x86_64-darwin ``                                 |
| [`e6d3bf57`](https://github.com/NixOS/nixpkgs/commit/e6d3bf57d610e3a877ff315684a82cb17a932842) | `` workflows: appease zizmor by installing npm pkgs from lockfile ``                   |
| [`f197f8e0`](https://github.com/NixOS/nixpkgs/commit/f197f8e0c66ac6b9132d9b6d139fed1caf4000d0) | `` vaultwarden: 1.36.0 -> 1.37.0 ``                                                    |
| [`ce655e6c`](https://github.com/NixOS/nixpkgs/commit/ce655e6c9c115d64a02ac0419a6eb7c35e454680) | `` gale: 1.13.4 -> 1.19.0 ``                                                           |
| [`6060ccb9`](https://github.com/NixOS/nixpkgs/commit/6060ccb9e8ce387c7f773872f0a79d6a31904c7b) | `` librewolf-unwrapped: 152.0.6-1 -> 153.0-3 ``                                        |
| [`614574d1`](https://github.com/NixOS/nixpkgs/commit/614574d1b002e82286c68fabc39ec29a95825680) | `` firefox/wrapper: enable strictDeps ``                                               |
| [`8c56925b`](https://github.com/NixOS/nixpkgs/commit/8c56925b18f4be8864c54e2e1b5017918768bd65) | `` invidious: 2.20260626.0 → 2.20260723.0 ``                                           |
| [`424fab16`](https://github.com/NixOS/nixpkgs/commit/424fab16b4126c54702bf419f3fb893ed4572bcb) | `` kamailio: 6.0.5 -> 6.1.3 ``                                                         |
| [`297c33e8`](https://github.com/NixOS/nixpkgs/commit/297c33e8b9049eeaff7ee368b087fe2f1c55ca21) | `` nixos/systemd-resolved: apply transformation to resolve section ``                  |
| [`6d342f51`](https://github.com/NixOS/nixpkgs/commit/6d342f51fee31e739a49cd3c0c314cad02da90df) | `` Revert "nixos/resolved: apply transformations to keys within resolved section" ``   |
| [`73aed9ad`](https://github.com/NixOS/nixpkgs/commit/73aed9ad86fa055d2d5d734eb3f1ee0030c5889f) | `` python3Packages.gdown: 5.2.1 -> 5.2.2 ``                                            |
| [`eea58474`](https://github.com/NixOS/nixpkgs/commit/eea58474f51c523b1aeffc31968a7c5e404877de) | `` .github: Bump actions/labeler from 6.2.0 to 7.0.0 ``                                |
| [`b0f6314e`](https://github.com/NixOS/nixpkgs/commit/b0f6314e77713b992b2bd05ee783d9ce1dcf8f6a) | `` pzip: mark vulnerable ``                                                            |
| [`92725a36`](https://github.com/NixOS/nixpkgs/commit/92725a369991672dbe40c85dffb1a3848c7424c5) | `` sops: 3.13.2 -> 3.13.3 ``                                                           |
| [`669d11b8`](https://github.com/NixOS/nixpkgs/commit/669d11b88a3f9e4b076b397fa8156d65f958cbf7) | `` ungoogled-chromium: 150.0.7871.181-1 -> 150.0.7871.186-1 ``                         |
| [`92feb8ec`](https://github.com/NixOS/nixpkgs/commit/92feb8ec80ef28e722bb56a1511a86682cc1c4f0) | `` anubis: fix build on darwin with sandbox enabled ``                                 |
| [`051e8ab4`](https://github.com/NixOS/nixpkgs/commit/051e8ab4b16f51b5e2cc3aa4277b0bc0e80c945a) | `` thunderbird-latest: 152.0.1 -> 153.0 ``                                             |
| [`448dce78`](https://github.com/NixOS/nixpkgs/commit/448dce7858124dd0e1abd5ae5daa5c8781ed16c1) | `` thunderbird-153: init at 153.0.1esr ``                                              |
| [`d8150d4d`](https://github.com/NixOS/nixpkgs/commit/d8150d4d669c882643d888c1b7d457801756ca6c) | `` pnpm: 11.15.0 -> 11.16.0 ``                                                         |
| [`1733c689`](https://github.com/NixOS/nixpkgs/commit/1733c68914c0c6bcac2920e760692564395187e2) | `` linux_5_10: 5.10.260 -> 5.10.261 ``                                                 |
| [`55a4ce77`](https://github.com/NixOS/nixpkgs/commit/55a4ce778cd5a1494e573c6d555682d1714765e8) | `` linux_5_15: 5.15.211 -> 5.15.212 ``                                                 |
| [`ddacdc58`](https://github.com/NixOS/nixpkgs/commit/ddacdc583f3a83218ed19aa336140778c3ccd333) | `` linux_6_1: 6.1.177 -> 6.1.178 ``                                                    |
| [`a237570d`](https://github.com/NixOS/nixpkgs/commit/a237570d2fa115333ee59dd3a11a52ff474dc921) | `` linux_6_6: 6.6.144 -> 6.6.145 ``                                                    |
| [`de71caa1`](https://github.com/NixOS/nixpkgs/commit/de71caa19e03d942592301cb21e75eb4be6d5f72) | `` linux_6_12: 6.12.96 -> 6.12.97 ``                                                   |
| [`ea17fa58`](https://github.com/NixOS/nixpkgs/commit/ea17fa586823bb89eb4ef7c20138f4f84eca899e) | `` linux_6_18: 6.18.39 -> 6.18.40 ``                                                   |
| [`c5784590`](https://github.com/NixOS/nixpkgs/commit/c5784590f98b42b4548d932005e365b4584c6be7) | `` linux_7_1: 7.1.4 -> 7.1.5 ``                                                        |
| [`862c34a7`](https://github.com/NixOS/nixpkgs/commit/862c34a7008e5315b7e677db3507ba07919b28c1) | `` ketesa: 1.3.0 -> 1.4.0 ``                                                           |
| [`129a5cbb`](https://github.com/NixOS/nixpkgs/commit/129a5cbb8a48e045b430649a2dffec57fbb2e0ad) | `` anubis: 1.25.0 -> 1.26.0 ``                                                         |
| [`25f53924`](https://github.com/NixOS/nixpkgs/commit/25f539243acc8f82e0d720531af65839642b2312) | `` vicinae: 0.23.1 -> 0.23.2 ``                                                        |
| [`bdd760d3`](https://github.com/NixOS/nixpkgs/commit/bdd760d3f7ed43e32cc5b3155224302409f0ec66) | `` chromium,chromedriver: 150.0.7871.181 -> 150.0.7871.186 ``                          |
| [`91502a41`](https://github.com/NixOS/nixpkgs/commit/91502a4124c890130ba1a11a1431e6197ca5f00c) | `` python3Packages.pyfuse3: Fix cross-compilation ``                                   |
| [`bdf61e4b`](https://github.com/NixOS/nixpkgs/commit/bdf61e4bf075c1eb24c1cec4b1a5e1a03c9a4b16) | `` protoc-gen-grpc-java: 1.82.2 -> 1.83.0 ``                                           |
| [`46071cab`](https://github.com/NixOS/nixpkgs/commit/46071cabba72efe59b6e7edc69eb61e44ae4b043) | `` talhelper: 3.1.10 -> 3.1.14 ``                                                      |
| [`f0c5a189`](https://github.com/NixOS/nixpkgs/commit/f0c5a18954d4895ffbdc2b6dcf5346394dbbf2a3) | `` hmcl: 3.15.3 -> 3.16.2 ``                                                           |
| [`37d6a04f`](https://github.com/NixOS/nixpkgs/commit/37d6a04f0ebcce7559baedc5bf77c19393a43ff5) | `` matomo: 5.10.0 -> 5.12.0 ``                                                         |
| [`546a2eb5`](https://github.com/NixOS/nixpkgs/commit/546a2eb5ac657fd473cc5f6dd4e33c5f603243d9) | `` mattermost: 11.7.6 -> 11.7.7 ``                                                     |
| [`b0faa288`](https://github.com/NixOS/nixpkgs/commit/b0faa28848d7c93a6766362d9d1d268738a7d76a) | `` winbox4: add martinkontsek as a maintainer ``                                       |
| [`19dbe076`](https://github.com/NixOS/nixpkgs/commit/19dbe076266de26baf63f8f6a97750d648170d71) | `` coqPackages.mathcomp-word: 3.4 → 3.5 ``                                             |
| [`a82a4c9d`](https://github.com/NixOS/nixpkgs/commit/a82a4c9dcc2ae16f1be9e2b53c256b44f3966ce2) | `` matrix-synapse: 1.156.0 -> 1.157.1 ``                                               |
| [`30dfa7cd`](https://github.com/NixOS/nixpkgs/commit/30dfa7cdbb490bfc7c8e2dc65d503cba44eac4d8) | `` thunderbird-140: 140.12.1esr -> 140.13.0esr ``                                      |
| [`0564ca28`](https://github.com/NixOS/nixpkgs/commit/0564ca289ead44c8270d5d1edfc0343f0f12d81c) | `` siyuan: 3.6.5 -> 3.7.1 ``                                                           |
| [`9f9a32e5`](https://github.com/NixOS/nixpkgs/commit/9f9a32e5eb57d2a602c813eb7b0083940c06f960) | `` containerd: 2.3.0 -> 2.3.1 ``                                                       |
| [`51d52633`](https://github.com/NixOS/nixpkgs/commit/51d52633a3bc0c0f3a024b67812815e03e9b6d74) | `` proftpd: 1.3.9a -> 1.3.9c ``                                                        |
| [`2a6c8adc`](https://github.com/NixOS/nixpkgs/commit/2a6c8adcda7b2263a7c8a8d1a3564f6f8a9ba502) | `` buildbox: 1.4.11 -> 1.4.13 ``                                                       |
| [`e54365c5`](https://github.com/NixOS/nixpkgs/commit/e54365c561f6917749258831da2ce8e0662e93ab) | `` buildbox: 1.4.10 -> 1.4.11 ``                                                       |
| [`f1541921`](https://github.com/NixOS/nixpkgs/commit/f15419211a12508df17323c281ac662c72e4b71e) | `` buildbox: 1.4.8 -> 1.4.10 ``                                                        |
| [`7e76b897`](https://github.com/NixOS/nixpkgs/commit/7e76b897c2247c0e2501bbde394fe94681af141d) | `` buildbox: 1.4.7 -> 1.4.8 ``                                                         |
| [`a3fddd0a`](https://github.com/NixOS/nixpkgs/commit/a3fddd0af86bb83a9dde7349b5d5e9098d7c8437) | `` buildbox: 1.4.6 -> 1.4.7 ``                                                         |
| [`c266b211`](https://github.com/NixOS/nixpkgs/commit/c266b21111a71efeb8d73559e803e1e518ab513b) | `` freetube: 0.25.0 -> 0.25.1 ``                                                       |
| [`473a2694`](https://github.com/NixOS/nixpkgs/commit/473a2694ec85ab9972da58b58840755a0c6be350) | `` upsun: 5.10.7 -> 5.10.8 ``                                                          |
| [`30854711`](https://github.com/NixOS/nixpkgs/commit/30854711b26a81b62a3e957083f2b595b2ffd8eb) | `` stylelint-lsp: 2.0.1 -> 2.0.1-unstable-2026-07-19, migrate to pnpm_11 ``            |
| [`f4b2eda8`](https://github.com/NixOS/nixpkgs/commit/f4b2eda8ab42e831f9b6b16babac351fd8748bc0) | `` stylelint-lsp: switch to nodejs-slim and move to nativeBuildInputs ``               |
| [`8c6deaef`](https://github.com/NixOS/nixpkgs/commit/8c6deaefd9de007d0c0da587acbc944573d64510) | `` stylelint-lsp: add smoke test ``                                                    |
| [`185688b7`](https://github.com/NixOS/nixpkgs/commit/185688b7a5c19c21e076a38347921c4b85618656) | `` stylelint-lsp: use pnpmBuildHook ``                                                 |
| [`4c1fdac4`](https://github.com/NixOS/nixpkgs/commit/4c1fdac45c4d273a3d421411350677da3b693156) | `` postgresqlPackages.postgis: 3.6.3 -> 3.6.4 ``                                       |
| [`e3bc7d8f`](https://github.com/NixOS/nixpkgs/commit/e3bc7d8f5877da51d7c8e8cd67b8e8efe108eb7b) | `` nextcloud-talk-desktop: 2.1.1 -> 2.2.1 ``                                           |
| [`d025df34`](https://github.com/NixOS/nixpkgs/commit/d025df3435b18e6c405ccfa5173da76b137d57b1) | `` coqPackages.multinomials: 2.4.0 -> 2.5.0 ``                                         |
| [`d12488e1`](https://github.com/NixOS/nixpkgs/commit/d12488e103d227b95c8590ff55f0387eeb113ca5) | `` python3Packages.pycapnp: 2.2.2 -> 2.2.3 ``                                          |
| [`804547f7`](https://github.com/NixOS/nixpkgs/commit/804547f7ee62f340c8a099d2509c0dcc0e59e107) | `` commet-chat: init at 0.4.2+hotfix.2 ``                                              |
| [`2e44623f`](https://github.com/NixOS/nixpkgs/commit/2e44623f51f75a06a552b3991585abe85e0b77f0) | `` maintainers: add ckgxrg ``                                                          |
| [`9cedb4f2`](https://github.com/NixOS/nixpkgs/commit/9cedb4f2076ccc6bcf1bd700ac4c7a05de2f24c7) | `` lemmy-ui: use pnpm_11 ``                                                            |
| [`58fbef2f`](https://github.com/NixOS/nixpkgs/commit/58fbef2f4a313ef61176ceab4b239088a26e4b15) | `` lemmy-server: 0.19.18 -> 0.19.19 ``                                                 |
| [`41cbbc5c`](https://github.com/NixOS/nixpkgs/commit/41cbbc5cb9b342b933fc75e26495c309ffafa6d4) | `` openresolv: 3.17.0 -> 3.17.4 ``                                                     |
| [`70213e29`](https://github.com/NixOS/nixpkgs/commit/70213e29c90dc2bbc4d0905b8f3e5b089dd1c9a7) | `` winbox4: 4.1 -> 4.2 ``                                                              |
| [`ca8f22ec`](https://github.com/NixOS/nixpkgs/commit/ca8f22ec09bca3f7c692e8c93b23a6cacebaf715) | `` mdfried: move env variables into env for structuredAttrs ``                         |
| [`784f97d1`](https://github.com/NixOS/nixpkgs/commit/784f97d15dc67042f0a26693327a0e1d38850c68) | `` mdfried: 0.22.2 -> 0.22.4 ``                                                        |
| [`67a26e34`](https://github.com/NixOS/nixpkgs/commit/67a26e342ffacbd270d2bde883a5474ad2c712ad) | `` mdfried: add pdf support ``                                                         |
| [`aa6ced49`](https://github.com/NixOS/nixpkgs/commit/aa6ced49e152c3d517eebe17622954ade48fb293) | `` mdfried: 0.22.0 -> 0.22.2 ``                                                        |
| [`aa43d4f0`](https://github.com/NixOS/nixpkgs/commit/aa43d4f0f7b46cdac9367cad52ea3ef4bda36186) | `` mdfried: 0.15.0 -> 0.22.0 ``                                                        |
| [`9ec5d0ec`](https://github.com/NixOS/nixpkgs/commit/9ec5d0ecef90a308aca1d4dd5c9cd01627fb4483) | `` jetbrains.pycharm: 2026.1.2 -> 2026.1.4 ``                                          |
| [`03e90e51`](https://github.com/NixOS/nixpkgs/commit/03e90e51b56d15e301afce54a25607c0aca4f169) | `` modular-services: init pkgs.holo-daemon.services ``                                 |
| [`9f50fc3f`](https://github.com/NixOS/nixpkgs/commit/9f50fc3f90e477426ae28295e1c8ad1e9762bcb0) | `` holo-daemon-modular-service: add test ``                                            |
| [`b4c46948`](https://github.com/NixOS/nixpkgs/commit/b4c46948f8be5925dcef3362389d2f0d74a672b2) | `` cpufetch: fix x86_64-darwin build (add sysctl.c on Darwin too) ``                   |