### PR TITLE
Revert niri libdisplay-info-0.3.0 workaround (superseded by nixpkgs#546004)

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -188,22 +188,6 @@
       "workaround": "features/desktop/print/default.nix -- `system-config-printer-iconfix` overrides system-config-printer's .desktop `Icon=printer` to an absolute path pointing at the package's own bundled `i-network-printer.png`, bypassing icon-theme-name resolution entirely (see FIXME(vicinae-468-printer-icon)).",
       "revert_action": "No upstream PR/issue exists yet for this specific \"printer\" name bug (only the linked discussion, where multiple reporters hit the identical symptom, unresolved as of Oct 2025) so `min_version` stays null (BLOCKED) until one is filed and a fix version is known. Once vicinae ships a fix and our pinned nixpkgs' `vicinae` package version reflects it, set `min_version` accordingly (or `done: true` after manually confirming `Icon=printer` renders correctly in vicinae), then delete `system-config-printer-iconfix` and its FIXME from features/desktop/print/default.nix, reverting to a plain `programs.system-config-printer.enable = true;`.",
       "$comment": "No upstream_pr recorded yet -- if one is opened for this specific bug, add its number here so the checker nudges once merged."
-    },
-    {
-      "id": "niri-libdisplay-info-0-4",
-      "done": false,
-      "summary": "niri (built by niri-flake's `make-niri` against our own ambient `pkgs`, not a pin of its own) fails to build once our nixpkgs pin carries `libdisplay-info` 0.4.0: niri's Rust crate dependency (Smithay/libdisplay-info-rs) still pins `libdisplay-info = \"0.3.0\"` and its build.rs enforces `libdisplay-info < 0.4.0` via pkg-config. nixpkgs hit the identical wall with its own `niri` package (NixOS/nixpkgs#545976) and worked around it with a new generic `libdisplay-info_0_3` package (NixOS/nixpkgs#546004), but that fix never reaches us since niri-flake doesn't use nixpkgs' `niri` derivation.",
-      "repo": "Smithay/libdisplay-info-rs",
-      "check": "release-contains-commit",
-      "fix_commit": "3911e0344bb2db5839f2c646d25e8c2a8b5223d9",
-      "tracking": [
-        "https://github.com/NixOS/nixpkgs/issues/545976",
-        "https://github.com/NixOS/nixpkgs/pull/546004",
-        "https://github.com/Smithay/libdisplay-info-rs/pull/20"
-      ],
-      "workaround": "features/desktop/environments/niri/default.nix -- `programs.niri.package` override that reconstructs the default package (`options.programs.niri.package.default`) with its `libdisplay-info` build input overridden back to 0.3.0 via `fetchFromGitLab` (see FIXME(niri-libdisplay-info-0-4)).",
-      "revert_action": "This is a 3-hop upstream chain: (1) Smithay/libdisplay-info-rs PR #20 (tracked here, adds 0.4.0 support) merges and ships in a release -- this is what `release-contains-commit` actually detects; (2) niri-wm/niri then needs to bump its own `libdisplay-info` Cargo dependency past \"0.3.0\" to pick that release up; (3) niri-flake (epireyn's fork, our `niri` input) needs to bump its `niri-stable`/`niri-unstable` source pin to a niri release/commit that contains that bump. When this entry resolves, DO NOT immediately delete the workaround -- first check niri-wm/niri's Cargo.toml (or run `nix eval .#nixosConfigurations.maranello.config.programs.niri.package.buildInputs` after bumping the `niri` flake input) to confirm libdisplay-info's upper bound has actually moved past 0.4.0 before removing the `package` override and its FIXME from features/desktop/environments/niri/default.nix, then set `done: true`.",
-      "$comment": "release-contains-commit is checked against Smithay/libdisplay-info-rs's own releases (hop 1 only); hops 2-3 require a manual follow-up check as described in revert_action before it's actually safe to delete the workaround."
     }
   ]
 }

--- a/features/desktop/environments/niri/default.nix
+++ b/features/desktop/environments/niri/default.nix
@@ -2,7 +2,6 @@
   lib,
   pkgs,
   config,
-  options,
   user,
   extraUsers ? [ ],
   ...
