### PR TITLE
chore(flake/colmena): `e82594c2` -> `9a5eb9a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1785163180,
-        "narHash": "sha256-S1VWYFaaTkf4KH5HajutUFFMZft1oPhoo9pCqYF/HL8=",
+        "lastModified": 1785176853,
+        "narHash": "sha256-nss1LQfeHCplrLTo0IHH0g1f9zVGzq/vpEOITPK9iNQ=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "e82594c22942c78f12baa4f0af81a92d324860d4",
+        "rev": "9a5eb9a09c71bb1bd8ad728d51c6f45d3868a3b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                               |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`ede4cb62`](https://github.com/nix-community/colmena/commit/ede4cb62cfd8a7cb9b43ee43df170a18fe9bdc39) | `` integration-tests: enable flakes-streaming test `` |
| [`7981db5c`](https://github.com/nix-community/colmena/commit/7981db5c9dc07d4a2e44135f84437d6fb0676ab4) | `` hive: fix `--evaluator streaming` noop ``          |
| [`f6569e13`](https://github.com/nix-community/colmena/commit/f6569e1387552a52bba501a7a9dceaf112b37e60) | `` formatter: fix ci and find repo root with git ``   |