### PR TITLE
fix: restore fleet-wide reboot detection (nixos-needsreboot v0.3.0)

### DIFF
--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -167,8 +167,18 @@ fi
 # Fail loud if nix eval can't enumerate nixosConfigurations -- a broken
 # flake silently producing an empty host list would defeat the whole
 # point of this verification gate.
-if ! ALL_HOSTS_JSON="$(nix eval .#nixosConfigurations --apply 'cfgs: builtins.attrNames cfgs' --json 2>&1)"; then
-  printf 'ERROR: failed to enumerate nixosConfigurations:\n%s\n' "$ALL_HOSTS_JSON" >&2
+#
+# stderr is captured to a file rather than folded in with 2>&1: nix prints
+# "Using saved setting for 'extra-substituters = ...'" notices for this
+# flake's nixConfig whenever the invoking user is not a trusted user, and
+# merging those into the JSON turns them into bogus host names.
+NIX_EVAL_STDERR="$(mktemp)"
+trap 'rm -f "$NIX_EVAL_STDERR"' EXIT
+if ! ALL_HOSTS_JSON="$(
+  nix eval .#nixosConfigurations --apply 'cfgs: builtins.attrNames cfgs' --json \
+    2>"$NIX_EVAL_STDERR"
+)"; then
+  printf 'ERROR: failed to enumerate nixosConfigurations:\n%s\n' "$(cat "$NIX_EVAL_STDERR")" >&2
   exit 1
 fi
 mapfile -t ALL_HOSTS < <(echo "$ALL_HOSTS_JSON" | tr -d '[]" ' | tr ',' '\n' | grep -v '^$')

--- a/flake.lock
+++ b/flake.lock
@@ -873,11 +873,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1764529576,
-        "narHash": "sha256-0KnDDF+K6C3Pj/b/o30lTRNUxDq4SwZU1K17zsrrOT4=",
+        "lastModified": 1785715923,
+        "narHash": "sha256-wLYdAvZ4TAmZFVuprvq5fydQYXqxdqbYAcaFm4q8XZo=",
         "owner": "fredclausen",
         "repo": "nixos-needsreboot",
-        "rev": "4eac6a8686e583184f9414450a746a6ee0a90db5",
+        "rev": "7c72623c2ea71853dd9f2ab07044188f1f50fe5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Symptom

Every server reported "no reboot required" while running a kernel several
point releases behind its own activated closure. On `sdrhub` and `acarshub`:

```text
/nix/var/nix/profiles/system/kernel -> /nix/store/kdgyjhyv...-linux-6.18.41/bzImage
/run/booted-system/kernel           -> /nix/store/f72lfjxh...-linux-6.18.33/bzImage
/run/reboot-required                : ABSENT
nixos_needs_reboot{host="sdrhub"}   : 0
uptime                              : 4w5d (sdrhub) / 7w (acarshub)
```

Journal, every 10 minutes, on every host:

```text
nixos-needs-reboot-metric.sh[679562]: You are using the latest NixOS generation, no need to reboot
```

## Root cause

`nixos-needsreboot` identified the booted and the activated generation by the
contents of `nixos-version`, which is `config.system.nixos.label`. Both read
`26.05pre-git`, so the identity check matched and the tool exited before
`upgrades_available()` ever compared the kernel.

The label is rev-less on servers specifically because colmena calls
`eval-config.nix` directly (see the comment at `flake/lib/mk-system.nix:121`)
and bypasses the `system.nixos.versionSuffix` injection that
`nixpkgs.lib.nixosSystem` performs. Desktops built through `nixosConfigurations`
get `26.11.20260801.148bab9` and were unaffected, which is why this went
unnoticed.

Blast radius: `nixos_needs_reboot` has been pinned at 0 fleet-wide, so the
`NixOSNeedsReboot` alert rule, the "Nodes Needing Reboot" fleet-overview panel,
the fastfetch line and the wayle indicator have all been silently reporting
"no reboot required" since they were deployed.

## Fix

`nixos-needsreboot` v0.3.0 (fredclausen/nixos-needsreboot#1) identifies
generations by their canonicalized `/nix/store` closure path. It also fixes the
version ordering, which previously reported a downgrade as an upgrade,
duplicated the reason line when two segments moved at once, and missed
`6.19 -> 6.19.1` entirely -- the exact shape of a nixpkgs kernel point release.

Second commit fixes a pre-existing bug in the `nixos-eval-impacted-hosts`
skill script that folded nix's `extra-substituters` notice into the host list,
breaking `--eval` for non-trusted users.

## Verification

- `impacted-hosts.sh origin/main` -> `GLOBAL` (matches the `# CI: global (all linux)` classification of the input).
- `impacted-hosts.sh origin/main --eval` -> all 9 hosts eval clean, no `evaluation warning:`.
- Upstream crate: 16 unit tests, clippy `-D warnings`, `nix build` all green; the
  two regression tests were confirmed to fail against the old logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved impacted-host detection by separating diagnostic messages from host data.
  * Added clearer error output when host enumeration fails.
  * Temporary evaluation files are now cleaned up automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->