### PR TITLE
chore(flake/nixpkgs): `624af665` -> `0954f7ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -992,11 +992,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`7039d0e0`](https://github.com/NixOS/nixpkgs/commit/7039d0e069d01f1d913870fecb13e81384c89599) | `` rumdl: 0.2.37 -> 0.2.45 ``                                                        |
| [`eca92b89`](https://github.com/NixOS/nixpkgs/commit/eca92b890d89b57bc14290d409eb942d035ec08d) | `` go-sendxmpp: 0.16.0 -> 0.17.0 ``                                                  |
| [`e462a3c2`](https://github.com/NixOS/nixpkgs/commit/e462a3c24928ebdbcee6aa3fdafb5b14552bb6c2) | `` ocamlPackages.spdx_licenses: 1.4.0 → 1.5.0 ``                                     |
| [`58e5d988`](https://github.com/NixOS/nixpkgs/commit/58e5d9885cd1edb646b321aee5a9e80d3653eaf7) | `` xenia-canary: 0-unstable-2026-07-19 -> 0-unstable-2026-07-27 ``                   |
| [`da1a3bb0`](https://github.com/NixOS/nixpkgs/commit/da1a3bb07a757f5d789ba547a5f87d6c605291b1) | `` moor: 2.15.1 -> 2.15.2 ``                                                         |
| [`cf738a76`](https://github.com/NixOS/nixpkgs/commit/cf738a767950339bcea6789e5335903c56f58e3e) | `` chhoto-url: 7.4.10 -> 7.5.0 ``                                                    |
| [`189ba0b2`](https://github.com/NixOS/nixpkgs/commit/189ba0b2d3d4b0f1bf82c02905ee9cf16ec61921) | `` vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.85 -> 1.1.86 ``         |
| [`7146de4b`](https://github.com/NixOS/nixpkgs/commit/7146de4bbc4f45fc39e38477a35dc4760a994769) | `` postgresqlPackages.timescaledb-apache: 2.28.3 -> 2.29.0 ``                        |
| [`f270f0a0`](https://github.com/NixOS/nixpkgs/commit/f270f0a0db9ee83b6be2a5108d88c0f2a034ce5e) | `` timoni: 0.27.0 -> 0.27.1 ``                                                       |
| [`c728ed52`](https://github.com/NixOS/nixpkgs/commit/c728ed520c267cca5df29d7999f913dc41115813) | `` betteralign: 0.14.2 -> 0.14.3 ``                                                  |
| [`6de24019`](https://github.com/NixOS/nixpkgs/commit/6de24019468ad37f06940b5064d43caa4d508bf2) | `` libretro.beetle-psx: 0-unstable-2026-07-18 -> 0-unstable-2026-07-28 ``            |
| [`1e7842c9`](https://github.com/NixOS/nixpkgs/commit/1e7842c9a9649be985a9ae5d05739c765e06bc60) | `` python3Packages.victron-mqtt: 2026.7.5 -> 2026.7.6 ``                             |
| [`3dfc9d11`](https://github.com/NixOS/nixpkgs/commit/3dfc9d11c807d719b127ac11395f404426e83421) | `` zashboard: 3.15.0 -> 3.16.0 ``                                                    |
| [`333a01f4`](https://github.com/NixOS/nixpkgs/commit/333a01f48ba099b84bf9b86ad60ec6aed150887d) | `` cooper-hewitt: fix version ``                                                     |
| [`d4467aa6`](https://github.com/NixOS/nixpkgs/commit/d4467aa625c20cd4543c2d08753ab4a66cd043fe) | `` lessc: 4.7.0 -> 4.8.1 ``                                                          |
| [`59c7b7dc`](https://github.com/NixOS/nixpkgs/commit/59c7b7dc88b746d06a85f688d179b8edfd752a48) | `` culvert: fix version ``                                                           |
| [`b0f8391e`](https://github.com/NixOS/nixpkgs/commit/b0f8391eca1d5f68883254820cb4e5b1bb6a18ac) | `` home-assistant-custom-components.midea_ac: 2026.7.1 -> 2026.7.2 ``                |
| [`26057afe`](https://github.com/NixOS/nixpkgs/commit/26057afe9d40ddbde21c1ee434c31061121b58e7) | `` xh: 0.26.1 -> 0.26.2 ``                                                           |
| [`296dcf45`](https://github.com/NixOS/nixpkgs/commit/296dcf45e492664a70cac7800843f2702a36ef27) | `` sage: use threaded ntl on darwin but patch to appease linker ``                   |
| [`7233f759`](https://github.com/NixOS/nixpkgs/commit/7233f75959385a78b8b65330caceab54788e8aa3) | `` explo: 1.1.2 -> 1.1.3 ``                                                          |
| [`2ba6e5de`](https://github.com/NixOS/nixpkgs/commit/2ba6e5de25348bc5ef2d4b570f00298e5662b17e) | `` cryptoscan: 1.3.0 -> 1.4.0 ``                                                     |
| [`97e9ae1c`](https://github.com/NixOS/nixpkgs/commit/97e9ae1ca39542f4c9dbe0979679826c79a6b143) | `` panache: enable install check ``                                                  |
| [`a35a111a`](https://github.com/NixOS/nixpkgs/commit/a35a111a4548e0098e6bfd22c40979c5f9a10c76) | `` knossosnet: 1.3.9 -> 1.3.10 ``                                                    |
| [`7fb6f966`](https://github.com/NixOS/nixpkgs/commit/7fb6f9662aa5226e051b33c38f7ad244206ab4f7) | `` panache: add update script ``                                                     |
| [`fc37f5fa`](https://github.com/NixOS/nixpkgs/commit/fc37f5fa9c69858044e5a93e317dc47fcd437aec) | `` bfscripts: fix version ``                                                         |
| [`e4b53430`](https://github.com/NixOS/nixpkgs/commit/e4b534301ea41a986387847a137e2f4d01b780f7) | `` apacheHttpdPackages.mod_mbtiles: fix version ``                                   |
| [`e96be01c`](https://github.com/NixOS/nixpkgs/commit/e96be01ce2c31f77780b52c62d253c411c79c764) | `` comfortaa: modernize ``                                                           |
| [`991c4b3a`](https://github.com/NixOS/nixpkgs/commit/991c4b3aa56eaf0a207e05552c1bf4837ac8ff0f) | `` zsh-completion-sync: 0.4.0 -> 0.4.1 ``                                            |
| [`87c928bc`](https://github.com/NixOS/nixpkgs/commit/87c928bc12d6ca80c014118c5c5bfe107ad915f7) | `` mcp-grafana: 0.17.2 -> 1.0.0 ``                                                   |
| [`e949e860`](https://github.com/NixOS/nixpkgs/commit/e949e860013c5d50ce64483226e1019e2e11ccb8) | `` nixos/uki: allow deviceTree to be excluded from UKI ``                            |
| [`86e65b7a`](https://github.com/NixOS/nixpkgs/commit/86e65b7a670317ce9a1dcc03afa37ca9fef3a377) | `` python3Packages.opower: 0.18.6 -> 0.19.0 ``                                       |
| [`5f4fc6f6`](https://github.com/NixOS/nixpkgs/commit/5f4fc6f6044327b4df3ec0d74582ecbbb0e3d2d9) | `` aws-vault: 7.13.0 -> 7.13.1 ``                                                    |
| [`5abf6062`](https://github.com/NixOS/nixpkgs/commit/5abf60627bdfa14206aca0d8344ea37ffcddfed0) | `` prowler: 5.35.0 -> 5.36.0 ``                                                      |
| [`72007dd1`](https://github.com/NixOS/nixpkgs/commit/72007dd1e04527da89bf035ae7e2e7700c83f9d2) | `` python3Packages.exllamav3: 1.1.0 -> 1.2.1 ``                                      |
| [`c6f95834`](https://github.com/NixOS/nixpkgs/commit/c6f9583452ae916f5d84552f59df6a25a5467f17) | `` libretro.bluemsx: 0-unstable-2026-07-19 -> 0-unstable-2026-07-27 ``               |
| [`6887e079`](https://github.com/NixOS/nixpkgs/commit/6887e079fa57c80ff0fe0c8c8fc33a95c30bff48) | `` nix-output-monitor: 2.1.8 -> 2.2.0 ``                                             |
| [`b2c6ead8`](https://github.com/NixOS/nixpkgs/commit/b2c6ead8d20290ba279217dc39e5f97d5a3b0e8e) | `` javaPackages.compiler.openjdk11: 11.0.32+1 -> 11.0.32+9 ``                        |
| [`421077cc`](https://github.com/NixOS/nixpkgs/commit/421077cca8b57c3e5e62c91d2253772a307124d1) | `` courier-prime: set __structuredAttrs & strictDeps ``                              |
| [`f75fb4a1`](https://github.com/NixOS/nixpkgs/commit/f75fb4a1bf24e7e5191754d8fdb242120d91aea8) | `` osmium: 0.0.30-alpha -> 0.0.32-alpha ``                                           |
| [`94837559`](https://github.com/NixOS/nixpkgs/commit/948375590367360a626e059d2b4ce13a8f9618f6) | `` pg-schema-diff: 1.0.7 -> 1.0.8 ``                                                 |
| [`c1406e0f`](https://github.com/NixOS/nixpkgs/commit/c1406e0f58d2358aa12c477dfda80fe614af672b) | `` vscode-extensions.sourcery.sourcery: 1.43.0 -> 1.44.0 ``                          |
| [`e9ee0fa1`](https://github.com/NixOS/nixpkgs/commit/e9ee0fa1663c09e9971096e09871bb6bd4bfd065) | `` nh-unwrapped: 4.4.1 -> 4.4.2 ``                                                   |
| [`998e7b43`](https://github.com/NixOS/nixpkgs/commit/998e7b434a615cda69609b10bdb1be13f1cd2321) | `` borgbackup: fix build failure ``                                                  |
| [`8d0c589d`](https://github.com/NixOS/nixpkgs/commit/8d0c589d0064838f7e2e797839d58d91ee0fd51c) | `` multica-cli: 0.4.4 -> 0.4.13 ``                                                   |
| [`ae377cb9`](https://github.com/NixOS/nixpkgs/commit/ae377cb981aae1b9dbf1352ccd64544f5c64048f) | `` mcp-language-server: use tag instead of rev ``                                    |
| [`83e05277`](https://github.com/NixOS/nixpkgs/commit/83e052773e265135e2fda1db38efa8b8e5685f09) | `` topgrade: 17.8.0 -> 17.9.0 ``                                                     |
| [`282a7d66`](https://github.com/NixOS/nixpkgs/commit/282a7d66b62715a22cd69caaee7bcac4a63e7aae) | `` doc: mention wasi -> wasip1 rename in release notes ``                            |
| [`e5d3534b`](https://github.com/NixOS/nixpkgs/commit/e5d3534ba01905c5d268677d3ca4791c2d43a9c3) | `` shairport-sync: 5.1 -> 5.2 ``                                                     |
| [`bd6051aa`](https://github.com/NixOS/nixpkgs/commit/bd6051aa5f850e4f9ff80d6c86201e9337c3bad3) | `` systems: also rename pkgsCross.wasi32, leaving aliases ``                         |
| [`629b4ee0`](https://github.com/NixOS/nixpkgs/commit/629b4ee093941ee8338a68b3f018e27a2e415b33) | `` systems: rename extant wasi targets to wasip1 ``                                  |
| [`b266e7d2`](https://github.com/NixOS/nixpkgs/commit/b266e7d2fc3562d97a8b5ed91cc914e8dac4a4c1) | `` devenv: 2.1.2 -> 2.2.0 ``                                                         |
| [`6fcdeca5`](https://github.com/NixOS/nixpkgs/commit/6fcdeca597c7bd2a13d1624236ada18604649f92) | `` python3Packages.xknx: 3.16.0 -> 3.17.0 ``                                         |
| [`2ce1be73`](https://github.com/NixOS/nixpkgs/commit/2ce1be73deb0badd3d6566fe8fed9b25c9432300) | `` vimPlugins.codediff-nvim: 2.49.2 -> 2.53.1 ``                                     |
| [`ec07ae88`](https://github.com/NixOS/nixpkgs/commit/ec07ae88e040f440581c0846c9a6e58cbab45c24) | `` buildPythonPackage: only override bootstrap hooks once ``                         |
| [`45c00f22`](https://github.com/NixOS/nixpkgs/commit/45c00f22fd3d141da66ef4162070a12d19cdb124) | `` mtail: 3.4.4 -> 3.4.5 ``                                                          |
| [`30fa960d`](https://github.com/NixOS/nixpkgs/commit/30fa960d4819d97b0b546ed3dcecddc8ac9c596a) | `` home-assistant-custom-components.frigidaire: 0.1.33 -> 0.1.37 ``                  |
| [`c8eb0267`](https://github.com/NixOS/nixpkgs/commit/c8eb026729de0dc5172d43235febff9d1f23fde7) | `` python3Packages.total-connect-client: 2025.12.2 -> 2026.7 ``                      |
| [`79d0ae6a`](https://github.com/NixOS/nixpkgs/commit/79d0ae6aaa5a9fb1e05abe68e92cbfd354bc55c2) | `` kubectl-rabbitmq: 2.22.1 -> 2.22.3 ``                                             |
| [`900d9da7`](https://github.com/NixOS/nixpkgs/commit/900d9da7a44960d2ce02ca62a3dd6e9d9d6b4ea6) | `` python3Packages.iamdata: 0.1.202607271 -> 0.1.202607281 ``                        |
| [`45f9f973`](https://github.com/NixOS/nixpkgs/commit/45f9f9733e7267d5e8e814c5f2deeef9e40464d0) | `` python3Packages.targ: 0.6.0 -> 0.7.0 ``                                           |
| [`ad2190c9`](https://github.com/NixOS/nixpkgs/commit/ad2190c9029432b36cca2828c2abc4583a3121d8) | `` gdevelop: 5.6.274 -> 5.6.276 ``                                                   |
| [`76817d24`](https://github.com/NixOS/nixpkgs/commit/76817d240fbfaa7c0d7636059cfb580541c81909) | `` aerc: 0.21.0 -> 0.22.0 ``                                                         |
| [`5f051272`](https://github.com/NixOS/nixpkgs/commit/5f051272ee12c61b68574fb94907ec3041c2c4e1) | `` kopuz: 0.12.0 -> 0.13.0 ``                                                        |
| [`2daec55e`](https://github.com/NixOS/nixpkgs/commit/2daec55e30c43b078cefdc85aa89020f9fd3dcc5) | `` flyctl: 0.4.71 -> 0.4.75 ``                                                       |
| [`41dbfd34`](https://github.com/NixOS/nixpkgs/commit/41dbfd34a71f0ba40a316b455d89f531fb02752b) | `` lockbook-desktop: 26.7.16 -> 26.7.23 ``                                           |
| [`189bfb6a`](https://github.com/NixOS/nixpkgs/commit/189bfb6a3b07cd63502c10b1511789e5181428f2) | `` vscode-extensions.kilocode.kilo-code: 7.3.53 -> 7.4.16 ``                         |
| [`a6d31175`](https://github.com/NixOS/nixpkgs/commit/a6d311758c809fc91faf2d575c9d28faf7160a55) | `` python3Packages.ocrmypdf_16: drop ``                                              |
| [`f696eba9`](https://github.com/NixOS/nixpkgs/commit/f696eba92a91018897b68eeaa3f740dc8f0043b9) | `` paperless-ngx: 2.20.15 -> 3.0.4 ``                                                |
| [`e2c1995d`](https://github.com/NixOS/nixpkgs/commit/e2c1995dbf4dab4e625b24005f8907b955eb1a88) | `` lazyrsync: init at 0.1.1 ``                                                       |
| [`7ea63914`](https://github.com/NixOS/nixpkgs/commit/7ea6391400a588fc07e54db1c5951a3f11c3c998) | `` tauon: 10.0.1 -> 11.1.1 ``                                                        |
| [`75fe7381`](https://github.com/NixOS/nixpkgs/commit/75fe7381660c5e1fa2e38a1c92fe7af87dca01c0) | `` dnsproxy: 0.83.0 -> 0.83.1 ``                                                     |
| [`bce76591`](https://github.com/NixOS/nixpkgs/commit/bce7659126b686ff2ba1f25b35334bd300f3d219) | `` iay: 0.4.3 -> 0.5.0 ``                                                            |
| [`0e54aaa7`](https://github.com/NixOS/nixpkgs/commit/0e54aaa7db7feb04a194460115fe1ad709c3f556) | `` firefox-bin-unwrapped: 153.0 -> 153.0.1 ``                                        |
| [`e8dfe479`](https://github.com/NixOS/nixpkgs/commit/e8dfe479566f69267f4f6afc6af4715a93151cd3) | `` firefox-unwrapped: 153.0 -> 153.0.1 ``                                            |
| [`47b9b1db`](https://github.com/NixOS/nixpkgs/commit/47b9b1db8290040669fb992f6eb5f2446b058959) | `` hns: 1.0.8 -> 1.1.0 ``                                                            |
| [`c8b0fa07`](https://github.com/NixOS/nixpkgs/commit/c8b0fa0739c3670ceca9b2f3cc320d004ad5a6a2) | `` matrix-synapse: 1.157.1 -> 1.157.2 ``                                             |
| [`b87548a0`](https://github.com/NixOS/nixpkgs/commit/b87548a0839688019c812adc5c17217613379fe4) | `` trezor-suite: 26.6.1 -> 26.7.2 ``                                                 |
| [`59c95e79`](https://github.com/NixOS/nixpkgs/commit/59c95e79754c29e5bc508f52160db5ac61a4794f) | `` python3Packages.ttkbootstrap: 2.0.0 -> 2.0.1 ``                                   |
| [`da50cfbb`](https://github.com/NixOS/nixpkgs/commit/da50cfbb4ecbed0fb3edf254f49f52562384cb29) | `` hyena: drop ``                                                                    |
| [`e4046f4b`](https://github.com/NixOS/nixpkgs/commit/e4046f4b02ff40d059d0d26b1856d9ba67c9d6ec) | `` nxv: add jamesbrink as maintainer ``                                              |
| [`1db84162`](https://github.com/NixOS/nixpkgs/commit/1db84162b54773809e040f95dd51e89af92c7012) | `` nxv: 0.1.4 -> 0.6.0 ``                                                            |
| [`13585e73`](https://github.com/NixOS/nixpkgs/commit/13585e73f9a8bf539584d55bc2952fea2eb8e5ae) | `` noctalia: fix nvidia gpu support ``                                               |
| [`52caf939`](https://github.com/NixOS/nixpkgs/commit/52caf939de6dd4adbba23dbf4d3aeb8e1a498bc9) | `` python3Packages.beets-filetote: fix tests with beets2.13 ``                       |
| [`7454e332`](https://github.com/NixOS/nixpkgs/commit/7454e3320ba8644441c40d1893476fd4f3c23744) | `` python3Packages.beets: 2.12.0 -> 2.13.0 ``                                        |
| [`5d70ccbe`](https://github.com/NixOS/nixpkgs/commit/5d70ccbec8c5be3dc0e43220f7d14291c7582657) | `` python3Packages.beets-filetote: replace tests exclusion with upstream patch ``    |
| [`4406f77a`](https://github.com/NixOS/nixpkgs/commit/4406f77ab66659bbdc49c2250968d92f04b161dc) | `` courier-prime: fix version, various ``                                            |
| [`c8bd68ca`](https://github.com/NixOS/nixpkgs/commit/c8bd68ca9f2d64e27dd25e8f7a4d11157a688c36) | `` kdePackages.syntax-highlighting: add darwin support ``                            |
| [`b7317063`](https://github.com/NixOS/nixpkgs/commit/b7317063c52a0e0c102de10660337dd9fa84e545) | `` rustup-toolchain-install-master: 1.12.0 -> 1.12.1 ``                              |
| [`8ce724a7`](https://github.com/NixOS/nixpkgs/commit/8ce724a70ae92e9e876b005426e26ee96511124b) | `` oelint-adv: 9.9.2 -> 9.10.3 ``                                                    |
| [`2fb127d4`](https://github.com/NixOS/nixpkgs/commit/2fb127d45948093661af1ea7c4e3de8907a4fe9e) | `` kin-openapi: 0.142.0 -> 0.145.0 ``                                                |
| [`fe87195f`](https://github.com/NixOS/nixpkgs/commit/fe87195f04063511f0af3cd1076992893ce355e3) | `` python3Packages.geoparquet: fix build ``                                          |
| [`e4d0747b`](https://github.com/NixOS/nixpkgs/commit/e4d0747b4ba40f12cc90e1b288bbfd885479f85b) | `` pretix: 2026.6.0 -> 2026.6.1 ``                                                   |
| [`176e3ae3`](https://github.com/NixOS/nixpkgs/commit/176e3ae39f7ec64cdf5f8ad186730a3dc7d58531) | `` deck: 1.64.0 -> 1.65.0 ``                                                         |
| [`1489c9a1`](https://github.com/NixOS/nixpkgs/commit/1489c9a1d5370a0d7fe4d204e44e40c2a8c5c304) | `` xen: patch with XSA-508 ``                                                        |
| [`75cf4c43`](https://github.com/NixOS/nixpkgs/commit/75cf4c4338525ab07351b4852968e89d53c54744) | `` xen: patch with XSA-507 ``                                                        |
| [`8b1b2b2e`](https://github.com/NixOS/nixpkgs/commit/8b1b2b2ef2a2d3b0a4e502f15288ef3a43a4e80b) | `` xen: patch with XSA-506 ``                                                        |
| [`7e3086df`](https://github.com/NixOS/nixpkgs/commit/7e3086dfb90c4a838af0558e82f7e5647d68b0af) | `` xen: patch with XSA-505 ``                                                        |
| [`b5e82973`](https://github.com/NixOS/nixpkgs/commit/b5e8297324448dade81266ba48e5c6170e47f6df) | `` xen: patch with XSA-504 ``                                                        |
| [`3001f48a`](https://github.com/NixOS/nixpkgs/commit/3001f48acc070f9460f392796a134ccc37dbd29a) | `` xen: patch with XSA-503 ``                                                        |
| [`b654658d`](https://github.com/NixOS/nixpkgs/commit/b654658d88903f756492026df5e2d0b5fbab47ba) | `` xen: patch with XSA-502 ``                                                        |
| [`6880fc9f`](https://github.com/NixOS/nixpkgs/commit/6880fc9fbfd846e394d0eb937e737ce434a793ec) | `` xen: patch with XSA-501 ``                                                        |
| [`38406cc3`](https://github.com/NixOS/nixpkgs/commit/38406cc3f62832734eaa4f0ef88c2641d5dea182) | `` xen: patch with XSA-500 ``                                                        |
| [`3233257a`](https://github.com/NixOS/nixpkgs/commit/3233257af835946854c2fda0d1a7b36a362fd7ac) | `` xen: patch with XSA-499 ``                                                        |
| [`e26179ae`](https://github.com/NixOS/nixpkgs/commit/e26179ae6de02e213bbcce750973719a264b1e4d) | `` xen: patch with XSA-497 ``                                                        |
| [`f3059149`](https://github.com/NixOS/nixpkgs/commit/f30591491f647f75f89a50b2e5cbf7ce08ae0555) | `` xen: patch with XSA-495 ``                                                        |
| [`5cbf2fbc`](https://github.com/NixOS/nixpkgs/commit/5cbf2fbcef13939c3625acff1f5041f85d33e4b6) | `` seamonkey: 2.53.23 -> 2.53.24 ``                                                  |
| [`54f9709f`](https://github.com/NixOS/nixpkgs/commit/54f9709fb0b8827aa358cf9a66024316b2bfaf77) | `` libretro.meteor: 0-unstable-2026-04-20 -> 0-unstable-2026-07-22 ``                |
| [`a57e2c8c`](https://github.com/NixOS/nixpkgs/commit/a57e2c8cc68df5306e2816771fbf2598080d8eb9) | `` python3Packages.pyreqwest: 0.12.0 -> 0.12.2 ``                                    |
| [`5ef11054`](https://github.com/NixOS/nixpkgs/commit/5ef110547f5010ddc1da4d61ecacffdb6d7064dd) | `` libretro.fbneo: 0-unstable-2026-07-19 -> 0-unstable-2026-07-28 ``                 |
| [`9711623f`](https://github.com/NixOS/nixpkgs/commit/9711623f245989662f03ed3d4801c5f9168ad57a) | `` diskwatch: 0.1.3 -> 0.1.5 ``                                                      |
| [`d19a014c`](https://github.com/NixOS/nixpkgs/commit/d19a014cc31a3b6f7e62cd21e150b53de88a36f6) | `` python3Packages.npe2: rename from napari-npe2; fix pname ``                       |
| [`4252f381`](https://github.com/NixOS/nixpkgs/commit/4252f381bc90b5d973ffb0b340f4c4f9d7369fb6) | `` python3Packages.roma: 1.5.6 -> 1.5.7 ``                                           |
| [`f7015493`](https://github.com/NixOS/nixpkgs/commit/f7015493a33b861d520f8ee575f37cbf6f25ebce) | `` fetchtastic: 0.10.11 -> 0.11.1 ``                                                 |
| [`56232146`](https://github.com/NixOS/nixpkgs/commit/5623214600fe82d8108edf3a75c264c91c357d8a) | `` checkstyle: 13.8.0 -> 13.9.0 ``                                                   |
| [`b989b125`](https://github.com/NixOS/nixpkgs/commit/b989b125bb118e3bb6c5343fe697b7d00d8ac9cd) | `` cine: 1.7.4 -> 1.8.0 ``                                                           |
| [`3b1d3690`](https://github.com/NixOS/nixpkgs/commit/3b1d369027816004711eaec431c67d65f07d1f08) | `` plezy: 2.9.1 -> 2.10.0 ``                                                         |
| [`5b475e39`](https://github.com/NixOS/nixpkgs/commit/5b475e396fca5af24134013e4befea3fb02ca271) | `` netbird-dashboard: 2.90.6 -> 2.90.8 ``                                            |
| [`af93afee`](https://github.com/NixOS/nixpkgs/commit/af93afee461bd7268d1440753e1c10104d554bf6) | `` netbird: 0.75.0 -> 0.75.1 ``                                                      |
| [`bc184caf`](https://github.com/NixOS/nixpkgs/commit/bc184caf8adf49a95e103ef7b273f5819b6c9d1a) | `` python3Packages.types-tqdm: 4.68.0.20260608 -> 4.69.0.20260728 ``                 |
| [`01fc1be5`](https://github.com/NixOS/nixpkgs/commit/01fc1be54bba45436dfbe7b68ab5f673bb2e9126) | `` libretro.hatari: 0-unstable-2026-06-10 -> 0-unstable-2026-07-28 ``                |
| [`d29f7416`](https://github.com/NixOS/nixpkgs/commit/d29f7416dbda032067e18a4d9a56e35bf8b6f362) | `` v2ray-rules-dat: 202607182241 -> 202607272255 ``                                  |
| [`7849bef0`](https://github.com/NixOS/nixpkgs/commit/7849bef0ed365c613d2b6feeb566a2595e269b26) | `` python3Packages.libknot: 3.5.5 -> 3.5.6 ``                                        |
| [`eee9f785`](https://github.com/NixOS/nixpkgs/commit/eee9f7857ba5f0f114102fd1267708a2aedbbafd) | `` python3Packages.beets-audible: fix uv_build version constraint ``                 |
| [`f7527713`](https://github.com/NixOS/nixpkgs/commit/f75277132966a2c24d17013218c575cb55e0e7de) | `` netcoredbg: expose only executables to bin, add update script ``                  |
| [`e92d15d4`](https://github.com/NixOS/nixpkgs/commit/e92d15d4b49f025f3a8dced7d8a109046047176f) | `` python3Packages.subliminal: modernize dependencies attribute ``                   |
| [`9267c999`](https://github.com/NixOS/nixpkgs/commit/9267c9995d46d521a0471c31e5dc79e4d7d5c736) | `` n8n: fix source hash ``                                                           |
| [`716dc3f0`](https://github.com/NixOS/nixpkgs/commit/716dc3f0a527b0335f55dacf4a12c6325b7d7067) | `` python3Packages.pypng: 0.20231004.0 -> 0.20250521.0 ``                            |
| [`fee92bb9`](https://github.com/NixOS/nixpkgs/commit/fee92bb942b5ef2cc090f1424055e84f96206c40) | `` enzyme: 0.0.286 -> 0.0.289 ``                                                     |
| [`84282cd1`](https://github.com/NixOS/nixpkgs/commit/84282cd1336e680b654668847a5db81db36ce74c) | `` usage: 3.5.5 -> 4.0.0 ``                                                          |
| [`612e2a7c`](https://github.com/NixOS/nixpkgs/commit/612e2a7c66e47929424bbf14a6f3e165e1b1061f) | `` python3Packages.teslemetry-stream: 0.9.1 -> 0.9.2 ``                              |
| [`0d5c261b`](https://github.com/NixOS/nixpkgs/commit/0d5c261be74f9fdc09424f7ba2aa944b997a63d7) | `` grafana: 13.1.0 -> 13.1.1 ``                                                      |
| [`76ba86cf`](https://github.com/NixOS/nixpkgs/commit/76ba86cf8bc53026d9dd48b0cc195b551829910c) | `` wezterm: reorganize app bundle and codesign to enable notifications on darwin ``  |
| [`4ba0ebac`](https://github.com/NixOS/nixpkgs/commit/4ba0ebacc98183f33b556ecbf450793e1ab58b6c) | `` ghostfolio: 3.29.0 -> 3.35.0 ``                                                   |
| [`4883abde`](https://github.com/NixOS/nixpkgs/commit/4883abde8e067f74ab3642e5dfee56b5fc24af6a) | `` codex-acp: remove tlvince from maintainers ``                                     |
| [`ed2a5c78`](https://github.com/NixOS/nixpkgs/commit/ed2a5c787393efc07b4b810755de616c59b52d30) | `` libretro.beetle-supafaust: 0-unstable-2026-04-20 -> 0-unstable-2026-07-22 ``      |
| [`f4a77cf5`](https://github.com/NixOS/nixpkgs/commit/f4a77cf51845d8bf58d3792a7851de332687977c) | `` python3Packages.lazrs: 0.8.1 -> 0.8.2 ``                                          |
| [`05a23e13`](https://github.com/NixOS/nixpkgs/commit/05a23e1359c2b7b648b339ee1541cfb9879424a5) | `` irust: 1.76.2 -> 1.77.1 ``                                                        |
| [`918cd8f1`](https://github.com/NixOS/nixpkgs/commit/918cd8f1706ce8018472338fb50164fe0aba4747) | `` slskd: move upload settings under transfers ``                                    |
| [`d84bec21`](https://github.com/NixOS/nixpkgs/commit/d84bec2181195c422b99b872217b5eabe2e2a0d7) | `` python3Packages.llama-cloud: 2.11.0 -> 2.13.0 ``                                  |
| [`b320b43c`](https://github.com/NixOS/nixpkgs/commit/b320b43ca32f8f5999fc7cad03839231e76241c7) | `` slskd: add units to speed_limits options ``                                       |
| [`252235af`](https://github.com/NixOS/nixpkgs/commit/252235afb179c2ce5d7e2e3a4618da2dcb934132) | `` slskd: 0.24.5 -> 0.26.0 ``                                                        |
| [`1df0a985`](https://github.com/NixOS/nixpkgs/commit/1df0a985d78bfa4f5443827538e10dc49f41c84b) | `` irrd: 4.5.2 -> 4.5.3 ``                                                           |
| [`a6b5e324`](https://github.com/NixOS/nixpkgs/commit/a6b5e3240ea5d5515104c9515b83c473cf73f82e) | `` syswatch: 0.7.5 -> 0.7.7 ``                                                       |
| [`5aee07ea`](https://github.com/NixOS/nixpkgs/commit/5aee07ea664358f7e05d9e0eeb7b9b0cc1370ed9) | `` osqp-eigen: 0.11.1 -> 0.11.2 ``                                                   |
| [`55eb52eb`](https://github.com/NixOS/nixpkgs/commit/55eb52ebc22f34eb3f8ef1a29f6fb0b0dd452aa2) | `` github-mcp-server: 1.6.0 -> 1.7.0 ``                                              |
| [`2da22a3e`](https://github.com/NixOS/nixpkgs/commit/2da22a3eda4651c7ffc09f1309ce5e779be06c71) | `` cloudflare-dynamic-dns: 4.5.1 -> 4.5.2 ``                                         |
| [`f8d12fb7`](https://github.com/NixOS/nixpkgs/commit/f8d12fb72b7c08b321f575e0d7deac60ef447a49) | `` python3Packages.torch-geometric: 2.8.0 -> 2.8.0.post1 ``                          |
| [`152deaec`](https://github.com/NixOS/nixpkgs/commit/152deaec97525ec8426d276690af73040bd06965) | `` reticulum-group-chat: 1.12.0 -> 1.15.0 ``                                         |
| [`bf7060dd`](https://github.com/NixOS/nixpkgs/commit/bf7060dd1b2b669e8b1666662ad7c01e23492c64) | `` got: 0.126 -> 0.127 ``                                                            |
| [`8665aa3f`](https://github.com/NixOS/nixpkgs/commit/8665aa3f1cd122ea31cd870ec39e8926d0fc4f03) | `` matrix-continuwuity: make rocksdb overridable ``                                  |
| [`a1f194fc`](https://github.com/NixOS/nixpkgs/commit/a1f194fce9c84a102232dbebaaa6e6c7a0f27ea0) | `` audiobookshelf: 2.35.1 -> 2.36.0 ``                                               |
| [`4f9caf70`](https://github.com/NixOS/nixpkgs/commit/4f9caf70e0139801ed08530726166e62d3e6c8f8) | `` python3Packages.types-regex: 2026.7.10.20260711 -> 2026.7.19.20260720 ``          |
| [`d8d77b02`](https://github.com/NixOS/nixpkgs/commit/d8d77b02ba3e3e070c27dffdc21b2b33513c6ab5) | `` atuin: 18.17.1 -> 18.18.0 ``                                                      |
| [`efed8c88`](https://github.com/NixOS/nixpkgs/commit/efed8c88b86ad2c770bf8f2d802d8b9845bd8a81) | `` terraform-backend: 0.2.1 -> 0.2.2 ``                                              |
| [`98e971fe`](https://github.com/NixOS/nixpkgs/commit/98e971fe13ef4407ad31c636f5d06abe92bb74c6) | `` vimPlugins.coqtail: 1.9.0 -> 1.10.0 ``                                            |
| [`b950b7ea`](https://github.com/NixOS/nixpkgs/commit/b950b7ea77ec5542a7f4daf1faea183b761bce43) | `` vimPlugins.codecompanion-nvim: 19.20.0 -> 19.21.0 ``                              |
| [`4860dfea`](https://github.com/NixOS/nixpkgs/commit/4860dfea21c1cdf2a02d3d190651fcc7da0b2582) | `` vimPlugins.copilot-lua: 3.0.0 -> 3.0.1 ``                                         |
| [`373ee5fb`](https://github.com/NixOS/nixpkgs/commit/373ee5fb766a3a827272542bb25503f6ff35011a) | `` vimPlugins.neotest-java: 0.38.0 -> 0.38.1 ``                                      |
| [`c45f4b28`](https://github.com/NixOS/nixpkgs/commit/c45f4b2834ce72c7712bfafe4f8b7bb6ea1da35b) | `` vimPlugins.obsidian-nvim: 3.16.5 -> 3.16.6 ``                                     |
| [`010f43c3`](https://github.com/NixOS/nixpkgs/commit/010f43c34998fd1064987527b39a5cb6662b56fc) | `` vimPlugins.project-nvim: 5.2.0-1 -> 5.3.0-1 ``                                    |
| [`7e39f00d`](https://github.com/NixOS/nixpkgs/commit/7e39f00deba7c979bc6f33c3684049227fc381d4) | `` vimPlugins.vim-fern: 1.59.0 -> 1.59.1 ``                                          |
| [`8ea1b629`](https://github.com/NixOS/nixpkgs/commit/8ea1b6298d807b291d85c7a344bf8d0d29a71b39) | `` vimPlugins: update on 2026-07-27 ``                                               |
| [`1b3c8764`](https://github.com/NixOS/nixpkgs/commit/1b3c876496cc4b0a447c09a1ec98aaf91a088fcf) | `` tlsanalyzer: 0.2.2 -> 0.3.0 ``                                                    |
| [`2f4b7493`](https://github.com/NixOS/nixpkgs/commit/2f4b749300069f31a932fce059bec86de6ce1981) | `` bitrise: 2.42.0 -> 2.42.1 ``                                                      |
| [`368b07ac`](https://github.com/NixOS/nixpkgs/commit/368b07acd8bef36483dcba4a091b72916b61add1) | `` pwninit: 3.3.2 -> 3.3.3 ``                                                        |
| [`606ab5f6`](https://github.com/NixOS/nixpkgs/commit/606ab5f623afdb3fd6d5490ced7f571deb2265e7) | `` warp-terminal: 0.2026.07.15.08.55.stable_01 -> 0.2026.07.22.09.01.stable_01 ``    |
| [`7b49b14c`](https://github.com/NixOS/nixpkgs/commit/7b49b14c94652a895d7e0524ef802e4416d963d6) | `` tsgolint: add anish as maintainer ``                                              |
| [`a2e0e6e9`](https://github.com/NixOS/nixpkgs/commit/a2e0e6e9f3837f83256003fca7908abb8f26c6c2) | `` tsgolint: enable structuredAttrs and strictDeps, add changelog ``                 |
| [`d8184fe3`](https://github.com/NixOS/nixpkgs/commit/d8184fe38f4a41e516e821f56985dfd35b50c735) | `` tsgolint: 0.25.0 -> 7.0.2001 ``                                                   |
| [`2b15e520`](https://github.com/NixOS/nixpkgs/commit/2b15e520fd4d7188740bc765be60eceb7b8d2160) | `` river{,-classic}: fix build on aarch64 ``                                         |
| [`3993a8ce`](https://github.com/NixOS/nixpkgs/commit/3993a8ce88d38567094737165a2d83d309c6a3b9) | `` kirimoto: 4.7.1 -> 4.7.2 ``                                                       |
| [`dbd30bed`](https://github.com/NixOS/nixpkgs/commit/dbd30bed42be9ae99243120193118ad82e22ad69) | `` ninjabrain-bot: fix mvnHash ``                                                    |
| [`d52c5d59`](https://github.com/NixOS/nixpkgs/commit/d52c5d59fc3a375caa205fc40f7febd085d6c20c) | `` xss-lock: fix version ``                                                          |
| [`1de59380`](https://github.com/NixOS/nixpkgs/commit/1de59380f9479e84f817c5f4ae3ca37fcfc47153) | `` rust/import-cargo-lock: avoid optionalAttrs, use head ``                          |
| [`36250059`](https://github.com/NixOS/nixpkgs/commit/36250059ace1b53ec87940bc17770dd057e6f10a) | `` rust/import-cargo-lock: only perform prefix checks once ``                        |
| [`ec85d085`](https://github.com/NixOS/nixpkgs/commit/ec85d08502046548ea0a2d41577f46e4609e1706) | `` rust/import-cargo-lock: move some logic to higher scope ``                        |
| [`befbd52e`](https://github.com/NixOS/nixpkgs/commit/befbd52e44d7220b15b1df7b7a6e5c046a88069b) | `` rust/import-cargo-lock: inherit functions ``                                      |
| [`7549d27f`](https://github.com/NixOS/nixpkgs/commit/7549d27f6a06890de810de7cb04ab2b0a2af779f) | `` evhz: fix version, license ``                                                     |
| [`61e98190`](https://github.com/NixOS/nixpkgs/commit/61e9819004b5ddae83b7bef534be62413db32b3b) | `` hexchat: drop ``                                                                  |
| [`f70d1772`](https://github.com/NixOS/nixpkgs/commit/f70d17722b4e620295674a73d4984956799e31e3) | `` buck2: add cbarrete as maintainer ``                                              |
| [`1f522173`](https://github.com/NixOS/nixpkgs/commit/1f522173978e087a56f7fab712be457489871da0) | `` libretro.desmume2015: 0-unstable-2026-04-20 -> 0-unstable-2026-07-26 ``           |
| [`68b2872a`](https://github.com/NixOS/nixpkgs/commit/68b2872a53dbe30e282aee822156226542d4c58d) | `` mailpit: 1.30.4 -> 1.30.5 ``                                                      |
| [`38e7c026`](https://github.com/NixOS/nixpkgs/commit/38e7c026c51af92942918396d6cdfcdcefeb0b72) | `` six-sines: 1.2.0 -> 1.2.1 ``                                                      |
| [`fcfbd0ac`](https://github.com/NixOS/nixpkgs/commit/fcfbd0acaf562643fd35a9d418d9f3316db5f4f5) | `` noctalia: 5.0.0-beta.5 -> 5.0.0-beta.6 ``                                         |
| [`79ea660f`](https://github.com/NixOS/nixpkgs/commit/79ea660f4d7b69f6db57cae40941d050b3fe9e15) | `` python3Packages.epaper-dithering: 5.0.9 -> 6.0.0 ``                               |
| [`72fa90da`](https://github.com/NixOS/nixpkgs/commit/72fa90da006b47e4ff86aece6d900acda4d50987) | `` jiratui: 1.10.1 -> 1.11.2 ``                                                      |
| [`7f5cae5b`](https://github.com/NixOS/nixpkgs/commit/7f5cae5b7dee30f66d4ccc83f962afaf13b773a0) | `` bootil: fix version ``                                                            |
| [`756d0afc`](https://github.com/NixOS/nixpkgs/commit/756d0afcf342085cfb456a8869488fd181366e87) | `` crackle: fix version ``                                                           |
| [`1530a930`](https://github.com/NixOS/nixpkgs/commit/1530a9306893c50a00e46089039d6f0d56f6fc80) | `` bioawk: fix version ``                                                            |
| [`2b48a332`](https://github.com/NixOS/nixpkgs/commit/2b48a332d2f3ab2e9bcf58765b3cf7ee2eab73f1) | `` squeezelite: 2.0.0.1577 -> 2.0.0.1584 ``                                          |
| [`b58ac64f`](https://github.com/NixOS/nixpkgs/commit/b58ac64f4211d2d3574e137d0f0fe0775ee95af8) | `` copyparty: 1.20.18 -> 1.20.19 ``                                                  |
| [`fd1addcb`](https://github.com/NixOS/nixpkgs/commit/fd1addcbcbbe4789e09ee0a65cb2e24edc0e54ba) | `` python3Packages.langchain-google-genai: 4.2.7 -> 4.3.2 ``                         |
| [`18199e5b`](https://github.com/NixOS/nixpkgs/commit/18199e5be48441850469538d584779ad3097c774) | `` kazumi: 2.2.0 -> 2.2.3 ``                                                         |
| [`4bdef5b5`](https://github.com/NixOS/nixpkgs/commit/4bdef5b5a667444626c244754cfebc4d07764c86) | `` terraform-providers.opentelekomcloud_opentelekomcloud: 1.37.1 -> 1.37.2 ``        |
| [`ced01af5`](https://github.com/NixOS/nixpkgs/commit/ced01af52d241a51f606a8f8fc4152c3a378fda5) | `` arcdps-log-manager: 1.16 -> 1.16.1 ``                                             |
| [`82e00784`](https://github.com/NixOS/nixpkgs/commit/82e0078428dbca9836a26cee9ed2aacfaea2bfcf) | `` hm: apply upstream patch for gcc 16 ``                                            |
| [`6955390e`](https://github.com/NixOS/nixpkgs/commit/6955390ec3804b4a66c3aab740d4225f1a67f139) | `` awakened-poe-trade: 3.28.103 -> 3.29.102 ``                                       |
| [`e7848c3a`](https://github.com/NixOS/nixpkgs/commit/e7848c3a30698ae775344e5f94cc7275963396c2) | `` musescore-evolution: 3.7.0-unstable-2026-06-30 -> 3.7.0-unstable-2026-07-25 ``    |
| [`d03b1bcf`](https://github.com/NixOS/nixpkgs/commit/d03b1bcfce27690636c9429fb2752699fafdb6f1) | `` fence: 0.1.62 -> 0.1.64 ``                                                        |
| [`95592cab`](https://github.com/NixOS/nixpkgs/commit/95592cab2e6ac2d1c59f0df04c01ccf69ff61580) | `` vivaldi: 8.1.4087.55 -> 8.1.4087.58 ``                                            |
| [`d62bbca2`](https://github.com/NixOS/nixpkgs/commit/d62bbca2c45125c2bbc84fb627336d544218b379) | `` blocky: 0.33.0 -> 0.34.0 ``                                                       |
| [`807bbbcc`](https://github.com/NixOS/nixpkgs/commit/807bbbcc6ef08b96121af0353952fb0e431e8b02) | `` cargo-readme: 3.3.3 -> 3.4.0 ``                                                   |
| [`dd699acc`](https://github.com/NixOS/nixpkgs/commit/dd699acc84c7e2b7c7429e0fcba6e193d9f314f1) | `` python3Packages.tencentcloud-sdk-python: 3.1.140 -> 3.1.142 ``                    |
| [`0370c38f`](https://github.com/NixOS/nixpkgs/commit/0370c38f06fdd683e7f20cb98191d976001ec100) | `` dblab: 0.46.0 -> 0.47.0 ``                                                        |
| [`bc94c4cd`](https://github.com/NixOS/nixpkgs/commit/bc94c4cd2d484b9c42b1efdb95ccb4d1a2b7fbf6) | `` python3Packages.simplepush: modernize ``                                          |
| [`384d0648`](https://github.com/NixOS/nixpkgs/commit/384d06481cec31869d2ce7b9641b000b4e324e40) | `` python313Packages.iamdata: 0.1.202607261 -> 0.1.202607271 ``                      |
| [`201776db`](https://github.com/NixOS/nixpkgs/commit/201776db8318b0f00022d0c7abcee42d379da629) | `` python313Packages.iamdata: 0.1.202607251 -> 0.1.202607261 ``                      |
| [`786e534e`](https://github.com/NixOS/nixpkgs/commit/786e534ea4785a1c7c507fdff22c80b2507b0226) | `` luaPackages.rocks-lazy-nvim: init at 1.2.1-1 ``                                   |
| [`b176ca2c`](https://github.com/NixOS/nixpkgs/commit/b176ca2c99e2bb867d5cd3f711e4b9c14bdb6066) | `` python3Packages.free-proxy: 1.2.1 -> 1.2.2 ``                                     |
| [`59cec748`](https://github.com/NixOS/nixpkgs/commit/59cec7483b2f79e066aa5ff6ed50ee080eed9de9) | `` matrix-continuwuity: 26.6.2 -> 26.7.1 ``                                          |
| [`4a5b1053`](https://github.com/NixOS/nixpkgs/commit/4a5b10531ccf5332ba22828f3818841392ef36ae) | `` gitea: 1.27.0 -> 1.27.1 ``                                                        |
| [`0d430d1d`](https://github.com/NixOS/nixpkgs/commit/0d430d1d1dbc50dfee9182b1bd6567c84a11d590) | `` napi-rs-cli_3: init at 3.7.4 ``                                                   |
| [`efa8264e`](https://github.com/NixOS/nixpkgs/commit/efa8264ee0bc05b552a9a4c60db8b5cc16fe3625) | `` Revert ".github: Bump actions/checkout from 6.0.3 to 7.0.1" ``                    |
| [`400b6766`](https://github.com/NixOS/nixpkgs/commit/400b6766ce0e099edc6a77ef73b16be01296b89f) | `` amp-cli: 0.0.1784391370-g49c6a1 -> 0.0.1785170481-ga5b614 ``                      |
| [`a306177e`](https://github.com/NixOS/nixpkgs/commit/a306177e0480bf94dc62dc9f22bb1719ea73709d) | `` seanime: 3.10.1 -> 3.10.2 ``                                                      |
| [`4c359c4d`](https://github.com/NixOS/nixpkgs/commit/4c359c4daf1314378d5d7a017a1552c84415ca00) | `` rustdesk-server: 1.1.14 -> 1.1.16 ``                                              |
| [`a7c960be`](https://github.com/NixOS/nixpkgs/commit/a7c960befc498e647156307158a82e102b0ed007) | `` maintainers: add kiryuulight ``                                                   |
| [`cdfcd741`](https://github.com/NixOS/nixpkgs/commit/cdfcd7416a9ef9bdc7cde4c9729c700586a81ce6) | `` maintainers/github-teams.json: Automated sync ``                                  |
| [`5b6feca1`](https://github.com/NixOS/nixpkgs/commit/5b6feca140f78923faffd2ac2a193b8a9b9d1f15) | `` python3Packages.tlds: 2026041800 -> 2026072401 ``                                 |
| [`48be4478`](https://github.com/NixOS/nixpkgs/commit/48be4478bb3a185848542d4bc12e1f34bf383f91) | `` oauth2l: 1.3.3 -> 1.3.4 ``                                                        |
| [`1fc04be7`](https://github.com/NixOS/nixpkgs/commit/1fc04be71949b010554725c318341a2ce4dd9e79) | `` nixos/doc: add release note for eval-config extraArgs/check removal ``            |
| [`294e09aa`](https://github.com/NixOS/nixpkgs/commit/294e09aafd0692c9107785006faedaab402920b9) | `` python3Packages.pypaperless: use finalAttrs ``                                    |
| [`47b4a22b`](https://github.com/NixOS/nixpkgs/commit/47b4a22b2c2a53e7ab213d9cc99f4b034978a681) | `` python3Packages.pypaperless: use pyprojectVersionPatchHook ``                     |
| [`57534980`](https://github.com/NixOS/nixpkgs/commit/575349808d7b308cbd721fdb665b7049e859f9c4) | `` python3Packages.pypaperless: 5.2.2 -> 5.2.3 ``                                    |
| [`f08dbb3f`](https://github.com/NixOS/nixpkgs/commit/f08dbb3fc7ccd5798885233d097473d956699ffa) | `` secretspec: 0.16.0 -> 0.17.0 ``                                                   |
| [`b5647858`](https://github.com/NixOS/nixpkgs/commit/b56478586a3a0e7448485ad66b0a67ddf8777abb) | `` mpfr: Update license to LGPLv3+ ``                                                |
| [`8c4bb4e3`](https://github.com/NixOS/nixpkgs/commit/8c4bb4e35cadb47f3499c977ee8e2ae7b6d250d3) | `` aquamarine: 0.13.0 -> 0.14.0 ``                                                   |
| [`5862773b`](https://github.com/NixOS/nixpkgs/commit/5862773b8febd0541da90ffb876a41163f314da9) | `` libmpc: Update license to LGPLv3+ ``                                              |
| [`e3b32431`](https://github.com/NixOS/nixpkgs/commit/e3b32431a13188840214d1e8960ca71dc41a3996) | `` hyprland: 0.56.0 -> 0.56.1 ``                                                     |
| [`5f633eec`](https://github.com/NixOS/nixpkgs/commit/5f633eec056e9100e2b0e04c3e488dc611699515) | `` python3Packages.modbus-connection: 3.8.1 -> 3.9.0 ``                              |
| [`2dd36e88`](https://github.com/NixOS/nixpkgs/commit/2dd36e88dea0c270266002ecfe4f6223e5f33a47) | `` python3Packages.tmodbus: 0.4.1 -> 0.5.0 ``                                        |
| [`997ee839`](https://github.com/NixOS/nixpkgs/commit/997ee8399931fbb8ff192484cdc30f83c7e95a94) | `` python3Packages.imap-tools: use finalAttrs ``                                     |
| [`ab20775a`](https://github.com/NixOS/nixpkgs/commit/ab20775a1732e4e88f4f5c475ee070224ae2c3b3) | `` nixos/netplan: init module ``                                                     |
| [`49a23147`](https://github.com/NixOS/nixpkgs/commit/49a231470045ec477e2da56952cc9c7acae6d84b) | `` python3Packages.imap-tools: 1.13.0 -> 1.14.0 ``                                   |
| [`c756c554`](https://github.com/NixOS/nixpkgs/commit/c756c55418098771b544613c69b06b8bac787a8b) | `` python3Packages.ahocorapy: 1.6.2 -> 1.8.0 ``                                      |
| [`89fcbf50`](https://github.com/NixOS/nixpkgs/commit/89fcbf50d1ac793afaceb371bc73351c057774a7) | `` unified-memory-framework: 1.1.0 -> 1.2.0 ``                                       |
| [`7095b5d8`](https://github.com/NixOS/nixpkgs/commit/7095b5d8883f31ad230244968b6c1c238fe8c08b) | `` libretro.snes9x2010: 0-unstable-2026-07-07 -> 0-unstable-2026-07-23 ``            |
| [`9f1f12c6`](https://github.com/NixOS/nixpkgs/commit/9f1f12c6024ef22710bebad3b88167c652021f83) | `` lint-staged: 17.1.0 -> 17.2.0 ``                                                  |
| [`7b584e09`](https://github.com/NixOS/nixpkgs/commit/7b584e09f4cee4f6645dabf648009e6b7f02efec) | `` terraform-providers.goharbor_harbor: 3.12.1 -> 3.12.3 ``                          |
| [`fd915fe8`](https://github.com/NixOS/nixpkgs/commit/fd915fe8e7026dd9746da1988e238ca54df08972) | `` lakectl: 1.83.0 -> 1.84.1 ``                                                      |
| [`99738ed1`](https://github.com/NixOS/nixpkgs/commit/99738ed17a9f6d8c2239a3457fc057a15d4717b3) | `` rtk: remove obsolete Rust 1.97 workaround ``                                      |
| [`026ec36b`](https://github.com/NixOS/nixpkgs/commit/026ec36b5a12369b3573425ace0c64f7d2fd5c31) | `` dotenvx: 2.14.0 -> 2.19.0 ``                                                      |
| [`de8d8629`](https://github.com/NixOS/nixpkgs/commit/de8d86294e10e91ed2978a216f667c39f908e6ca) | `` dbgate: 7.2.1 -> 7.2.3 ``                                                         |
| [`0357df36`](https://github.com/NixOS/nixpkgs/commit/0357df364cbf2a5a0366e63f6d802013afab8f16) | `` zettlr: 4.6.0 -> 4.7.0 ``                                                         |
| [`2b71fd4d`](https://github.com/NixOS/nixpkgs/commit/2b71fd4d31751a8697a76fdf242632812d797490) | `` tpm-luks: drop ``                                                                 |
| [`5d16de6f`](https://github.com/NixOS/nixpkgs/commit/5d16de6ff9bf8ea71d9e7ef3cd532f1f83facf50) | `` lm_sensors: fix homepage URL ``                                                   |
| [`fb44a145`](https://github.com/NixOS/nixpkgs/commit/fb44a14549664658bc53b25be0f4a73d7689a573) | `` xdg-desktop-portal: remove unused input ``                                        |
| [`37eb1c2b`](https://github.com/NixOS/nixpkgs/commit/37eb1c2b19c8b4584621e88dec351721144d68a6) | `` aliases: Drop indiscrete package name alias ``                                    |
| [`bd95bbd2`](https://github.com/NixOS/nixpkgs/commit/bd95bbd289557ae0f0655cf1f2fa6b031e69a41e) | `` arkade: 0.11.113 -> 0.11.114 ``                                                   |
| [`1a52a662`](https://github.com/NixOS/nixpkgs/commit/1a52a66216b16990fd0bc3b7ef6872a71ebfc93b) | `` vscode-extensions.hashicorp.terraform: 2.39.3 -> 2.40.0 ``                        |
| [`ebee878c`](https://github.com/NixOS/nixpkgs/commit/ebee878c1701ccb1b01377ddc02614437f3c8e97) | `` forgejo-runner: 12.13.1 -> 12.13.2 ``                                             |
| [`f6484a62`](https://github.com/NixOS/nixpkgs/commit/f6484a62ca8ca51995018a188069d27e9346e6e2) | `` python3Packages.datadog: 0.52.2 -> 0.53.0 ``                                      |
| [`29d57cd9`](https://github.com/NixOS/nixpkgs/commit/29d57cd97539701d5323ded17fbe4e66e6716be4) | `` beamPackages.expert: 0.1.7 -> 0.1.8 ``                                            |
| [`f17fc509`](https://github.com/NixOS/nixpkgs/commit/f17fc50979d2c567edfbab97bfe5ef150e2645a9) | `` radicle-desktop: 0.13.0 -> 0.14.0 ``                                              |
| [`aae7a0da`](https://github.com/NixOS/nixpkgs/commit/aae7a0da4b0c94e4a42b2fe059cb4257a91982e9) | `` beam29Packages.erlang: 29.0.3 -> 29.0.4 ``                                        |
| [`38ea49bc`](https://github.com/NixOS/nixpkgs/commit/38ea49bce7cb67e4b635434dadb6bb032b84340e) | `` beam28Packages.erlang: 28.5.0.3 -> 28.5.0.4 ``                                    |
| [`48084203`](https://github.com/NixOS/nixpkgs/commit/480842033af36a3b473ec0c7f7aaaf83b8185966) | `` beam27Packages.erlang: 27.3.4.14 -> 27.3.4.15 ``                                  |
| [`85ba3905`](https://github.com/NixOS/nixpkgs/commit/85ba3905f12510aa4304ed2ab3dbb8e10fe13e39) | `` smux: 0.4.0 -> 0.6.0 ``                                                           |
| [`17ba9755`](https://github.com/NixOS/nixpkgs/commit/17ba975583d0169458b65540a88b84694412df7f) | `` remnote: 1.26.32 -> 1.27.10 ``                                                    |
| [`20b7093f`](https://github.com/NixOS/nixpkgs/commit/20b7093f1905eda9ce4d377ff53d53d0da158b2b) | `` python3.pkgs.ariadne: fix build ``                                                |
| [`bba65967`](https://github.com/NixOS/nixpkgs/commit/bba6596763820b2ec4edfefd4721ad586fc3af9d) | `` team-list: Leave minimal-bootstrap team ``                                        |
| [`182227e7`](https://github.com/NixOS/nixpkgs/commit/182227e72af03365b0fdb4ef61b3c5d90e18ddec) | `` speedtest-tracker: 1.14.1 -> 1.14.6 ``                                            |
| [`25bffce9`](https://github.com/NixOS/nixpkgs/commit/25bffce9dfb7ad8e33f6b805296d890bb337f05c) | `` openbangla-keyboard: fix build caused by cmake update ``                          |
| [`14309db6`](https://github.com/NixOS/nixpkgs/commit/14309db66a6de22c1b323cfcbd903c9337935699) | `` rime-wanxiang: 16.0.1 -> 16.3.2 ``                                                |
| [`1edff5e3`](https://github.com/NixOS/nixpkgs/commit/1edff5e3ecf1cafc2af712245ef75d0c903d3d1d) | `` nixos/virtualbox-guest: Prefix udev rules with number < 72 for uaccess to work `` |
| [`5c984472`](https://github.com/NixOS/nixpkgs/commit/5c98447233cc77c56d455500faf2466a16bfef85) | `` open-webui: 0.10.2 -> 0.11.0 ``                                                   |
| [`36bc4bd9`](https://github.com/NixOS/nixpkgs/commit/36bc4bd99036a53618de43ce709dce54e1aa35ab) | `` python3Packages.pygame-gui: fix METADATA version ``                               |
| [`6738ac14`](https://github.com/NixOS/nixpkgs/commit/6738ac143c891f6d7e745bae489d7e783a18fdd8) | `` aver: 0.27.0 -> 0.27.1 ``                                                         |
| [`b4bbfb5d`](https://github.com/NixOS/nixpkgs/commit/b4bbfb5da330b415fd4c8ee90b875a4a5c64638e) | `` mullvad: run all tests and add meta.platforms attribute ``                        |
| [`92c6c48d`](https://github.com/NixOS/nixpkgs/commit/92c6c48d4a9c9cd4ec2b273508bf166c49d9c731) | `` nixos/release-notes: add entry regarding the mullvad GUI migration ``             |
| [`97daa666`](https://github.com/NixOS/nixpkgs/commit/97daa666b6321469ed710ac4aceb163d4838c7dd) | `` python3Packages.python3-otr: modernize ``                                         |
| [`383949df`](https://github.com/NixOS/nixpkgs/commit/383949df645889612b98afc3c8be3d3de85cefed) | `` python3Packages.python3-otr: rename from otr, fix build ``                        |
| [`04de5c10`](https://github.com/NixOS/nixpkgs/commit/04de5c10bb3570f01d0831db3ab957d0250d65d4) | `` nixos/mullvad-vpn: split daemon package from GUI package, refactor ``             |
| [`1f580ada`](https://github.com/NixOS/nixpkgs/commit/1f580ada731a4a555054ca2e6fc88c198762fd71) | `` osm2pgsql: pyosmium to osmium ``                                                  |
| [`6a206118`](https://github.com/NixOS/nixpkgs/commit/6a2061189846da4adc381c5383173732db2785dd) | `` python3Packages.pyosmium: update pname to match python metadata ``                |
| [`94ce9494`](https://github.com/NixOS/nixpkgs/commit/94ce9494ea84ed81bb57c93cfe817e49cc429b08) | `` python3Packages.nominatim-api: fix pname to match python metadata ``              |
| [`f111cdf6`](https://github.com/NixOS/nixpkgs/commit/f111cdf65648ddc434c284b04220cd3a6da5fb82) | `` dashy-ui: 4.4.5 -> 4.5.1 ``                                                       |
| [`bf925919`](https://github.com/NixOS/nixpkgs/commit/bf925919c34bca1b466ad177b30dd569d6f049c0) | `` mastodon: 4.6.3 -> 4.6.4 ``                                                       |
| [`ea586dcf`](https://github.com/NixOS/nixpkgs/commit/ea586dcf6c9ad3a9537cd7883f8bcd3b25a6594c) | `` go-httpbin: 2.24.0 -> 2.25.0 ``                                                   |
| [`ec0be03c`](https://github.com/NixOS/nixpkgs/commit/ec0be03ce09df8cb9d5485b42454642d383c5440) | `` python3Packages.langchain-anthropic: 1.4.8 -> 1.5.2 ``                            |
| [`ae065a2d`](https://github.com/NixOS/nixpkgs/commit/ae065a2d83537d2039259547bc4dadd3d0d26db1) | `` llama-swap: define cache directories ``                                           |
| [`aaa0369f`](https://github.com/NixOS/nixpkgs/commit/aaa0369f9b7cd10605cac3bf743ae85776036674) | `` vacuum-go: 0.29.10 -> 0.30.0 ``                                                   |
| [`a0925d5e`](https://github.com/NixOS/nixpkgs/commit/a0925d5efc832ed49dbd5a11a88f6a2104c274be) | `` python3Packages.subliminal: 2.6.0 -> 2.7.1 ``                                     |
| [`294de738`](https://github.com/NixOS/nixpkgs/commit/294de7382cb33eb4fb3985b50e9df6817d2525e0) | `` python3Packages.parselmouth: fix pname ``                                         |
| [`22644f46`](https://github.com/NixOS/nixpkgs/commit/22644f4626174c3053be9067b0f2bbb3b6a4f570) | `` python3Packages.osmapi: 5.0.0 -> 6.0.0 ``                                         |
| [`15fea9b3`](https://github.com/NixOS/nixpkgs/commit/15fea9b3bde642cd12653d4f17414a00b702eb11) | `` postgresqlPackages.pg_topn: 2.7.0 -> 2.7.1 ``                                     |
| [`df04ba27`](https://github.com/NixOS/nixpkgs/commit/df04ba27983bc333547ca1c2e6bf2c47c8c1970e) | `` libretro.gpsp: 0-unstable-2026-06-29 -> 0-unstable-2026-07-21 ``                  |
| [`d15727cb`](https://github.com/NixOS/nixpkgs/commit/d15727cb7f15bb21edc72cb64e87444b0baab323) | `` python3.pkgs.pyscf: 2.13.1 -> 2.14.0 ``                                           |
| [`a5c05336`](https://github.com/NixOS/nixpkgs/commit/a5c05336b7a6eb4a04fcae240d534c4c6ee1aa9e) | `` linux_testing: 7.2-rc4 -> 7.2-rc5 ``                                              |
| [`6a8acfbb`](https://github.com/NixOS/nixpkgs/commit/6a8acfbba61e425a16f8ab3decf27ab1337020ca) | `` lsr: modernize ``                                                                 |
| [`33a51a62`](https://github.com/NixOS/nixpkgs/commit/33a51a626dfca1d5ad9638a22f89f17143b0cf2e) | `` python3Packages.opaque: fix version in python metadata ``                         |
| [`0d020ea8`](https://github.com/NixOS/nixpkgs/commit/0d020ea817163f3dffd68999c908a360b29477c3) | `` python3Packages.aioghost: 0.4.19 -> 0.4.21 ``                                     |
| [`948e8934`](https://github.com/NixOS/nixpkgs/commit/948e8934a5a3b2e2999b23cab785b250ba8582e3) | `` zig-zlint: modernize ``                                                           |
| [`b1578675`](https://github.com/NixOS/nixpkgs/commit/b1578675c29929812716b4cbb644f5b72f5c644d) | `` python3Packages.ruff-format: fix build ``                                         |
| [`497610d3`](https://github.com/NixOS/nixpkgs/commit/497610d399822a7bac68c99a9a9e58e671047674) | `` komari-agent: 1.2.13 -> 1.2.60 ``                                                 |
| [`254e86ea`](https://github.com/NixOS/nixpkgs/commit/254e86ead9f5fd6090adab80ea81999e2fb0ae49) | `` python3Packages.cachier: fix build ``                                             |
| [`22d8e58b`](https://github.com/NixOS/nixpkgs/commit/22d8e58b59a4787311ccf18696db05e2b7073c0d) | `` kodiPackages.arteplussept: 1.5.2 -> 1.5.3 ``                                      |
| [`9158b77c`](https://github.com/NixOS/nixpkgs/commit/9158b77c128d45e230aa7735e1b9971e723702e6) | `` libretro.mame2003-plus: 0-unstable-2026-06-11 -> 0-unstable-2026-07-19 ``         |
| [`c5728b82`](https://github.com/NixOS/nixpkgs/commit/c5728b82cf210517e374077cc85023cc6ede677f) | `` pangolin-cli: 0.14.0 -> 0.15.0 ``                                                 |
| [`cd45f95d`](https://github.com/NixOS/nixpkgs/commit/cd45f95d9132bca7d40897123b5fb08f3f530b3b) | `` terraform-providers.hashicorp_awscc: 1.93.0 -> 1.94.0 ``                          |
| [`4df53647`](https://github.com/NixOS/nixpkgs/commit/4df53647ad0c81c51d5d8ed6575861c69814c30f) | `` python3Packages.altcha: 2.0.2 -> 2.1.0 ``                                         |
| [`0ac37982`](https://github.com/NixOS/nixpkgs/commit/0ac3798258d730398b28114d582d73f62605b764) | `` cursor-cli: 0-unstable-2026-07-16 -> 0-unstable-2026-07-23 ``                     |
| [`b91e2ad7`](https://github.com/NixOS/nixpkgs/commit/b91e2ad78a8da554581d0800a75caeec04b186b2) | `` vscode-extensions.vue.volar: 3.3.7 -> 3.3.8 ``                                    |
| [`c50d6933`](https://github.com/NixOS/nixpkgs/commit/c50d69337fd61a5133bf476e97dbf5d62be7b75a) | `` matrix-alertmanager-receiver: 2026.7.15 -> 2026.7.22 ``                           |
| [`eb3a47e9`](https://github.com/NixOS/nixpkgs/commit/eb3a47e93129c601a885a8eb2f4327230e1fc262) | `` croc: 10.4.13 -> 10.6.0 ``                                                        |
| [`38208de5`](https://github.com/NixOS/nixpkgs/commit/38208de5328004554216e2751d9fb0df479f591e) | `` gallery-dl: 1.32.6 -> 1.32.8 ``                                                   |
| [`097adc1c`](https://github.com/NixOS/nixpkgs/commit/097adc1cd2c1d5694f18027ee89d852a88c960fa) | `` nixos/xen: fix finalSection detection when using a debug build ``                 |
| [`abd2f0bb`](https://github.com/NixOS/nixpkgs/commit/abd2f0bb8fbc4d14bab3d26b864a1159d7a4de18) | `` talosctl: 1.13.5 -> 1.13.7 ``                                                     |
| [`6f6e68bb`](https://github.com/NixOS/nixpkgs/commit/6f6e68bb5eec906b205cb047dff87f2dcc95f5ea) | `` androidStudioPackages.beta: 2026.1.3.5 -> 2026.1.3.6 ``                           |
| [`0c8fc6b6`](https://github.com/NixOS/nixpkgs/commit/0c8fc6b6827dffa2d8c4a387f77dc93516dccb44) | `` python3Packages.confuse: 2.2.0 -> 2.2.1 ``                                        |
| [`609bc044`](https://github.com/NixOS/nixpkgs/commit/609bc044979e1016a8ad6af4b649857be69284b9) | `` kicadAddons.kikit: fix build ``                                                   |
| [`524e1c6d`](https://github.com/NixOS/nixpkgs/commit/524e1c6d4c29acd5387030a89353eae3b8d61c9b) | `` air: 1.66.0 -> 1.67.3 ``                                                          |
| [`13bee6d6`](https://github.com/NixOS/nixpkgs/commit/13bee6d6ed6cfe666b4aabecddf551f6205a2883) | `` python3Packages.quickjs: fix build/test for quickjs 2026-06-04 ``                 |
| [`f297ba4a`](https://github.com/NixOS/nixpkgs/commit/f297ba4ac79735f4c5b46769335541a6f93b8588) | `` python3Packages.types-six: 1.17.0.20260518 -> 1.17.0.20260724 ``                  |
| [`13f91e3f`](https://github.com/NixOS/nixpkgs/commit/13f91e3f0391b5923d804b491cb2ca6916cfcd39) | `` technitium-dns-server: 15.3.0 -> 15.4.0 ``                                        |
| [`ba38f3ab`](https://github.com/NixOS/nixpkgs/commit/ba38f3abdc669a1a4709d6f6c194c9dfaaf065ea) | `` python3Packages.textual-slider: 91e64baf -> 0.2.0 ``                              |
| [`a0280ca3`](https://github.com/NixOS/nixpkgs/commit/a0280ca31d2458142f1b0f8f7afd0aff96879472) | `` winboat: remove maintainer ppom ``                                                |
| [`97b47b06`](https://github.com/NixOS/nixpkgs/commit/97b47b06532c50e25f897208667ef95a8b56ba45) | `` kubexporter: 0.8.8 -> 0.9.0 ``                                                    |
| [`f90da5fe`](https://github.com/NixOS/nixpkgs/commit/f90da5fe566450084e3aa40ab57297143c1936d9) | `` oxker: 0.13.2 -> 0.13.3 ``                                                        |
| [`5846e68f`](https://github.com/NixOS/nixpkgs/commit/5846e68f5defcc8b5be888b162bb594a04d57a54) | `` netassert: 2.1.4 -> 2.1.5 ``                                                      |
| [`0e7a2df1`](https://github.com/NixOS/nixpkgs/commit/0e7a2df1cd5d55bc28ab263309f208cd48400021) | `` vermouth: init at 1.9.7 ``                                                        |
| [`ae3e58cf`](https://github.com/NixOS/nixpkgs/commit/ae3e58cf0fda58252f13a4fff970738dbe760ab1) | `` v2rayn: 7.24.1 -> 7.24.3 ``                                                       |
| [`4b366219`](https://github.com/NixOS/nixpkgs/commit/4b366219c1b8bd56bfe669cd30656b43f7774be0) | `` ffmpeg-headless: Disable LLVM CUDA on powerpc64-linux ``                          |
| [`f5f460d3`](https://github.com/NixOS/nixpkgs/commit/f5f460d322ae04a1f44a79c1a7653854d726f29e) | `` tektoncd-cli: 0.45.0 -> 0.45.1 ``                                                 |
| [`b7d1f215`](https://github.com/NixOS/nixpkgs/commit/b7d1f215aa11aa86706fd698addb3e0125ca7469) | `` go-jsonschema: 0.23.1 -> 0.24.0 ``                                                |
| [`d9d2b220`](https://github.com/NixOS/nixpkgs/commit/d9d2b220bb435e8d08503c81a7a7d85c48f202be) | `` terraform-providers.digitalocean_digitalocean: 2.95.0 -> 2.96.0 ``                |
| [`c90dc07a`](https://github.com/NixOS/nixpkgs/commit/c90dc07a1c3edfe31db0fd8e9ede7605660c1053) | `` gcx: 0.5.0 -> 0.6.0 ``                                                            |
| [`0abec1a6`](https://github.com/NixOS/nixpkgs/commit/0abec1a68ae50a53e12cd859fa0226c0211d800f) | `` dms-shell: 1.5.2 -> 1.5.3 ``                                                      |
| [`7ff2de66`](https://github.com/NixOS/nixpkgs/commit/7ff2de66be671caa3d8d38087cb33ed911ba3562) | `` tectonic-unwrapped: 0.16.9 -> 0.17.0 ``                                           |
| [`894d1ab4`](https://github.com/NixOS/nixpkgs/commit/894d1ab4f0f5caaaaf88ab2e999176990f6f42a9) | `` anubis: 1.26.0 -> 1.26.2 ``                                                       |
| [`7cbc5433`](https://github.com/NixOS/nixpkgs/commit/7cbc54331e9cfaf2dccd43feca6c0dda4623b1a0) | `` neowall: 0.5.2 -> 0.5.3 ``                                                        |
| [`dfd8844b`](https://github.com/NixOS/nixpkgs/commit/dfd8844b8e73f86c8ed65dbcd9ed8c79b3c332f8) | `` luaPackages.tree-sitter-kulala_http: 0.3.0-1 -> 0.3.1-1 ``                        |
| [`77eca693`](https://github.com/NixOS/nixpkgs/commit/77eca6938e3024c5bbee04ee695003ab73858e74) | `` luaPackages.std-normalize: 2.0.3-1 -> 2.0.4-1 ``                                  |
| [`59951e82`](https://github.com/NixOS/nixpkgs/commit/59951e829cdbc9b8f96cf8b251280de79627caea) | `` luaPackages.std-_debug: 1.0.1-1 -> 1.1.0-1 ``                                     |
| [`6ec49b59`](https://github.com/NixOS/nixpkgs/commit/6ec49b5984848aa88db111c66e6185eb8fe91e85) | `` luaPackages.neotest: 5.19.2-1 -> 5.20.0-1 ``                                      |

*... and 341 more commits (truncated)*