### PR TITLE
chore(flake/niri): `492c3624` -> `2a55039d`

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -188,22 +188,6 @@
       "workaround": "features/desktop/print/default.nix -- `system-config-printer-iconfix` overrides system-config-printer's .desktop `Icon=printer` to an absolute path pointing at the package's own bundled `i-network-printer.png`, bypassing icon-theme-name resolution entirely (see FIXME(vicinae-468-printer-icon)).",
       "revert_action": "No upstream PR/issue exists yet for this specific \"printer\" name bug (only the linked discussion, where multiple reporters hit the identical symptom, unresolved as of Oct 2025) so `min_version` stays null (BLOCKED) until one is filed and a fix version is known. Once vicinae ships a fix and our pinned nixpkgs' `vicinae` package version reflects it, set `min_version` accordingly (or `done: true` after manually confirming `Icon=printer` renders correctly in vicinae), then delete `system-config-printer-iconfix` and its FIXME from features/desktop/print/default.nix, reverting to a plain `programs.system-config-printer.enable = true;`.",
       "$comment": "No upstream_pr recorded yet -- if one is opened for this specific bug, add its number here so the checker nudges once merged."
-    },
-    {
-      "id": "niri-libdisplay-info-0-4",
-      "done": false,
-      "summary": "niri (built by niri-flake's `make-niri` against our own ambient `pkgs`, not a pin of its own) fails to build once our nixpkgs pin carries `libdisplay-info` 0.4.0: niri's Rust crate dependency (Smithay/libdisplay-info-rs) still pins `libdisplay-info = \"0.3.0\"` and its build.rs enforces `libdisplay-info < 0.4.0` via pkg-config. nixpkgs hit the identical wall with its own `niri` package (NixOS/nixpkgs#545976) and worked around it with a new generic `libdisplay-info_0_3` package (NixOS/nixpkgs#546004), but that fix never reaches us since niri-flake doesn't use nixpkgs' `niri` derivation.",
-      "repo": "Smithay/libdisplay-info-rs",
-      "check": "release-contains-commit",
-      "fix_commit": "3911e0344bb2db5839f2c646d25e8c2a8b5223d9",
-      "tracking": [
-        "https://github.com/NixOS/nixpkgs/issues/545976",
-        "https://github.com/NixOS/nixpkgs/pull/546004",
-        "https://github.com/Smithay/libdisplay-info-rs/pull/20"
-      ],
-      "workaround": "features/desktop/environments/niri/default.nix -- `programs.niri.package` override that reconstructs the default package (`options.programs.niri.package.default`) with its `libdisplay-info` build input overridden back to 0.3.0 via `fetchFromGitLab` (see FIXME(niri-libdisplay-info-0-4)).",
-      "revert_action": "This is a 3-hop upstream chain: (1) Smithay/libdisplay-info-rs PR #20 (tracked here, adds 0.4.0 support) merges and ships in a release -- this is what `release-contains-commit` actually detects; (2) niri-wm/niri then needs to bump its own `libdisplay-info` Cargo dependency past \"0.3.0\" to pick that release up; (3) niri-flake (epireyn's fork, our `niri` input) needs to bump its `niri-stable`/`niri-unstable` source pin to a niri release/commit that contains that bump. When this entry resolves, DO NOT immediately delete the workaround -- first check niri-wm/niri's Cargo.toml (or run `nix eval .#nixosConfigurations.maranello.config.programs.niri.package.buildInputs` after bumping the `niri` flake input) to confirm libdisplay-info's upper bound has actually moved past 0.4.0 before removing the `package` override and its FIXME from features/desktop/environments/niri/default.nix, then set `done: true`.",
-      "$comment": "release-contains-commit is checked against Smithay/libdisplay-info-rs's own releases (hop 1 only); hops 2-3 require a manual follow-up check as described in revert_action before it's actually safe to delete the workaround."
     }
   ]
 }

--- a/features/desktop/environments/modules/wayle/default.nix
+++ b/features/desktop/environments/modules/wayle/default.nix
@@ -47,10 +47,7 @@ let
   # Use the same niri package the system actually installs
   # (config.programs.niri.package, from niri.nixosModules.niri) rather than
   # nixpkgs' own `pkgs.niri`. They're different derivations; referencing
-  # nixpkgs' `pkgs.niri` here forced an extra, entirely separate niri build
-  # (which independently hits the libdisplay-info 0.4.0 break -- see
-  # FIXME(niri-libdisplay-info-0-4) in features/desktop/environments/niri/default.nix)
-  # even after niri-flake's package was fixed.
+  # nixpkgs' `pkgs.niri` here forced an extra, entirely separate niri build.
   niriBin = lib.getExe config.programs.niri.package;
   systemdRun = "${pkgs.systemd}/bin/systemd-run";
   detectCompositor = ''

