### PR TITLE
chore(flake/nixpkgs-stable): `8623c4c2` -> `21ea275a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -960,11 +960,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1785104993,
-        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
+        "lastModified": 1785386831,
+        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
+        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`f730125f`](https://github.com/NixOS/nixpkgs/commit/f730125f6ea29aa5971f8362b0413e4d835a7233) | `` nodejs_26: 26.5.0 -> 26.5.1 ``                                                                                 |
| [`52aa1def`](https://github.com/NixOS/nixpkgs/commit/52aa1def1b365ea480a81d8c74163ae54ed47921) | `` services.kanidm: fix broken link in description ``                                                             |
| [`9de65f6c`](https://github.com/NixOS/nixpkgs/commit/9de65f6c121e9b17c8f21c95e62c1b4f765b8775) | `` treefmt.withConfig: prevent an empty path segment in PATH when `config.runtimeInputs` is empty ``              |
| [`b98aef47`](https://github.com/NixOS/nixpkgs/commit/b98aef472e326b2f1248e88164766fd835bddd9e) | `` python3Packages.beets: 2.13.0 -> 2.13.1 ``                                                                     |
| [`a3ffa8c4`](https://github.com/NixOS/nixpkgs/commit/a3ffa8c49dd49186093b36c3d34bcaeb102f5b7b) | `` python3Packages.beets-filetote: fix tests with beets2.13 ``                                                    |
| [`1192309c`](https://github.com/NixOS/nixpkgs/commit/1192309c752e5da9a0b9cc42ef4077a0844c59bb) | `` python3Packages.beets: 2.12.0 -> 2.13.0 ``                                                                     |
| [`5f38a5e1`](https://github.com/NixOS/nixpkgs/commit/5f38a5e1b86a9e473036cea7771b2ea65179ef7c) | `` python3Packages.beets-filetote: replace tests exclusion with upstream patch ``                                 |
| [`d540ccb9`](https://github.com/NixOS/nixpkgs/commit/d540ccb93a0664115c1613bdc28099f010a579c7) | `` stremio-linux-shell: 1.1.3 -> 1.1.4 ``                                                                         |
| [`0b46c3bb`](https://github.com/NixOS/nixpkgs/commit/0b46c3bb1e9d09f4f5ab9f138f2f48be0f6f849a) | `` vaultwarden: 1.37.0 -> 1.37.1 ``                                                                               |
| [`8adecd23`](https://github.com/NixOS/nixpkgs/commit/8adecd23a96e7d4274ce8d13bb6813076c1723e6) | `` vrcx: 2026.05.03 -> 2026.07.18 ``                                                                              |
| [`978e7c7c`](https://github.com/NixOS/nixpkgs/commit/978e7c7caa36328dc8dac4dc7763ebb73b08da3a) | `` libiec61850: 1.6.1 -> 1.6.2 ``                                                                                 |
| [`21dd6ba2`](https://github.com/NixOS/nixpkgs/commit/21dd6ba2642cb02716df412233aab917deb29806) | `` chiri: migrate pnpm fetcher to version 4 ``                                                                    |
| [`2865ba2c`](https://github.com/NixOS/nixpkgs/commit/2865ba2c725b66ff79956d87d69db4eacbccd055) | `` chiri: 0.9.1 -> 0.9.2 ``                                                                                       |
| [`b0ef938e`](https://github.com/NixOS/nixpkgs/commit/b0ef938e1a9b11a4afee28d5426fe8621c8a2049) | `` chiri: 0.9.0 -> 0.9.1 ``                                                                                       |
| [`258fa721`](https://github.com/NixOS/nixpkgs/commit/258fa7219da4daf03b1f14b3451f6711239708f2) | `` chiri: 0.8.1 -> 0.9.0 ``                                                                                       |
| [`bdee3e19`](https://github.com/NixOS/nixpkgs/commit/bdee3e19fdb550475b1730bfca0ffe825bfd0989) | `` tailscale: 1.98.9 -> 1.98.10 ``                                                                                |
| [`989aeb3a`](https://github.com/NixOS/nixpkgs/commit/989aeb3a009426ebad0b9afe525cad039c53f10e) | `` chromium: remove warnObsoleteVersionConditional ``                                                             |
| [`26288e70`](https://github.com/NixOS/nixpkgs/commit/26288e70445155195b9a148f0b9108d16be2496b) | `` chromium: remove no longer needed version conditionals ``                                                      |
| [`e3a337d6`](https://github.com/NixOS/nixpkgs/commit/e3a337d611e084f24bb3a7a109c7c327053fcb42) | `` nixos/resolved: filter null values from config ``                                                              |
| [`7a7782a4`](https://github.com/NixOS/nixpkgs/commit/7a7782a4014f66f4c065c5bcd74e44bbeeb610b3) | `` jackett: 0.24.2237 -> 0.24.2288 ``                                                                             |
| [`86063f75`](https://github.com/NixOS/nixpkgs/commit/86063f75a990fcefda009a9cfec070556493b597) | `` python3Packages.geoparquet: fix build ``                                                                       |
| [`166c6174`](https://github.com/NixOS/nixpkgs/commit/166c6174776d9de7ea3e36c4c7a3e77e981191d6) | `` javaPackages.compiler.openjdk11: 11.0.32+1 -> 11.0.32+9 ``                                                     |
| [`d04f9c72`](https://github.com/NixOS/nixpkgs/commit/d04f9c727f22fa3eb764bb91d462c3815e34e9d8) | `` chhoto-url: 7.4.10 -> 7.5.0 ``                                                                                 |
| [`70d4a02b`](https://github.com/NixOS/nixpkgs/commit/70d4a02bd96f21c3ef940fbd141635136baa0385) | `` scx.rustscheds: aarch64-linux is good ``                                                                       |
| [`3c57a1d1`](https://github.com/NixOS/nixpkgs/commit/3c57a1d1c6a2180bc2d67668348f912b6d070ddd) | `` nixosTests.scx: add missing rustscheds ``                                                                      |
| [`3f4242c1`](https://github.com/NixOS/nixpkgs/commit/3f4242c1d80a474b6cc40d9cf2a94f1d7032a84a) | `` nixosTests.scx: remove cscheds ``                                                                              |
| [`f730125f`](https://github.com/NixOS/nixpkgs/commit/f730125f6ea29aa5971f8362b0413e4d835a7233) | `` nodejs_26: 26.5.0 -> 26.5.1 ``                                                                                 |
| [`52aa1def`](https://github.com/NixOS/nixpkgs/commit/52aa1def1b365ea480a81d8c74163ae54ed47921) | `` services.kanidm: fix broken link in description ``                                                             |
| [`9de65f6c`](https://github.com/NixOS/nixpkgs/commit/9de65f6c121e9b17c8f21c95e62c1b4f765b8775) | `` treefmt.withConfig: prevent an empty path segment in PATH when `config.runtimeInputs` is empty ``              |
| [`b98aef47`](https://github.com/NixOS/nixpkgs/commit/b98aef472e326b2f1248e88164766fd835bddd9e) | `` python3Packages.beets: 2.13.0 -> 2.13.1 ``                                                                     |
| [`a3ffa8c4`](https://github.com/NixOS/nixpkgs/commit/a3ffa8c49dd49186093b36c3d34bcaeb102f5b7b) | `` python3Packages.beets-filetote: fix tests with beets2.13 ``                                                    |
| [`1192309c`](https://github.com/NixOS/nixpkgs/commit/1192309c752e5da9a0b9cc42ef4077a0844c59bb) | `` python3Packages.beets: 2.12.0 -> 2.13.0 ``                                                                     |
| [`5f38a5e1`](https://github.com/NixOS/nixpkgs/commit/5f38a5e1b86a9e473036cea7771b2ea65179ef7c) | `` python3Packages.beets-filetote: replace tests exclusion with upstream patch ``                                 |
| [`d540ccb9`](https://github.com/NixOS/nixpkgs/commit/d540ccb93a0664115c1613bdc28099f010a579c7) | `` stremio-linux-shell: 1.1.3 -> 1.1.4 ``                                                                         |
| [`0b46c3bb`](https://github.com/NixOS/nixpkgs/commit/0b46c3bb1e9d09f4f5ab9f138f2f48be0f6f849a) | `` vaultwarden: 1.37.0 -> 1.37.1 ``                                                                               |
| [`8adecd23`](https://github.com/NixOS/nixpkgs/commit/8adecd23a96e7d4274ce8d13bb6813076c1723e6) | `` vrcx: 2026.05.03 -> 2026.07.18 ``                                                                              |
| [`978e7c7c`](https://github.com/NixOS/nixpkgs/commit/978e7c7caa36328dc8dac4dc7763ebb73b08da3a) | `` libiec61850: 1.6.1 -> 1.6.2 ``                                                                                 |
| [`21dd6ba2`](https://github.com/NixOS/nixpkgs/commit/21dd6ba2642cb02716df412233aab917deb29806) | `` chiri: migrate pnpm fetcher to version 4 ``                                                                    |
| [`2865ba2c`](https://github.com/NixOS/nixpkgs/commit/2865ba2c725b66ff79956d87d69db4eacbccd055) | `` chiri: 0.9.1 -> 0.9.2 ``                                                                                       |
| [`b0ef938e`](https://github.com/NixOS/nixpkgs/commit/b0ef938e1a9b11a4afee28d5426fe8621c8a2049) | `` chiri: 0.9.0 -> 0.9.1 ``                                                                                       |
| [`258fa721`](https://github.com/NixOS/nixpkgs/commit/258fa7219da4daf03b1f14b3451f6711239708f2) | `` chiri: 0.8.1 -> 0.9.0 ``                                                                                       |
| [`bdee3e19`](https://github.com/NixOS/nixpkgs/commit/bdee3e19fdb550475b1730bfca0ffe825bfd0989) | `` tailscale: 1.98.9 -> 1.98.10 ``                                                                                |
| [`989aeb3a`](https://github.com/NixOS/nixpkgs/commit/989aeb3a009426ebad0b9afe525cad039c53f10e) | `` chromium: remove warnObsoleteVersionConditional ``                                                             |
| [`26288e70`](https://github.com/NixOS/nixpkgs/commit/26288e70445155195b9a148f0b9108d16be2496b) | `` chromium: remove no longer needed version conditionals ``                                                      |
| [`e3a337d6`](https://github.com/NixOS/nixpkgs/commit/e3a337d611e084f24bb3a7a109c7c327053fcb42) | `` nixos/resolved: filter null values from config ``                                                              |
| [`7a7782a4`](https://github.com/NixOS/nixpkgs/commit/7a7782a4014f66f4c065c5bcd74e44bbeeb610b3) | `` jackett: 0.24.2237 -> 0.24.2288 ``                                                                             |
| [`86063f75`](https://github.com/NixOS/nixpkgs/commit/86063f75a990fcefda009a9cfec070556493b597) | `` python3Packages.geoparquet: fix build ``                                                                       |
| [`166c6174`](https://github.com/NixOS/nixpkgs/commit/166c6174776d9de7ea3e36c4c7a3e77e981191d6) | `` javaPackages.compiler.openjdk11: 11.0.32+1 -> 11.0.32+9 ``                                                     |
| [`d04f9c72`](https://github.com/NixOS/nixpkgs/commit/d04f9c727f22fa3eb764bb91d462c3815e34e9d8) | `` chhoto-url: 7.4.10 -> 7.5.0 ``                                                                                 |
| [`70d4a02b`](https://github.com/NixOS/nixpkgs/commit/70d4a02bd96f21c3ef940fbd141635136baa0385) | `` scx.rustscheds: aarch64-linux is good ``                                                                       |
| [`3c57a1d1`](https://github.com/NixOS/nixpkgs/commit/3c57a1d1c6a2180bc2d67668348f912b6d070ddd) | `` nixosTests.scx: add missing rustscheds ``                                                                      |
| [`3f4242c1`](https://github.com/NixOS/nixpkgs/commit/3f4242c1d80a474b6cc40d9cf2a94f1d7032a84a) | `` nixosTests.scx: remove cscheds ``                                                                              |
| [`e0d9dea0`](https://github.com/NixOS/nixpkgs/commit/e0d9dea0fa3690e7c1a9f8e7410819a251b8cd0a) | `` scx.rustscheds: 1.1.1 -> 1.1.2 ``                                                                              |
| [`78777536`](https://github.com/NixOS/nixpkgs/commit/787775362fcfa45abd3dce35f003f1ed3c438596) | `` python3Packages.exllamav3: 1.1.0 -> 1.2.1 ``                                                                   |
| [`f76797e0`](https://github.com/NixOS/nixpkgs/commit/f76797e02a8ff64ca7da9c7444934345b527b89e) | `` nixos/uki: allow deviceTree to be excluded from UKI ``                                                         |
| [`4ab841fa`](https://github.com/NixOS/nixpkgs/commit/4ab841fa15b4ee8a302fb0f0644cec92684fbf86) | `` openlist: 4.2.3 -> 4.2.4 ``                                                                                    |
| [`7b006ad4`](https://github.com/NixOS/nixpkgs/commit/7b006ad4f8f1ddf1bb014f93b8870d75e6c69f23) | `` xen: patch with XSA-508 ``                                                                                     |
| [`781f8f74`](https://github.com/NixOS/nixpkgs/commit/781f8f74026b19473ea0486d544ddfd12635f719) | `` xen: patch with XSA-507 ``                                                                                     |
| [`a1a243c1`](https://github.com/NixOS/nixpkgs/commit/a1a243c1656d405b424b9d2eb2c8f4320ea75ed6) | `` xen: patch with XSA-506 ``                                                                                     |
| [`5eb0d1ca`](https://github.com/NixOS/nixpkgs/commit/5eb0d1ca048a265d28d6bcf4d668b1d83f63a4f8) | `` xen: patch with XSA-505 ``                                                                                     |
| [`cae50eeb`](https://github.com/NixOS/nixpkgs/commit/cae50eebdfa1b64a41c5b350231ae4958631b89d) | `` xen: patch with XSA-504 ``                                                                                     |
| [`30e51b88`](https://github.com/NixOS/nixpkgs/commit/30e51b880e052e78c0260bd2f127d8451924cd88) | `` xen: patch with XSA-503 ``                                                                                     |
| [`367c1613`](https://github.com/NixOS/nixpkgs/commit/367c16131c877546ace988ebd1176062e674c903) | `` xen: patch with XSA-502 ``                                                                                     |
| [`558641db`](https://github.com/NixOS/nixpkgs/commit/558641dbee6ea8b1108cb2aac2413fc688d2c334) | `` xen: patch with XSA-501 ``                                                                                     |
| [`3e9e11c4`](https://github.com/NixOS/nixpkgs/commit/3e9e11c4f10229f3edb56ec13188c790a7a6b8ca) | `` xen: patch with XSA-500 ``                                                                                     |
| [`11c440a2`](https://github.com/NixOS/nixpkgs/commit/11c440a2f1576f4d59655390b835916d8a5faaa1) | `` xen: patch with XSA-499 ``                                                                                     |
| [`78a88c8a`](https://github.com/NixOS/nixpkgs/commit/78a88c8a5498a6a377c29e39795ec290f8c57db9) | `` xen: patch with XSA-497 ``                                                                                     |
| [`8cc52e97`](https://github.com/NixOS/nixpkgs/commit/8cc52e979b9ddaab62087dbc404085b197570b71) | `` xen: patch with XSA-495 ``                                                                                     |
| [`8cb923ad`](https://github.com/NixOS/nixpkgs/commit/8cb923ad5ba9e7aa992caf59d26bda4e6157bb05) | `` buck2: add cbarrete as maintainer ``                                                                           |
| [`bd388504`](https://github.com/NixOS/nixpkgs/commit/bd388504ad363d0749138be33c05285f42331483) | `` n8n: fix source hash ``                                                                                        |
| [`c7a29a73`](https://github.com/NixOS/nixpkgs/commit/c7a29a73e991e6aceb3fb6d900593d45023740f8) | `` firefox-bin-unwrapped: 153.0 -> 153.0.1 ``                                                                     |
| [`681d8784`](https://github.com/NixOS/nixpkgs/commit/681d8784f2877affbee197ebd074827f58b0441e) | `` firefox-unwrapped: 153.0 -> 153.0.1 ``                                                                         |
| [`029be205`](https://github.com/NixOS/nixpkgs/commit/029be205169d1d95d4f4f3821228a51a51f7a500) | `` dia: unstable-2025-10-26 -> 0.97.2-unstable-2026-07-24, fix build ``                                           |
| [`9353cb0c`](https://github.com/NixOS/nixpkgs/commit/9353cb0cd6c6649cdda125b5e23e1a33498c7917) | `` team-list: Leave minimal-bootstrap team ``                                                                     |
| [`a726e513`](https://github.com/NixOS/nixpkgs/commit/a726e5133471413fd5b7a47f889bb63330ece4ae) | `` winbox4: 4.2 -> 4.3 ``                                                                                         |
| [`4816172b`](https://github.com/NixOS/nixpkgs/commit/4816172b2e07b41c0b7f6509453e54c612ac8ed2) | `` grafana-loki: 3.7.3 -> 3.7.4 ``                                                                                |
| [`ea09560f`](https://github.com/NixOS/nixpkgs/commit/ea09560f33ce6e6982f2f17f5eec8cbed5d38cab) | `` lockbook-desktop: 26.7.16 -> 26.7.23 ``                                                                        |
| [`0ffee0eb`](https://github.com/NixOS/nixpkgs/commit/0ffee0eb23655a5bb5a145e691de0caaac036964) | `` checkstyle: 13.8.0 -> 13.9.0 ``                                                                                |
| [`2abd366e`](https://github.com/NixOS/nixpkgs/commit/2abd366e196d422147ba2a085d90115379932adf) | `` technitium-dns-server: 15.3.0 -> 15.4.0 ``                                                                     |
| [`aa299199`](https://github.com/NixOS/nixpkgs/commit/aa29919919a204119dd7d87165d799cbbe21e9bb) | `` matrix-synapse: 1.157.1 -> 1.157.2 ``                                                                          |
| [`6ac9a1d5`](https://github.com/NixOS/nixpkgs/commit/6ac9a1d5a720fe3f259dedf90ab3997041020cb2) | `` chatzone-desktop: 5.6.2 -> 5.7.0 ``                                                                            |
| [`3c9b6f7e`](https://github.com/NixOS/nixpkgs/commit/3c9b6f7e93a7e3113435b41f5eff35f18b30a3a0) | `` drawy: 1.0.1 -> 1.0.2 ``                                                                                       |
| [`d30a3194`](https://github.com/NixOS/nixpkgs/commit/d30a31949c317bab860c8f442eddc345fe5f0884) | `` prowlarr: 2.4.0.5397 -> 2.5.2.5491 ``                                                                          |
| [`57f68ac4`](https://github.com/NixOS/nixpkgs/commit/57f68ac4d1f1a998d5c7ad2db41d4431dba33148) | `` tinyauth: 5.1.1 -> 5.1.2 ``                                                                                    |
| [`91c05b7f`](https://github.com/NixOS/nixpkgs/commit/91c05b7f25346f05c5e911c2ba3d389cb458e710) | `` duplicati: 2.3.0.3 -> 2.3.0.4 ``                                                                               |
| [`c491277c`](https://github.com/NixOS/nixpkgs/commit/c491277ca2a7c89e52276008fa2f4dc7a4d5d0ec) | `` pretix: 2026.4.5 -> 2026.4.6 ``                                                                                |
| [`b691719c`](https://github.com/NixOS/nixpkgs/commit/b691719c74533048a7482453206ac13bf050e57d) | `` kubernetes: 1.36.2 -> 1.36.3 ``                                                                                |
| [`a6db0da1`](https://github.com/NixOS/nixpkgs/commit/a6db0da1134565c571c03f8719b1e31c0e20ee6a) | `` duplicati: 2.3.0.1 -> 2.3.0.3 ``                                                                               |
| [`0def7138`](https://github.com/NixOS/nixpkgs/commit/0def71383414c4e0e52adbcf58230e79dee83be0) | `` kicadAddons.kikit: fix build ``                                                                                |
| [`b8d2a65c`](https://github.com/NixOS/nixpkgs/commit/b8d2a65c576d8a3444e140aa77374a3d27a13b15) | `` ghostfolio: 3.29.0 -> 3.35.0 ``                                                                                |
| [`da25f8b1`](https://github.com/NixOS/nixpkgs/commit/da25f8b1d96e0ec0ad581868b6a35317400a3e98) | `` nixos/virtualbox-guest: Prefix udev rules with number < 72 for uaccess to work ``                              |
| [`b9185969`](https://github.com/NixOS/nixpkgs/commit/b91859698c6d02e09d05e5dc7913fcb781354c72) | `` vivaldi-ffmpeg-codecs: (mixed) -> 123075 ``                                                                    |
| [`993de286`](https://github.com/NixOS/nixpkgs/commit/993de286e8037d0a408f8ff118e3076a59207324) | `` vivaldi-ffmpeg-codecs: fix update script ``                                                                    |
| [`ff39e340`](https://github.com/NixOS/nixpkgs/commit/ff39e340e6d3bd14a4d9da14a222d49bed18199b) | `` irrd: 4.5.2 -> 4.5.3 ``                                                                                        |
| [`767a9606`](https://github.com/NixOS/nixpkgs/commit/767a96067f0f683aff0d8214185be549d7321d4e) | `` open-webui: 0.10.2 -> 0.11.0 ``                                                                                |
| [`a716376b`](https://github.com/NixOS/nixpkgs/commit/a716376b5f917ecce84b159fc90d086183e93cd0) | `` mailpit: 1.30.4 -> 1.30.5 ``                                                                                   |
| [`b23cab0c`](https://github.com/NixOS/nixpkgs/commit/b23cab0cb5b9d4b7f7f1dbd96434a3414c9205e5) | `` pkgsStatic.coreutils: fix build ``                                                                             |
| [`bd49717c`](https://github.com/NixOS/nixpkgs/commit/bd49717c20d71cf22db755667329b54f1a818d0b) | `` beam29Packages.erlang: 29.0.3 -> 29.0.4 ``                                                                     |
| [`73991ecc`](https://github.com/NixOS/nixpkgs/commit/73991ecc10da26b571e476e0f3ba56aa36278c42) | `` beam28Packages.erlang: 28.5.0.3 -> 28.5.0.4 ``                                                                 |
| [`2839e6f4`](https://github.com/NixOS/nixpkgs/commit/2839e6f44f7b7470e8621364a2fc78f5ae54ba89) | `` beam27Packages.erlang: 27.3.4.14 -> 27.3.4.15 ``                                                               |
| [`e559ca8a`](https://github.com/NixOS/nixpkgs/commit/e559ca8a28eab90f8b80d961b70d841bc9b309b3) | `` mpfr: Update license to LGPLv3+ ``                                                                             |
| [`658b290e`](https://github.com/NixOS/nixpkgs/commit/658b290eb32cdab667adad47990d90d7712d49fa) | `` libmpc: Update license to LGPLv3+ ``                                                                           |
| [`5d97b9d1`](https://github.com/NixOS/nixpkgs/commit/5d97b9d112470a006595929cdfd96be548f4fb45) | `` gitea: 1.27.0 -> 1.27.1 ``                                                                                     |
| [`df5bbfcf`](https://github.com/NixOS/nixpkgs/commit/df5bbfcf4ebdfe39f423b0777d4b45092d205b3d) | `` protobuf_{21,25,27,29,30,31}: fix 32-bit build ``                                                              |
| [`cbe6d90b`](https://github.com/NixOS/nixpkgs/commit/cbe6d90bcda2a0760588a915fd595d0fb9434506) | `` dashy-ui: 4.4.2 -> 4.4.5 ``                                                                                    |
| [`4926fba9`](https://github.com/NixOS/nixpkgs/commit/4926fba9df80ddf767f6e4eee4734e4eec8e6226) | `` mozillavpn: 2.38.0 -> 2.39.0 ``                                                                                |
| [`fb928492`](https://github.com/NixOS/nixpkgs/commit/fb928492f5ead0a0710f05b1292b7ed4597a9522) | `` zoom-us: 7.1.0.3715 -> 7.1.5.4332 ``                                                                           |
| [`48abb866`](https://github.com/NixOS/nixpkgs/commit/48abb8663c04141a7f698a73ed30f9f727d400d5) | `` linux_testing: 7.2-rc4 -> 7.2-rc5 ``                                                                           |
| [`93ae442d`](https://github.com/NixOS/nixpkgs/commit/93ae442ddeba22b497260f672c724cd7442e469a) | `` maintainers/github-teams.json: Automated sync ``                                                               |
| [`a49e2e30`](https://github.com/NixOS/nixpkgs/commit/a49e2e30e0e1dff06deac36bbd6bcbade4f3b36d) | `` zoom-us: 7.0.5.3034 -> 7.1.0.3715 ``                                                                           |
| [`6e5b8ba3`](https://github.com/NixOS/nixpkgs/commit/6e5b8ba361f938f858fbeb48d6636fe80a014547) | `` radicle-desktop: 0.13.0 -> 0.14.0 ``                                                                           |
| [`ad38bb1b`](https://github.com/NixOS/nixpkgs/commit/ad38bb1b38fdc1991af00c9b97313e8ebdcdcf9a) | `` python3Packages.quickjs: fix build/test for quickjs 2026-06-04 ``                                              |
| [`b61c7650`](https://github.com/NixOS/nixpkgs/commit/b61c76500e32444782d7dc56568a9561edb6dc6f) | `` quickjs: 2025-09-13-2 -> 2026-06-04, unmark as insecure ``                                                     |
| [`88b79267`](https://github.com/NixOS/nixpkgs/commit/88b79267d035da9252b5dac796d3cdf9dadef0b5) | `` forgejo-runner: 12.13.1 -> 12.13.2 ``                                                                          |
| [`4db37663`](https://github.com/NixOS/nixpkgs/commit/4db3766343e4dd7a4d9b2cb141ceeb8789971da0) | `` outline: 1.9.1 -> 1.9.2 ``                                                                                     |
| [`d926b5ca`](https://github.com/NixOS/nixpkgs/commit/d926b5cacfe11ddd002f76abc512125ab0212792) | `` gradle: fix update script with structuredAttrs ``                                                              |
| [`e7ad6059`](https://github.com/NixOS/nixpkgs/commit/e7ad6059f4bc740e9eadc21a98f200e702fd7684) | `` nixos/paperless: Configure Tika and Gotenberg endpoints to work with non-default listen addresses and ports `` |
| [`d2939395`](https://github.com/NixOS/nixpkgs/commit/d293939580adba296b4a11a0a711529a7a3c72b8) | `` virtualbox: 7.2.12 -> 7.2.14 ``                                                                                |
| [`e7a50098`](https://github.com/NixOS/nixpkgs/commit/e7a500989047e788ec03ba6c7b5faca8f6bb4e30) | `` talosctl: 1.13.5 -> 1.13.7 ``                                                                                  |
| [`53cd7c00`](https://github.com/NixOS/nixpkgs/commit/53cd7c00415936f9ca0bad80266c76bf753df802) | `` mastodon: 4.6.3 -> 4.6.4 ``                                                                                    |
| [`82f441ec`](https://github.com/NixOS/nixpkgs/commit/82f441ec5d04429b42facf520279dc49c2fe0561) | `` etcd: 3.6.13 -> 3.6.14 ``                                                                                      |
| [`350e6a5b`](https://github.com/NixOS/nixpkgs/commit/350e6a5b0e380fe6ef485b9cb08480efbe361198) | `` anubis: 1.26.0 -> 1.26.2 ``                                                                                    |
| [`bffe6b09`](https://github.com/NixOS/nixpkgs/commit/bffe6b0982f3facbceb2cfebca5b75622d1180bb) | `` firefox/wrapper: inject gsettings schema paths into XDG_DATA_DIRS ``                                           |
| [`cf7848dc`](https://github.com/NixOS/nixpkgs/commit/cf7848dcd285ef852c7578092c990da2f0c75331) | `` jetbrains.*: 2026.1.* -> 2026.2.0.* ``                                                                         |
| [`4e8f054c`](https://github.com/NixOS/nixpkgs/commit/4e8f054c353c19ebc4b2780db635d932de24a58b) | `` jetbrains: fix linux builder script for 2026.2 IDEs ``                                                         |
| [`1dd397e0`](https://github.com/NixOS/nixpkgs/commit/1dd397e02c47be8569d0df0525749fa85fa27f61) | `` jetbrains.*-oss: mark as insecure ``                                                                           |
| [`97b2bb8f`](https://github.com/NixOS/nixpkgs/commit/97b2bb8f8ea01bd344e8f2d4aa9dc2e5fa86f6f0) | `` jetbrains.webstorm: 2026.1.3 -> 2026.1.4 ``                                                                    |
| [`e6f095b4`](https://github.com/NixOS/nixpkgs/commit/e6f095b45db67e2872b9ef17cfc0d63a7e83963e) | `` tectonic-unwrapped: 0.16.9 -> 0.17.0 ``                                                                        |
| [`d8fbec87`](https://github.com/NixOS/nixpkgs/commit/d8fbec87cb4060e4801890df1aa36bdf884bde8a) | `` adguardhome: 0.107.77 -> 0.107.78 ``                                                                           |
| [`6e68f949`](https://github.com/NixOS/nixpkgs/commit/6e68f9495aa07ea8bee3f9f8d103fd86e969450e) | `` anytype: 0.55.5 -> 0.56.0 ``                                                                                   |
| [`d20b2b7f`](https://github.com/NixOS/nixpkgs/commit/d20b2b7f7347ec9c9ac9a59b17bb0b06dd9df554) | `` emacsPackages.b4-review-mode: init at 0.15.2 ``                                                                |
| [`cb040dcb`](https://github.com/NixOS/nixpkgs/commit/cb040dcbde1218621aede0d27a89c322767bc045) | `` vimPlugins.b4-review-vim: init at 0.15.2 ``                                                                    |
| [`86ae12e5`](https://github.com/NixOS/nixpkgs/commit/86ae12e5d49dbb5defe6793119d8a7e3e7eda43b) | `` b4: expose misc/ source tree via passthru.src-misc ``                                                          |
| [`8f3d75f1`](https://github.com/NixOS/nixpkgs/commit/8f3d75f13e1b5a37bad736e556c75fef42754ee9) | `` thunderbird-latest-bin-unwrapped: 152.0.1 -> 153.0 ``                                                          |
| [`e0595901`](https://github.com/NixOS/nixpkgs/commit/e0595901bdc5b93da4473c84784289a80bd153b9) | `` opengist: 1.13.1 -> 1.14.0 ``                                                                                  |
| [`33ecf48c`](https://github.com/NixOS/nixpkgs/commit/33ecf48ca6624f81b70601ad50bb22e6f7666cd7) | `` brave: 1.92.139 -> 1.92.144 ``                                                                                 |
| [`00a57db5`](https://github.com/NixOS/nixpkgs/commit/00a57db57c5fd91b350b33ba703b8f0042fb5810) | `` technitium-dns-server{,-library}: modernize package with structuredAttrs and finalAttrs ``                     |
| [`f01dd812`](https://github.com/NixOS/nixpkgs/commit/f01dd81226bc1a3bfc024f34d39b48b45e056f16) | `` h2o: 2.3.0-rolling-2026-06-26 → 2.3.0-rolling-2026-06-29 ``                                                    |
| [`8d8b25be`](https://github.com/NixOS/nixpkgs/commit/8d8b25be199e58bef316d169f07802be85a23628) | `` h2o: optionally add Zstandard support ``                                                                       |
| [`9ebd5073`](https://github.com/NixOS/nixpkgs/commit/9ebd5073cde169e14fb7a7f9e56c856744254e72) | `` h2o: 2.3.0-rolling-2026-06-25 → 2.3.0-rolling-2026-06-26 ``                                                    |
| [`736c3efd`](https://github.com/NixOS/nixpkgs/commit/736c3efd16db1cec4edd1058e46d0aec578cda43) | `` h2o: make Brotli optional ``                                                                                   |
| [`0b56f956`](https://github.com/NixOS/nixpkgs/commit/0b56f9562b00ca7de615f14fcca41fdd8dab226c) | `` h2o: 2.3.0-rolling-2026-06-24 → 2.3.0-rolling-2026-06-25 ``                                                    |
| [`eb89ce86`](https://github.com/NixOS/nixpkgs/commit/eb89ce866e6efd1cb2c260aeb0830e0d8c743e99) | `` h2o: makeWrapper → makeBinaryWrapper ``                                                                        |
| [`e252649a`](https://github.com/NixOS/nixpkgs/commit/e252649af45b41ff40ed51532236ff3d43221f0b) | `` h2o: 2.3.0-rolling-2026-06-23 → 2.3.0-rolling-2026-06-24 ``                                                    |
| [`64acf53a`](https://github.com/NixOS/nixpkgs/commit/64acf53aeea65cfb7cd41fdb5f84572e4146bfcc) | `` h2o: 2.3.0-rolling-2026-06-22 → 2.3.0-rolling-2026-06-23 ``                                                    |
| [`e98bdecf`](https://github.com/NixOS/nixpkgs/commit/e98bdecf5401f0607e45be0a98b94bea8a259ab5) | `` h2o: 2.3.0-rolling-2026-06-17 → 2.3.0-rolling-2026-06-22 ``                                                    |
| [`ea9f2e97`](https://github.com/NixOS/nixpkgs/commit/ea9f2e97e08b62dbcead6361387e04516ce18c64) | `` h2o: 2.3.0-rolling-2026-06-16 → 2.3.0-rolling-2026-06-17 ``                                                    |
| [`6ab5f6eb`](https://github.com/NixOS/nixpkgs/commit/6ab5f6eb1fecd59ba34345fbbf2ebb8855fd6a37) | `` h2o: 2.3.0-rolling-2026-06-10 → 2.3.0-rolling-2026-06-16 ``                                                    |
| [`d19fdbbc`](https://github.com/NixOS/nixpkgs/commit/d19fdbbc36d0b438059ee12948a8f048e9954330) | `` h2o: 2.3.0-rolling-2026-06-04 → 2.3.0-rolling-2026-06-10 ``                                                    |
| [`94ae65cd`](https://github.com/NixOS/nixpkgs/commit/94ae65cd133d42fedf55ee2895ec08197fe2d494) | `` h2o: 2.3.0-rolling-2026-05-29 → 2.3.0-rolling-2026-06-04 ``                                                    |
| [`13d8be86`](https://github.com/NixOS/nixpkgs/commit/13d8be863a9558f6b43cb736f07d551227955cd1) | `` h2o: 2.3.0-rolling-2026-05-28 → 2.3.0-rolling-2026-05-29 ``                                                    |
| [`f1550bee`](https://github.com/NixOS/nixpkgs/commit/f1550beea05ff6ed3ca62b746aaf5c34f9240843) | `` h2o: 2.3.0-rolling-2026-05-25 → 2.3.0-rolling-2026-05-28 ``                                                    |
| [`5396dc01`](https://github.com/NixOS/nixpkgs/commit/5396dc01668b08c956c24b2969890e56c81209b6) | `` h2o: 2.3.0-rolling-2026-05-15 → 2.3.0-rolling-2026-05-25 ``                                                    |
| [`8b7607da`](https://github.com/NixOS/nixpkgs/commit/8b7607da130618d0203db578a25e5abc6fc62ff0) | `` limine: 12.5.0 -> 12.5.1 ``                                                                                    |
| [`fb8fab2a`](https://github.com/NixOS/nixpkgs/commit/fb8fab2a6aedb783a0748f6f324a06fc3798d4e1) | `` limine: 12.4.2 -> 12.5.0 ``                                                                                    |
| [`32311fc9`](https://github.com/NixOS/nixpkgs/commit/32311fc9b4bd4eb09fee44b0f03e0161f136c0a9) | `` limine: 12.4.1 -> 12.4.2 ``                                                                                    |
| [`6a149e81`](https://github.com/NixOS/nixpkgs/commit/6a149e81de401c9130338934293f69e1356e5bdc) | `` element-{web,desktop}: 1.12.23 -> 1.12.24 ``                                                                   |
| [`a2abf0ea`](https://github.com/NixOS/nixpkgs/commit/a2abf0ea7ffcf887f5b246782758e2e17ccbd8e3) | `` n8n: use sqlite from nixpkgs ``                                                                                |
| [`fb23113e`](https://github.com/NixOS/nixpkgs/commit/fb23113e599ba3990afa8e347c5072250b55dcd9) | `` n8n: 2.28.6 -> 2.31.4 ``                                                                                       |
| [`064c7fa2`](https://github.com/NixOS/nixpkgs/commit/064c7fa24f416ac23b7e4cedb372f607992f1fb7) | `` criu: add riscv64 support ``                                                                                   |
| [`1935ae66`](https://github.com/NixOS/nixpkgs/commit/1935ae665dc5683f728e3a5141883aab22133949) | `` policycoreutils: 3.10 -> 3.11 ``                                                                               |
| [`098613bf`](https://github.com/NixOS/nixpkgs/commit/098613bf8b1fcffc4177974a80b17b20359bb1f9) | `` dbgate: 6.6.9 -> 7.2.1 ``                                                                                      |
| [`9bf093c1`](https://github.com/NixOS/nixpkgs/commit/9bf093c1b99245fd3f845cc4b47a0590f652e878) | `` python3Packages.ansible-core: 2.21.0 -> 2.21.1 ``                                                              |
| [`919c375b`](https://github.com/NixOS/nixpkgs/commit/919c375bb035f06c85febf92550cef73e5c79e6f) | `` nixos/paperless: Use security.pki.caBundle to automatically accept self-signed certificates ``                 |
| [`339712ed`](https://github.com/NixOS/nixpkgs/commit/339712ed1dc184fbf6d01f01764a268ff79aea5b) | `` trurl: add diogotcorreia as maintainer ``                                                                      |
| [`cda95d43`](https://github.com/NixOS/nixpkgs/commit/cda95d4396c0298407af419ac1ca9ba66ec1b45b) | `` trurl: fix tests with curl 8.21.0 ``                                                                           |
| [`61af2273`](https://github.com/NixOS/nixpkgs/commit/61af2273a8a60e41bccf1bdec45225e1dcb2fb41) | `` duckdb: fix treefmt ``                                                                                         |
| [`598cde6c`](https://github.com/NixOS/nixpkgs/commit/598cde6ca85081f06c69c5ad065b3a8724ec7d9c) | `` gdal: fix tests with libtiff 4.7.2 ``                                                                          |
| [`113d68d9`](https://github.com/NixOS/nixpkgs/commit/113d68d960290e9d2468f4a1957f92dd30611933) | `` duckdb: work around the excessive logging ``                                                                   |