### PR TITLE
chore(flake/darwin): `57a3171f` -> `15abb8c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784500460,
-        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`7eff017c`](https://github.com/nix-darwin/nix-darwin/commit/7eff017c1cf32ffaf5f611e740aef497cb2613d3) | `` tests/system.newslog: init ``     |
| [`8e611880`](https://github.com/nix-darwin/nix-darwin/commit/8e6118803a60069affea8ab579d2ece2804eadd2) | `` systems.newsyslog: init module `` |