--- a/features/desktop/environments/niri/default.nix
+++ b/features/desktop/environments/niri/default.nix
@@ -2,7 +2,6 @@
   lib,
   pkgs,
   config,
-  options,
   user,
   extraUsers ? [ ],
   ...
@@ -20,50 +19,6 @@ in
 
     programs.niri = {
       enable = true;
-
-      # FIXME(niri-libdisplay-info-0-4): WORKAROUND, not a fix.
-      #
-      # niri.nixosModules.niri (from niri-flake) defaults `programs.niri.package`
-      # to a fresh build against *our own* ambient `pkgs` (see niri-flake's
-      # `make-package-set pkgs` / `make-niri`'s `libdisplay-info` arg) rather
-      # than a pin of its own. Once our nixpkgs pin carries `libdisplay-info`
-      # 0.4.0, every niri build fails:
-      #
-      #   pkg-config exited with status code 1
-      #   Requested 'libdisplay-info < 0.4.0' but version of libdisplay-info is 0.4.0
-      #
-      # because niri (niri-wm/niri) still pins its `libdisplay-info` Rust
-      # crate (Smithay/libdisplay-info-rs) to "0.3.0", whose build.rs
-      # enforces that upper bound via pkg-config.
-      #
-      # nixpkgs hit the identical wall with its own `niri` package and
-      # worked around it by pinning to a new generic `libdisplay-info_0_3`
-      # package (NixOS/nixpkgs#546004, closes
-      # https://github.com/NixOS/nixpkgs/issues/545976). That fix doesn't
-      # reach us because niri-flake's builder never touches nixpkgs' `niri`
-      # derivation -- it builds niri itself from niri-wm/niri sources against
-      # whatever `libdisplay-info` our own `pkgs` provides.
-      #
-      # Work around it the same way nixpkgs did: override *just* niri's
-      # `libdisplay-info` build input back to 0.3.0. Scoped to niri's package
-      # override only (via `options...default.override`) -- does not touch
-      # the system-wide `pkgs.libdisplay-info` used by anything else.
-      #
-      # Revert: once niri (niri-wm/niri) or Smithay/libdisplay-info-rs bumps
-      # to support libdisplay-info >= 0.4, delete this `package` override
-      # and the FIXME. See .github/workflows/track-upstream-fixes.yaml.
-      package = options.programs.niri.package.default.override {
-        libdisplay-info = pkgs.libdisplay-info.overrideAttrs (finalAttrs: {
-          version = "0.3.0";
-          src = pkgs.fetchFromGitLab {
-            domain = "gitlab.freedesktop.org";
-            owner = "emersion";
-            repo = "libdisplay-info";
-            rev = finalAttrs.version;
-            hash = "sha256-nXf2KGovNKvcchlHlzKBkAOeySMJXgxMpbi5z9gLrdc=";
-          };
-        });
-      };
     };
     programs.xwayland.enable = true;
 

--- a/flake.lock
+++ b/flake.lock
@@ -759,11 +759,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1785141602,
-        "narHash": "sha256-ocTDt5KXMI19qLuTp2Pk5dycNxR+eC/q/zlffpzvYTs=",
+        "lastModified": 1785402917,
+        "narHash": "sha256-C9xscDh7W/S3GqBF5Dc144kn7eXsPCb7TjYc9m3Dg3o=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "492c36242b43027d63ac737749dcdb7923e97894",
+        "rev": "2a55039d6ee0feff268b6d865fb744050c6a0c7d",
         "type": "github"
       },
       "original": {
@@ -944,11 +944,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1785104993,
-        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
+        "lastModified": 1785002762,
+        "narHash": "sha256-Y0BbgB3BLLHEUK88g4oSp3DerIx7rCX0iwICKJcY7/c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
+        "rev": "f7a2e428f5d71c47a5a938a3c5ad7138bb291093",
         "type": "github"
       },
       "original": {
@@ -1149,11 +1149,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                    |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`2a55039d`](https://github.com/epireyn/niri-flake/commit/2a55039d6ee0feff268b6d865fb744050c6a0c7d) | `` fix: #46 use libdisplay-info_0_3 when available ``                      |
| [`2f429e07`](https://github.com/epireyn/niri-flake/commit/2f429e0796566a2581f2047e4577df1b9358b6ee) | `` fix: Do not create flake update PR when niri-unstable fails to build `` |
| [`0f718772`](https://github.com/epireyn/niri-flake/commit/0f7187728bf559d72c164d5c8e2289596c19a779) | `` Update workflow automation rules to prevent merging failed checks ``    |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Niri package configuration to use the default package.
  * Removed an obsolete compatibility workaround and related upstream-fix tracking.
  * Clarified package selection documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->