### PR TITLE
chore(flake/nixpkgs-stable): `21ea275a` -> `5b4f72e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -960,11 +960,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1785386831,
-        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
+        "lastModified": 1785491804,
+        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
+        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`9b27d4a2`](https://github.com/NixOS/nixpkgs/commit/9b27d4a2cb63191e2f4802336d8080c54127a337) | `` linux_xanmod: 6.18.40 -> 6.18.41 ``                                        |
| [`21253c10`](https://github.com/NixOS/nixpkgs/commit/21253c10a51396a16ab4b84a297ee350ed43c668) | `` gh: 2.96.0 -> 2.97.0 ``                                                    |
| [`98b662b7`](https://github.com/NixOS/nixpkgs/commit/98b662b742878ca4752be8b9f5cba325d339fcae) | `` maintainers: add staticdev to nextcloud team ``                            |
| [`d6dcea34`](https://github.com/NixOS/nixpkgs/commit/d6dcea34aca364026f6b2ef5a82686b9d863f604) | `` nextcloudPackages: update ``                                               |
| [`07da2218`](https://github.com/NixOS/nixpkgs/commit/07da221878233c1fec6047017086d384ca294cf2) | `` nezha-agent: 2.2.3 -> 2.3.0 ``                                             |
| [`d9820197`](https://github.com/NixOS/nixpkgs/commit/d9820197acc4775670f5a0c123735ff67e244171) | `` gotestdox: 0.2.2 -> 0.2.3 ``                                               |
| [`bf6dfd56`](https://github.com/NixOS/nixpkgs/commit/bf6dfd5687415b776841049aedc511f7725f1a5a) | `` easycrypt: 2026.06 → 2026.07 ``                                            |
| [`c1261d7c`](https://github.com/NixOS/nixpkgs/commit/c1261d7cf457ee9a07991ff13accd4a26d5fcef8) | `` minizinc: 2.9.7 → 2.10.0 ``                                                |
| [`918a7499`](https://github.com/NixOS/nixpkgs/commit/918a74995eea5c6377774044b1724e254ad68582) | `` incus-lts: apply security fixes ``                                         |
| [`2e292df0`](https://github.com/NixOS/nixpkgs/commit/2e292df054b5b3fe9c76e37603fac2061bc3775e) | `` incus: 7.2.0 -> 7.3.0 ``                                                   |
| [`a87a4cd2`](https://github.com/NixOS/nixpkgs/commit/a87a4cd276d019ba8d60f4439ffddd6ad74f41a5) | `` ejabberd: 26.04 -> 26.07 ``                                                |
| [`a9e629d7`](https://github.com/NixOS/nixpkgs/commit/a9e629d7be3f64b41c97da60f97a8801760b26e0) | `` forgejo: 16.0.1 -> 16.0.2 ``                                               |
| [`6fd71a88`](https://github.com/NixOS/nixpkgs/commit/6fd71a882a860c54c627b4debd1b56615985d118) | `` forgejo-lts: 15.0.5 -> 15.0.6 ``                                           |
| [`b99daae8`](https://github.com/NixOS/nixpkgs/commit/b99daae83a5cfa6a51aedae5bacacf561695392e) | `` python3Packages.pydantic-ai-slim: 1.107.0 -> 1.107.1 ``                    |
| [`035ba66b`](https://github.com/NixOS/nixpkgs/commit/035ba66bbf6002271d0a3885400b03c0c62561d6) | `` python3Packages.pydantic-graph: 1.107.0 -> 1.107.1 ``                      |
| [`b3ca1e9d`](https://github.com/NixOS/nixpkgs/commit/b3ca1e9d8cd6e6321e5a5b52d9001ca19cc5b08f) | `` python3Packages.pydantic-ai-slim: 1.106.0 -> 1.107.0 ``                    |
| [`4e0d8c12`](https://github.com/NixOS/nixpkgs/commit/4e0d8c124e54220bcfb522825d5dde2c90e9c5a4) | `` python3Packages.pydantic-graph: 1.106.0 -> 1.107.0 ``                      |
| [`4204abf0`](https://github.com/NixOS/nixpkgs/commit/4204abf0ab553d85e776d691a6b2b545c558f08b) | `` python3Packages.genai-prices: 0.0.65 -> 0.0.66 ``                          |
| [`0f089dde`](https://github.com/NixOS/nixpkgs/commit/0f089dde916190c1f8c6e0c4ac9d8e16b2954987) | `` python3Packages.pydantic-ai-slim: 1.105.0 -> 1.106.0 ``                    |
| [`d5f858a6`](https://github.com/NixOS/nixpkgs/commit/d5f858a660200870d3a86458f2f4f3bac945ea2a) | `` python3Packages.pydantic-graph: 1.105.0 -> 1.106.0 ``                      |
| [`9009a35f`](https://github.com/NixOS/nixpkgs/commit/9009a35f4392d022fd24494c24a4d5d69ea8c6c7) | `` python3Packages.genai-prices: 0.0.62 -> 0.0.65 ``                          |
| [`f4fecb2d`](https://github.com/NixOS/nixpkgs/commit/f4fecb2d03cbc077ea3fac036a6d65825b14471c) | `` python3Packages.pydantic-ai-slim: 1.104.0 -> 1.105.0 ``                    |
| [`57516d70`](https://github.com/NixOS/nixpkgs/commit/57516d70edacd65da7fe830408a2822c3a6eae42) | `` python3Packages.pydantic-graph: 1.104.0 -> 1.105.0 ``                      |
| [`380ab872`](https://github.com/NixOS/nixpkgs/commit/380ab8726529536f47ca24d0ddc5e059c4709dc9) | `` python3Packages.httpx2: 2.2.0 -> 2.3.0 ``                                  |
| [`e4f17ff3`](https://github.com/NixOS/nixpkgs/commit/e4f17ff3c91065c797de6c3a7701fc5a8ff8f320) | `` python3Packages.httpcore2: 2.2.0 -> 2.3.0 ``                               |
| [`667383b4`](https://github.com/NixOS/nixpkgs/commit/667383b40477bf8c02d2debb45705fea720e68ff) | `` python3Packages.pydantic-ai-slim: 1.103.0 -> 1.104.0 ``                    |
| [`c0b3a4a3`](https://github.com/NixOS/nixpkgs/commit/c0b3a4a37531fdbf31253da15cee246853fc189d) | `` python3Packages.pydantic-graph: 1.103.0 -> 1.104.0 ``                      |
| [`c9c6e30d`](https://github.com/NixOS/nixpkgs/commit/c9c6e30d25a7d89c24ffbe723bdfa2c5974eedbe) | `` python3Packages.pydantic-ai-slim: 1.102.0 -> 1.103.0 ``                    |
| [`893857c5`](https://github.com/NixOS/nixpkgs/commit/893857c5ca47cbd989d4d2373287881393ec20f5) | `` python3Packages.pydantic-graph: 1.102.0 -> 1.103.0 ``                      |
| [`561d2f3b`](https://github.com/NixOS/nixpkgs/commit/561d2f3b25c914e985b47b3ba22fc2ce5e349f4a) | `` python3Packages.genai-prices: 0.0.61 -> 0.0.62 ``                          |
| [`2d525954`](https://github.com/NixOS/nixpkgs/commit/2d5259548e54f8897fee73929dafc61e77d3d8b5) | `` python3Packages.httpx2: init at 2.2.0 ``                                   |
| [`92dc85b8`](https://github.com/NixOS/nixpkgs/commit/92dc85b82d9dd510cc16399f1a0282c7b31fdd6e) | `` python3Packages.httpcore2: init at 2.2.0 ``                                |
| [`4d5604b0`](https://github.com/NixOS/nixpkgs/commit/4d5604b09b8dd9a5d3808974936b5997b9e58808) | `` diff-so-fancy: 1.4.10 -> 1.4.12 ``                                         |
| [`61a8f5a9`](https://github.com/NixOS/nixpkgs/commit/61a8f5a98256a803fca46a3df9d624dcb46cf797) | `` openiscsi: 2.1.11 -> 2.1.12 ``                                             |
| [`419f4738`](https://github.com/NixOS/nixpkgs/commit/419f473848c01ae307906b4deb637186ba8e8961) | `` fetchYarnDeps: set impureEnvVars ``                                        |
| [`e72ef3b3`](https://github.com/NixOS/nixpkgs/commit/e72ef3b3e0a9c4d39ffd8ccae15a2622ccf8a57d) | `` sing-box: 1.13.14 -> 1.13.15 ``                                            |
| [`2e545fcf`](https://github.com/NixOS/nixpkgs/commit/2e545fcfa2521a2a523fa39e7a28f2761167ccbb) | `` tail-tray: 0.2.33 -> 0.2.34 ``                                             |
| [`fcfcfff3`](https://github.com/NixOS/nixpkgs/commit/fcfcfff390828511aac9b41c059bccdc0d27c880) | `` rubyPackages.concurrent-ruby: 1.3.5 -> 1.3.8 ``                            |
| [`d2eb06ce`](https://github.com/NixOS/nixpkgs/commit/d2eb06cea4b09391b26077ed9f961d92b777eb44) | `` chromium,chromedriver: 150.0.7871.186 -> 151.0.7922.71 ``                  |
| [`eec87a98`](https://github.com/NixOS/nixpkgs/commit/eec87a9865b7e91324a260f4f3a048d4f1b02592) | `` google-chrome: 150.0.7871.186 -> 151.0.7922.71 ``                          |
| [`aec1d721`](https://github.com/NixOS/nixpkgs/commit/aec1d72190723d65a03f365a2ba9e5ec5db78b41) | `` bitcoin: 31.0 -> 31.1 ``                                                   |
| [`0dafcffa`](https://github.com/NixOS/nixpkgs/commit/0dafcffa4d61309af96f4e9a0456af9d0a435663) | `` ledger-live-desktop: 4.11.0 -> 4.13.0 ``                                   |
| [`542613d0`](https://github.com/NixOS/nixpkgs/commit/542613d084c6ec5dd159dc7dc8147760274309d9) | `` mastodon: patch CVE-2026-66066/GHSA-xr9x-r78c-5hrm in activesupport gem `` |
| [`09d73497`](https://github.com/NixOS/nixpkgs/commit/09d73497eb374292c096bd97bd331e938a655d91) | `` librewolf-unwrapped: 152.0-3 -> 153.0.1-1 ``                               |
| [`39b83ce4`](https://github.com/NixOS/nixpkgs/commit/39b83ce40126c9d849ce84e765de94c2588b9878) | `` xfr: 0.9.21 -> 0.9.22 ``                                                   |
| [`857e8938`](https://github.com/NixOS/nixpkgs/commit/857e8938e2084bd986bc91d01bb0c650522e3b58) | `` ledger-live-desktop: 4.10.0 -> 4.11.0 ``                                   |
| [`1ea5cc38`](https://github.com/NixOS/nixpkgs/commit/1ea5cc387f4bc73173a70aa8bad63ae55829685d) | `` ledger-live-desktop: 4.8.0 -> 4.10.0 ``                                    |
| [`ce5d465e`](https://github.com/NixOS/nixpkgs/commit/ce5d465e4357fa40ef100d46f9884e603276f971) | `` python3Packages.mapclassify: 2.10.0 -> 2.10.0-unstable-2026-07-20 ``       |
| [`3ec0ea71`](https://github.com/NixOS/nixpkgs/commit/3ec0ea71682a8107ad9dd50af091eda8caf2e65f) | `` knot-*: avoid the legacy download URLs under secure.nic.cz ``              |
| [`14530c01`](https://github.com/NixOS/nixpkgs/commit/14530c010e8191e63451ce1b77e1baae307ee53c) | `` deadnix: add versionCheckHook to installCheckPhase ``                      |
| [`b6ada4fd`](https://github.com/NixOS/nixpkgs/commit/b6ada4fdc2e924fac3375d296c1a195ea02daa6c) | `` deadnix: 1.3.1 -> 1.3.2 ``                                                 |
| [`3a7ded69`](https://github.com/NixOS/nixpkgs/commit/3a7ded692578eb2b4ef90c008f5f8e139a43303c) | `` deadnix: add diogotcorreia as maintainer ``                                |
| [`291438cd`](https://github.com/NixOS/nixpkgs/commit/291438cdb6e38e92c2484308af9f0af1a06b54e1) | `` deadnix: add passthru.updateScript ``                                      |
| [`f3fef157`](https://github.com/NixOS/nixpkgs/commit/f3fef157e03c7a71ca392690be870eb389871f06) | `` nodejs_22: 22.23.1 -> 22.23.2 ``                                           |
| [`6eb8e843`](https://github.com/NixOS/nixpkgs/commit/6eb8e843a03ae1c002ac5cf4abd87d46ad779195) | `` nh-unwrapped: modernize ``                                                 |
| [`6b7d3b3a`](https://github.com/NixOS/nixpkgs/commit/6b7d3b3ac94dd42cfea4a8cfbfa4762a89d262d0) | `` nh-unwrapped: 4.4.1 -> 4.4.2 ``                                            |
| [`d995cbf8`](https://github.com/NixOS/nixpkgs/commit/d995cbf84eece5ddcb5a5350b88d083418d0b83e) | `` dawarich: bump rails to 8.0.5.1 to fix CVE-2026-66066 ``                   |
| [`1d3d1392`](https://github.com/NixOS/nixpkgs/commit/1d3d139221a3d333c10d3286a6455a82325f74ad) | `` redis: 8.8.0 -> 8.8.1 ``                                                   |
| [`bf3f2cdc`](https://github.com/NixOS/nixpkgs/commit/bf3f2cdc6b9f462d7cb9b76f6fcd0ce11f4e672b) | `` papra: 26.5.0 -> 26.6.1 ``                                                 |
| [`960bfc46`](https://github.com/NixOS/nixpkgs/commit/960bfc463beebb7cd721716c37e0ec2246a5559a) | `` papra: 26.4.0 -> 26.5.0 ``                                                 |
| [`bc4bca0f`](https://github.com/NixOS/nixpkgs/commit/bc4bca0fdbd97ba57583bf0163bfe49944b4c9be) | `` foundationdb: support aarch64-darwin ``                                    |
| [`8848a323`](https://github.com/NixOS/nixpkgs/commit/8848a323ce24dbc4cd0fd70848b0f4d2cb0ff3e3) | `` hercules: 4.8 -> 4.9.1 ``                                                  |
| [`6006d24f`](https://github.com/NixOS/nixpkgs/commit/6006d24f68ea865ea13e3bfa5c97436dd7b0362c) | `` sub-store-frontend: 2.26.5 -> 2.27.3 ``                                    |