### PR TITLE
chore(flake/home-manager): `e705714e` -> `bf9ce9fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -715,11 +715,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785306346,
-        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`bf9ce9fe`](https://github.com/nix-community/home-manager/commit/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe) | `` chromium: add support for brave-origin ``                         |
| [`47a42757`](https://github.com/nix-community/home-manager/commit/47a4275796d486fece3dfa7b55c31c723afb5386) | `` docs: fix link to allowed-users documentation ``                  |
| [`02711ea9`](https://github.com/nix-community/home-manager/commit/02711ea959a70e031c52e1e44b4b25d2c72de32f) | `` nixbot: migrate buildbot-nix config to nixbot ``                  |
| [`e8827fbb`](https://github.com/nix-community/home-manager/commit/e8827fbbb12015a8dd9f66285aec79d655bcb9f6) | `` Translate using Weblate (Hungarian) ``                            |
| [`2e671597`](https://github.com/nix-community/home-manager/commit/2e6715977106c498355a70bcefd2c78a33c94558) | `` mise: allow mutable global configuration ``                       |
| [`6d25edfb`](https://github.com/nix-community/home-manager/commit/6d25edfbd109bd6c0bb950a2fb6c37141795e3f1) | `` hyprland: fix session cleanup with systemd (hyprlang) ``          |
| [`277f1299`](https://github.com/nix-community/home-manager/commit/277f129993e89e78805fb7881a27896a52445e50) | `` hyprland: fix session cleanup with systemd integration enabled `` |
| [`ca287c20`](https://github.com/nix-community/home-manager/commit/ca287c205447e1671c52c2400b262e735e5657ca) | `` buildbot-nix: build release branches ``                           |