### PR TITLE
chore(flake/nixvim): `acd69cc1` -> `a19efae6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1186,11 +1186,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1785364321,
-        "narHash": "sha256-BLuHl+nZKb+FDq3GAM6L+UBEiyVepXANA31fT1F56pw=",
+        "lastModified": 1785527278,
+        "narHash": "sha256-rYFSM491MFFA1V6oax5PngXbevGt6n0o8sKhwFoItE0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "acd69cc15d57004e8cb4495034320263a3d362ea",
+        "rev": "a19efae6c1afe426e8243d79f6dfbab186be6df8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`a19efae6`](https://github.com/nix-community/nixvim/commit/a19efae6c1afe426e8243d79f6dfbab186be6df8) | `` nixbot: build stable branches on push `` |