### PR TITLE
chore(flake/freminal): `cb4ff646` -> `f8ebd17a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1785165134,
-        "narHash": "sha256-YwxUlzXYxqp1iSXVz6iajvLJ1ZVuA4LXpFBhdQZTHgc=",
+        "lastModified": 1785346782,
+        "narHash": "sha256-FmCEtAXxafRgTHD3IyOmBaUUujwCRz6godjGApS9iRg=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "cb4ff646b1c518f16d289fc37c0cfc80b0f7f886",
+        "rev": "f8ebd17a91e54437cffc89ca6621a9cbbe5fbca0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`f8ebd17a`](https://github.com/fredsystems/freminal/commit/f8ebd17a91e54437cffc89ca6621a9cbbe5fbca0) | `` docs: update ``                                                                       |
| [`0773c817`](https://github.com/fredsystems/freminal/commit/0773c817efbfd3f89ff9d526897f8f4da7b2055c) | `` docs: record 121.12-121.14 as merged (PR #467) ``                                     |
| [`1c2fcf13`](https://github.com/fredsystems/freminal/commit/1c2fcf1341f4be7a41afdac59ab7a03152ef6518) | `` docs: record 121.12-121.14 and the two items the Group B work surfaced ``             |
| [`883cf18e`](https://github.com/fredsystems/freminal/commit/883cf18ef90ff615cbd7c4e07648ab0a5d2f3202) | `` perf: 121.14 -- narrow animation_in_flight from presence to actual motion ``          |
| [`6607a908`](https://github.com/fredsystems/freminal/commit/6607a90860f0b80ca7c8fb8015585caaea49f00d) | `` fix: 121.13 -- chrome cache was disabled for the duration of pointer motion ``        |
| [`aa3fed6c`](https://github.com/fredsystems/freminal/commit/aa3fed6c9c871e322b1d6571cd40b41869646b6b) | `` perf: 121.12 -- route every in-frame repaint request through the delay aggregation `` |
| [`09c0e709`](https://github.com/fredsystems/freminal/commit/09c0e709fcdcf3f19c98bf401da17911f9f1412a) | `` chore(deps): update taiki-e/install-action action to v2.85.3 ``                       |
| [`821dc9cf`](https://github.com/fredsystems/freminal/commit/821dc9cfc8c2d9c8223bc1d9552ee6c35afe9d1c) | `` chore(deps): update toml and cargo lock ``                                            |
| [`f5e9f3e8`](https://github.com/fredsystems/freminal/commit/f5e9f3e8614cdd90628d1ff6d608a580e78162e8) | `` docs: update plan versions and other doc drifts ``                                    |
| [`80131011`](https://github.com/fredsystems/freminal/commit/80131011b08a90a65db53bd89175c285ba0407c4) | `` chore(version): 0.12.0-beta.7 ``                                                      |
| [`f762ca02`](https://github.com/fredsystems/freminal/commit/f762ca02f41a76449e09dc1a64c6114ba9bdf51f) | `` fix: address CodeRabbit review on #465 (one real bug + cleanups) ``                   |
| [`57c39958`](https://github.com/fredsystems/freminal/commit/57c399589401e3e6ada3029ab365fe55a211ed6d) | `` docs: corroborate Finding 3 with laptop A/B; fix A12; record next targets ``          |
| [`5481752d`](https://github.com/fredsystems/freminal/commit/5481752dbbeb169d1142053320425d55b430d040) | `` docs: reopen the decoupling direction after Phase 0 (leaning against) ``              |
| [`19780e16`](https://github.com/fredsystems/freminal/commit/19780e1600b9dbca0d20f6cd138546cc2722d225) | `` perf: SPIKE pointer-frame suppression + egui repaint-delay override ``                |
| [`ab88d0f5`](https://github.com/fredsystems/freminal/commit/ab88d0f598d4f3402d004b528b0513f129aee65d) | `` perf: instrument egui repaint causes (issue #459 item 2) ``                           |
| [`7d483998`](https://github.com/fredsystems/freminal/commit/7d4839985b90414df934683929e0adf8a16d9c1f) | `` fix: RedrawRequested permanently disqualified ChromeMode::Replay (#436) ``            |
| [`436a54f1`](https://github.com/fredsystems/freminal/commit/436a54f1fee670a078e6004effdfbf6b2400ddb6) | `` perf: instrument ChromeMode::Replay gate blockers (issue #459 item 2) ``              |
| [`1fe46957`](https://github.com/fredsystems/freminal/commit/1fe46957c35988f01331569766e86c7588e2d17a) | `` docs: rewrite DECOUPLING_FRAMEWORK as a ratified implementation plan ``               |
| [`0620cc60`](https://github.com/fredsystems/freminal/commit/0620cc60cb2dc5a45c4f250001c637e62b0e06a3) | `` perf: feature-gated frame-profiling harness (issue #459 item 2) ``                    |
| [`cb1d5155`](https://github.com/fredsystems/freminal/commit/cb1d515589b5a6620d59383a0695ff5e1c6e3363) | `` perf: skip GUI repaint for no-op PTY inputs (issue #459) ``                           |
| [`a9fb1210`](https://github.com/fredsystems/freminal/commit/a9fb12101b08881c16f4b637023982a0ae8f05ad) | `` perf: region-gate pointer-move full-present (issue #459 item 9) ``                    |
| [`555a8b5b`](https://github.com/fredsystems/freminal/commit/555a8b5be288612467af105b7502cf029b7a61bc) | `` fix: command-block gutter hover repaint over-firing (issue #459 item 2) ``            |
| [`f4cd9747`](https://github.com/fredsystems/freminal/commit/f4cd97471cd5a52b62dbc9aa1b72814a598d837b) | `` perf: FaceId-keyed FontManager caches -> FxHashMap (issue #459 item 1) ``             |
| [`05dea3a7`](https://github.com/fredsystems/freminal/commit/05dea3a7da8f55ce0657349d87a2953530e3ae94) | `` test: batched LF+flatten benchmark at scrollback capacity (issue #457/#459) ``        |