### PR TITLE
chore(flake/nixpkgs): `e2587cae` -> `624af665`

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -188,6 +188,22 @@
       "workaround": "features/desktop/print/default.nix -- `system-config-printer-iconfix` overrides system-config-printer's .desktop `Icon=printer` to an absolute path pointing at the package's own bundled `i-network-printer.png`, bypassing icon-theme-name resolution entirely (see FIXME(vicinae-468-printer-icon)).",
       "revert_action": "No upstream PR/issue exists yet for this specific \"printer\" name bug (only the linked discussion, where multiple reporters hit the identical symptom, unresolved as of Oct 2025) so `min_version` stays null (BLOCKED) until one is filed and a fix version is known. Once vicinae ships a fix and our pinned nixpkgs' `vicinae` package version reflects it, set `min_version` accordingly (or `done: true` after manually confirming `Icon=printer` renders correctly in vicinae), then delete `system-config-printer-iconfix` and its FIXME from features/desktop/print/default.nix, reverting to a plain `programs.system-config-printer.enable = true;`.",
       "$comment": "No upstream_pr recorded yet -- if one is opened for this specific bug, add its number here so the checker nudges once merged."
+    },
+    {
+      "id": "niri-libdisplay-info-0-4",
+      "done": false,
+      "summary": "niri (built by niri-flake's `make-niri` against our own ambient `pkgs`, not a pin of its own) fails to build once our nixpkgs pin carries `libdisplay-info` 0.4.0: niri's Rust crate dependency (Smithay/libdisplay-info-rs) still pins `libdisplay-info = \"0.3.0\"` and its build.rs enforces `libdisplay-info < 0.4.0` via pkg-config. nixpkgs hit the identical wall with its own `niri` package (NixOS/nixpkgs#545976) and worked around it with a new generic `libdisplay-info_0_3` package (NixOS/nixpkgs#546004), but that fix never reaches us since niri-flake doesn't use nixpkgs' `niri` derivation.",
+      "repo": "Smithay/libdisplay-info-rs",
+      "check": "release-contains-commit",
+      "fix_commit": "3911e0344bb2db5839f2c646d25e8c2a8b5223d9",
+      "tracking": [
+        "https://github.com/NixOS/nixpkgs/issues/545976",
+        "https://github.com/NixOS/nixpkgs/pull/546004",
+        "https://github.com/Smithay/libdisplay-info-rs/pull/20"
+      ],
+      "workaround": "features/desktop/environments/niri/default.nix -- `programs.niri.package` override that reconstructs the default package (`options.programs.niri.package.default`) with its `libdisplay-info` build input overridden back to 0.3.0 via `fetchFromGitLab` (see FIXME(niri-libdisplay-info-0-4)).",
+      "revert_action": "This is a 3-hop upstream chain: (1) Smithay/libdisplay-info-rs PR #20 (tracked here, adds 0.4.0 support) merges and ships in a release -- this is what `release-contains-commit` actually detects; (2) niri-wm/niri then needs to bump its own `libdisplay-info` Cargo dependency past \"0.3.0\" to pick that release up; (3) niri-flake (epireyn's fork, our `niri` input) needs to bump its `niri-stable`/`niri-unstable` source pin to a niri release/commit that contains that bump. When this entry resolves, DO NOT immediately delete the workaround -- first check niri-wm/niri's Cargo.toml (or run `nix eval .#nixosConfigurations.maranello.config.programs.niri.package.buildInputs` after bumping the `niri` flake input) to confirm libdisplay-info's upper bound has actually moved past 0.4.0 before removing the `package` override and its FIXME from features/desktop/environments/niri/default.nix, then set `done: true`.",
+      "$comment": "release-contains-commit is checked against Smithay/libdisplay-info-rs's own releases (hop 1 only); hops 2-3 require a manual follow-up check as described in revert_action before it's actually safe to delete the workaround."
     }
   ]
 }

--- a/features/desktop/environments/modules/wayle/default.nix
+++ b/features/desktop/environments/modules/wayle/default.nix
@@ -44,7 +44,14 @@ let
   # hyprshutdown in its own transient scope, fully decoupled from wayle's
   # process tree and signal propagation, so it survives wayle being killed and
   # runs to completion (GUI, Hyprland exit, and --post-cmd).
-  niriBin = lib.getExe pkgs.niri;
+  # Use the same niri package the system actually installs
+  # (config.programs.niri.package, from niri.nixosModules.niri) rather than
+  # nixpkgs' own `pkgs.niri`. They're different derivations; referencing
+  # nixpkgs' `pkgs.niri` here forced an extra, entirely separate niri build
+  # (which independently hits the libdisplay-info 0.4.0 break -- see
+  # FIXME(niri-libdisplay-info-0-4) in features/desktop/environments/niri/default.nix)
+  # even after niri-flake's package was fixed.
+  niriBin = lib.getExe config.programs.niri.package;
   systemdRun = "${pkgs.systemd}/bin/systemd-run";
   detectCompositor = ''
     # Returns: prints "hyprland", "niri", or "unknown".

--- a/features/desktop/environments/niri/default.nix
+++ b/features/desktop/environments/niri/default.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  options,
   user,
   extraUsers ? [ ],
   ...
@@ -19,6 +20,50 @@ in
 
     programs.niri = {
       enable = true;
+
+      # FIXME(niri-libdisplay-info-0-4): WORKAROUND, not a fix.
+      #
+      # niri.nixosModules.niri (from niri-flake) defaults `programs.niri.package`
+      # to a fresh build against *our own* ambient `pkgs` (see niri-flake's
+      # `make-package-set pkgs` / `make-niri`'s `libdisplay-info` arg) rather
+      # than a pin of its own. Once our nixpkgs pin carries `libdisplay-info`
+      # 0.4.0, every niri build fails:
+      #
+      #   pkg-config exited with status code 1
+      #   Requested 'libdisplay-info < 0.4.0' but version of libdisplay-info is 0.4.0
+      #
+      # because niri (niri-wm/niri) still pins its `libdisplay-info` Rust
+      # crate (Smithay/libdisplay-info-rs) to "0.3.0", whose build.rs
+      # enforces that upper bound via pkg-config.
+      #
+      # nixpkgs hit the identical wall with its own `niri` package and
+      # worked around it by pinning to a new generic `libdisplay-info_0_3`
+      # package (NixOS/nixpkgs#546004, closes
+      # https://github.com/NixOS/nixpkgs/issues/545976). That fix doesn't
+      # reach us because niri-flake's builder never touches nixpkgs' `niri`
+      # derivation -- it builds niri itself from niri-wm/niri sources against
+      # whatever `libdisplay-info` our own `pkgs` provides.
+      #
+      # Work around it the same way nixpkgs did: override *just* niri's
+      # `libdisplay-info` build input back to 0.3.0. Scoped to niri's package
+      # override only (via `options...default.override`) -- does not touch
+      # the system-wide `pkgs.libdisplay-info` used by anything else.
+      #
+      # Revert: once niri (niri-wm/niri) or Smithay/libdisplay-info-rs bumps
+      # to support libdisplay-info >= 0.4, delete this `package` override
+      # and the FIXME. See .github/workflows/track-upstream-fixes.yaml.
+      package = options.programs.niri.package.default.override {
+        libdisplay-info = pkgs.libdisplay-info.overrideAttrs (finalAttrs: {
+          version = "0.3.0";
+          src = pkgs.fetchFromGitLab {
+            domain = "gitlab.freedesktop.org";
+            owner = "emersion";
+            repo = "libdisplay-info";
+            rev = finalAttrs.version;
+            hash = "sha256-nXf2KGovNKvcchlHlzKBkAOeySMJXgxMpbi5z9gLrdc=";
+          };
+        });
+      };
     };
     programs.xwayland.enable = true;
 