@@ -20,50 +19,6 @@ in
 
     programs.niri = {
       enable = true;
-
-      # FIXME(niri-libdisplay-info-0-4): WORKAROUND, not a fix.
-      #
-      # niri.nixosModules.niri (from niri-flake) defaults `programs.niri.package`
-      # to a fresh build against *our own* ambient `pkgs` (see niri-flake's
-      # `make-package-set pkgs` / `make-niri`'s `libdisplay-info` arg) rather
-      # than a pin of its own. Once our nixpkgs pin carries `libdisplay-info`
-      # 0.4.0, every niri build fails:
-      #
-      #   pkg-config exited with status code 1
-      #   Requested 'libdisplay-info < 0.4.0' but version of libdisplay-info is 0.4.0
-      #
-      # because niri (niri-wm/niri) still pins its `libdisplay-info` Rust
-      # crate (Smithay/libdisplay-info-rs) to "0.3.0", whose build.rs
-      # enforces that upper bound via pkg-config.
-      #
-      # nixpkgs hit the identical wall with its own `niri` package and
-      # worked around it by pinning to a new generic `libdisplay-info_0_3`
-      # package (NixOS/nixpkgs#546004, closes
-      # https://github.com/NixOS/nixpkgs/issues/545976). That fix doesn't
-      # reach us because niri-flake's builder never touches nixpkgs' `niri`
-      # derivation -- it builds niri itself from niri-wm/niri sources against
-      # whatever `libdisplay-info` our own `pkgs` provides.
-      #
-      # Work around it the same way nixpkgs did: override *just* niri's
-      # `libdisplay-info` build input back to 0.3.0. Scoped to niri's package
-      # override only (via `options...default.override`) -- does not touch
-      # the system-wide `pkgs.libdisplay-info` used by anything else.
-      #
-      # Revert: once niri (niri-wm/niri) or Smithay/libdisplay-info-rs bumps
-      # to support libdisplay-info >= 0.4, delete this `package` override
-      # and the FIXME. See .github/workflows/track-upstream-fixes.yaml.
-      package = options.programs.niri.package.default.override {
-        libdisplay-info = pkgs.libdisplay-info.overrideAttrs (finalAttrs: {
-          version = "0.3.0";
-          src = pkgs.fetchFromGitLab {
-            domain = "gitlab.freedesktop.org";
-            owner = "emersion";
-            repo = "libdisplay-info";
-            rev = finalAttrs.version;
-            hash = "sha256-nXf2KGovNKvcchlHlzKBkAOeySMJXgxMpbi5z9gLrdc=";
-          };
-        });
-      };
     };
     programs.xwayland.enable = true;
 


### PR DESCRIPTION
## Summary

Reverts commit 6f84408e (`fix(niri): pin libdisplay-info to 0.3.0 to unbreak niri build`).

That workaround is now obsolete **and actively broken**:

- nixpkgs merged `NixOS/nixpkgs#546004` on 2026-07-26, adding a `libdisplay-info_0_3` package. Our nixpkgs pin has since advanced past that commit (`624af665` -> `0954f7ee` via #2105, merged 2026-07-30).
- niri-flake's own `make-niri` (as of commit `2a55039d`, the version bumped in #2101) now takes a `libdisplay-info_0_3 ? libdisplay-info` build input and asserts `libdisplay-info_0_3.version == "0.3.0"`. With our current nixpkgs pin, that resolves natively -- no override needed.
- Worse, our workaround's `options.programs.niri.package.default.override { libdisplay-info = ...; }` pattern breaks unconditionally under niri-flake's new code: reaching `.default`'s `.override` attribute forces the *unmodified* default package first, which throws its own failing assert (on a nixpkgs pin lacking `libdisplay-info_0_3`) before our override args are ever merged in. This is what's failing CI on #2101 -- the PR's CI ran against a merge-base that predated our own nixpkgs bump.

## Root cause of #2101's CI failure

Not a real regression -- a stale merge-base race. #2101 (niri bump to `2a55039d`) and #2105 (nixpkgs bump to `0954f7ee`, which happens to include the nixpkgs-side fix) merged within the same minute, and #2101's CI evaluated against a merge-base that didn't yet include #2105.

## Verification

- Reproduced the exact CI failure (`error: string '"0.4.0"' is not equal to string '"0.3.0"'`) locally in a worktree of the `update-niri` branch (unmodified).
- Confirmed nixpkgs `0954f7ee` (current `main`'s pin) already provides `libdisplay-info_0_3` = 0.3.0.
- Merged `main` into `update-niri` and confirmed `nix build .#nixosConfigurations.maranello.config.system.build.toplevel` succeeds with **no package override at all** -- niri links against `libdisplay-info-0.3.0` natively (`nix path-info` shows `niri-26.04`; `buildInputs` includes `libdisplay-info-0.3.0`).
- `nix eval` of both `Daytona` and `maranello` toplevels pass on this revert branch against current `main`.

Once this merges, #2101 (or any re-run of its CI against a fresh merge-base) should build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Niri desktop environment integration to use its standard display information dependency.
  * Removed an obsolete compatibility workaround and associated release tracking.

* **Refactor**
  * Simplified Niri configuration while preserving the existing enablement option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->