### PR TITLE
chore(flake/nixvim): `48409beb` -> `acd69cc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1186,11 +1186,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1785001306,
-        "narHash": "sha256-xWqmquUtqKXLeDZ1oQUO+rV4sjA9TShIJhLL8M5Bozo=",
+        "lastModified": 1785364321,
+        "narHash": "sha256-BLuHl+nZKb+FDq3GAM6L+UBEiyVepXANA31fT1F56pw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "48409beb41e8e28b64e8160ca82d8a93fb628963",
+        "rev": "acd69cc15d57004e8cb4495034320263a3d362ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`acd69cc1`](https://github.com/nix-community/nixvim/commit/acd69cc15d57004e8cb4495034320263a3d362ea) | `` plugins/treesitter: support folding.disable for nvim-treesitter-legacy `` |
| [`2aeba159`](https://github.com/nix-community/nixvim/commit/2aeba1593148c5eff0f36d15cb7b58e0be6a486a) | `` plugins/treesitter: restore folding for nvim-treesitter-legacy ``         |
| [`b79ccde6`](https://github.com/nix-community/nixvim/commit/b79ccde69ac8d2954bb5c6b626f08f5f392039a8) | `` plugins/treesitter: return early if there is no parser available ``       |
| [`dc0c5e35`](https://github.com/nix-community/nixvim/commit/dc0c5e350e8a02985b4445c326e0f8b698fe5dd3) | `` plugins/treesitter: improve Nixvim's native tree-sitter setup ``          |
| [`1b436e6a`](https://github.com/nix-community/nixvim/commit/1b436e6a6528e32f91b9401026a31c58a977e88a) | `` modules/lsp/servers: document common configurations ``                    |
| [`49669202`](https://github.com/nix-community/nixvim/commit/4966920244200d4566f52a3831febfcf67b83f1f) | `` modules/lsp/servers: document tinymist configuration ``                   |
| [`2633ab9f`](https://github.com/nix-community/nixvim/commit/2633ab9f52374c1f82d680531300e3fad1a831aa) | `` modules/lsp/servers: support documentation overrides ``                   |