--- a/flake.lock
+++ b/flake.lock
@@ -992,11 +992,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`8bc29659`](https://github.com/NixOS/nixpkgs/commit/8bc296598776bb29339781a38799ed7d60cdfcb7) | `` python3Packages.rns: 1.4.1 -> 1.4.2 ``                                                        |
| [`24151b67`](https://github.com/NixOS/nixpkgs/commit/24151b6706ad1cd8dfed47ba5d20e69849be0eb6) | `` zerofs: 2.0.10 -> 2.1.1 ``                                                                    |
| [`7adb50f8`](https://github.com/NixOS/nixpkgs/commit/7adb50f8140227acca8caa21c4a6202fafa1f49f) | `` nixos/authelia: use lib.types.externalPath ``                                                 |
| [`57a14d60`](https://github.com/NixOS/nixpkgs/commit/57a14d60038f5da146bebf8fa432b29ae7b7b289) | `` cargo-semver-checks: 0.48.0 -> 0.49.0 ``                                                      |
| [`b9790dd5`](https://github.com/NixOS/nixpkgs/commit/b9790dd548fc2b3604956cf571962d46235e14d3) | `` fluffychat: 2.6.0 -> 2.8.0 ``                                                                 |
| [`05b2a58d`](https://github.com/NixOS/nixpkgs/commit/05b2a58d0e2914f864b717e8981d39b52fb81d99) | `` keycloak.plugins.scim-keycloak-user-storage-spi: drop ``                                      |
| [`060f9ad2`](https://github.com/NixOS/nixpkgs/commit/060f9ad2310c42358b6226bdc90ca9ed3626aecd) | `` keycloak.plugins.scim-for-keycloak: drop ``                                                   |
| [`2e793376`](https://github.com/NixOS/nixpkgs/commit/2e7933762974d30a05f79c851ec37ac4294d6c9e) | `` nixos/qbittorrent: clarify profileDir option documentation ``                                 |
| [`2cf9acd6`](https://github.com/NixOS/nixpkgs/commit/2cf9acd6475d41fb2b4c2aba050a30c5c8234ac6) | `` Revert "gitlab-container-registry: 4.39.0 -> 4.40.2" ``                                       |
| [`93f925c9`](https://github.com/NixOS/nixpkgs/commit/93f925c9cb7ae786340266aaa30b9286c7bec229) | `` qownnotes: 26.7.7 -> 26.7.9 ``                                                                |
| [`dedc5429`](https://github.com/NixOS/nixpkgs/commit/dedc54290abf42043a846ddd123f34ff42cd6f91) | `` python3Packages.ufomerge: 1.9.6 -> 1.9.7 ``                                                   |
| [`7492b063`](https://github.com/NixOS/nixpkgs/commit/7492b063a3b4e7b0184f9784a9751a38bea3ed77) | `` emacs.pkgs.org: update src hash ``                                                            |
| [`0dcfd773`](https://github.com/NixOS/nixpkgs/commit/0dcfd77351fa88819e1be679171360c657f1530d) | `` limine: 12.5.1 -> 12.5.2 ``                                                                   |
| [`0f319f71`](https://github.com/NixOS/nixpkgs/commit/0f319f718de3684a7f62613b6adfc881188b84ca) | `` json-tui: Fix linux build ``                                                                  |
| [`7aa383af`](https://github.com/NixOS/nixpkgs/commit/7aa383af5dad27b517c2a5485033bd1e5417d113) | `` rtk: 0.43.0 -> 0.44.0 ``                                                                      |
| [`866b9231`](https://github.com/NixOS/nixpkgs/commit/866b9231a089214187fd1b8645487adaed17b308) | `` androidStudioPackages.canary: 2026.1.4.1 -> 2026.1.4.2 ``                                     |
| [`6691e495`](https://github.com/NixOS/nixpkgs/commit/6691e495dce3bf59e0780bf21cfa610adaed6e5d) | `` ytdl-sub: 2026.07.16 -> 2026.07.17.post1 ``                                                   |
| [`c9119d55`](https://github.com/NixOS/nixpkgs/commit/c9119d55788dd35ac1c6adaafba4fd17c84b2f7b) | `` python3Packages.textstat: enable __structuredAttrs ``                                         |
| [`8314348f`](https://github.com/NixOS/nixpkgs/commit/8314348fb47f5f2c8171dcae8876f6665a7363bd) | `` python3Packages.textstat: cleanup ``                                                          |
| [`da44678a`](https://github.com/NixOS/nixpkgs/commit/da44678a773a7b589794188762e120ffd23cb7ea) | `` python3Packages.textstat: fix build ``                                                        |
| [`1a4991a3`](https://github.com/NixOS/nixpkgs/commit/1a4991a36b9394d3b9645a15102140d09f29e289) | `` zandronum: build without gtk2 support ``                                                      |
| [`f4699037`](https://github.com/NixOS/nixpkgs/commit/f4699037884ed430d7149a67329013365d4899fb) | `` drawterm: modernize ``                                                                        |
| [`860dd86e`](https://github.com/NixOS/nixpkgs/commit/860dd86e500447ba78b062c4380776049891f4e5) | `` drawterm: fix darwin build ``                                                                 |
| [`19cc5f39`](https://github.com/NixOS/nixpkgs/commit/19cc5f39052bdc625e08a5a0cbcb7a6a5cddc990) | `` yaralyzer: relax chardet ``                                                                   |
| [`41e1d2f7`](https://github.com/NixOS/nixpkgs/commit/41e1d2f7de6ba6bc544df4e645685c0dc1c6abd4) | `` opentrack: 2026.1.0-unstable-2026-07-14 -> 2026.1.0-unstable-2026-07-24 ``                    |
| [`271b95e4`](https://github.com/NixOS/nixpkgs/commit/271b95e43c33a4ce631d606db117985ca4d5bb11) | `` bbrew: 2.3.1 -> 2.3.2 ``                                                                      |
| [`ea534133`](https://github.com/NixOS/nixpkgs/commit/ea534133ccae18029d605506cf40736bd1a9b616) | `` libargs: 6.4.9 -> 6.6.0 ``                                                                    |
| [`9dafa32b`](https://github.com/NixOS/nixpkgs/commit/9dafa32bd48d30f68b30d3e138c83b5032e6ee09) | `` osu-lazer: 2026.711.0 -> 2026.726.0 ``                                                        |
| [`ce1c1ae4`](https://github.com/NixOS/nixpkgs/commit/ce1c1ae44d90098f651f387e0921eb1a8624aabc) | `` osu-lazer-bin: 2026.711.0 -> 2026.726.0 ``                                                    |
| [`8b028bd3`](https://github.com/NixOS/nixpkgs/commit/8b028bd36bffa32e5b5b8ff5336194038a3cce04) | `` python3Packages.policy-sentry: migrate to finalAttrs ``                                       |
| [`cd8efc22`](https://github.com/NixOS/nixpkgs/commit/cd8efc229e21ba1d14424803f5339bf7ce36079d) | `` python3Packages.policy-sentry: use pyprojectVersionPatchHook ``                               |
| [`1f741a4e`](https://github.com/NixOS/nixpkgs/commit/1f741a4eda22ca7bce36410018f006aecd6015b0) | `` python3Packages.pynfsclient: fix version ``                                                   |
| [`295965a6`](https://github.com/NixOS/nixpkgs/commit/295965a621cb61be3812906570c57ac368b1ed3a) | `` python3Packages.nvdlib: modernize ``                                                          |
| [`41c457b8`](https://github.com/NixOS/nixpkgs/commit/41c457b8fd114d0f97952dd87bbaa3f8b728fcd9) | `` python3Packages.nvdlib: fix version ``                                                        |
| [`47c6ef53`](https://github.com/NixOS/nixpkgs/commit/47c6ef533ec56733c26560dd77843e99cbe05181) | `` python3Packages.frigidaire: 0.18.49 -> 0.18.50 ``                                             |
| [`8dec3a1d`](https://github.com/NixOS/nixpkgs/commit/8dec3a1d935ecc7c7a9955de0d30ad936022977b) | `` mullvad: 2026.2 -> 2026.3, refactor and move to by-name ``                                    |
| [`d7d7376e`](https://github.com/NixOS/nixpkgs/commit/d7d7376e75783d87f03f15367c2d1f1ef3cb3b24) | `` swagger-codegen3: add anthonyroussel to maintainers ``                                        |
| [`07a6f498`](https://github.com/NixOS/nixpkgs/commit/07a6f498d3950d7afb624141d4abca35408cd8e3) | `` swagger-codegen3: 3.0.75 -> 3.0.81 ``                                                         |
| [`50bc34ed`](https://github.com/NixOS/nixpkgs/commit/50bc34ed1d597f0b6c45a7e65921ca793ccf1b9b) | `` fresh-editor: 0.4.4 -> 0.4.5 ``                                                               |
| [`5796b279`](https://github.com/NixOS/nixpkgs/commit/5796b27982be9fe0be00468a88de6010dc477718) | `` swagger-codegen3: use maven.buildMavenPackage ``                                              |
| [`cd9d12ae`](https://github.com/NixOS/nixpkgs/commit/cd9d12aee02775489651e89580a70ac99638d2de) | `` python3Packages.pulsectl-asyncio: migrate to finalAttrs ``                                    |
| [`2cdce7cb`](https://github.com/NixOS/nixpkgs/commit/2cdce7cbdae17d52332deb957b9057b28843bc15) | `` python313Packages.pulsectl-asyncio: 1.2.2 -> 1.3.2 ``                                         |
| [`742ae968`](https://github.com/NixOS/nixpkgs/commit/742ae9683bbdef4d0ff2b7d444c23a2c03b3a395) | `` postgresql_19: 19beta1 -> 19beta2 ``                                                          |
| [`58e0525c`](https://github.com/NixOS/nixpkgs/commit/58e0525c1acaaf7383b8700ef57a8f211db8478e) | `` python313Packages.py-ocsf-models: 0.9.0 -> 0.10.0 ``                                          |
| [`f3f975fe`](https://github.com/NixOS/nixpkgs/commit/f3f975fe214f5102fc92ee98c2f74089543d3a9b) | `` sonarlint-ls: remove unused pcre dependency ``                                                |
| [`52bfc741`](https://github.com/NixOS/nixpkgs/commit/52bfc741edea204c21ed2998e808ca06fb815b47) | `` google-chrome: add aarch64-linux support ``                                                   |
| [`34034244`](https://github.com/NixOS/nixpkgs/commit/340342443b6cb9d0f9fda50e6dd9efe26b0f69bc) | `` nixos/authelia: Only check assertions on enabled instances ``                                 |
| [`5b79c00d`](https://github.com/NixOS/nixpkgs/commit/5b79c00d129017ed3fb636db1830cd5397939108) | `` fluxcd: 2.9.2 -> 2.9.3 ``                                                                     |
| [`2575b4ad`](https://github.com/NixOS/nixpkgs/commit/2575b4ad45cbf32aa9bbd4e53d6f368327bcdd40) | `` redpanda-client: 26.1.13 -> 26.1.14 ``                                                        |
| [`f9954f41`](https://github.com/NixOS/nixpkgs/commit/f9954f41751fd91808cd481898bf46cf295926de) | `` mongodb-atlas-cli: 1.56.0 -> 1.57.0 ``                                                        |
| [`eb9e73fd`](https://github.com/NixOS/nixpkgs/commit/eb9e73fd3d550624d10c04725a5acf2d2005bb06) | `` pmtiles: 1.31.1 -> 1.31.2 ``                                                                  |
| [`1e3f9e15`](https://github.com/NixOS/nixpkgs/commit/1e3f9e15800fb025381e31e73c21c1374af14fbf) | `` linux_xanmod_latest: 7.1.4 -> 7.1.5 ``                                                        |
| [`4ba3c269`](https://github.com/NixOS/nixpkgs/commit/4ba3c26909615afe6a6a7b2b8a9f64fa4a5e2bb9) | `` linux_xanmod: 6.18.39 -> 6.18.40 ``                                                           |
| [`c5a3e112`](https://github.com/NixOS/nixpkgs/commit/c5a3e112d6ae0be5f7b201c9c99a41cf0e76980a) | `` models-dev: sdk-v0.0.5-unstable-2026-07-17 -> sdk-v0.0.5-unstable-2026-07-26 ``               |
| [`b28fac50`](https://github.com/NixOS/nixpkgs/commit/b28fac504de9403c981bc7fe082fa7fd4a646e5a) | `` vscode-extensions.ms-python.vscode-pylance: 2026.2.1 -> 2026.3.1 ``                           |
| [`a87dac71`](https://github.com/NixOS/nixpkgs/commit/a87dac715ccb0c25eae3bbc85610b174b9710121) | `` osu-lazer-bin: use new appimageTools wrapper pattern ``                                       |
| [`cc1d8f8c`](https://github.com/NixOS/nixpkgs/commit/cc1d8f8ce348a9068e5e02ceeeb336547fe459c6) | `` autopush-rs: 1.82.2 -> 1.82.3 ``                                                              |
| [`dab31fdd`](https://github.com/NixOS/nixpkgs/commit/dab31fdd2c285128b27ea6ca5294d6234d95a8ed) | `` oxlint: 1.73.0 -> 1.75.0 ``                                                                   |
| [`1e5832f6`](https://github.com/NixOS/nixpkgs/commit/1e5832f69a0ef894537aa56f06f0801b0a7ec96c) | `` terraform-providers.fastly_fastly: 9.3.0 -> 9.4.0 ``                                          |
| [`c01c953a`](https://github.com/NixOS/nixpkgs/commit/c01c953a427cbd6efc042bb2909fae17d7d9e5ec) | `` stasis: 1.3.0 -> 1.4.0 ``                                                                     |
| [`b05b2c61`](https://github.com/NixOS/nixpkgs/commit/b05b2c6139b795c38984579bde715a52516d43ae) | `` spring: cleanup undropped files ``                                                            |
| [`fda10cdc`](https://github.com/NixOS/nixpkgs/commit/fda10cdc0239069d4b49c76a85ec575b0d04a6f9) | `` cargo-insta: 1.47.2 -> 1.48.0 ``                                                              |
| [`4279a496`](https://github.com/NixOS/nixpkgs/commit/4279a496261f40fb08d4518a554aca41e4198910) | `` vscode-extensions.johnpapa.winteriscoming: 1.4.4 -> 1.5.0 ``                                  |
| [`c61decfb`](https://github.com/NixOS/nixpkgs/commit/c61decfbb99cdce88fdf580a821cc805d10992df) | `` tensor: fix version ``                                                                        |
| [`9bfd02c8`](https://github.com/NixOS/nixpkgs/commit/9bfd02c8c4764b92df8eff693cab49a070e31947) | `` pretix: relax django-scopes constraint ``                                                     |
| [`3b3321f8`](https://github.com/NixOS/nixpkgs/commit/3b3321f818cb2f0bc0c3342e37c11530cffc5656) | `` pretalx: relax django-scopes constraint ``                                                    |
| [`2d4e8486`](https://github.com/NixOS/nixpkgs/commit/2d4e84860407aba0f1795144869cff3a2e19c355) | `` python3Packages.django-scopes: use pep517 build ``                                            |
| [`a6c5047f`](https://github.com/NixOS/nixpkgs/commit/a6c5047f4ff7ac7898475c1a6e6ccca680b10ff4) | `` meh: fix version scheme ``                                                                    |
| [`a63be665`](https://github.com/NixOS/nixpkgs/commit/a63be6657fc2b05ed86db826ac3ffb09e162c680) | `` schedctl: restricts to GNU/Linux only ``                                                      |
| [`476a1839`](https://github.com/NixOS/nixpkgs/commit/476a18394d071d9f7dc3446fc42e671fbc2110e3) | `` hecate: fix version ``                                                                        |
| [`6e527fbf`](https://github.com/NixOS/nixpkgs/commit/6e527fbf3f9fe1ba1e72cbbb2ac2dc494940451e) | `` raspi-utils: 0-unstable-2026-07-08 -> 0-unstable-2026-07-24 ``                                |
| [`7aee0257`](https://github.com/NixOS/nixpkgs/commit/7aee0257a6078416f176bd367a56cf6846a1cbec) | `` lwc: fix version ``                                                                           |
| [`6a68c9db`](https://github.com/NixOS/nixpkgs/commit/6a68c9db897df920808e32370cb1b4d2443a3943) | `` usacloud: 1.22.4 -> 1.22.8 ``                                                                 |
| [`f401b5d0`](https://github.com/NixOS/nixpkgs/commit/f401b5d066f6484eb005c7b62b87336e448eaeee) | `` iotools: fix version ``                                                                       |
| [`8958d89b`](https://github.com/NixOS/nixpkgs/commit/8958d89b52f897d7bc1e793395b556974d0d834b) | `` ion: fix version ``                                                                           |
| [`a1cfd015`](https://github.com/NixOS/nixpkgs/commit/a1cfd01560ebf07bd45cba8dbec2ac3265274813) | `` faq: modernize, fix version ``                                                                |
| [`f4bfa10d`](https://github.com/NixOS/nixpkgs/commit/f4bfa10dd4aa110ca85ab2f53611dc3ad259750e) | `` pup: fix version scheme ``                                                                    |
| [`09a4fcc4`](https://github.com/NixOS/nixpkgs/commit/09a4fcc4da7fde453fab2cdf7d5b876ff4253b58) | `` rc: fix version scheme ``                                                                     |
| [`f21195e5`](https://github.com/NixOS/nixpkgs/commit/f21195e55800ee0431a5d02a9f3fb52336fdf188) | `` python3Packages.python-mpv-jsonipc: 1.2.2 -> 1.2.3 ``                                         |
| [`8d831c77`](https://github.com/NixOS/nixpkgs/commit/8d831c778ef7a3e42295daacfef92e3b88939685) | `` justify: fix version scheme ``                                                                |
| [`9146541e`](https://github.com/NixOS/nixpkgs/commit/9146541e5319833ae23c614e0fcfc35c81641023) | `` ponysay: fix version scheme ``                                                                |
| [`4c8aa7e5`](https://github.com/NixOS/nixpkgs/commit/4c8aa7e5b9aa458a4d00b9e009ca150292eb70d4) | `` miniflux: 2.3.2 -> 2.3.3 ``                                                                   |
| [`5ac617f6`](https://github.com/NixOS/nixpkgs/commit/5ac617f653ed19e3634dcde57dcbbf05006e7e17) | `` vscode-extensions.saoudrizwan.claude-dev: 4.0.8 -> 4.0.11 ``                                  |
| [`86dc66e4`](https://github.com/NixOS/nixpkgs/commit/86dc66e4ee0b8986b6b3de31b18866de62ec050c) | `` tranquil-pds-frontend: 0.6.5 -> 0.6.6 ``                                                      |
| [`01ca76dc`](https://github.com/NixOS/nixpkgs/commit/01ca76dcbc3e48f87d60aca98d9429f4c3edcbef) | `` rPackages.talib: fix build ``                                                                 |
| [`28a7542c`](https://github.com/NixOS/nixpkgs/commit/28a7542ca22586235fdc8cf1dc5585b31453dffc) | `` rPackages.{BayesPET,GapAnalysis}: fix build ``                                                |
| [`4959772f`](https://github.com/NixOS/nixpkgs/commit/4959772f70e61063d42c70c4cf5616e9f910f3af) | `` rPackages.{minimaxALT,netboost,impARI,telegramR}: fix build ``                                |
| [`b850a337`](https://github.com/NixOS/nixpkgs/commit/b850a337c85cc1340f33e86f062045ffbea4302e) | `` rPackages.Rmpi: remove unnecessary configure flags ``                                         |
| [`ab1fe49f`](https://github.com/NixOS/nixpkgs/commit/ab1fe49f69d70146e58acdbdd7df15844d12c8ea) | `` rPackages.npRmpi: fix build ``                                                                |
| [`99ec0209`](https://github.com/NixOS/nixpkgs/commit/99ec020953b4d65293160e4328e2e1734d250ba7) | `` rPackages: fix more builds ``                                                                 |
| [`9b2b89ee`](https://github.com/NixOS/nixpkgs/commit/9b2b89eeca7aac1db04d1dbde973acee32a6571e) | `` rPackages.{RFIF,gridmicrotex}: fix build ``                                                   |
| [`a6f3f5e1`](https://github.com/NixOS/nixpkgs/commit/a6f3f5e1a141203ce921dd739ba89543d13b64f6) | `` rPackages.{BinaryDosage,cmtkr,drogonR,lstar}: fix build ``                                    |
| [`9bc8a2ef`](https://github.com/NixOS/nixpkgs/commit/9bc8a2ef64432e0b4ac53cc61d12d4fec1725058) | `` rPackages.{automerge,libipldr}: fix build ``                                                  |
| [`1c13ea5c`](https://github.com/NixOS/nixpkgs/commit/1c13ea5c1f9f3f44c2bea632f12a73489e912637) | `` rPackages.rvMF: fix build ``                                                                  |
| [`497ff4c1`](https://github.com/NixOS/nixpkgs/commit/497ff4c10e785da40ae36c7354edb7748524f0a6) | `` rPackages.mx_crypto: fix build ``                                                             |
| [`3c5a75f4`](https://github.com/NixOS/nixpkgs/commit/3c5a75f40e60a8881c37ccf406ab718983009504) | `` rPackages.sundialr: fix build ``                                                              |
| [`2ab6dfb5`](https://github.com/NixOS/nixpkgs/commit/2ab6dfb50c28cea80cd9578358e0cd4107f83c3b) | `` rPackages.scip: fix build ``                                                                  |
| [`088cf6c9`](https://github.com/NixOS/nixpkgs/commit/088cf6c9f29b5f504edbac475ac0465baf805a75) | `` rPackages.Uno: fix build ``                                                                   |
| [`febfb4bd`](https://github.com/NixOS/nixpkgs/commit/febfb4bdfa456ff3376c8f0a9e110169e3eafaca) | `` rPackages.buildRPackage: patch shebangs automatically in configure ``                         |
| [`9a18c354`](https://github.com/NixOS/nixpkgs/commit/9a18c354882b71eacb6ae3081f6953a8580653fd) | `` rPackages: Remove explicit references to split outputs ``                                     |
| [`38e6d109`](https://github.com/NixOS/nixpkgs/commit/38e6d10918ab37e6fd30b29a354bfce72697045e) | `` R: move to pkgs/by-name ``                                                                    |
| [`73a89410`](https://github.com/NixOS/nixpkgs/commit/73a89410bfdc8323a2e4bc5aa61df53a80541dc5) | `` R: move default withRecommendedPackages value into package file ``                            |
| [`2867d59a`](https://github.com/NixOS/nixpkgs/commit/2867d59a3e023cd57b6c40b0da15a25d2dbef6d7) | `` rPackages.fraq: add missing deps ``                                                           |
| [`1c9b1139`](https://github.com/NixOS/nixpkgs/commit/1c9b1139d56fb4376760f1f7a017023e0c11789b) | `` rPackages.redatamx: fix build, set unfree ``                                                  |
| [`134290ea`](https://github.com/NixOS/nixpkgs/commit/134290ea714cb6a709a80dbc996af5ccdc81d477) | `` rPackages.HiSpaR: add missing dep ``                                                          |
| [`44467822`](https://github.com/NixOS/nixpkgs/commit/444678226f9a3e24bde6899e15f663802d15be2e) | `` rPackages.{FactoMineR,pander}: remove extra RDepends ``                                       |
| [`7c7dab19`](https://github.com/NixOS/nixpkgs/commit/7c7dab194d34eb64d675877b302503243122479f) | `` rPackages: append extra RDepends to propagatedBuildInputs ``                                  |
| [`4a25c9a0`](https://github.com/NixOS/nixpkgs/commit/4a25c9a06fe71f61b6992bbe8250ebb0174b403c) | `` rPackages.SingleR: fix build ``                                                               |
| [`d50bfc3f`](https://github.com/NixOS/nixpkgs/commit/d50bfc3ff7fd6cbdf3cb4a3a8a907fa209540d19) | `` rPackages.stringfish: don't use vendored pcre2 ``                                             |
| [`d7d3021e`](https://github.com/NixOS/nixpkgs/commit/d7d3021eb7441551c04de729c928ad195081bbdd) | `` rPackages: unify and fix packages using R CMD config --ldflags ``                             |
| [`ab4af867`](https://github.com/NixOS/nixpkgs/commit/ab4af867cf8e38f08ed8d0629d5f9597971a6c25) | `` rPackages: prune packagesToSkipCheck ``                                                       |
| [`f9effd33`](https://github.com/NixOS/nixpkgs/commit/f9effd33385ff2de5920f6d833ec902e91af591a) | `` rPackages.Rmpi: fix missing symbol error ``                                                   |
| [`2f8f40d2`](https://github.com/NixOS/nixpkgs/commit/2f8f40d2ead843baeb6e46f774814853f33fcddd) | `` rPackages.V8: unpin icu ``                                                                    |
| [`e0ff1801`](https://github.com/NixOS/nixpkgs/commit/e0ff1801121343a68e51574e02c7a2341c656197) | `` rPackages: fix strictDeps build for broken packages ``                                        |
| [`b3bd3fef`](https://github.com/NixOS/nixpkgs/commit/b3bd3fef87f9de56201f787bdc9e88f64f69fecf) | `` rPackages.cn_farms: fix build by dropping patch ``                                            |
| [`97b1439f`](https://github.com/NixOS/nixpkgs/commit/97b1439fc98c2fd350452fc7172f78c890b8d37b) | `` rPackages: fix strictDeps build for several packages (part 6) ``                              |
| [`9684a329`](https://github.com/NixOS/nixpkgs/commit/9684a329bf969ed01bef8f02b347a77e29f76d75) | `` rPackages: fix strictDeps build for several packages (part 5) ``                              |
| [`8d9e8784`](https://github.com/NixOS/nixpkgs/commit/8d9e8784dacf68581329d230daa6e9a3f92408a3) | `` rPackages: fix strictDeps build for several packages (part 4) ``                              |
| [`8529f994`](https://github.com/NixOS/nixpkgs/commit/8529f99427b4515f3c046ca5ec947861057b73b7) | `` rPackages: fix strictDeps build for several packages (part 3) ``                              |
| [`6e5e7484`](https://github.com/NixOS/nixpkgs/commit/6e5e7484d6991b152fdcdb9bafc21dd9a5277c80) | `` rPackages.{unix,RAppArmor}: use libapparmor ``                                                |
| [`70ed8960`](https://github.com/NixOS/nixpkgs/commit/70ed89608f11464b89207784c10713f16405e6a3) | `` rPackages: fix strictDeps build for several packages (part 2) ``                              |
| [`747d9fea`](https://github.com/NixOS/nixpkgs/commit/747d9feae6be19db94220c80697e7cdab43e0918) | `` rPackages: apply keep-sorted directives ``                                                    |
| [`378d5c74`](https://github.com/NixOS/nixpkgs/commit/378d5c7497d2884d61aa62583933d6f86f3587c2) | `` rPackages: add keep-sorted directives ``                                                      |
| [`662771f7`](https://github.com/NixOS/nixpkgs/commit/662771f7926c508f58c1b9119ebb415f9e1c060a) | `` rPackages.pathfindR: remove broken patch ``                                                   |
| [`8706bc4b`](https://github.com/NixOS/nixpkgs/commit/8706bc4b89d8ce7aeccf5b67f1b71e525f59b50a) | `` jasp-desktop: 0.97.1 -> 0.98.1 ``                                                             |
| [`9651249d`](https://github.com/NixOS/nixpkgs/commit/9651249dd16d384c6f573a6cae232f9905f26173) | `` rPackages: fix strictDeps build for several packages (part 1) ``                              |
| [`e072c356`](https://github.com/NixOS/nixpkgs/commit/e072c356b15483c65529d99b57432649334d4b43) | `` rPackages.V8: fixed build ``                                                                  |
| [`014130f6`](https://github.com/NixOS/nixpkgs/commit/014130f61027685af17b066f4a610bd23fabf432) | `` rPackages.pak: fix build ``                                                                   |
| [`052bce24`](https://github.com/NixOS/nixpkgs/commit/052bce2493949ad7885f9173e1b8163ef4f3fa7d) | `` rPackages.RSQLite: fix build ``                                                               |
| [`e061c6a4`](https://github.com/NixOS/nixpkgs/commit/e061c6a434fe2c55508be4fdf815586f8c9ec863) | `` rPackages: CRAN and BioC update ``                                                            |
| [`519bc6a8`](https://github.com/NixOS/nixpkgs/commit/519bc6a880a6740d78447e0ec97e708dbde25fdd) | `` R: 4.6.0 -> 4.6.1 ``                                                                          |
| [`ac312f87`](https://github.com/NixOS/nixpkgs/commit/ac312f87f9b6bd3edd65674bfcbce8101fe97d86) | `` tranquil-pds: 0.6.5 -> 0.6.6 ``                                                               |
| [`6942ec2e`](https://github.com/NixOS/nixpkgs/commit/6942ec2e593c056a1f942c68ea6f08e8dcbea7d2) | `` bitwarden-cli: 2026.6.0 -> 2026.7.0 ``                                                        |
| [`9efd12f6`](https://github.com/NixOS/nixpkgs/commit/9efd12f65cf4e60a6f003f00eb4af47fd830cd57) | `` nufmt: 0-unstable-2026-07-16 -> 0-unstable-2026-07-23 ``                                      |
| [`39b8e3e8`](https://github.com/NixOS/nixpkgs/commit/39b8e3e86219bb9cb94c0fa2112932f033cdce53) | `` wildergarden-maim: __structuredAttrs fix ``                                                   |
| [`c6770640`](https://github.com/NixOS/nixpkgs/commit/c6770640fbbf804b7599c3738996cb9676536916) | `` lemminx: remove unused pcre dependency ``                                                     |
| [`a7503406`](https://github.com/NixOS/nixpkgs/commit/a7503406b272274bb9a4611941854f55e746579f) | `` par-lang: 0-unstable-2026-07-15 -> 0-unstable-2026-07-24 ``                                   |
| [`02723ee2`](https://github.com/NixOS/nixpkgs/commit/02723ee2126d861efbb4e82b1210e19fe3f1c14d) | `` python3Packages.gpiozero: 2.0.1 -> 2.0.1.post2 ``                                             |
| [`bcf4cf6b`](https://github.com/NixOS/nixpkgs/commit/bcf4cf6bd46f79219ff7f48454171abdb18293b3) | `` telegram-bot-api: 10.1 -> 10.2 ``                                                             |
| [`03631f80`](https://github.com/NixOS/nixpkgs/commit/03631f803df578002d3a98b1b18800b9e3d9d3c8) | `` jetbrains.*: 2026.1.* -> 2026.2.0.* ``                                                        |
| [`d38e056c`](https://github.com/NixOS/nixpkgs/commit/d38e056c5282c4b6d0709360197ed5656883b2ff) | `` jetbrains: fix linux builder script for 2026.2 IDEs ``                                        |
| [`147944a0`](https://github.com/NixOS/nixpkgs/commit/147944a023c9d8006e7698ec2a9d5723aed4be6f) | `` simplenote: add missing desktopName ``                                                        |
| [`a9d93733`](https://github.com/NixOS/nixpkgs/commit/a9d937331d3b2ea5aa35a2c1d2e6dc9ff9f12d2e) | `` pixinsight: inherit meta correctly ``                                                         |
| [`2e8c34b7`](https://github.com/NixOS/nixpkgs/commit/2e8c34b71a62b304386917efa10dabd4b4ad35b7) | `` appimageTools: support finalAttrs ``                                                          |
| [`47b64519`](https://github.com/NixOS/nixpkgs/commit/47b6451999e2ef29df336994f729b5061b11f908) | `` buildFHSEnv: support finalAttrs ``                                                            |
| [`4723fa56`](https://github.com/NixOS/nixpkgs/commit/4723fa5617c9b9db8711d29eff78724d51216b8c) | `` python3Packages.elevenlabs: 2.58.0 -> 2.59.0 ``                                               |
| [`13ba359f`](https://github.com/NixOS/nixpkgs/commit/13ba359ff20de04d710e5022b22e76abb914061e) | `` kubelogin-oidc: 1.36.2 -> 1.36.3 ``                                                           |
| [`8d4da6ad`](https://github.com/NixOS/nixpkgs/commit/8d4da6ade4ae77109af92b606186862756cba730) | `` python313Packages.publicsuffixlist: 1.0.2.20260724 -> 1.0.2.20260725 ``                       |
| [`8be50135`](https://github.com/NixOS/nixpkgs/commit/8be50135f32b6d9303f0206ec95583a1435f4d63) | `` dracut: add patch for CVE-2026-6893 ``                                                        |
| [`c3aec2ba`](https://github.com/NixOS/nixpkgs/commit/c3aec2ba8d56d47376f9555da5a1f1457aa24e4b) | `` home-assistant-custom-components.cover_time_based: 4.7.2 -> 4.9.0 ``                          |
| [`5b0fc7e1`](https://github.com/NixOS/nixpkgs/commit/5b0fc7e18d16772149f38354a763b077828b7d06) | `` edopro: Fix passthru.updateScript ``                                                          |
| [`90076235`](https://github.com/NixOS/nixpkgs/commit/90076235a195376d8f241931521fe0fe65d83762) | `` python313Packages.iamdata: 0.1.202607241 -> 0.1.202607251 ``                                  |
| [`d484c84b`](https://github.com/NixOS/nixpkgs/commit/d484c84be4614dddd3c54c3e6f3bab765c938dfc) | `` biome: 2.5.4 -> 2.5.5 ``                                                                      |
| [`6466a6cb`](https://github.com/NixOS/nixpkgs/commit/6466a6cb43549672d4ff41b0c041b24897f357ff) | `` jetbrains.*-oss: mark as insecure ``                                                          |
| [`57154f3d`](https://github.com/NixOS/nixpkgs/commit/57154f3d7f3b1d8c009ac4f1bf08543172b8a1c7) | `` hyprlandPlugins.hy3: 0.55.0 -> 0.56.0.1 ``                                                    |
| [`dd904cf1`](https://github.com/NixOS/nixpkgs/commit/dd904cf1103ca69799e9d58856a53b6b38fa8399) | `` noctalia: 5.0.0-beta.4 -> 5.0.0-beta.5 ``                                                     |
| [`1f6d4ed2`](https://github.com/NixOS/nixpkgs/commit/1f6d4ed2df039ba8e7ee4eb67a33669d52e381ee) | `` nix-store-veritysetup-generator: 1.0.0 -> 1.0.1 ``                                            |
| [`8b8f9564`](https://github.com/NixOS/nixpkgs/commit/8b8f9564d80c0576a269f60b173903dbbac4c861) | `` libdeltachat: 2.56.0 -> 2.57.0 ``                                                             |
| [`8626d323`](https://github.com/NixOS/nixpkgs/commit/8626d323522793d486cd0dae668f5dda7081591f) | `` vimPlugins.gh-dash-nvim: init at 1.0.0 ``                                                     |
| [`7c51ba2a`](https://github.com/NixOS/nixpkgs/commit/7c51ba2a3ee2c7905535c25a5f3d7bd683a4d545) | `` stremio-service: init at 0.1.21 ``                                                            |
| [`f2da850d`](https://github.com/NixOS/nixpkgs/commit/f2da850dfd89d85495a3261a58245902ca5468ae) | `` blueprint-compiler: set strictDeps ``                                                         |
| [`ca745171`](https://github.com/NixOS/nixpkgs/commit/ca7451712638d8ce12528625356ed95c9669d521) | `` panache: enable install check ``                                                              |
| [`32ae2848`](https://github.com/NixOS/nixpkgs/commit/32ae28483421e608bdfedc844a486675a7cf8fa3) | `` nushell-plugin-hcl: 0.114.0 -> 0.114.1 ``                                                     |
| [`e9d32fce`](https://github.com/NixOS/nixpkgs/commit/e9d32fcea264b252def9d67f001407d999bda86b) | `` wayle: 0.6.0 -> 0.7.0 ``                                                                      |
| [`e85527a6`](https://github.com/NixOS/nixpkgs/commit/e85527a6d3b9611a291e42f309c437cedf1ad59b) | `` nextcloud34: 34.0.1 -> 34.0.2 ``                                                              |
| [`fea8410e`](https://github.com/NixOS/nixpkgs/commit/fea8410e613b28ae5bdc83e8aab8fbb182987540) | `` nextcloud33: 33.0.6 -> 33.0.7 ``                                                              |
| [`e2d3dd84`](https://github.com/NixOS/nixpkgs/commit/e2d3dd843037f7e30a342db9673ad1b4ca0184a9) | `` nextcloud32: 32.0.12 -> 32.0.13 ``                                                            |
| [`648564c5`](https://github.com/NixOS/nixpkgs/commit/648564c5b430d36d8dc3c74db95d4e7ba3008b05) | `` nextcloud34Packages: update ``                                                                |
| [`f5c3aebd`](https://github.com/NixOS/nixpkgs/commit/f5c3aebdcc1c4416fb20f1f5b84a986f5b3932fe) | `` nextcloud33Packages: update ``                                                                |
| [`f3e0c865`](https://github.com/NixOS/nixpkgs/commit/f3e0c8655d15fd89f4dc98b8ace4ad41e9aebc83) | `` nextcloud32Packages: update ``                                                                |
| [`cfb4cc0d`](https://github.com/NixOS/nixpkgs/commit/cfb4cc0d96d5f7323b90e89fa9921331254094f2) | `` bento: 1.18.1 -> 1.19.0 ``                                                                    |
| [`61092877`](https://github.com/NixOS/nixpkgs/commit/610928778ec854a68e3bf04797cbdd697b420569) | `` python3Packages.pyisy: 3.6.1 -> 3.7.0 ``                                                      |
| [`14f9cea1`](https://github.com/NixOS/nixpkgs/commit/14f9cea17e32876247a51cd42ee0d831c5c44ea2) | `` kopuz: 0.10.0 -> 0.12.0 ``                                                                    |
| [`ca59ee9a`](https://github.com/NixOS/nixpkgs/commit/ca59ee9ad2e12f32885763d3e5e2deeb63751780) | `` cargo-shear: 1.13.2 -> 1.13.3 ``                                                              |
| [`e4c7ce47`](https://github.com/NixOS/nixpkgs/commit/e4c7ce47acfcd44c442c254fa2c91037ced50a94) | `` nixos/release-notes: fix option references for virtualisation.containers.registries ``        |
| [`51ae3bcf`](https://github.com/NixOS/nixpkgs/commit/51ae3bcfd3732e03576269f9276d65b9f786076d) | `` emacsPackages.ghostel: 0.44.0 -> 0.45.0 ``                                                    |
| [`8540bced`](https://github.com/NixOS/nixpkgs/commit/8540bcedbad30e986961502c18530eb47f0e7140) | `` phantun: init at 0.8.1 ``                                                                     |
| [`55a5ffdd`](https://github.com/NixOS/nixpkgs/commit/55a5ffdda8538b642f2fa3dfadfe4ffc2bf971b9) | `` vscode-extensions.oxc.oxc-vscode: 1.58.0 -> 1.59.0 ``                                         |
| [`e27d2a93`](https://github.com/NixOS/nixpkgs/commit/e27d2a93fd42b48d257801cb96f25064e5ababb6) | `` mangowc: alias mango instead of throwing ``                                                   |
| [`b0f3e5a2`](https://github.com/NixOS/nixpkgs/commit/b0f3e5a22add62f93a7acc86c90e9be17a01dc5a) | `` n8n: use sqlite from nixpkgs ``                                                               |
| [`90b33c2f`](https://github.com/NixOS/nixpkgs/commit/90b33c2f2d6560619e1835919a5465f30645ed1d) | `` overseerr: migrate overseerr to seerr ``                                                      |
| [`ea14011c`](https://github.com/NixOS/nixpkgs/commit/ea14011c437151a1dfa2a1f0a2559bbce70e8281) | `` wildergarden-maim: init at 1.1.1-unstable-2025-12-17 ``                                       |
| [`6b7fb8f2`](https://github.com/NixOS/nixpkgs/commit/6b7fb8f2ce766024c7d4f463b3821df36e1ff8bb) | `` cargo-binstall: 1.21.0 -> 1.21.1 ``                                                           |
| [`3baf5a75`](https://github.com/NixOS/nixpkgs/commit/3baf5a75f47bbf66a50a7b83c7fae2d91ca2ec48) | `` python3Packages.sqlobject: remove paste from dependencies ``                                  |
| [`ba2fbde8`](https://github.com/NixOS/nixpkgs/commit/ba2fbde84cdca9e3a6963246cb3315f4a224d382) | `` maintainers: drop jf-uu ``                                                                    |
| [`c6c6e3ee`](https://github.com/NixOS/nixpkgs/commit/c6c6e3ee3a870834af9e4e61830dfa305a432889) | `` terraform-providers.hashicorp_azurerm: 4.79.0 -> 4.81.0 ``                                    |
| [`f846b7a7`](https://github.com/NixOS/nixpkgs/commit/f846b7a768a6e4d9005423a02187e11233ce86ff) | `` rustfs: 1.0.0-beta.10 -> 1.0.0-beta.11 ``                                                     |
| [`052d503a`](https://github.com/NixOS/nixpkgs/commit/052d503aee086ab432109d9e58d01a41ca5cca15) | `` n8n: 2.28.6 -> 2.31.4 ``                                                                      |
| [`95d4c6bc`](https://github.com/NixOS/nixpkgs/commit/95d4c6bc0b9baf044bc9dff10830c519c8afe093) | `` flux-build: init at 3.0.10 ``                                                                 |
| [`add81a03`](https://github.com/NixOS/nixpkgs/commit/add81a03c2274abcdd2b4546539202cd69fd7e26) | `` maintainers: add MNThomson ``                                                                 |
| [`61c0fc64`](https://github.com/NixOS/nixpkgs/commit/61c0fc6475d5011b113dc727d1fb30c414e3502b) | `` python3Packages.perplexityai: 0.41.0 -> 0.42.0 ``                                             |
| [`039d87ba`](https://github.com/NixOS/nixpkgs/commit/039d87ba011907c53267e6d340c60e1c89062f79) | `` python3Packages.pyimouapi: improve meta.changelog ``                                          |
| [`88c98a0d`](https://github.com/NixOS/nixpkgs/commit/88c98a0d79def77c3b10df4f972c824e72cc09c9) | `` fsuae: enable parallel building ``                                                            |
| [`6935b590`](https://github.com/NixOS/nixpkgs/commit/6935b590e84bf160e6106b917e542f9add07d034) | `` sage: rename python package from sagelib to sagemath ``                                       |
| [`a94b09f8`](https://github.com/NixOS/nixpkgs/commit/a94b09f8d5157474486eac8841040df7bb7f03bb) | `` xmodmap: 1.0.11 -> 1.0.12 ``                                                                  |
| [`122a9f7b`](https://github.com/NixOS/nixpkgs/commit/122a9f7be626fd697fb11af65cd2559373337605) | `` bant: 0.3.0 -> 0.3.3 ``                                                                       |
| [`5dad9377`](https://github.com/NixOS/nixpkgs/commit/5dad9377a7d7b7b1fdb8b28cb6d524346f13bbe9) | `` feishu-cli: 1.35.0 -> 1.37.1 ``                                                               |
| [`081e6f29`](https://github.com/NixOS/nixpkgs/commit/081e6f29efeb587e5aa7051a45b61b5efbaf3ce1) | `` bisq1: 1.10.3 -> 1.10.4 ``                                                                    |
| [`138f9b04`](https://github.com/NixOS/nixpkgs/commit/138f9b0486b701aec6b19fe40c7fec1564b30ac6) | `` emacsPackages.majutsu: update to 0.6.0-unstable-2026-07-23 ``                                 |
| [`976a38d3`](https://github.com/NixOS/nixpkgs/commit/976a38d3a8f8d519a2072ac95e71442c5e203cdc) | `` bottom: 0.14.4 -> 0.14.6 ``                                                                   |
| [`a608783b`](https://github.com/NixOS/nixpkgs/commit/a608783b6184d0b2bc664557746b422f3b0191d8) | `` neocmakelsp: 0.10.4 -> 0.11.0 ``                                                              |
| [`2efbe86b`](https://github.com/NixOS/nixpkgs/commit/2efbe86bc8088ba17d56bd274541d31ada21dd9d) | `` llama-cpp: 10063 -> 10121 ``                                                                  |
| [`c16695a7`](https://github.com/NixOS/nixpkgs/commit/c16695a7b7b3171c92ceca458ff2f9e319b54be7) | `` troubadix: 26.7.1 -> 26.7.2 ``                                                                |
| [`d92de351`](https://github.com/NixOS/nixpkgs/commit/d92de35181ffc884a7f88dab44d0610f1141daec) | `` ocelot-desktop: avoid putting empty segments in PATH and LD_LIBRARY_PATH ``                   |
| [`25fca87e`](https://github.com/NixOS/nixpkgs/commit/25fca87ec6d7d28064a5abf07b98f5dc707cda51) | `` lstk: 0.17.0 -> 0.18.0 ``                                                                     |
| [`7f5568e6`](https://github.com/NixOS/nixpkgs/commit/7f5568e6cfa3264be741a1a55b2553064c8257c8) | `` gearboy: 3.8.9 -> 3.8.11 ``                                                                   |
| [`12766e45`](https://github.com/NixOS/nixpkgs/commit/12766e45af39112458933c5e04b028711b0782cc) | `` tclPackages.cffi: init at 2.0.3 ``                                                            |
| [`5e002b0a`](https://github.com/NixOS/nixpkgs/commit/5e002b0a52dba3517db92219abfe5dffac9f1d90) | `` davinci-resolve: 21.0.1 -> 21.0.3 ``                                                          |
| [`eb2ab836`](https://github.com/NixOS/nixpkgs/commit/eb2ab8368b5e11a83ef492f8e13b6e220ad4e836) | `` python3Packages.oelint-parser: 8.11.6 -> 8.12.1 ``                                            |
| [`4664e700`](https://github.com/NixOS/nixpkgs/commit/4664e700a0c9d6d855111efd672ecc042095bb7b) | `` glaze: 7.9.0 -> 7.9.1 ``                                                                      |
| [`25f99338`](https://github.com/NixOS/nixpkgs/commit/25f9933883dcf0ea1506b48fa60b7349cb922307) | `` pulumi, pulumi-python, python3Packages.pulumi: add nicoo as maintainer ``                     |
| [`9186f602`](https://github.com/NixOS/nixpkgs/commit/9186f602e08011e55a7551c772f10fab448dde90) | `` diodon: 1.13.0 -> 1.14.0 ``                                                                   |
| [`cf949f24`](https://github.com/NixOS/nixpkgs/commit/cf949f245d31708b77fd1df5408f819374dd389a) | `` zed-editor: 1.11.3 -> 1.12.0 ``                                                               |
| [`9aefb1f6`](https://github.com/NixOS/nixpkgs/commit/9aefb1f67011301a19c7a3c50acc538ee1223064) | `` gamescope: 3.16.24 -> 3.16.25 ``                                                              |
| [`883b7297`](https://github.com/NixOS/nixpkgs/commit/883b72977756553ca5cef29e347a367f941cfe90) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.347 -> 0.13.348 `` |
| [`f22784b1`](https://github.com/NixOS/nixpkgs/commit/f22784b1b757bb5070f6e28dd709f1456738e3c0) | `` rapidyaml: 0.11.1 -> 0.16.0 ``                                                                |
| [`58b8317b`](https://github.com/NixOS/nixpkgs/commit/58b8317b71cec659ebb1b719d7a066beb223a5dc) | `` fabric-ai: 1.4.459 -> 1.4.460 ``                                                              |
| [`c9a0980d`](https://github.com/NixOS/nixpkgs/commit/c9a0980d2100073d053a2de09e7ff49bfc6d8c37) | `` python3Packages.django-scopes: 2.0.0 -> 2.1.0 ``                                              |
| [`6086a178`](https://github.com/NixOS/nixpkgs/commit/6086a1781826712082ec8df6c4e876d772873e01) | `` claude-code: 2.1.219 -> 2.1.220 ``                                                            |
| [`c8c7cf2e`](https://github.com/NixOS/nixpkgs/commit/c8c7cf2e9ef356454ea69406947a565cd52bb061) | `` python3Packages.langgraph-runtime-inmem: 0.30.0 -> 0.31.1 ``                                  |
| [`e79819a2`](https://github.com/NixOS/nixpkgs/commit/e79819a2a86a57cb194f0e96bdc2af1c0adda3d2) | `` python3Packages.pyeconet: 0.2.2 -> 0.2.5 ``                                                   |
| [`66bd9979`](https://github.com/NixOS/nixpkgs/commit/66bd9979a5f805c8fd5275f8e34760531eb8cb33) | `` octoprint: 1.11.7 -> 1.11.8 ``                                                                |
| [`8ce69b14`](https://github.com/NixOS/nixpkgs/commit/8ce69b14f4621fd64f088704ae2a76e219cd7fc0) | `` vimPlugins.fff-nvim: fix illegal instructions by targetting a baseline CPU ``                 |
| [`d782d6e1`](https://github.com/NixOS/nixpkgs/commit/d782d6e1dbe7df9e300307b8ef154305c1ea43c0) | `` zellij: avoid putting empty path segment into PATH when `extraPackages` is empty ``           |
| [`d4ddaa94`](https://github.com/NixOS/nixpkgs/commit/d4ddaa94ab9719a1fb4529647eeaaa4eb135ea92) | `` python3Packages.yoto-api: 4.3.1 -> 4.3.2 ``                                                   |
| [`c57addab`](https://github.com/NixOS/nixpkgs/commit/c57addab0d377f02b41b92fcd67d6ca44e0be36d) | `` docker: avoid setting empty path segments into PATH ``                                        |
| [`9e124508`](https://github.com/NixOS/nixpkgs/commit/9e124508fe6363e116343507eddd1527c624bb5c) | `` namespace-cli: 0.0.531 -> 0.0.550 ``                                                          |
| [`1993a706`](https://github.com/NixOS/nixpkgs/commit/1993a70695b6013833506780a408b531e02ee31d) | `` modsecurity_standalone: pcre -> pcre2 ``                                                      |
| [`5f7d67a4`](https://github.com/NixOS/nixpkgs/commit/5f7d67a4e1e1a7b1c180cfd557efc6c400d7a0fe) | `` stoat-desktop: 1.4.0 -> 1.4.2 ``                                                              |
| [`d71f49f3`](https://github.com/NixOS/nixpkgs/commit/d71f49f36162562809523bd29fa67a16ece9ae0b) | `` mapnik: 4.2.2 -> 4.3.0 ``                                                                     |
| [`087d7014`](https://github.com/NixOS/nixpkgs/commit/087d701440f5126f9c102e98cc2328f88dbe5974) | `` gotify-server: 2.9.1 -> 3.0.0 ``                                                              |
| [`a8d9220a`](https://github.com/NixOS/nixpkgs/commit/a8d9220a6f68f5c0631419bc7b7b744f586f40e6) | `` element-{web,desktop}: 1.12.23 -> 1.12.24 ``                                                  |
| [`de2aae02`](https://github.com/NixOS/nixpkgs/commit/de2aae02a622c5adecd7af1371e9c3f10c8dd16e) | `` xclock: 1.2.0 -> 1.2.1 ``                                                                     |
| [`c19d3ebf`](https://github.com/NixOS/nixpkgs/commit/c19d3ebf3861dbee097ba76898487a2cd41cb5ba) | `` kingfisher: 1.107.0 -> 1.109.0 ``                                                             |
| [`c2ce3cde`](https://github.com/NixOS/nixpkgs/commit/c2ce3cdea79f953b4f7a975f649883655dd7ed19) | `` algol68g: 3.12.2 -> 3.12.3 ``                                                                 |
| [`fcb270cc`](https://github.com/NixOS/nixpkgs/commit/fcb270ccb90dc5f0415d2a9bf586812ffb2a2358) | `` xkbprint: 1.0.7 -> 1.0.8 ``                                                                   |
| [`be2807d4`](https://github.com/NixOS/nixpkgs/commit/be2807d4fc7fd6dfa84a63073f3c88dc6ba1fb1b) | `` python3Packages.oelint-data: 1.5.10 -> 1.5.12 ``                                              |
| [`bb213d9d`](https://github.com/NixOS/nixpkgs/commit/bb213d9d4a2bcb94e45b3db34aa8a90ede1625ce) | `` polonium: 1.2.0 -> 1.2.1 ``                                                                   |
| [`7b882f05`](https://github.com/NixOS/nixpkgs/commit/7b882f05f2c7a64ffd666c1b00a53d6c123087ed) | `` buzztrax: switch from gtk2 to gtk3 ``                                                         |
| [`2c73b968`](https://github.com/NixOS/nixpkgs/commit/2c73b96824a674f7c466136d873747ad0420ac6a) | `` python3Packages.rns: 1.4.0 -> 1.4.1 ``                                                        |
| [`052a8a41`](https://github.com/NixOS/nixpkgs/commit/052a8a41df7fb52598b9f590ee014be2a3f03042) | `` libretro.beetle-vb: 0-unstable-2026-06-14 -> 0-unstable-2026-07-22 ``                         |
| [`e51a4d90`](https://github.com/NixOS/nixpkgs/commit/e51a4d900d80c6ce87cc8a5f37318ec5dce96f7a) | `` libaribcaption: 1.1.1 -> 1.1.2 ``                                                             |
| [`eee706d3`](https://github.com/NixOS/nixpkgs/commit/eee706d3b9baa38dfc74fef669fd3e4035032b3a) | `` pnpm: 11.16.0 -> 11.17.0 ``                                                                   |
| [`36188b18`](https://github.com/NixOS/nixpkgs/commit/36188b18a19442ea45e12d525b2622ec5458ba63) | `` libretro.melonds: 0-unstable-2026-06-25 -> 0-unstable-2026-07-19 ``                           |
| [`ec69cf3f`](https://github.com/NixOS/nixpkgs/commit/ec69cf3f7b865bd6ed95451855518fb1d070d2dc) | `` Revert "nixos/modular-services: add portable `process.environment`" ``                        |
| [`9de8e0f7`](https://github.com/NixOS/nixpkgs/commit/9de8e0f7e2b0f119d13ef4eabef2b96f37e57f04) | `` cubeb: 0-unstable-2026-07-16 -> 0-unstable-2026-07-25 ``                                      |
| [`6c534f04`](https://github.com/NixOS/nixpkgs/commit/6c534f04d3a3e6291952fae6504a3d3944893d94) | `` nixos/home-assistant: allow serial for zbt1/zbt2 ``                                           |
| [`59fdf1c1`](https://github.com/NixOS/nixpkgs/commit/59fdf1c1911c0537e36ba22ef9bf70c4711ac986) | `` python3Packages.mhcgnomes: 3.32.1 -> 3.33.4 ``                                                |
| [`649f5511`](https://github.com/NixOS/nixpkgs/commit/649f55119422635b4a1dd8a4aaa804b44cdf4709) | `` python3Packages.pyimouapi: 1.3.0 -> 1.3.2 ``                                                  |
| [`b6daa608`](https://github.com/NixOS/nixpkgs/commit/b6daa6081481b73009683917a9d601875a9d64ee) | `` automatic-timezoned: 2.0.143 -> 2.0.149 ``                                                    |
| [`969ff17e`](https://github.com/NixOS/nixpkgs/commit/969ff17e86369158c72369226bf7db7b254ef91f) | `` adminer: 5.4.2 -> 5.5.1 ``                                                                    |
| [`92fdff41`](https://github.com/NixOS/nixpkgs/commit/92fdff41d64896da618aa81268dcb8003ac117bd) | `` cloudflared: 2026.7.2 -> 2026.7.3 ``                                                          |
| [`ad43cfde`](https://github.com/NixOS/nixpkgs/commit/ad43cfde13e181cfb7c968d2981c4cc07d3ab312) | `` libretro.dolphin: 0-unstable-2026-07-12 -> 0-unstable-2026-07-23 ``                           |
| [`be5fbdd9`](https://github.com/NixOS/nixpkgs/commit/be5fbdd94f1b07a5a708ea4d97340e79c86bd77d) | `` nixos/userborn: fix cross compilation with userborn.static.enable ``                          |
| [`57e38620`](https://github.com/NixOS/nixpkgs/commit/57e38620cea7aa143acec10156da72fb8ac95623) | `` python3Packages.imgw-pib: 2.4.3 -> 2.5.0 ``                                                   |
| [`1e3e3222`](https://github.com/NixOS/nixpkgs/commit/1e3e322248f773cbd47c05796b534aff392c4874) | `` mymake: 2.4.4 -> 2.4.5 ``                                                                     |
| [`611eeadc`](https://github.com/NixOS/nixpkgs/commit/611eeadc376c767ea40d3fbf6c61b79f0a93113b) | `` tideways-daemon: 1.18.0 -> 1.18.2 ``                                                          |
| [`aee66850`](https://github.com/NixOS/nixpkgs/commit/aee66850fb600fd4f10b48c978b6e0c3d758a4c3) | `` libretro.picodrive: 0-unstable-2026-04-02 -> 0-unstable-2026-07-23 ``                         |
| [`f34ccff1`](https://github.com/NixOS/nixpkgs/commit/f34ccff1bf32ef76823d74d7d5c097044de3d3e6) | `` rustnet: 1.3.0 -> 1.5.0 ``                                                                    |
| [`5ad3074a`](https://github.com/NixOS/nixpkgs/commit/5ad3074a6c6fa36b6c234279d56ba642e6dd52ab) | `` communique: 1.2.1 -> 1.2.3 ``                                                                 |
| [`350b25e5`](https://github.com/NixOS/nixpkgs/commit/350b25e579c6928b5a72df7ac17e062c7e1fb6f8) | `` fromager: 0.71.0 -> 0.91.0 ``                                                                 |
| [`b19aa3bf`](https://github.com/NixOS/nixpkgs/commit/b19aa3bf5f6ee12fad3138ab47980f9ecaf7532d) | `` openasar: 0-unstable-2026-07-12 -> 0-unstable-2026-07-24 ``                                   |
| [`02763c64`](https://github.com/NixOS/nixpkgs/commit/02763c64508603f919c99522f05e68c2213ec7f9) | `` fasmg: l7xm -> l8vn ``                                                                        |
| [`ccd93dce`](https://github.com/NixOS/nixpkgs/commit/ccd93dcec1daa7ff5d0a5676276762d3acded561) | `` python3Packages.pypi-simple: init at 1.8.0 ``                                                 |
| [`05bb9463`](https://github.com/NixOS/nixpkgs/commit/05bb94630248c1d03e3f11ca1d115ca502759ec5) | `` python3Packages.mailbits: init at 0.2.3 ``                                                    |
| [`c40e052b`](https://github.com/NixOS/nixpkgs/commit/c40e052b8e3989dd4c6d3883c315ad886d74ca77) | `` python3Packages.nftables: fix version & modernize ``                                          |
| [`a16f93f8`](https://github.com/NixOS/nixpkgs/commit/a16f93f8dad4b38f57026365aa5f79d284dcdfda) | `` brave, brave-origin: extract shared builder, init at 1.92.144 ``                              |
| [`e589763a`](https://github.com/NixOS/nixpkgs/commit/e589763ae036ec2495f41a7a86ef0df6ea882530) | `` opencv4: drop gtk2 support for highgui ``                                                     |
| [`c485262d`](https://github.com/NixOS/nixpkgs/commit/c485262d71c4d4b6c9d58df3abf8f6701560c7b5) | `` fsuae: drop unused gtk2 ``                                                                    |
| [`3927e90c`](https://github.com/NixOS/nixpkgs/commit/3927e90c19179589bf6224dd0714cc95bf54c513) | `` libdisplay-info: 0.3.0 -> 0.4.0 ``                                                            |
| [`f6ac678e`](https://github.com/NixOS/nixpkgs/commit/f6ac678e71bf894f596de15818ca94a2cdcbdf3d) | `` kchat: 3.3.3 -> 3.3.5 ``                                                                      |
| [`a08dbb18`](https://github.com/NixOS/nixpkgs/commit/a08dbb1895d779b1f90b064e88d3a45f503b6e85) | `` python3Packages.stripe: 15.3.0 -> 15.3.1 ``                                                   |
| [`cfb5b9e0`](https://github.com/NixOS/nixpkgs/commit/cfb5b9e004513ddb4576227e308fced2b9d0d2fd) | `` xpipe: 23.7 -> 23.8 ``                                                                        |
| [`0471148d`](https://github.com/NixOS/nixpkgs/commit/0471148d157db243f1fff10b8bae27af57b3f237) | `` hedgedoc: 1.11.0 -> 1.11.1 ``                                                                 |
| [`77c44d76`](https://github.com/NixOS/nixpkgs/commit/77c44d762061c80d08aa9fa770cceb2ca8bd6382) | `` home-assistant-custom-lovelace-modules.multiple-entity-row: 4.7.0 -> 4.7.1 ``                 |
| [`64cb9bd3`](https://github.com/NixOS/nixpkgs/commit/64cb9bd3610151febf1c2df774f24a5086b23a40) | `` aube: 1.29.1 -> 1.32.0 ``                                                                     |
| [`a4757b8f`](https://github.com/NixOS/nixpkgs/commit/a4757b8f04b34c31d17c291a091fe50f57f90198) | `` terraform-providers.aliyun_alicloud: 1.285.0 -> 1.286.0 ``                                    |
| [`36fbe6bc`](https://github.com/NixOS/nixpkgs/commit/36fbe6bc2b2eca2d9bef15c04b2f24324def2a51) | `` fosrl-newt: 1.14.0 -> 1.15.0 ``                                                               |
| [`e770f303`](https://github.com/NixOS/nixpkgs/commit/e770f303ab0ea832e278a5dd8b6b15ef0cdb5279) | `` python3Packages.homeassistant-stubs: 2026.7.3 -> 2026.7.4 ``                                  |
| [`cb187f88`](https://github.com/NixOS/nixpkgs/commit/cb187f88a6558d485390973c6212b9fa00b21235) | `` home-assistant: 2026.7.3 -> 2026.7.4 ``                                                       |
| [`109e168b`](https://github.com/NixOS/nixpkgs/commit/109e168b031f5f327f984bd6106389ec85f9a27f) | `` python3Packages.yoto-api: 4.3.1 -> 4.3.2 ``                                                   |
| [`d1fd4312`](https://github.com/NixOS/nixpkgs/commit/d1fd431204ae887f025570443e84cc2d64b9fd4d) | `` python3Packages.pylamarzocco: 2.4.2 -> 2.4.3 ``                                               |
| [`4f22b001`](https://github.com/NixOS/nixpkgs/commit/4f22b00129194016b0b2fc04a935436fb19934a4) | `` python3Packages.pybravia: 0.4.1 -> 0.5.1 ``                                                   |
| [`eb60e6ac`](https://github.com/NixOS/nixpkgs/commit/eb60e6ac5bcd424c51d0c2e878e29c354615fd44) | `` claude-code: allow easily overriding manifest ``                                              |
| [`c705f56a`](https://github.com/NixOS/nixpkgs/commit/c705f56ade5b9ea56d6f032488509b07f0ac3809) | `` vaultwarden: 1.36.0 -> 1.37.0 ``                                                              |
| [`69b64155`](https://github.com/NixOS/nixpkgs/commit/69b641559c3ab80d9392c40775e143236cdb7802) | `` nginxStable: apply patches for gcc 16 in rtmp module ``                                       |
| [`e5001506`](https://github.com/NixOS/nixpkgs/commit/e50015067e5f8d39f3b5d7ecac98f024a820f0de) | `` gridtracker2: 2.260714.0 -> 2.260723.0 ``                                                     |
| [`e16ea1e9`](https://github.com/NixOS/nixpkgs/commit/e16ea1e997ddb1e65733d9b33001f8365d4a856c) | `` grafanaPlugins.grafana-opensearch-datasource: 2.33.1 -> 2.34.0 ``                             |
| [`2d50e90f`](https://github.com/NixOS/nixpkgs/commit/2d50e90f1a3feffe051750066555c19772405e58) | `` python3Packages.vsure: 2.9.0 -> 2.10.0 ``                                                     |
| [`15ba2518`](https://github.com/NixOS/nixpkgs/commit/15ba2518a6d9ba05b62f8f90ab3d8fc8dfb83215) | `` libsForQt5.mapbox-gl-qml: 3.0.0 -> 3.2.2 ``                                                   |
| [`eb7e56fe`](https://github.com/NixOS/nixpkgs/commit/eb7e56fe88c5ff359dac98d2a86587820d2a3740) | `` mitmproxy: unpinn all dependencies ``                                                         |
| [`f86bce24`](https://github.com/NixOS/nixpkgs/commit/f86bce24974ec79a2d5e2c3668bde6475baf36cd) | `` shell: pin a Nixpkgs that supports x86_64-darwin ``                                           |
| [`7ce5dd4b`](https://github.com/NixOS/nixpkgs/commit/7ce5dd4b46e76d0bd761bf43e2999482d14ce20d) | `` jjui: 0.10.8 -> 0.10.9 ``                                                                     |
| [`c9ba965d`](https://github.com/NixOS/nixpkgs/commit/c9ba965d276018a328ea470f87847f5a8f81802a) | `` linuxKernel.kernels.linux_zen: 7.1.3 -> 7.1.4 ``                                              |
| [`4e2415b3`](https://github.com/NixOS/nixpkgs/commit/4e2415b3c27f305c0b809e8a25f65b2e76d46067) | `` nixos/systemd-resolved: apply transformation to resolve section ``                            |
| [`9f42db50`](https://github.com/NixOS/nixpkgs/commit/9f42db501a7ed2b7fb6094f335e5b56e9b30816b) | `` Revert "nixos/resolved: apply transformations to keys within resolved section" ``             |
| [`863a5fb6`](https://github.com/NixOS/nixpkgs/commit/863a5fb60d179a58a2f22109594f240ec8e6986f) | `` valgrind: add albfsg as maintainer ``                                                         |
| [`a8602ba8`](https://github.com/NixOS/nixpkgs/commit/a8602ba8339126cfc02593259f5c0fc76afefa87) | `` maintainers: add albfsg ``                                                                    |
| [`af4df060`](https://github.com/NixOS/nixpkgs/commit/af4df060ce50a700ea13dc71e5330e3e50355678) | `` jftui: enable darwin support ``                                                               |
| [`8046b0ab`](https://github.com/NixOS/nixpkgs/commit/8046b0ab06155bbe41b76aacbdbb9149ede62da9) | `` gale: 1.13.4 -> 1.19.0 ``                                                                     |
| [`0ea3ab2e`](https://github.com/NixOS/nixpkgs/commit/0ea3ab2e4a340e2ef6edf2152ef9b3ab9a568b9f) | `` python3Packages.alibabacloud-credentials: 1.0.9 -> 1.0.10 ``                                  |
| [`a7b5d243`](https://github.com/NixOS/nixpkgs/commit/a7b5d2437520cc5690f3649deca8d1e340e520e7) | `` python3Packages.alibabacloud-tea-util: 0.3.14 -> 0.3.15 ``                                    |
| [`7c932793`](https://github.com/NixOS/nixpkgs/commit/7c932793bc7e8839ddddad07bc3be41949c8acd8) | `` python3Packages.tencentcloud-sdk-python: 3.1.139 -> 3.1.140 ``                                |
| [`d5082056`](https://github.com/NixOS/nixpkgs/commit/d5082056e8d0452c339189805485a8996ec2d1be) | `` python313Packages.iamdata: 0.1.202607231 -> 0.1.202607241 ``                                  |
| [`b0dfdb3b`](https://github.com/NixOS/nixpkgs/commit/b0dfdb3b75bacd3e2bcb89ee9470ab777cf34fe9) | `` python3Packages.quixote: migrate to finalAttrs ``                                             |
| [`2c4cf474`](https://github.com/NixOS/nixpkgs/commit/2c4cf4741f58e7f90015f090c2aae73fa3848df5) | `` nerva: 1.42.12 -> 1.48.1 ``                                                                   |
| [`262b73cd`](https://github.com/NixOS/nixpkgs/commit/262b73cdac70f17d524dab1d5b627edd582674c5) | `` devin-desktop: 3.4.27 -> 3.5.17 ``                                                            |
| [`1092529c`](https://github.com/NixOS/nixpkgs/commit/1092529c3c206cc33ae7ef54b24f574a8386d41e) | `` reticulum-group-chat: 1.11.0 -> 1.12.0 ``                                                     |
| [`ca3cf208`](https://github.com/NixOS/nixpkgs/commit/ca3cf20814eb2bf206f4e163e63ec4cacca8062b) | `` ungoogled-chromium: 150.0.7871.181-1 -> 150.0.7871.186-1 ``                                   |
| [`cf8f9a94`](https://github.com/NixOS/nixpkgs/commit/cf8f9a948b90e9f579dedfb01d355aa7189d3df5) | `` tailscale: 1.98.8 -> 1.98.9 ``                                                                |
| [`2a2608af`](https://github.com/NixOS/nixpkgs/commit/2a2608af3bc46130d1504c14dea0c8622045b2a9) | `` grafana-loki: 3.7.3 -> 3.7.4 ``                                                               |
| [`4ed9282b`](https://github.com/NixOS/nixpkgs/commit/4ed9282b387e7231b5d2e1dc6a032067877a25f9) | `` strawberry: 1.2.18 -> 1.2.21 ``                                                               |
| [`ffc0a728`](https://github.com/NixOS/nixpkgs/commit/ffc0a728767c3ed47b072980667119ae6281a15e) | `` home-assistant-custom-components.cover_time_based: init at 4.7.2 ``                           |
| [`4bb6931e`](https://github.com/NixOS/nixpkgs/commit/4bb6931eceb9c11dcd729f64200c90d0dfd80d30) | `` pdns-recursor: 5.4.3 -> 5.4.4 ``                                                              |
| [`9fb8aa39`](https://github.com/NixOS/nixpkgs/commit/9fb8aa39dab41dd957cd3c71a072241da2c19b59) | `` kawkab-mono-font: add talal to maintainers ``                                                 |
| [`e938fe14`](https://github.com/NixOS/nixpkgs/commit/e938fe14a6b5b4358e6ea43ade27bb2250d56bce) | `` kawkab-mono-font: improve `meta` ``                                                           |
| [`32a21106`](https://github.com/NixOS/nixpkgs/commit/32a211061d1bc46af8069f4d495ab9a2b5084d08) | `` kawkab-mono-font: 20151015 -> 0.501 ``                                                        |
| [`536a57b2`](https://github.com/NixOS/nixpkgs/commit/536a57b20cd643208c923ff49fcca23b4665fe41) | `` forecast: 0-unstable-2026-07-12 -> 0-unstable-2026-07-17 ``                                   |
| [`e0c8b3d1`](https://github.com/NixOS/nixpkgs/commit/e0c8b3d1f3de6b378679fd0915a6dc9f22aa02bd) | `` python3Packages.ct3: rename from cheetah3 ``                                                  |
| [`6b92d6bd`](https://github.com/NixOS/nixpkgs/commit/6b92d6bda04a7bc7452b2e4da7f2c71c3126fe97) | `` txtpbfmt: 0-unstable-2026-04-20 -> 0-unstable-2026-07-16 ``                                   |
| [`37c45941`](https://github.com/NixOS/nixpkgs/commit/37c45941805d0f5d9fe74c286c9fa1a1ce400f56) | `` trufflehog: 3.95.9 -> 3.96.0 ``                                                               |
| [`89951a73`](https://github.com/NixOS/nixpkgs/commit/89951a73a2306b9a960fc94dbcd963be785ffa6e) | `` criu: add riscv64 support ``                                                                  |
| [`c3fc243d`](https://github.com/NixOS/nixpkgs/commit/c3fc243d97749d81e0b13ca99788abb24947c68b) | `` python3Packages.zwave-js-server-python: 0.72.0 -> 0.73.0 ``                                   |
| [`e29c342b`](https://github.com/NixOS/nixpkgs/commit/e29c342b51311d226c93f22b5d431f44f707760c) | `` claude-code: 2.1.218 -> 2.1.219 ``                                                            |
| [`f82c86f5`](https://github.com/NixOS/nixpkgs/commit/f82c86f5bbf9270ff917d094f3d4035a2452aeb4) | `` dia: unstable-2025-10-26 -> 0.97.2-unstable-2026-07-24, fix build ``                          |
| [`2d92ea39`](https://github.com/NixOS/nixpkgs/commit/2d92ea3951b8e354a08c16369cc6ecdb67237d18) | `` abseil-cpp: allow overriding cxxStandard ``                                                   |
| [`429b020c`](https://github.com/NixOS/nixpkgs/commit/429b020c34986f015e4489b81287d833c39ef574) | `` pods: 3.1.0 -> 3.1.1 ``                                                                       |
| [`928ccf68`](https://github.com/NixOS/nixpkgs/commit/928ccf6805681a3809df2c047ab7717baaff6625) | `` hyprlandPlugins.hypr-darkwindow: 0.55.4 -> 0.56.0 ``                                          |

*... and 512 more commits (truncated)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for the Niri desktop environment by pinning `libdisplay-info` to a version known to work with the current setup.
  * Updated Niri session/logout handling to use the same Niri package that’s actually installed.
* **Chores**
  * Added upstream-fix tracking to ensure the compatibility workaround can be removed automatically once the corresponding upstream release is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->