### PR TITLE
fix(monitoring): repair silently-broken alerting and close fleet coverage gaps

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -3,3 +3,4 @@ nd
 edn
 ags
 deriver
+trough

--- a/.github/workflows/check-alert-metrics.yaml
+++ b/.github/workflows/check-alert-metrics.yaml
@@ -21,13 +21,33 @@ on:
       - ".github/workflows/check-alert-metrics.yaml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-alert-metrics:
     name: Referenced metrics exist
     runs-on: [self-hosted, Linux]
+
+    # This repository is public, and this job runs a script from the checked-out
+    # pull-request head on a persistent self-hosted runner that can reach the
+    # monitoring LAN. Without this guard a fork could edit
+    # scripts/check-alert-metrics.sh and get code execution on that runner.
+    #
+    # Written as "not a pull_request, or a same-repo pull_request" so
+    # workflow_dispatch keeps working. Every self-hosted job in this repository
+    # carries the same guard.
+    if: >-
+      ${{ github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The workspace persists between jobs on a self-hosted runner, so the
+          # default behaviour would leave the token in .git/config on disk.
+          persist-credentials: false
 
       - name: Check referenced metrics resolve
         run: ./scripts/check-alert-metrics.sh

--- a/.github/workflows/check-alert-metrics.yaml
+++ b/.github/workflows/check-alert-metrics.yaml
@@ -1,0 +1,33 @@
+---
+# Assert that every metric referenced by a Prometheus alerting rule actually
+# has series in Prometheus.
+#
+# Prometheus reports a rule matching nothing as health=ok, so a rule pointing
+# at a metric that does not exist never fires and never complains. Five such
+# rules accumulated here before anyone noticed. promtool cannot catch it --
+# the PromQL is valid -- so this is the backstop.
+#
+# Runs on the self-hosted Linux runner because it needs to reach the
+# monitoring LAN. The script exits 0 with a SKIPPED notice if Prometheus is
+# unreachable, so this never fails spuriously.
+name: Check Alert Metrics
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "modules/monitoring/master/alert-rules/**"
+      - "scripts/check-alert-metrics.sh"
+      - ".github/workflows/check-alert-metrics.yaml"
+  workflow_dispatch:
+
+jobs:
+  check-alert-metrics:
+    name: Referenced metrics exist
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check referenced metrics resolve
+        run: ./scripts/check-alert-metrics.sh

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -274,7 +274,7 @@ jobs:
     name: Build Darwin systems
     runs-on: [self-hosted, macOS]
     needs: [skip-if-clean, find-darwin]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-darwin.outputs.systems != '[]' }}
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-darwin.outputs.systems != '[]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       id-token: "write"
       contents: "read"
@@ -428,7 +428,7 @@ jobs:
     name: Build & push dev shell + packages (Darwin)
     runs-on: [self-hosted, macOS]
     needs: [skip-if-clean, find-devshell]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-devshell.outputs.changed == 'true' }}
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-devshell.outputs.changed == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -365,7 +365,7 @@ jobs:
     name: Build server systems
     runs-on: [self-hosted, Linux]
     needs: [skip-if-clean, find-systems]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-systems.outputs.servers != '[]' }}
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-systems.outputs.servers != '[]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       id-token: "write"
       contents: "read"
@@ -438,7 +438,7 @@ jobs:
     name: Build desktop systems
     runs-on: [self-hosted, Linux]
     needs: [skip-if-clean, find-systems]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-systems.outputs.desktops != '[]' }}
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-systems.outputs.desktops != '[]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       id-token: "write"
       contents: "read"
@@ -607,7 +607,7 @@ jobs:
     name: Build & push dev shell + packages
     runs-on: [self-hosted, Linux]
     needs: [skip-if-clean, find-devshell]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-devshell.outputs.changed == 'true' }}
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && needs.find-devshell.outputs.changed == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -98,7 +98,7 @@ jobs:
     name: Scan nixos/${{ matrix.system }}
     runs-on: [self-hosted, Linux]
     needs: [find-systems]
-    if: ${{ needs.find-systems.outputs.nixos != '[]' }}
+    if: ${{ needs.find-systems.outputs.nixos != '[]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -64,15 +64,12 @@ jobs:
         # all its Cargo dependencies on every run — which is both slow and
         # prone to transient crates.io 403s. The check derivation runs the
         # same hooks at build time without that dependency.
+        # This also validates the Prometheus alerting rules: the hook suite now
+        # includes a `prometheus alert rules` hook running `promtool check
+        # rules` plus the promtool unit tests, so no separate step is needed.
+        # Verified by reintroducing the sum()/count() bug, which fails this
+        # build with the specific test case that covers it.
         run: nix build --no-link --print-build-logs .#checks.x86_64-linux.pre-commit-check
-
-      - name: Validate Prometheus alerting rules
-        # Runs `promtool check rules` plus the promtool unit tests. Built
-        # explicitly rather than relying on `nix flake check`, which this
-        # workflow does not run -- without this step the alert-rule test suite
-        # would never execute in CI, which is how five permanently-silent
-        # rules accumulated in the first place.
-        run: nix build --no-link --print-build-logs .#checks.x86_64-linux.prometheus-alert-rules
 
   # =====================================================================
   # Required Check Summary

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,6 +66,14 @@ jobs:
         # same hooks at build time without that dependency.
         run: nix build --no-link --print-build-logs .#checks.x86_64-linux.pre-commit-check
 
+      - name: Validate Prometheus alerting rules
+        # Runs `promtool check rules` plus the promtool unit tests. Built
+        # explicitly rather than relying on `nix flake check`, which this
+        # workflow does not run -- without this step the alert-rule test suite
+        # would never execute in CI, which is how five permanently-silent
+        # rules accumulated in the first place.
+        run: nix build --no-link --print-build-logs .#checks.x86_64-linux.prometheus-alert-rules
+
   # =====================================================================
   # Required Check Summary
   # =====================================================================

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -113,9 +113,9 @@ their own modules rather than here: `scrapeConfigs` and `ruleFiles` are both
 | blackbox-https-redirect | 11 apex domains, must be 3xx              | instance, job            |
 | blackbox-http-internal  | 6 internal vhosts via the nginx proxy     | instance, job            |
 
-`dump978` was removed: nothing inside the container listens on the published
-port 9275, so it was a permanently-down phantom target. Its metrics are served
-by the container's own nginx, which currently 404s on `/metrics`.
+`dump978` is scraped on 9275, but only because the container now runs the
+`telegraf-*` image variant -- see below. It carries `metric_relabel_configs`,
+which no other job needs.
 
 Alertmanager routes by severity to three Pushover receivers, plus a `watchdog` receiver that pings healthchecks.io. Alertmanager, Grafana and Loki are all scraped. See [Notification transport](#notification-transport).
 
@@ -178,11 +178,63 @@ inside dump978:     dump978-fa on 30978-30979, readsb on 37981/37982, nginx on 8
 
 Ultrafeeder's exporter works on 9274 and emits `readsb_aircraft_*`, `readsb_messages_*`, `readsb_position_count_*`, and `readsb_signal_*`. The `readsb_stats_*` names used by the alert rules exist only in Loki's historical label index.
 
-dump978 sets `ENABLE_PROMETHEUS=true` and `PROMETHEUSPORT=9275` but serves metrics through its internal nginx, which currently returns 404 for `/metrics` and logs `open() "/run/readsb/stats.prom" failed`. That is a container configuration problem, tracked separately below.
+dump978 also appeared broken this way, but for a different reason -- see [dump978 telegraf variant](#dump978-telegraf-variant). Resolved.
 
 - [x] Remove the `sdrhub.local:9273` and `sdrhub.local:9275` targets
 - [x] Repoint `sdr-alerts.yaml` at the `readsb_aircraft_*` and `readsb_messages_*` families served on 9274
-- [ ] Decide whether dump978 metrics are wanted; if so fix the container's nginx metrics path
+- [x] dump978 metrics: root-caused to the image variant, fixed, and scraped
+
+### dump978 telegraf variant
+
+dump978 had `ENABLE_PROMETHEUS=true`, `PROMETHEUSPORT=9275` and
+`PROMETHEUSPATH=/metrics` all set correctly, and still served nothing.
+
+The `latest-*` image variant does not ship the telegraf binary, and both s6
+services degrade silently without it:
+
+```bash
+# /etc/s6-overlay/scripts/telegraf
+if [[ ! -f /usr/bin/telegraf ]]; then
+  sleep infinity
+fi
+```
+
+So `s6-svstat` reported `telegraf` and `telegraf_socat` as up for 55425 seconds
+while both slept, `/etc/telegraf/telegraf.d` never existed, and the published
+port accepted connections through docker-proxy only to reset them.
+
+Fixed by switching to `telegraf-build-801` -- the same application build number,
+so no version drift, with the binary included. `04-telegraf` then generates the
+prometheus output from the env vars that were already set. Cost: the telegraf
+binary adds roughly 310 MB uncompressed, and `mkUnit` runs `docker pull` in
+`ExecStartPre` on every unit restart.
+
+**The per-aircraft metrics are a cardinality bomb and must stay suppressed.**
+telegraf emits 23 metric families keyed on aircraft `address`, `callsign` and
+`flightplan_id` -- one set per aircraft, observed growing from 230 to 286 series
+within an hour. With 90d retention every aircraft ever seen would leave 23
+series behind permanently, and none of it answers a monitoring question;
+per-aircraft state is what tar1090 and skyaware978 are for.
+
+| Family         | Series | Cardinality               |
+| -------------- | ------ | ------------------------- |
+| `aircraft_`    | 286    | unbounded -- suppressed   |
+| `stats_`       | 21     | fixed -- this is the useful part |
+| `polar_range_` | 72     | fixed, bearing buckets    |
+| `go_`/`process_` | 44   | fixed, telegraf's runtime |
+
+Suppressed in two places deliberately: `INFLUXDB_SKIP_AIRCRAFT=true` on the
+container stops collection at source, and a `metric_relabel_configs` drop on
+`aircraft_.*` means Prometheus still refuses them if that env var is ever lost
+or a future image ignores it.
+
+The job also drops the `host` label, which telegraf sets to the container id.
+Left in place it would churn the whole series set on every container recreate
+and break continuity of the counters the job exists to watch.
+
+No UAT throughput alert yet: UAT is genuinely quiet at this site, so a
+zero-messages rule would repeat the quiet-frequency trap. It belongs with the
+Phase 6 baselines.
 
 ### Alloy metrics path
 
@@ -452,6 +504,27 @@ What genuinely does depend on hardware: the number of independent USB host contr
 - [x] Enable it on sdrhub, acarshub, vdlmhub, hfdlhub1 -- **not** hfdlhub2, which has no USB radios
 - [ ] Set `usbfs_memory_mb` proportionally if hosts are ever consolidated
 
+## Watchdog on the dashboards
+
+The Watchdog fires permanently by design, which made the fleet dashboard's
+`Active Alerts` panel read 1 forever. Two changes:
+
+- `Active Alerts` now excludes it: `count(ALERTS{alertstate="firing", alertname!="Watchdog"})`.
+- A separate **Alerting Pipeline** stat panel inverts it: FIRING is healthy and
+  renders `OK`, absence renders `DOWN`, and no data renders `NO DATA`, all red
+  except `OK`.
+
+**That panel is not a substitute for the external deadman.** If Prometheus or
+Grafana is down it shows `NO DATA` -- it is as blind as the alerting stack it
+watches. It only covers the narrower case where Prometheus is up but has
+stopped evaluating the rule. healthchecks.io remains authoritative.
+
+Karma's `filters.default` hides it for the same reason.
+
+The stat block is split across two rows: at `w=2`/`w=3` the panel titles were
+truncated on a narrow viewport. Row 1 is node state at `w=6`, row 2 is
+operational state at `w>=4`.
+
 ## Tuning workflow
 
 Thresholds cannot be derived from first principles. The deliverable is a tuning platform with defensible starting baselines, not a set of correct numbers.
@@ -533,11 +606,23 @@ accepted without complaint. The templates were therefore syntax-checked and
 rendered separately against a representative alert group. Any future template
 edit needs the same treatment.
 
-Not yet deployed: **Karma** for triage, recommended on fredvps bound to
-Tailscale rather than exposed publicly. Karma manages silences, so it is a
-control plane, not a read-only view -- a bad actor could silence every alert.
-Tailscale satisfies the off-LAN access requirement with no internet-facing
-attack surface.
+**Karma** is deployed on sdrhub, bound to `127.0.0.1:8090` and reached through
+the existing nginx proxy at `http://karma.sdrhub.lan/` (with a `.local` alias
+and AdGuard rewrites for both). No firewall port of its own, and `/karma/` on
+the landing vhost is a 302 to it rather than a sub-path proxy, because Karma
+serves assets from absolute paths.
+
+Loopback-only is deliberate. Karma creates and expires silences, so it is a
+control plane rather than a read-only view: anyone reaching the UI can silence
+every alert in the fleet, and the result is indistinguishable from a healthy
+quiet fleet. If it is ever published it needs auth in front of it (Karma has
+`authentication.basicAuth` and `authorization.acl`) or the Alertmanager entry
+set `readonly = true`. Off-LAN access, if wanted later, should be Tailscale
+rather than an internet-facing port.
+
+`filters.default` excludes the Watchdog, which fires permanently by design and
+would otherwise sit at the top of the UI forever, training the eye to ignore a
+non-empty dashboard. It is a default, not a restriction.
 
 - [x] Decide whether to adopt this proposal
 - [x] Independently of the above: move off the unauthenticated public ntfy.sh topic
@@ -603,10 +688,14 @@ The notification path was a single unmonitored point of failure: if Alertmanager
       hours, and 0 in the last 6 hours. It now reports "Receiver is OK" as often
       as "appears stale" (6 vs 6 in 6 hours) against 1 vs 334 beforehand. No
       container config change is needed; the underlying fault is gone.
-- [ ] `promtool check rules` as a *pre-commit* hook specifically. Deliberately
-      not done. The check runs in CI, so this would only move detection ~30
-      seconds earlier, and `precommit-base`'s `mkCheck` exposes no `extraHooks`
-      argument, so it would require changing that repo.
+- [x] `promtool check rules` + `test rules` as a pre-commit hook. `mkCheck`
+      exposes no `extraHooks` argument, but it is only a wrapper: `mkBaseCheck`
+      returns a composable `{ hooks, excludes, passthru }` module and
+      git-hooks' `run` consumes the merge, so a repo-local hook can be merged in
+      without touching `precommit-base`. `git-hooks` is reached through
+      `precommit-base`'s own inputs, avoiding a new flake input and the
+      four-place input-category sync. Verified with teeth: reintroducing the
+      sum()/count() bug fails the `pre-commit-check` build.
 - [ ] `runbook_url` annotations. Partially delivered by other means: Pushover
       notifications carry a tappable link to the alert's `GeneratorURL`, which
       was the concrete payoff wanted from `runbook_url` (open the graph rather

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -1,0 +1,565 @@
+# Monitoring and Alerting
+
+Reference for the Prometheus / Alertmanager / Loki / Grafana stack, the SDR container signal catalogue, and the open work required to make alerting on the decoder fleet trustworthy.
+
+## How to use this document
+
+This is a living reference, not a changelog. Three kinds of content live here:
+
+- **Reference** -- how the stack is wired, what signals exist, what they mean.
+- **Verified defects** -- concrete bugs found by querying the live stack, each with evidence and a checkbox.
+- **Work plan** -- phased tasks with checkboxes.
+
+Rules for maintaining it:
+
+- Tick a checkbox only when the change is deployed and verified against live Prometheus or Loki, not when the commit lands.
+- When a defect is fixed, leave the entry with its box ticked. The evidence is why the fix exists.
+- If a claim here is contradicted by the live stack, re-verify with the commands in [Verification commands](#verification-commands) and correct the document in the same commit as the code change.
+
+**Important for agents:** every defect in this document was found by querying the running Prometheus and Loki instances, not by reading the Nix code. Prior review passes that reasoned only from source missed all of them, because the failure mode is consistently "the config is syntactically fine and refers to a metric that does not exist." Reason from the live stack.
+
+## Stack topology
+
+### Component placement
+
+| Host      | Role              | node_exp | cAdvisor | Alloy | Prometheus | Alertmanager | Grafana | Loki |
+| --------- | ----------------- | -------- | -------- | ----- | ---------- | ------------ | ------- | ---- |
+| sdrhub    | monitoring-master | yes      | yes      | yes   | yes        | yes          | yes     | yes  |
+| fredhub   | monitoring-agent  | yes      | yes      | yes   | no         | no           | no      | no   |
+| fredvps   | monitoring-agent  | yes      | yes      | yes   | no         | no           | no      | no   |
+| acarshub  | monitoring-agent  | yes      | yes      | yes   | no         | no           | no      | no   |
+| vdlmhub   | monitoring-agent  | yes      | yes      | yes   | no         | no           | no      | no   |
+| hfdlhub1  | monitoring-agent  | yes      | yes      | yes   | no         | no           | no      | no   |
+| hfdlhub2  | monitoring-agent  | yes      | yes      | yes   | no         | no           | no      | no   |
+| maranello | desktop           | yes      | no       | no    | no         | no           | no      | no   |
+| Daytona   | desktop           | yes      | no       | yes   | no         | no           | no      | no   |
+
+Daytona is excluded from pull-based scraping at `modules/monitoring/master/prometheus.nix:13` and instead pushes via `prometheus.remote_write` and `loki.write` from a bespoke Alloy config at `hosts/linux/daytona/configuration.nix:51-134`.
+
+Versions in use: Prometheus 3.12.0, Loki 3.7.4, Alloy 1.16.0. Prometheus retention 90d, Loki retention 30d.
+
+### Scrape configuration
+
+Defined at `modules/monitoring/master/prometheus.nix:160-262`. Global `scrape_interval` and `evaluation_interval` are both 15s.
+
+| Job         | Targets                                              | Labels attached           |
+| ----------- | ---------------------------------------------------- | ------------------------- |
+| node        | all agents + desktops + sdrhub on :9100              | hostname, role, exporter  |
+| cadvisor    | all agents + sdrhub on :4567                         | hostname, role, exporter  |
+| ultrafeeder | sdrhub.local:9273, sdrhub.local:9274                 | none                      |
+| dump978     | sdrhub.local:9275                                    | none                      |
+| acarshub    | sdrhub.local:8085                                    | none                      |
+| prometheus  | 127.0.0.1:9090                                       | none                      |
+| pushgateway | 127.0.0.1:9091                                       | none                      |
+
+Alertmanager routes every severity to a single `ntfy` receiver on topic `fred-sdrhub-alerts` at `high` priority when firing. Nothing scrapes Alertmanager, Grafana, or Loki.
+
+## Verified defects
+
+### Dead alert rules
+
+Five of the twenty-two rules reference metrics with no active series. Prometheus reports all of them as `health=ok`, because a rule evaluating to an empty vector is considered healthy. They have never fired and cannot fire.
+
+| Rule                    | Location             | Missing metric                                | Cause                                                     |
+| ----------------------- | -------------------- | --------------------------------------------- | --------------------------------------------------------- |
+| DockerUnitFlapping      | docker-rules.yaml:5  | node_systemd_unit_restart_total                | collector flag not passed to node_exporter                |
+| SDRServiceFailure       | docker-rules.yaml:14 | promtail_custom_sdr_service_failure_total      | promtail replaced by Alloy, which uses unprefixed names   |
+| FeederUpstreamFailure   | docker-rules.yaml:23 | promtail_custom_feeder_upstream_failure_total  | same as above                                             |
+| UltrafeederNoAircraft   | sdr-alerts.yaml:5    | readsb_stats_aircraft_with_pos                 | exporter emits readsb_aircraft_* families instead         |
+| UltrafeederNotReceiving | sdr-alerts.yaml:14   | readsb_stats_messages                          | same as above                                             |
+
+`node_systemd_unit_restart_total` requires `--collector.systemd.enable-restarts-metrics`, which `modules/monitoring/agent/node_exporter.nix:278-287` does not pass.
+
+- [ ] Enable the systemd restarts collector, or rewrite `DockerUnitFlapping` against cAdvisor `container_start_time_seconds`
+- [ ] Delete `SDRServiceFailure` and `FeederUpstreamFailure`
+- [ ] Rewrite `sdr-alerts.yaml` against the metric families that actually exist
+
+### PrometheusTargetDown cannot fire
+
+`modules/monitoring/master/alert-rules/alert-rules.yaml:115`:
+
+```promql
+sum by (job, instance) (up{role!="desktop"} == 0) > 0
+```
+
+`== 0` filters to series valued zero. Summing zeros yields zero. `0 > 0` is false unconditionally. Verified live:
+
+```text
+up{role!="desktop"} == 0                               -> 2 series, value 0
+sum by (job,instance) (up{role!="desktop"} == 0)       -> 2 series, value 0
+sum by (job,instance) (up{role!="desktop"} == 0) > 0   -> EMPTY
+count by (job,instance) (up{role!="desktop"} == 0) > 0 -> 2 series, value 1
+```
+
+The fix is `count` rather than `sum`.
+
+- [ ] Replace `sum` with `count` in `PrometheusTargetDown`
+
+### Phantom scrape targets
+
+`sdrhub.local:9273` and `sdrhub.local:9275` are permanently down. The containers are healthy and decoding normally -- nothing is listening on those ports inside the containers. Docker publishes them, `docker-proxy` accepts the connection, and the connection is then reset because there is no upstream listener.
+
+```text
+host:   LISTEN 0.0.0.0:9273 / 9274 / 9275        (docker-proxy)
+curl 127.0.0.1:9273 -> Connection reset by peer
+curl 127.0.0.1:9274 -> 200
+curl 127.0.0.1:9275 -> Connection reset by peer
+
+inside ultrafeeder: readsb on 31003-31006, 32006-32008, 30002-30003 -- nothing on 9273
+inside dump978:     dump978-fa on 30978-30979, readsb on 37981/37982, nginx on 80 -- nothing on 9275
+```
+
+Ultrafeeder's exporter works on 9274 and emits `readsb_aircraft_*`, `readsb_messages_*`, `readsb_position_count_*`, and `readsb_signal_*`. The `readsb_stats_*` names used by the alert rules exist only in Loki's historical label index.
+
+dump978 sets `ENABLE_PROMETHEUS=true` and `PROMETHEUSPORT=9275` but serves metrics through its internal nginx, which currently returns 404 for `/metrics` and logs `open() "/run/readsb/stats.prom" failed`. That is a container configuration problem, tracked separately below.
+
+- [ ] Remove the `sdrhub.local:9273` and `sdrhub.local:9275` targets
+- [ ] Repoint `sdr-alerts.yaml` at the `readsb_aircraft_*` and `readsb_messages_*` families served on 9274
+- [ ] Decide whether dump978 metrics are wanted; if so fix the container's nginx metrics path
+
+### Alloy metrics path
+
+The log-to-metric pipeline in `modules/monitoring/agent/alloy.nix:59-84` is broken in three independent places, so fixing any one alone changes nothing.
+
+```text
+ss -lntp on sdrhub  -> LISTEN 127.0.0.1:12345
+cmdline             -> alloy run /nix/store/...-agent.alloy   (no --server.http.listen-addr)
+curl 127.0.0.1:12345/metrics     -> 200
+curl 192.168.31.20:12345/metrics -> 000 (refused)
+```
+
+1. Alloy's HTTP listener binds localhost only, so `firewall.allowedTCPPorts = [ 12345 ]` at `alloy.nix:101-103` has no effect.
+2. `prometheus.nix` defines no scrape job for Alloy.
+3. The alert rules reference `promtail_custom_*`; Alloy emits the counters unprefixed.
+
+This is orthogonal to log shipping, which works correctly on every host including Daytona. `loki.write` and `prometheus.remote_write` are outbound pushes and need no inbound listener; only a Prometheus pull from Alloy is blocked. The chosen resolution is to move rule evaluation into the Loki ruler and delete this block entirely rather than make Alloy scrapeable -- see [Decisions log](#decisions-log).
+
+- [ ] Delete the `loki.process "docker"` block and the port 12345 firewall opening from `alloy.nix`
+
+### Smaller correctness defects
+
+| Location                        | Defect                                                                                              |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| system-alerts.yaml:5            | `NixOSNotOnMain` excludes `daytona`; the host is `Daytona` and the regex is case-sensitive          |
+| sdr-alerts.yaml:9,18            | Annotations template `{{ $labels.hostname }}`; the ultrafeeder job attaches no `hostname` label     |
+| prometheus.nix:161-193          | Jobs ultrafeeder, dump978, acarshub, prometheus, pushgateway attach no labels at all                |
+| prometheus.nix:327              | Inhibit list references `SDRServiceFailure` and `FeederUpstreamFailure`, both being removed         |
+| adsb-docker-units.nix:31-82     | `mkUnit` silently ignores the `hostname`, `requires`, and `depends_on` keys set by several hosts    |
+| hardware/rtl-sdr.nix:17         | `lib.mkDefault` on a list option -- see [Kernel parameter merge hazard](#kernel-parameter-merge-hazard) |
+| grafana.nix:74                  | `secret_key` hardcoded in plaintext; the admin password is correctly sops-managed                   |
+
+- [ ] Fix the `Daytona` regex case sensitivity
+- [ ] Add `hostname` and `role` labels to the unlabelled scrape jobs
+- [ ] Update the Alertmanager inhibit list when the dead rules are removed
+- [ ] Either honour or remove the ignored keys in `mkUnit`
+- [ ] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
+- [ ] Move the Grafana `secret_key` into sops
+
+## Signal catalogue
+
+The SDR containers are inconsistent about error reporting, and a generic match on `error` is worthless. The signals below are ordered by reliability.
+
+### Throughput heartbeats
+
+Every decoder emits a periodic, machine-parseable throughput line. Over a 48h sample these arrived 575 times out of 576 expected, so the **absence** of a heartbeat is itself a strong signal that a container has wedged, independent of the value it carries.
+
+| Container family        | Log line                                                  | Period |
+| ----------------------- | --------------------------------------------------------- | ------ |
+| acarsdec-\*, dumpvdl2-\* | `[acars_bridge] [STATS] Total in the last 5 minutes: N`   | 5 min  |
+| dumphfdl-\*             | `[hfdl_stats] N hfdl messages received in last 5 mins`    | 5 min  |
+| ultrafeeder             | Prometheus exporter on :9274                              | scrape |
+
+Extraction:
+
+```logql
+sum by (host, unit) (
+  sum_over_time(
+    {unit=~"docker-(acarsdec|dumpvdl2)-.*"}
+      | regexp `Total in the last \d+ minutes: (?P<msgs>\d+)`
+      | unwrap msgs [10m]
+  )
+)
+```
+
+### Process death
+
+The SDRE base image is consistent about exactly one thing, `s6wrap`. This is the universal crash detector across the container family:
+
+```text
+[s6wrap] !!! CAUTION !!! Wrapped program terminated by signal: 11 (Segmentation fault)
+[s6wrap] Command line for terminated program was: /usr/local/bin/dumphfdl --soapysdr driver=sdrplay,...
+```
+
+Observed over 7 days:
+
+```text
+2  hfdlhub1  docker-dumphfdl-1.service  dumphfdl              Segmentation fault
+2  hfdlhub1  docker-dumphfdl-3.service  sdrplay_apiService    Segmentation fault
+1  hfdlhub1  docker-dumphfdl-1.service  dumphfdl              Aborted
+1  hfdlhub1  docker-dumphfdl-3.service  dumphfdl              Aborted
+1  hfdlhub1  docker-dumphfdl-1.service  sdrplay_apiService    Segmentation fault
+```
+
+hfdlobserver logs its own equivalents: `IQDecoderProcess@web888-NN exited with -11`, `encountered unrecoverable error`, and the state line `web888-NN via ['KiwiClientProcess not running', 'IQDecoderProcess not running']`.
+
+### Container healthchecks
+
+The images ship their own `HEALTHCHECK` directives; cAdvisor already exports `container_health_state` with 391 series fleet-wide. Coverage is uneven and, critically, **inversely correlated with failure rate** -- every crash observed was `dumphfdl` or `hfdlobserver`, and neither ships a healthcheck.
+
+```text
+sdrhub     ultrafeeder dump978 acarshub acarshubv4 adsbhub degoog fr24
+           opensky piaware planefinder planewatch radarvirtuel rbfeeder   = HC
+           acars_router  acars2pos  sdrmap  dozzle  dozzle-agent          = none
+acarshub   acarsdec-1/2/3                                                 = HC
+vdlmhub    dumpvdl2-1/2/3/4                                               = HC
+hfdlhub1   dumphfdl-1/2/3                                                 = none
+hfdlhub2   hfdlobserver                                                   = none
+```
+
+Treat this as a fast supplementary signal at `warning` severity where it exists. It is not a backbone and must never be the only signal for a container.
+
+### Curated error signatures
+
+Only unambiguous patterns, explicitly enumerated. Never a generic level match.
+
+| Pattern                                                   | Meaning                                   | Severity |
+| --------------------------------------------------------- | ----------------------------------------- | -------- |
+| `usb_claim_interface error`                               | cannot bind SDR (1219 hits, dump978)      | critical |
+| `Failed to submit transfer` / `async read failed`         | usbfs ceiling exhausted (515/520, vdlmhub) | critical |
+| `sdrplay_api_ServiceNotResponding`                        | SDRplay API service dead                  | critical |
+| `Server status: (not synchronized\|clock unstable)`       | MLAT broken                               | warning  |
+| `Connection retries will continue`                        | feeder upstream unreachable               | warning  |
+| `Lost N packets ... on USB, MLAT could be UNSTABLE`       | USB or system clock issue                 | warning  |
+| `sdre_stubborn_io.*(Disconnect occurred\|Write while disconnected)` | real upstream connection loss | warning  |
+| `[message-monitor] [WARNING] Restarting the ... service`  | container gave up on its own receiver     | warning  |
+
+For `acars_router` the discriminator is the **module path**, not the log level: `sdre_stubborn_io` indicates genuine connectivity loss, `message_handler` indicates data-quality noise.
+
+### Signals deliberately ignored
+
+Recording these so they are not "rediscovered" and added later.
+
+| Pattern                                                | Why it is noise                                            |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| `[R82XX] PLL not locked!`                              | normal during tuning                                       |
+| `message_handler.*Failed to parse received message`    | malformed upstream JSON, not a container failure           |
+| `acars2pos: failed distance check`                     | data quality filter working as designed                    |
+| `collectd: rrd_update_r ... illegal attempt`           | rrdtool bookkeeping noise                                  |
+| `Error response from daemon: No such container`        | emitted by our own `ExecStartPre` `docker rm -f`           |
+| `readsb: UAT TCP input: Connection to dump978 refused` | symptom of dump978 restarting; alert on the cause instead  |
+| `nginx: open() "/webapp/dist/favicon.ico" failed`      | cosmetic                                                   |
+
+## Traffic seasonality
+
+### Diurnal archetypes
+
+Mean messages per five-minute heartbeat, by hour of day, sampled over seven days:
+
+```text
+receiver         0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23
+acarsdec-1      17  10  14  12   8  13  17  23  24  30  28  32  31  20  26  25  20  22  22  18  20  26  17  17
+acarsdec-2      10   7  11   5   4   6  10  14  26  16  21  19  20  14  17  20  17  14  16  12  17  22  14  14
+acarsdec-3       0   0   0   0   0   0   0   0   0   0   0   1   0   0   0   0   0   0   0   0   0   0   0   0
+dumphfdl-1       2   1   0   0   0   0   0   5   7   0   1   0   0   0   0   1   1   1   3   5  26  28  26  14
+dumphfdl-2       0   0   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+dumphfdl-3       6  14  12  14   9   6  17  22  17  12   1   0   0   0   0   0   0   0   0   1   4   3   3   3
+dumpvdl2-1      24  20  13   7   5   7  16  38  61  80  73  57  53  47  48  38  42  51  45  48  36  34  26  24
+dumpvdl2-2      21  14   3   4   1  15  51  56  64  69  54  69  64  60  58  58  54  49  53  59  61  50  53  33
+dumpvdl2-3       0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+dumpvdl2-4       0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+```
+
+Three archetypes coexist in one fleet:
+
+- **VHF aviation** (acarsdec-1/2, dumpvdl2-1/2) -- daytime curve, 08-12 peak, 03-05 trough, roughly fifteenfold swing.
+- **HF propagation** (dumphfdl-1/3) -- inverted relative to VHF, and the two instances have nearly disjoint active windows. dumphfdl-1 peaks 20:00-23:00 and is dead 09:00-17:00; dumphfdl-3 peaks 01:00-08:00 and is dead 10:00-19:00. These windows drift with season, solar cycle, and scanner band selection.
+- **Flat zero** (acarsdec-3, dumpvdl2-3/4, dumphfdl-2) -- expected, these sit on very quiet frequencies.
+
+### Why fixed thresholds fail
+
+Traffic varies by hour of day, day of week, season, weather, and holiday. Christmas is far quieter than Independence Day; overnight is quiet, and Sunday more so than Thursday. A flat "zero messages for 30m" rule would page continuously for the legitimately quiet receivers, and a threshold tuned for a busy receiver's daytime peak would miss a failure overnight.
+
+A fixed per-receiver collection window is only marginally better, because the HF windows move. There is no static answer.
+
+### Baseline strategies
+
+Three complementary approaches, applied to different receiver classes.
+
+**Self-baseline, same hour, prior weeks.** Handles diurnal shape and day-of-week for free, since a Sunday compares against prior Sundays:
+
+```promql
+  sum_over_time(decoder_msgs[1h])
+    < 0.2 * avg_over_time(sum_over_time(decoder_msgs[1h])[3w:1w] offset 1w)
+and
+  avg_over_time(sum_over_time(decoder_msgs[1h])[3w:1w] offset 1w) > 5
+```
+
+The second clause is what makes quiet frequencies safe. If a receiver historically produced nothing at this hour, its baseline is near zero, the guard fails, and it never alerts. Averaging three weekly samples prevents one bad day from poisoning the baseline.
+
+**Share of fleet volume.** Self-baselining still breaks on holidays, because the prior week was an ordinary week. Comparing a receiver's *share* of its group's total instead of its absolute volume removes that entirely: if all receivers drop together, every share holds steady and nothing fires; if one dies, its share collapses while its siblings' shares rise. No calendar knowledge required. This only holds within a homogeneous group, so it applies to acarsdec-1/2/3 and dumpvdl2-1/2/3/4 but not across the HF receivers with disjoint windows.
+
+**Sibling comparison over a long window.** A self-baseline cannot detect a receiver that was already broken before the baseline window opened. Sibling comparison can -- dumphfdl-2 is flat zero across all 24 hours while both same-host, same-hardware siblings show clear propagation curves:
+
+```promql
+sum_over_time(decoder_msgs[7d])
+  < 0.05 * quantile by (host) (0.5, sum_over_time(decoder_msgs[7d]))
+```
+
+Low severity, long window, `repeat_interval` measured in days. A prompt to inspect an antenna, not a page.
+
+## USB and usbfs
+
+### Why the ceiling is hit
+
+librtlsdr pins roughly 3.75 MB per device (15 transfers of 256 KB). The kernel's global usbfs ceiling defaults to 16 MB:
+
+```text
+sdrhub    2 dongles ~  7.5 MB / 16 MB    fine
+acarshub  3 dongles ~ 11.3 MB / 16 MB    borderline
+vdlmhub   4 dongles ~ 15.0 MB / 16 MB    exhausted
+```
+
+This is the direct cause of the 515 `Failed to submit transfer` and 520 `async read failed` lines observed on vdlmhub over seven days, and vdlmhub is the only host producing them.
+
+### usbfs_memory_mb semantics
+
+From `drivers/usb/core/devio.c`:
+
+```c
+/* Limit on the total amount of memory we can allocate for transfers */
+static u32 usbfs_memory_mb = 16;
+module_param(usbfs_memory_mb, uint, 0644);
+MODULE_PARM_DESC(usbfs_memory_mb,
+    "maximum MB allowed for usbfs buffers (0 = no limit)");
+```
+
+Properties that matter:
+
+- The default of 16 is a **compile-time constant**. It is not derived from RAM, chipset, USB controller, or CPU. Identical on a mini PC and on a large server.
+- It is a **global, system-wide** cap shared by all usbfs users, not per-device or per-process.
+- It is a **ceiling, not an allocation**. Raising it consumes no memory.
+- `0` is documented as "no limit", implemented as the hard maximum of 2047 MB. The kernel parameter documentation reads `usbcore.usbfs_memory_mb= [USB] Memory limit (in MB) for buffers allocated by usbfs (default = 16, 0 = max = 2047)`. librtlsdr's suggestion to `echo 0` is therefore correct, not a bug -- we prefer an explicit bounded value for legibility.
+- `module_param(..., 0644)` makes it writable at runtime through sysfs.
+
+On every host in the fleet `usbcore` is **built into the kernel**, not a loadable module. `boot.extraModprobeConfig` is therefore a no-op, because `modprobe.d` only applies to modules that get loaded. The parameter has to come from the kernel command line.
+
+### Kernel parameter merge hazard
+
+`lib.mkDefault` on a list option does not merge -- a normal-priority definition wins outright and discards it. Verified with `lib.evalModules`:
+
+```text
+onlyMkDefault        -> [ "blacklist=dvb" ]
+mkDefaultPlusNormal  -> [ "usbcore.usbfs_memory_mb=1000" ]     <- blacklist silently gone
+bothNormal           -> [ "usbcore.usbfs_memory_mb=1000", "blacklist=dvb" ]
+```
+
+`modules/hardware/rtl-sdr.nix:17` sets `boot.kernelParams = lib.mkDefault [ "modprobe.blacklist=dvb_usb_rtl28xxu" ]`. If any other module sets `boot.kernelParams` at normal priority on the same host, that blacklist disappears silently. The `mkDefault` must be removed. This is currently latent, because `hardware-profile.rtl-sdr.enable` is set nowhere and `modules/hardware` is imported only by `profiles/desktop.nix`.
+
+### USB topology
+
+```text
+vdlmhub   Bus001 root_hub 12p 480M -> external 4-port hub -> 4x RTL2838
+acarshub  Bus001 root_hub 12p 480M -> external 4-port hub -> 3x RTL2838
+hfdlhub1  Bus001 root_hub 12p 480M -> 3x SDRplay RSP1a directly on root ports
+sdrhub    Bus003 root_hub 12p 480M -> external hub -> 2x RTL2832U   (4 buses total)
+hfdlhub2  no USB SDR hardware -- hfdlobserver drives network web888/KiwiSDR receivers
+```
+
+Bandwidth is not the constraint:
+
+```text
+dumpvdl2  1.26 Msps x 2 bytes = 2.52 MB/s x 4 = ~10.1 MB/s
+acarsdec  0.96 Msps x 2 bytes = 1.92 MB/s x 3 = ~ 5.8 MB/s
+USB 2.0 practical ceiling                      = ~35-40 MB/s
+```
+
+At roughly a quarter of the available bus, the failure is purely the accounting ceiling.
+
+### Consolidation guidance
+
+Because the ceiling is machine-independent and global, **consolidating servers makes this worse, not better**. Twelve radios on one box need roughly 45 MB against the same 16 MB default -- a guaranteed failure on day one, on better hardware. The parameter is a prerequisite for any multi-dongle host, and grows more essential as hosts get denser.
+
+What genuinely does depend on hardware: the number of independent USB host controllers (sdrhub exposes four buses, vdlmhub and acarshub two), whether radios are daisy-chained behind a single external hub (three of four hosts currently do this), and CPU available for demodulation. If consolidating, prefer multiple independent host controllers, avoid funnelling every radio through one hub, use powered hubs for bias-tee draw, and account for the RF and thermal cost of co-locating many dongles plus the concentration of the failure domain.
+
+- [ ] Add `modules/hardware/usbfs.nix` exposing `hardware-profile.usbfs.{enable,memoryMB}`
+- [ ] Enable it on sdrhub, acarshub, vdlmhub, hfdlhub1 -- **not** hfdlhub2, which has no USB radios
+- [ ] Set `usbfs_memory_mb` proportionally if hosts are ever consolidated
+
+## Tuning workflow
+
+Thresholds cannot be derived from first principles. The deliverable is a tuning platform with defensible starting baselines, not a set of correct numbers.
+
+- Alerts **fire immediately** rather than running in shadow mode, so real-time notifications provide the evidence for whether a threshold is right. See [Decisions log](#decisions-log).
+- Severity routing must land **before** the throughput alerts, so tuning noise goes to a different ntfy topic from `NodeDown`. Without it the channel that matters gets trained into background noise.
+- Persist baselines as recording rules so a Grafana panel can show actual against baseline against threshold per receiver. Tuning then means reading a graph and changing one number.
+- Keep thresholds in a Nix attrset, not inline in YAML, so a change is a one-line edit next to the container definition where the frequency list already lives.
+
+## Notification transport
+
+**Status: proposal only. Not adopted, not scheduled.** Recorded so the evaluation does not have to be repeated. Do not implement any of this without explicit sign-off -- the current ntfy path stays as-is for now.
+
+### Current path and its gaps
+
+Alertmanager routes every severity to a single `ntfy` receiver on topic `fred-sdrhub-alerts` at `high` priority via the `alertmanager-ntfy` bridge on `127.0.0.1:8000`.
+
+- Every severity shares one topic at one priority, so `FwupdUpdatesAvailable` (info, 24h) arrives as urgently as `NodeDown`. No transport change fixes this; it is a routing problem.
+- No acknowledgement and no escalation. An unseen alert is simply lost.
+- `alertmanager-ntfy` is a third-party bridge process in the critical path, and nothing monitors it. If it dies the result is silence, which is indistinguishable from health.
+- The topic is on **public ntfy.sh with no authentication**. Anyone who knows or guesses `fred-sdrhub-alerts` can subscribe and read hostnames, unit names, and failure detail. This is the one item worth mitigating independently of any migration, since it is cheap: rename to an unguessable topic, or self-host with auth.
+
+### Constraints captured
+
+- Phone is **iOS**. Rules out Gotify, whose iOS support is weak. Critical-alert delivery that bypasses Focus requires Pushover or the Home Assistant companion app.
+- **Home Assistant is not in use and not wanted.** Do not propose it again.
+- A one-time paid component is acceptable; Pushover's fee was explicitly approved in principle.
+- Grafana OnCall OSS is **archived as of 2026-03-24** and its Cloud Connection for mobile push, SMS, and voice is disabled. It is not a candidate. Do not re-evaluate it.
+
+### Delivery options evaluated
+
+| Option             | Native in Alertmanager | Self-host | Bypasses iOS Focus | Ack or escalation      | Notes                                                            |
+| ------------------ | ---------------------- | --------- | ------------------ | ---------------------- | ---------------------------------------------------------------- |
+| Pushover           | yes, `pushover_configs` | no        | yes, emergency priority | retries until acked | Removes the bridge from the critical path entirely               |
+| ntfy self-hosted   | needs bridge           | yes       | yes, priority 5    | no                     | Adds auth and private topics; keeps the existing bridge risk     |
+| Telegram           | yes, `telegram_configs` | no        | no                 | no                     | Free, good formatting and search; buried among ordinary chats    |
+| PagerDuty          | yes, `pagerduty_configs` | no      | yes, phone calls   | full escalation policies | Only option with true escalate-if-unacked; cloud dependency    |
+| Gotify             | needs bridge           | yes       | no                 | no                     | Android-oriented; ruled out by the iOS constraint                |
+| Email              | yes                    | yes       | no                 | no                     | Digest tier only                                                 |
+
+### Triage and console options
+
+| Option                          | Packaged as             | What it provides                                                                 |
+| ------------------------------- | ----------------------- | -------------------------------------------------------------------------------- |
+| Karma                           | `services.karma`        | Purpose-built Alertmanager console: grouped live state, silence management        |
+| Grafana Alertmanager datasource | Grafana already running | Browse and silence alerts in an existing UI with no rule migration                |
+| Alerta                          | `services.alerta`       | Alert database with deduplication, correlation, and history                       |
+| Uptime Kuma                     | `services.uptime-kuma`  | Blackbox checks and deadman hosting rather than an Alertmanager console           |
+
+All four are present in the pinned nixpkgs. Alertmanager is 0.33.1, ntfy-sh is 2.26.0.
+
+### Proposed target state
+
+If and when this is picked up:
+
+- Critical severity to **Pushover** with emergency priority, using the native receiver so `alertmanager-ntfy` leaves the critical path.
+- Warning and info to **ntfy** on a private authenticated topic as a digest with a long `repeat_interval`.
+- **Karma** on sdrhub for triage, plus the Alertmanager datasource in Grafana since it costs nothing.
+- Deadman switch on a **different provider and a different host** -- fredvps is off-site, so a deadman there survives a whole-house outage. A deadman sharing infrastructure with the thing it watches is decorative.
+
+Two independent providers also means a single provider outage does not blind the fleet.
+
+- [ ] Decide whether to adopt this proposal
+- [ ] Independently of the above: move off the unauthenticated public ntfy.sh topic
+
+## Work plan
+
+### Phase 1 -- correctness
+
+No tuning risk; all of these are outright bugs.
+
+- [ ] `PrometheusTargetDown`: `sum` to `count`
+- [ ] Drop the phantom 9273 and 9275 targets
+- [ ] Rewrite `sdr-alerts.yaml` against the families served on 9274
+- [ ] Delete `SDRServiceFailure` and `FeederUpstreamFailure`, update the inhibit list
+- [ ] Fix the `Daytona` regex case, add labels to unlabelled jobs
+- [ ] Add `modules/hardware/usbfs.nix` and enable on the four radio hosts
+- [ ] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
+
+### Phase 2 -- severity routing
+
+Prerequisite for anything noisy. **Transport-agnostic** -- this is entirely achievable on the existing ntfy setup and does not depend on the deferred [Notification transport](#notification-transport) proposal.
+
+- [ ] Split ntfy topics by severity; critical to a priority topic, warning and info to a digest
+- [ ] Set a long `repeat_interval` for the tuning tier
+- [ ] Expand inhibit rules: docker daemon down suppresses container alerts; decoder crash suppresses its own throughput alert
+
+### Phase 3 -- traffic-independent signals
+
+Deployable immediately, nothing to tune.
+
+- [ ] Enable the Loki ruler with `remote_write` into Prometheus and Alertmanager wiring
+- [ ] Crash detection on `s6wrap` and `exited with -11`
+- [ ] Heartbeat-absence detection
+- [ ] `container_health_state != 1` at warning severity
+- [ ] Curated error signature rules from the catalogue above
+- [ ] Remove the dead `loki.process "docker"` block from `alloy.nix`
+
+### Phase 4 -- monitoring stack resilience
+
+The notification path is currently a single unmonitored point of failure. If Alertmanager, alertmanager-ntfy, or ntfy.sh dies, silence is indistinguishable from health.
+
+- [ ] Deadman's switch: always-firing alert to a separate receiver backed by an external heartbeat monitor
+- [ ] Scrape Alertmanager, Grafana, and Loki
+- [ ] Alert on `alertmanager_notifications_failed_total` and `prometheus_notifications_dropped_total`
+- [ ] Alert on `prometheus_rule_evaluation_failures_total`, `prometheus_tsdb_wal_corruptions_total`
+- [ ] Per-host log-ingestion deadman via `absent_over_time({host="X"}[15m])`
+- [ ] Alert on `docker.service` being down, to avoid a storm of downstream container alerts
+
+### Phase 5 -- CI and container hygiene
+
+- [ ] `promtool test rules` wired into `flake/dev/checks.nix`
+- [ ] CI gate asserting every metric referenced in `alert-rules/*.yaml` returns a non-empty result
+- [ ] `promtool check rules` in pre-commit
+- [ ] Add `runbook_url` annotations to every alert
+- [ ] Raise dump978's internal `message-monitor` threshold; it currently restarts its own decoder about 20 times a day because UAT is legitimately quiet at this site
+- [ ] Blackbox exporter for certificate expiry and external endpoint probes
+- [ ] smartctl exporter, disk fill-rate prediction, systemd timer staleness
+
+### Phase 6 -- throughput baselines
+
+Requires three weeks of recorded history before the `offset 1w` comparison is meaningful. Start recording in Phase 3 so history accumulates while earlier phases land.
+
+- [ ] Record `decoder_msgs` via the Loki ruler
+- [ ] Self-baseline alerts once three weekly samples exist
+- [ ] Share-of-fleet alerts for the homogeneous acarsdec and dumpvdl2 groups
+- [ ] Sibling-comparison alerts at info severity
+
+## Verification commands
+
+Prometheus is at `192.168.31.20:9090`, Loki at `192.168.31.20:5678`. Both are reachable from the LAN without auth.
+
+Check whether a rule's metrics actually exist:
+
+```bash
+curl -sG "http://192.168.31.20:9090/api/v1/query" \
+  --data-urlencode 'query=count(node_systemd_unit_restart_total)'
+```
+
+List targets and their health:
+
+```bash
+curl -sG "http://192.168.31.20:9090/api/v1/targets?state=active" \
+  | python3 -c "import json,sys; [print(t['labels']['job'], t['labels']['instance'], t['health'], t['lastError'][:60]) for t in json.load(sys.stdin)['data']['activeTargets']]"
+```
+
+List rule health, including rules that are silently empty:
+
+```bash
+curl -sG "http://192.168.31.20:9090/api/v1/rules" \
+  | python3 -c "import json,sys; [print(g['name'], r['name'], r.get('health'), r.get('lastError','')) for g in json.load(sys.stdin)['data']['groups'] for r in g['rules']]"
+```
+
+Query container logs over a range:
+
+```bash
+curl -sG "http://192.168.31.20:5678/loki/api/v1/query_range" \
+  --data-urlencode 'query={unit=~"docker-.*"} |~ `s6wrap`' \
+  --data-urlencode "start=$(date -d '7 days ago' +%s)000000000" \
+  --data-urlencode "end=$(date +%s)000000000" \
+  --data-urlencode 'limit=1000'
+```
+
+Large regex alternations over a seven-day range will drop the Loki connection. Narrow the range to one or two days, or split the query.
+
+## Decisions log
+
+| Decision                                                     | Rationale                                                                                                                                     |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rules live in the Loki ruler, not Alloy `stage.metrics`      | One file on one host instead of a six-host colmena deploy per regex tweak. LogQL `unwrap` handles numeric heartbeat extraction, which `stage.metrics` cannot. Also removes the need for Alloy to be scrapeable. |
+| Alerts fire immediately rather than running in shadow mode   | Real-time notifications give the evidence needed to judge whether a threshold is right. Requires severity routing first so tuning noise is isolated from critical alerts. |
+| Throughput thresholds are relative, never absolute           | Traffic varies by hour, weekday, season, weather, and holiday, and the fleet contains three incompatible diurnal archetypes. No static threshold can be correct for all receivers. |
+| `usbfs_memory_mb` set via `boot.kernelParams`                | `usbcore` is built into the kernel on all hosts, so `modprobe.d` options do not apply. A `systemd.tmpfiles` write is added alongside so the setting also takes effect without a reboot. |
+| Explicit `1000` rather than `0`                              | `0` is valid and means the 2047 MB hard maximum, but a bounded value states intent and avoids an effectively unlimited pin budget.            |
+| usbfs enabled on four hosts, not five                        | hfdlhub2 has no USB SDR hardware; hfdlobserver drives network web888/KiwiSDR receivers. It cannot go in `profiles/adsb-hub.nix`, which is also imported by fredvps, fredhub, and hfdlhub2. |
+| Container healthchecks are a supplement, never a backbone    | Coverage is inversely correlated with failure rate -- the only containers observed crashing, dumphfdl and hfdlobserver, ship no healthcheck.  |
+| Notification transport change deferred                       | The evaluation is recorded under [Notification transport](#notification-transport) but no migration is scheduled. Severity routing is the actual blocker and is transport-agnostic, so it proceeds on the existing ntfy path. |
+| Grafana OnCall OSS excluded permanently                      | Archived 2026-03-24; Cloud Connection for mobile push, SMS, and voice is disabled. Recorded so it is not re-evaluated.                        |

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -17,23 +17,33 @@ eval, promtool and live query -- not that it is running in production.** The
 work landed on the `fix/monitoring-alerting-overhaul` branch; nothing has been
 applied to the fleet yet.
 
-Three things are expected on first apply, and none of them is a bug:
+Deployed and verified in production:
 
-- `SDRCannotClaimDevice` will fire immediately and persistently for dump978,
-  which logs roughly 240 `usb_claim_interface` failures an hour. It is a true
-  positive: that receiver genuinely cannot bind its device.
-- `SDRUsbfsBufferExhausted` will fire for vdlmhub until the host reboots and
-  picks up the new `usbcore.usbfs_memory_mb` kernel parameter. The
-  `systemd.tmpfiles` write applies it live, so this should clear on apply
-  without a reboot.
-- Warning and info alerts move to a new ntfy topic, `fred-sdrhub-digest`.
-  **It must be subscribed to** or those tiers will be invisible. Critical
-  deliberately stays on `fred-sdrhub-alerts` so an existing subscription keeps
-  receiving outages.
+- **usbfs ceiling** raised to 1000 MB on the four hosts with USB radios. This
+  resolved two long-standing faults: `usb_claim_interface error` on dump978
+  (37,948 events in 7 days, now zero) and `Failed to submit transfer` on
+  vdlmhub (2,095 events, now zero).
+- **smartctl exporter** on all six SMART-capable hosts, 20 metrics each.
+  sdrhub's Lexar NM620 reports 54% of rated write endurance consumed after
+  37.8 TB written -- the finding that justified adding it. Below the 80%
+  warning threshold, so it does not alert yet.
+- **blackbox exporter** probing 20 endpoints, 14 TLS certificates, minimum
+  headroom 49 days, zero failing probes.
+- **Pushover** replaced ntfy; `alertmanager-ntfy` removed from the critical
+  path. Critical alerts use emergency priority and re-alert until
+  acknowledged.
+- **Deadman** pings healthchecks.io. Recommended schedule: period 5m, grace
+  5m. `repeat_interval` is 1m so pings arrive every ~60s; tighter than that
+  false-alarms whenever a `nixos-rebuild` restarts Alertmanager.
 
-After applying, re-run `scripts/check-alert-metrics.sh`; the three metrics it
-currently reports MISSING are all produced by changes in this branch and should
-resolve.
+A trap worth knowing about, since it will recur on any new host: the nixpkgs
+smartctl module's udev rule is gated on `ACTION=="add"`, so it fires at boot
+and never again. Deploying the exporter to a running system leaves
+`/dev/nvme0` as `crw------- root root`, and the exporter serves
+`smartctl_devices 1` with no device metrics while its scrape target still
+reports up. Capabilities do not help -- the unit has CAP_SYS_RAWIO and
+CAP_SYS_ADMIN, and neither bypasses DAC. `modules/monitoring/agent/smartctl.nix`
+applies the ACL explicitly via a oneshot ordered before the exporter.
 
 ### Maintenance rules
 
@@ -422,7 +432,7 @@ Thresholds cannot be derived from first principles. The deliverable is a tuning 
 
 ## Notification transport
 
-**Status: proposal only. Not adopted, not scheduled.** Recorded so the evaluation does not have to be repeated. Do not implement any of this without explicit sign-off -- the current ntfy path stays as-is for now.
+**Status: adopted.** ntfy and the `alertmanager-ntfy` bridge have been removed; alerts go to Pushover via Alertmanager's native receiver, and the deadman pings healthchecks.io. The evaluation below is retained because it records why, and which options were rejected.
 
 ### Current path and its gaps
 
@@ -473,8 +483,8 @@ If and when this is picked up:
 
 Two independent providers also means a single provider outage does not blind the fleet.
 
-- [ ] Decide whether to adopt this proposal
-- [ ] Independently of the above: move off the unauthenticated public ntfy.sh topic
+- [x] Decide whether to adopt this proposal
+- [x] Independently of the above: move off the unauthenticated public ntfy.sh topic
 
 ## Work plan
 
@@ -527,9 +537,9 @@ The notification path is currently a single unmonitored point of failure. If Ale
 - [ ] `promtool check rules` in pre-commit
 - [ ] Add `runbook_url` annotations to every alert
 - [ ] Raise dump978's internal `message-monitor` threshold; it currently restarts its own decoder about 20 times a day because UAT is legitimately quiet at this site
-- [ ] Blackbox exporter for certificate expiry and external endpoint probes
+- [x] Blackbox exporter for certificate expiry and external endpoint probes
 - [x] Disk fill-rate prediction, systemd timer staleness, network errors, load saturation
-- [ ] smartctl exporter for SMART pre-failure attributes
+- [x] smartctl exporter for SMART pre-failure attributes
 
 ### Phase 6 -- throughput baselines
 

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -32,9 +32,21 @@ Deployed and verified in production:
 - **Pushover** replaced ntfy; `alertmanager-ntfy` removed from the critical
   path. Critical alerts use emergency priority and re-alert until
   acknowledged.
-- **Deadman** pings healthchecks.io. Recommended schedule: period 5m, grace
-  5m. `repeat_interval` is 1m so pings arrive every ~60s; tighter than that
-  false-alarms whenever a `nixos-rebuild` restarts Alertmanager.
+- **Deadman** pings healthchecks.io every 2 minutes. Schedule: **period 5m,
+  grace 10m**, giving ~15 minutes to detect total alerting failure.
+
+  The 2-minute cadence is not a typo for 1 minute. Alertmanager only
+  re-evaluates whether to notify on each `group_interval` tick, and its dedup
+  stage sends only when `lastNotify < now - repeat_interval`. With
+  `repeat_interval` equal to `group_interval`, the tick at exactly one interval
+  fails that test by a hair and slips to the next tick, so any
+  `repeat_interval >= group_interval` yields a real cadence of
+  `2 x group_interval`. Confirmed against the ping log: 09:25, 09:27, 09:29.
+
+  Grace is 10m rather than 5m so a reboot of sdrhub (1-3 minutes) does not
+  trip it. For planned maintenance longer than ~15 minutes, pause the check in
+  the healthchecks.io UI rather than widening the window permanently -- a
+  deadman with a 25-hour detection time is decoration.
 
 A trap worth knowing about, since it will recur on any new host: the nixpkgs
 smartctl module's udev rule is gated on `ACTION=="add"`, so it fires at boot

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -588,14 +588,30 @@ The notification path was a single unmonitored point of failure: if Alertmanager
 
 ### Phase 5 -- CI and container hygiene
 
-- [x] `promtool test rules` wired into `flake/dev/checks.nix`
-- [x] CI gate asserting every metric referenced in `alert-rules/*.yaml` returns a non-empty result
-- [ ] `promtool check rules` in pre-commit
-- [ ] Add `runbook_url` annotations to every alert
-- [ ] Raise dump978's internal `message-monitor` threshold; it currently restarts its own decoder about 20 times a day because UAT is legitimately quiet at this site
+- [x] `promtool check rules` and `promtool test rules` wired into `flake/dev/checks.nix`
+- [x] The flake check is actually executed by CI. It was not: `lint.yaml` builds
+      `pre-commit-check` directly and never runs `nix flake check`, so the rule
+      tests would have passed by never running -- the same failure mode they
+      exist to catch.
+- [x] CI gate asserting every metric referenced in `alert-rules/*.yaml` resolves
 - [x] Blackbox exporter for certificate expiry and external endpoint probes
 - [x] Disk fill-rate prediction, systemd timer staleness, network errors, load saturation
 - [x] smartctl exporter for SMART pre-failure attributes
+- [x] dump978 self-restart loop. **Resolved by the usbfs fix, not by changing
+      the container's threshold.** It was bouncing its own decoder because it
+      could not claim its device: 136 restarts in 7 days, 16 in the last 24
+      hours, and 0 in the last 6 hours. It now reports "Receiver is OK" as often
+      as "appears stale" (6 vs 6 in 6 hours) against 1 vs 334 beforehand. No
+      container config change is needed; the underlying fault is gone.
+- [ ] `promtool check rules` as a *pre-commit* hook specifically. Deliberately
+      not done. The check runs in CI, so this would only move detection ~30
+      seconds earlier, and `precommit-base`'s `mkCheck` exposes no `extraHooks`
+      argument, so it would require changing that repo.
+- [ ] `runbook_url` annotations. Partially delivered by other means: Pushover
+      notifications carry a tappable link to the alert's `GeneratorURL`, which
+      was the concrete payoff wanted from `runbook_url` (open the graph rather
+      than just read a name). Actual runbook prose does not exist yet, so a
+      literal `runbook_url` would point at nothing.
 
 ### Phase 6 -- throughput baselines
 

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -84,29 +84,48 @@ applies the ACL explicitly via a oneshot ordered before the exporter.
 
 Daytona is excluded from pull-based scraping at `modules/monitoring/master/prometheus.nix:13` and instead pushes via `prometheus.remote_write` and `loki.write` from a bespoke Alloy config at `hosts/linux/daytona/configuration.nix:51-134`.
 
-Versions in use: Prometheus 3.12.0, Loki 3.7.4, Alloy 1.16.0. Prometheus retention 90d, Loki retention 30d.
+Versions in use: Prometheus 3.12.0, Alertmanager 0.31.1, Loki 3.7.4, Alloy 1.16.0. Prometheus retention 90d, Loki retention 30d.
+
+sdrhub additionally runs the Loki ruler (29 rules across 6 groups) and a blackbox exporter; every agent runs a smartctl exporter.
 
 ### Scrape configuration
 
 Defined at `modules/monitoring/master/prometheus.nix:160-262`. Global `scrape_interval` and `evaluation_interval` are both 15s.
 
-| Job         | Targets                                              | Labels attached           |
-| ----------- | ---------------------------------------------------- | ------------------------- |
-| node        | all agents + desktops + sdrhub on :9100              | hostname, role, exporter  |
-| cadvisor    | all agents + sdrhub on :4567                         | hostname, role, exporter  |
-| ultrafeeder | sdrhub.local:9273, sdrhub.local:9274                 | none                      |
-| dump978     | sdrhub.local:9275                                    | none                      |
-| acarshub    | sdrhub.local:8085                                    | none                      |
-| prometheus  | 127.0.0.1:9090                                       | none                      |
-| pushgateway | 127.0.0.1:9091                                       | none                      |
+14 jobs, 49 targets, all healthy. The blackbox and smartctl jobs are defined by
+their own modules rather than here: `scrapeConfigs` and `ruleFiles` are both
+`listOf` options that merge across modules, so an exporter can be self-contained.
 
-Alertmanager routes every severity to a single `ntfy` receiver on topic `fred-sdrhub-alerts` at `high` priority when firing. Nothing scrapes Alertmanager, Grafana, or Loki.
+| Job                     | Targets                                   | Labels attached          |
+| ----------------------- | ----------------------------------------- | ------------------------ |
+| node                    | all agents + desktops + sdrhub on :9100   | hostname, role, exporter |
+| cadvisor                | all agents + sdrhub on :4567 (7)          | hostname, role, exporter |
+| smartctl                | 6 SMART-capable hosts on :9633            | hostname, role, exporter |
+| ultrafeeder             | sdrhub.local:9274                         | hostname, role           |
+| acarshub                | sdrhub.local:8085                         | hostname, role           |
+| prometheus              | 127.0.0.1:9090                            | hostname, role           |
+| alertmanager            | 127.0.0.1:9093                            | hostname, role           |
+| loki                    | 127.0.0.1:5678                            | hostname, role           |
+| grafana                 | 127.0.0.1:3333                            | hostname, role           |
+| pushgateway             | 127.0.0.1:9091 (honor_labels)             | hostname, role           |
+| blackbox-exporter       | 127.0.0.1:9115 (the exporter itself)      | none                     |
+| blackbox-https          | 3 public HTTPS endpoints, must be 2xx     | instance, job            |
+| blackbox-https-redirect | 11 apex domains, must be 3xx              | instance, job            |
+| blackbox-http-internal  | 6 internal vhosts via the nginx proxy     | instance, job            |
+
+`dump978` was removed: nothing inside the container listens on the published
+port 9275, so it was a permanently-down phantom target. Its metrics are served
+by the container's own nginx, which currently 404s on `/metrics`.
+
+Alertmanager routes by severity to three Pushover receivers, plus a `watchdog` receiver that pings healthchecks.io. Alertmanager, Grafana and Loki are all scraped. See [Notification transport](#notification-transport).
 
 ## Verified defects
 
 ### Dead alert rules
 
-Five of the twenty-two rules reference metrics with no active series. Prometheus reports all of them as `health=ok`, because a rule evaluating to an empty vector is considered healthy. They have never fired and cannot fire.
+**All defects in this section are fixed.** They are retained because the evidence explains why the current shape is what it is, and because the failure mode recurs.
+
+Five of the then-twenty-two rules referenced metrics with no active series. Prometheus reported all of them as `health=ok`, because a rule evaluating to an empty vector is considered healthy. They had never fired and could not fire. The rule set is now 49 alerts across 9 files, all covered by `promtool` unit tests and by `scripts/check-alert-metrics.sh`.
 
 | Rule                    | Location             | Missing metric                                | Cause                                                     |
 | ----------------------- | -------------------- | --------------------------------------------- | --------------------------------------------------------- |
@@ -438,7 +457,7 @@ What genuinely does depend on hardware: the number of independent USB host contr
 Thresholds cannot be derived from first principles. The deliverable is a tuning platform with defensible starting baselines, not a set of correct numbers.
 
 - Alerts **fire immediately** rather than running in shadow mode, so real-time notifications provide the evidence for whether a threshold is right. See [Decisions log](#decisions-log).
-- Severity routing must land **before** the throughput alerts, so tuning noise goes to a different ntfy topic from `NodeDown`. Without it the channel that matters gets trained into background noise.
+- Severity routing lands **before** the throughput alerts, so tuning noise arrives at a different Pushover priority from `NodeDown`. Without it the channel that matters gets trained into background noise. Decoder throughput alerts are `info`, which is Pushover priority -1: delivered silently, no sound.
 - Persist baselines as recording rules so a Grafana panel can show actual against baseline against threshold per receiver. Tuning then means reading a graph and changing one number.
 - Keep thresholds in a Nix attrset, not inline in YAML, so a change is a one-line edit next to the container definition where the frequency list already lives.
 
@@ -448,12 +467,12 @@ Thresholds cannot be derived from first principles. The deliverable is a tuning 
 
 ### Current path and its gaps
 
-Alertmanager routes every severity to a single `ntfy` receiver on topic `fred-sdrhub-alerts` at `high` priority via the `alertmanager-ntfy` bridge on `127.0.0.1:8000`.
+For the record, the path this replaced: every severity went to a single `ntfy` receiver on one public topic at `high` priority, via the `alertmanager-ntfy` bridge on `127.0.0.1:8000`.
 
 - Every severity shares one topic at one priority, so `FwupdUpdatesAvailable` (info, 24h) arrives as urgently as `NodeDown`. No transport change fixes this; it is a routing problem.
 - No acknowledgement and no escalation. An unseen alert is simply lost.
-- `alertmanager-ntfy` is a third-party bridge process in the critical path, and nothing monitors it. If it dies the result is silence, which is indistinguishable from health.
-- The topic is on **public ntfy.sh with no authentication**. Anyone who knows or guesses `fred-sdrhub-alerts` can subscribe and read hostnames, unit names, and failure detail. This is the one item worth mitigating independently of any migration, since it is cheap: rename to an unguessable topic, or self-host with auth.
+- `alertmanager-ntfy` was a third-party bridge process in the critical path that nothing monitored. If it died the result was silence, which is indistinguishable from health. Removed.
+- The topic was on **public ntfy.sh with no authentication**, and a ntfy topic name is effectively a password. Anyone who knew or guessed it could read hostnames, unit names and failure detail. Resolved by the migration: Pushover credentials live in sops.
 
 ### Constraints captured
 
@@ -482,18 +501,43 @@ Alertmanager routes every severity to a single `ntfy` receiver on topic `fred-sd
 | Alerta                          | `services.alerta`       | Alert database with deduplication, correlation, and history                       |
 | Uptime Kuma                     | `services.uptime-kuma`  | Blackbox checks and deadman hosting rather than an Alertmanager console           |
 
-All four are present in the pinned nixpkgs. Alertmanager is 0.33.1, ntfy-sh is 2.26.0.
+All four are present in the pinned nixpkgs. Karma remains the recommended triage console and is not yet deployed.
 
-### Proposed target state
+### Deployed state
 
-If and when this is picked up:
+- Critical severity to **Pushover** at priority 2 (emergency): re-alerts until
+  acknowledged and bypasses quiet hours, with `retry 2m` / `expire 1h` and the
+  `siren` sound. This acknowledgement behaviour is the main reason for leaving
+  ntfy -- an unseen critical was previously just lost.
+- Warning to Pushover at priority 0, resolved notifications sent.
+- Info to Pushover at priority -1 (silent, no sound), resolved notifications
+  suppressed. This is the tier decoder throughput alerts land in while their
+  thresholds are unproven.
+- Notifications carry a tappable link to the alert's `GeneratorURL`, so tapping
+  opens the Prometheus graph for that alert.
+- Credentials via `token_file` / `user_key_file`, sourced from sops through
+  `LoadCredential`. Alertmanager runs `DynamicUser=yes` so there is no stable
+  uid for sops to chown to. Using the `_file` variants also preserves build-time
+  `amtool` validation, which an envsubst placeholder would have forced off.
+- Deadman pings healthchecks.io from the `watchdog` receiver.
 
-- Critical severity to **Pushover** with emergency priority, using the native receiver so `alertmanager-ntfy` leaves the critical path.
-- Warning and info to **ntfy** on a private authenticated topic as a digest with a long `repeat_interval`.
-- **Karma** on sdrhub for triage, plus the Alertmanager datasource in Grafana since it costs nothing.
-- Deadman switch on a **different provider and a different host** -- fredvps is off-site, so a deadman there survives a whole-house outage. A deadman sharing infrastructure with the thing it watches is decorative.
+**Alertmanager requires both `token` and `user_key`.** It calls
+`api.pushover.net` directly rather than being a hosted "Pushover-powered
+service", so it supplies the application identity as well as the recipient.
+Pushover's own docs say "just supply your user key", but that addresses users of
+a hosted service which already holds its own application token.
 
-Two independent providers also means a single provider outage does not blind the fleet.
+**Caveat worth remembering: `amtool check-config` does not validate notifier
+templates.** An unterminated `{{ if }}` injected into the critical title was
+accepted without complaint. The templates were therefore syntax-checked and
+rendered separately against a representative alert group. Any future template
+edit needs the same treatment.
+
+Not yet deployed: **Karma** for triage, recommended on fredvps bound to
+Tailscale rather than exposed publicly. Karma manages silences, so it is a
+control plane, not a read-only view -- a bad actor could silence every alert.
+Tailscale satisfies the off-LAN access requirement with no internet-facing
+attack surface.
 
 - [x] Decide whether to adopt this proposal
 - [x] Independently of the above: move off the unauthenticated public ntfy.sh topic
@@ -514,9 +558,9 @@ No tuning risk; all of these are outright bugs.
 
 ### Phase 2 -- severity routing
 
-Prerequisite for anything noisy. **Transport-agnostic** -- this is entirely achievable on the existing ntfy setup and does not depend on the deferred [Notification transport](#notification-transport) proposal.
+Prerequisite for anything noisy. Was implemented on ntfy first and carried over to Pushover unchanged, since the routing tree is transport-agnostic.
 
-- [x] Split ntfy topics by severity; critical to a priority topic, warning and info to a digest
+- [x] Route by severity (implemented on ntfy topics, now Pushover priorities)
 - [x] Set a long `repeat_interval` for the tuning tier
 - [x] Expand inhibit rules: docker daemon down suppresses container alerts; decoder crash suppresses its own throughput alert
 
@@ -533,7 +577,7 @@ Deployable immediately, nothing to tune.
 
 ### Phase 4 -- monitoring stack resilience
 
-The notification path is currently a single unmonitored point of failure. If Alertmanager, alertmanager-ntfy, or ntfy.sh dies, silence is indistinguishable from health.
+The notification path was a single unmonitored point of failure: if Alertmanager or the delivery bridge died, silence was indistinguishable from health. Now monitored, and the deadman covers total failure.
 
 - [x] Deadman's switch: always-firing alert to a separate receiver backed by an external heartbeat monitor
 - [x] Scrape Alertmanager, Grafana, and Loki
@@ -610,5 +654,5 @@ Large regex alternations over a seven-day range will drop the Loki connection. N
 | Explicit `1000` rather than `0`                              | `0` is valid and means the 2047 MB hard maximum, but a bounded value states intent and avoids an effectively unlimited pin budget.            |
 | usbfs enabled on four hosts, not five                        | hfdlhub2 has no USB SDR hardware; hfdlobserver drives network web888/KiwiSDR receivers. It cannot go in `profiles/adsb-hub.nix`, which is also imported by fredvps, fredhub, and hfdlhub2. |
 | Container healthchecks are a supplement, never a backbone    | Coverage is inversely correlated with failure rate -- the only containers observed crashing, dumphfdl and hfdlobserver, ship no healthcheck.  |
-| Notification transport change deferred                       | The evaluation is recorded under [Notification transport](#notification-transport) but no migration is scheduled. Severity routing is the actual blocker and is transport-agnostic, so it proceeds on the existing ntfy path. |
+| Migrated ntfy to Pushover                                    | Acknowledgement was the deciding factor: Pushover priority 2 re-alerts until acked, so an unseen critical is not lost. Also removes the unmonitored `alertmanager-ntfy` bridge from the critical path and moves credentials into sops. |
 | Grafana OnCall OSS excluded permanently                      | Archived 2026-03-24; Cloud Connection for mobile push, SMS, and voice is disabled. Recorded so it is not re-evaluated.                        |

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -96,22 +96,22 @@ Defined at `modules/monitoring/master/prometheus.nix:160-262`. Global `scrape_in
 their own modules rather than here: `scrapeConfigs` and `ruleFiles` are both
 `listOf` options that merge across modules, so an exporter can be self-contained.
 
-| Job                     | Targets                                   | Labels attached          |
-| ----------------------- | ----------------------------------------- | ------------------------ |
-| node                    | all agents + desktops + sdrhub on :9100   | hostname, role, exporter |
-| cadvisor                | all agents + sdrhub on :4567 (7)          | hostname, role, exporter |
-| smartctl                | 6 SMART-capable hosts on :9633            | hostname, role, exporter |
-| ultrafeeder             | sdrhub.local:9274                         | hostname, role           |
-| acarshub                | sdrhub.local:8085                         | hostname, role           |
-| prometheus              | 127.0.0.1:9090                            | hostname, role           |
-| alertmanager            | 127.0.0.1:9093                            | hostname, role           |
-| loki                    | 127.0.0.1:5678                            | hostname, role           |
-| grafana                 | 127.0.0.1:3333                            | hostname, role           |
-| pushgateway             | 127.0.0.1:9091 (honor_labels)             | hostname, role           |
-| blackbox-exporter       | 127.0.0.1:9115 (the exporter itself)      | none                     |
-| blackbox-https          | 3 public HTTPS endpoints, must be 2xx     | instance, job            |
-| blackbox-https-redirect | 11 apex domains, must be 3xx              | instance, job            |
-| blackbox-http-internal  | 6 internal vhosts via the nginx proxy     | instance, job            |
+| Job                     | Targets                                 | Labels attached          |
+| ----------------------- | --------------------------------------- | ------------------------ |
+| node                    | all agents + desktops + sdrhub on :9100 | hostname, role, exporter |
+| cadvisor                | all agents + sdrhub on :4567 (7)        | hostname, role, exporter |
+| smartctl                | 6 SMART-capable hosts on :9633          | hostname, role, exporter |
+| ultrafeeder             | sdrhub.local:9274                       | hostname, role           |
+| acarshub                | sdrhub.local:8085                       | hostname, role           |
+| prometheus              | 127.0.0.1:9090                          | hostname, role           |
+| alertmanager            | 127.0.0.1:9093                          | hostname, role           |
+| loki                    | 127.0.0.1:5678                          | hostname, role           |
+| grafana                 | 127.0.0.1:3333                          | hostname, role           |
+| pushgateway             | 127.0.0.1:9091 (honor_labels)           | hostname, role           |
+| blackbox-exporter       | 127.0.0.1:9115 (the exporter itself)    | none                     |
+| blackbox-https          | 3 public HTTPS endpoints, must be 2xx   | instance, job            |
+| blackbox-https-redirect | 11 apex domains, must be 3xx            | instance, job            |
+| blackbox-http-internal  | 6 internal vhosts via the nginx proxy   | instance, job            |
 
 `dump978` is scraped on 9275, but only because the container now runs the
 `telegraf-*` image variant -- see below. It carries `metric_relabel_configs`,
@@ -127,13 +127,13 @@ Alertmanager routes by severity to three Pushover receivers, plus a `watchdog` r
 
 Five of the then-twenty-two rules referenced metrics with no active series. Prometheus reported all of them as `health=ok`, because a rule evaluating to an empty vector is considered healthy. They had never fired and could not fire. The rule set is now 49 alerts across 9 files, all covered by `promtool` unit tests and by `scripts/check-alert-metrics.sh`.
 
-| Rule                    | Location             | Missing metric                                | Cause                                                     |
-| ----------------------- | -------------------- | --------------------------------------------- | --------------------------------------------------------- |
-| DockerUnitFlapping      | docker-rules.yaml:5  | node_systemd_unit_restart_total                | collector flag not passed to node_exporter                |
-| SDRServiceFailure       | docker-rules.yaml:14 | promtail_custom_sdr_service_failure_total      | promtail replaced by Alloy, which uses unprefixed names   |
-| FeederUpstreamFailure   | docker-rules.yaml:23 | promtail_custom_feeder_upstream_failure_total  | same as above                                             |
-| UltrafeederNoAircraft   | sdr-alerts.yaml:5    | readsb_stats_aircraft_with_pos                 | exporter emits readsb_aircraft_* families instead         |
-| UltrafeederNotReceiving | sdr-alerts.yaml:14   | readsb_stats_messages                          | same as above                                             |
+| Rule                    | Location             | Missing metric                                | Cause                                                   |
+| ----------------------- | -------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| DockerUnitFlapping      | docker-rules.yaml:5  | node_systemd_unit_restart_total               | collector flag not passed to node_exporter              |
+| SDRServiceFailure       | docker-rules.yaml:14 | promtail_custom_sdr_service_failure_total     | promtail replaced by Alloy, which uses unprefixed names |
+| FeederUpstreamFailure   | docker-rules.yaml:23 | promtail_custom_feeder_upstream_failure_total | same as above                                           |
+| UltrafeederNoAircraft   | sdr-alerts.yaml:5    | readsb_stats_aircraft_with_pos                | exporter emits `readsb_aircraft_*` families instead     |
+| UltrafeederNotReceiving | sdr-alerts.yaml:14   | readsb_stats_messages                         | same as above                                           |
 
 `node_systemd_unit_restart_total` requires `--collector.systemd.enable-restarts-metrics`, which `modules/monitoring/agent/node_exporter.nix:278-287` does not pass.
 
@@ -216,12 +216,12 @@ within an hour. With 90d retention every aircraft ever seen would leave 23
 series behind permanently, and none of it answers a monitoring question;
 per-aircraft state is what tar1090 and skyaware978 are for.
 
-| Family         | Series | Cardinality               |
-| -------------- | ------ | ------------------------- |
-| `aircraft_`    | 286    | unbounded -- suppressed   |
-| `stats_`       | 21     | fixed -- this is the useful part |
-| `polar_range_` | 72     | fixed, bearing buckets    |
-| `go_`/`process_` | 44   | fixed, telegraf's runtime |
+| Family           | Series | Cardinality                      |
+| ---------------- | ------ | -------------------------------- |
+| `aircraft_`      | 286    | unbounded -- suppressed          |
+| `stats_`         | 21     | fixed -- this is the useful part |
+| `polar_range_`   | 72     | fixed, bearing buckets           |
+| `go_`/`process_` | 44     | fixed, telegraf's runtime        |
 
 Suppressed in two places deliberately: `INFLUXDB_SKIP_AIRCRAFT=true` on the
 container stops collection at source, and a `metric_relabel_configs` drop on
@@ -257,15 +257,15 @@ This is orthogonal to log shipping, which works correctly on every host includin
 
 ### Smaller correctness defects
 
-| Location                        | Defect                                                                                              |
-| ------------------------------- | --------------------------------------------------------------------------------------------------- |
-| system-alerts.yaml:5            | `NixOSNotOnMain` excludes `daytona`; the host is `Daytona` and the regex is case-sensitive          |
-| sdr-alerts.yaml:9,18            | Annotations template `{{ $labels.hostname }}`; the ultrafeeder job attaches no `hostname` label     |
-| prometheus.nix:161-193          | Jobs ultrafeeder, dump978, acarshub, prometheus, pushgateway attach no labels at all                |
-| prometheus.nix:327              | Inhibit list references `SDRServiceFailure` and `FeederUpstreamFailure`, both being removed         |
-| adsb-docker-units.nix:31-82     | `mkUnit` silently ignores the `hostname`, `requires`, and `depends_on` keys set by several hosts    |
-| hardware/rtl-sdr.nix:17         | `lib.mkDefault` on a list option -- see [Kernel parameter merge hazard](#kernel-parameter-merge-hazard) |
-| grafana.nix:74                  | `secret_key` hardcoded in plaintext; the admin password is correctly sops-managed                   |
+| Location                    | Defect                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- |
+| system-alerts.yaml:5        | `NixOSNotOnMain` excludes `daytona`; the host is `Daytona` and the regex is case-sensitive              |
+| sdr-alerts.yaml:9,18        | Annotations template `{{ $labels.hostname }}`; the ultrafeeder job attaches no `hostname` label         |
+| prometheus.nix:161-193      | Jobs ultrafeeder, dump978, acarshub, prometheus, pushgateway attach no labels at all                    |
+| prometheus.nix:327          | Inhibit list references `SDRServiceFailure` and `FeederUpstreamFailure`, both being removed             |
+| adsb-docker-units.nix:31-82 | `mkUnit` silently ignores the `hostname`, `requires`, and `depends_on` keys set by several hosts        |
+| hardware/rtl-sdr.nix:17     | `lib.mkDefault` on a list option -- see [Kernel parameter merge hazard](#kernel-parameter-merge-hazard) |
+| grafana.nix:74              | `secret_key` hardcoded in plaintext; the admin password is correctly sops-managed                       |
 
 - [x] Fix the `Daytona` regex case sensitivity
 - [x] Add `hostname` and `role` labels to the unlabelled scrape jobs
@@ -282,11 +282,11 @@ The SDR containers are inconsistent about error reporting, and a generic match o
 
 Every decoder emits a periodic, machine-parseable throughput line. Over a 48h sample these arrived 575 times out of 576 expected, so the **absence** of a heartbeat is itself a strong signal that a container has wedged, independent of the value it carries.
 
-| Container family        | Log line                                                  | Period |
-| ----------------------- | --------------------------------------------------------- | ------ |
-| acarsdec-\*, dumpvdl2-\* | `[acars_bridge] [STATS] Total in the last 5 minutes: N`   | 5 min  |
-| dumphfdl-\*             | `[hfdl_stats] N hfdl messages received in last 5 mins`    | 5 min  |
-| ultrafeeder             | Prometheus exporter on :9274                              | scrape |
+| Container family         | Log line                                                | Period |
+| ------------------------ | ------------------------------------------------------- | ------ |
+| acarsdec-\*, dumpvdl2-\* | `[acars_bridge] [STATS] Total in the last 5 minutes: N` | 5 min  |
+| dumphfdl-\*              | `[hfdl_stats] N hfdl messages received in last 5 mins`  | 5 min  |
+| ultrafeeder              | Prometheus exporter on :9274                            | scrape |
 
 Extraction:
 
@@ -335,22 +335,47 @@ hfdlhub1   dumphfdl-1/2/3                                                 = none
 hfdlhub2   hfdlobserver                                                   = none
 ```
 
-Treat this as a fast supplementary signal at `warning` severity where it exists. It is not a backbone and must never be the only signal for a container.
+Treat this as a supplementary signal at `warning` severity where it exists. It is not a backbone and must never be the only signal for a container.
+
+**Two traps in `container_health_state`, both of which produced false positives before being fixed.**
+
+The value encoding is:
+
+```text
+ 1  healthy
+-1  no healthcheck defined in the image
+ 0  unhealthy  OR  still inside its start_period
+```
+
+A naive `!= 1` fires for all 34 containers that simply have no healthcheck. That one is obvious once seen.
+
+The second is not. **cAdvisor does not distinguish Docker's `starting` from `unhealthy`** -- both are `0`. These images deliberately use long start periods, because their healthchecks assert on message counts over the preceding hour or two:
+
+| Containers                            | start_period |
+| ------------------------------------- | ------------ |
+| piaware, dump978                      | 2h           |
+| acarsdec, dumpvdl2, acarshub, feeders | 1h           |
+| ultrafeeder, fr24                     | 10m          |
+| planewatch, radarvirtuel, degoog      | under 2m     |
+
+So a rule without a start-time gate fires roughly ten minutes after **every restart** and keeps firing for up to two hours -- on every deploy, for the containers that matter most. Observed doing exactly that to piaware, which was healthy and three minutes old at the time.
+
+`ContainerUnhealthy` therefore gates on `(time() - container_start_time_seconds) > 9000`, a margin over the longest start_period in the fleet. A slow gate is acceptable because nothing fast depends on this rule: `DecoderHeartbeatMissing` is 20m, and the Loki `s6wrap` crash rules, `DockerUnitFlapping` and `ContainerRestarting` are all healthcheck-independent. There is a regression test, and removing the gate makes it fail.
 
 ### Curated error signatures
 
 Only unambiguous patterns, explicitly enumerated. Never a generic level match.
 
-| Pattern                                                   | Meaning                                   | Severity |
-| --------------------------------------------------------- | ----------------------------------------- | -------- |
-| `usb_claim_interface error`                               | cannot bind SDR (1219 hits, dump978)      | critical |
-| `Failed to submit transfer` / `async read failed`         | usbfs ceiling exhausted (515/520, vdlmhub) | critical |
-| `sdrplay_api_ServiceNotResponding`                        | SDRplay API service dead                  | critical |
-| `Server status: (not synchronized\|clock unstable)`       | MLAT broken                               | warning  |
-| `Connection retries will continue`                        | feeder upstream unreachable               | warning  |
-| `Lost N packets ... on USB, MLAT could be UNSTABLE`       | USB or system clock issue                 | warning  |
-| `sdre_stubborn_io.*(Disconnect occurred\|Write while disconnected)` | real upstream connection loss | warning  |
-| `[message-monitor] [WARNING] Restarting the ... service`  | container gave up on its own receiver     | warning  |
+| Pattern                                                             | Meaning                                    | Severity |
+| ------------------------------------------------------------------- | ------------------------------------------ | -------- |
+| `usb_claim_interface error`                                         | cannot bind SDR (1219 hits, dump978)       | critical |
+| `Failed to submit transfer` / `async read failed`                   | usbfs ceiling exhausted (515/520, vdlmhub) | critical |
+| `sdrplay_api_ServiceNotResponding`                                  | SDRplay API service dead                   | critical |
+| `Server status: (not synchronized\|clock unstable)`                 | MLAT broken                                | warning  |
+| `Connection retries will continue`                                  | feeder upstream unreachable                | warning  |
+| `Lost N packets ... on USB, MLAT could be UNSTABLE`                 | USB or system clock issue                  | warning  |
+| `sdre_stubborn_io.*(Disconnect occurred\|Write while disconnected)` | real upstream connection loss              | warning  |
+| `[message-monitor] [WARNING] Restarting the ... service`            | container gave up on its own receiver      | warning  |
 
 For `acars_router` the discriminator is the **module path**, not the log level: `sdre_stubborn_io` indicates genuine connectivity loss, `message_handler` indicates data-quality noise.
 
@@ -358,15 +383,15 @@ For `acars_router` the discriminator is the **module path**, not the log level: 
 
 Recording these so they are not "rediscovered" and added later.
 
-| Pattern                                                | Why it is noise                                            |
-| ------------------------------------------------------ | ---------------------------------------------------------- |
-| `[R82XX] PLL not locked!`                              | normal during tuning                                       |
-| `message_handler.*Failed to parse received message`    | malformed upstream JSON, not a container failure           |
-| `acars2pos: failed distance check`                     | data quality filter working as designed                    |
-| `collectd: rrd_update_r ... illegal attempt`           | rrdtool bookkeeping noise                                  |
-| `Error response from daemon: No such container`        | emitted by our own `ExecStartPre` `docker rm -f`           |
-| `readsb: UAT TCP input: Connection to dump978 refused` | symptom of dump978 restarting; alert on the cause instead  |
-| `nginx: open() "/webapp/dist/favicon.ico" failed`      | cosmetic                                                   |
+| Pattern                                                | Why it is noise                                           |
+| ------------------------------------------------------ | --------------------------------------------------------- |
+| `[R82XX] PLL not locked!`                              | normal during tuning                                      |
+| `message_handler.*Failed to parse received message`    | malformed upstream JSON, not a container failure          |
+| `acars2pos: failed distance check`                     | data quality filter working as designed                   |
+| `collectd: rrd_update_r ... illegal attempt`           | rrdtool bookkeeping noise                                 |
+| `Error response from daemon: No such container`        | emitted by our own `ExecStartPre` `docker rm -f`          |
+| `readsb: UAT TCP input: Connection to dump978 refused` | symptom of dump978 restarting; alert on the cause instead |
+| `nginx: open() "/webapp/dist/favicon.ico" failed`      | cosmetic                                                  |
 
 ## Traffic seasonality
 
@@ -415,7 +440,7 @@ and
 
 The second clause is what makes quiet frequencies safe. If a receiver historically produced nothing at this hour, its baseline is near zero, the guard fails, and it never alerts. Averaging three weekly samples prevents one bad day from poisoning the baseline.
 
-**Share of fleet volume.** Self-baselining still breaks on holidays, because the prior week was an ordinary week. Comparing a receiver's *share* of its group's total instead of its absolute volume removes that entirely: if all receivers drop together, every share holds steady and nothing fires; if one dies, its share collapses while its siblings' shares rise. No calendar knowledge required. This only holds within a homogeneous group, so it applies to acarsdec-1/2/3 and dumpvdl2-1/2/3/4 but not across the HF receivers with disjoint windows.
+**Share of fleet volume.** Self-baselining still breaks on holidays, because the prior week was an ordinary week. Comparing a receiver's _share_ of its group's total instead of its absolute volume removes that entirely: if all receivers drop together, every share holds steady and nothing fires; if one dies, its share collapses while its siblings' shares rise. No calendar knowledge required. This only holds within a homogeneous group, so it applies to acarsdec-1/2/3 and dumpvdl2-1/2/3/4 but not across the HF receivers with disjoint windows.
 
 **Sibling comparison over a long window.** A self-baseline cannot detect a receiver that was already broken before the baseline window opened. Sibling comparison can -- dumphfdl-2 is flat zero across all 24 hours while both same-host, same-hardware siblings show clear propagation curves:
 
@@ -556,23 +581,23 @@ For the record, the path this replaced: every severity went to a single `ntfy` r
 
 ### Delivery options evaluated
 
-| Option             | Native in Alertmanager | Self-host | Bypasses iOS Focus | Ack or escalation      | Notes                                                            |
-| ------------------ | ---------------------- | --------- | ------------------ | ---------------------- | ---------------------------------------------------------------- |
-| Pushover           | yes, `pushover_configs` | no        | yes, emergency priority | retries until acked | Removes the bridge from the critical path entirely               |
-| ntfy self-hosted   | needs bridge           | yes       | yes, priority 5    | no                     | Adds auth and private topics; keeps the existing bridge risk     |
-| Telegram           | yes, `telegram_configs` | no        | no                 | no                     | Free, good formatting and search; buried among ordinary chats    |
-| PagerDuty          | yes, `pagerduty_configs` | no      | yes, phone calls   | full escalation policies | Only option with true escalate-if-unacked; cloud dependency    |
-| Gotify             | needs bridge           | yes       | no                 | no                     | Android-oriented; ruled out by the iOS constraint                |
-| Email              | yes                    | yes       | no                 | no                     | Digest tier only                                                 |
+| Option           | Native in Alertmanager   | Self-host | Bypasses iOS Focus      | Ack or escalation        | Notes                                                         |
+| ---------------- | ------------------------ | --------- | ----------------------- | ------------------------ | ------------------------------------------------------------- |
+| Pushover         | yes, `pushover_configs`  | no        | yes, emergency priority | retries until acked      | Removes the bridge from the critical path entirely            |
+| ntfy self-hosted | needs bridge             | yes       | yes, priority 5         | no                       | Adds auth and private topics; keeps the existing bridge risk  |
+| Telegram         | yes, `telegram_configs`  | no        | no                      | no                       | Free, good formatting and search; buried among ordinary chats |
+| PagerDuty        | yes, `pagerduty_configs` | no        | yes, phone calls        | full escalation policies | Only option with true escalate-if-unacked; cloud dependency   |
+| Gotify           | needs bridge             | yes       | no                      | no                       | Android-oriented; ruled out by the iOS constraint             |
+| Email            | yes                      | yes       | no                      | no                       | Digest tier only                                              |
 
 ### Triage and console options
 
-| Option                          | Packaged as             | What it provides                                                                 |
-| ------------------------------- | ----------------------- | -------------------------------------------------------------------------------- |
-| Karma                           | `services.karma`        | Purpose-built Alertmanager console: grouped live state, silence management        |
-| Grafana Alertmanager datasource | Grafana already running | Browse and silence alerts in an existing UI with no rule migration                |
-| Alerta                          | `services.alerta`       | Alert database with deduplication, correlation, and history                       |
-| Uptime Kuma                     | `services.uptime-kuma`  | Blackbox checks and deadman hosting rather than an Alertmanager console           |
+| Option                          | Packaged as             | What it provides                                                           |
+| ------------------------------- | ----------------------- | -------------------------------------------------------------------------- |
+| Karma                           | `services.karma`        | Purpose-built Alertmanager console: grouped live state, silence management |
+| Grafana Alertmanager datasource | Grafana already running | Browse and silence alerts in an existing UI with no rule migration         |
+| Alerta                          | `services.alerta`       | Alert database with deduplication, correlation, and history                |
+| Uptime Kuma                     | `services.uptime-kuma`  | Blackbox checks and deadman hosting rather than an Alertmanager console    |
 
 All four are present in the pinned nixpkgs. Karma remains the recommended triage console and is not yet deployed.
 
@@ -750,14 +775,14 @@ Large regex alternations over a seven-day range will drop the Loki connection. N
 
 ## Decisions log
 
-| Decision                                                     | Rationale                                                                                                                                     |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Rules live in the Loki ruler, not Alloy `stage.metrics`      | One file on one host instead of a six-host colmena deploy per regex tweak. LogQL `unwrap` handles numeric heartbeat extraction, which `stage.metrics` cannot. Also removes the need for Alloy to be scrapeable. |
-| Alerts fire immediately rather than running in shadow mode   | Real-time notifications give the evidence needed to judge whether a threshold is right. Requires severity routing first so tuning noise is isolated from critical alerts. |
-| Throughput thresholds are relative, never absolute           | Traffic varies by hour, weekday, season, weather, and holiday, and the fleet contains three incompatible diurnal archetypes. No static threshold can be correct for all receivers. |
-| `usbfs_memory_mb` set via `boot.kernelParams`                | `usbcore` is built into the kernel on all hosts, so `modprobe.d` options do not apply. A `systemd.tmpfiles` write is added alongside so the setting also takes effect without a reboot. |
-| Explicit `1000` rather than `0`                              | `0` is valid and means the 2047 MB hard maximum, but a bounded value states intent and avoids an effectively unlimited pin budget.            |
-| usbfs enabled on four hosts, not five                        | hfdlhub2 has no USB SDR hardware; hfdlobserver drives network web888/KiwiSDR receivers. It cannot go in `profiles/adsb-hub.nix`, which is also imported by fredvps, fredhub, and hfdlhub2. |
-| Container healthchecks are a supplement, never a backbone    | Coverage is inversely correlated with failure rate -- the only containers observed crashing, dumphfdl and hfdlobserver, ship no healthcheck.  |
-| Migrated ntfy to Pushover                                    | Acknowledgement was the deciding factor: Pushover priority 2 re-alerts until acked, so an unseen critical is not lost. Also removes the unmonitored `alertmanager-ntfy` bridge from the critical path and moves credentials into sops. |
-| Grafana OnCall OSS excluded permanently                      | Archived 2026-03-24; Cloud Connection for mobile push, SMS, and voice is disabled. Recorded so it is not re-evaluated.                        |
+| Decision                                                   | Rationale                                                                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rules live in the Loki ruler, not Alloy `stage.metrics`    | One file on one host instead of a six-host colmena deploy per regex tweak. LogQL `unwrap` handles numeric heartbeat extraction, which `stage.metrics` cannot. Also removes the need for Alloy to be scrapeable.                                                                                |
+| Alerts fire immediately rather than running in shadow mode | Real-time notifications give the evidence needed to judge whether a threshold is right. Requires severity routing first so tuning noise is isolated from critical alerts.                                                                                                                      |
+| Throughput thresholds are relative, never absolute         | Traffic varies by hour, weekday, season, weather, and holiday, and the fleet contains three incompatible diurnal archetypes. No static threshold can be correct for all receivers.                                                                                                             |
+| `usbfs_memory_mb` set via `boot.kernelParams`              | `usbcore` is built into the kernel on all hosts, so `modprobe.d` options do not apply. A `systemd.tmpfiles` write is added alongside so the setting also takes effect without a reboot.                                                                                                        |
+| Explicit `1000` rather than `0`                            | `0` is valid and means the 2047 MB hard maximum, but a bounded value states intent and avoids an effectively unlimited pin budget.                                                                                                                                                             |
+| usbfs enabled on four hosts, not five                      | hfdlhub2 has no USB SDR hardware; hfdlobserver drives network web888/KiwiSDR receivers. It cannot go in `profiles/adsb-hub.nix`, which is also imported by fredvps, fredhub, and hfdlhub2.                                                                                                     |
+| Container healthchecks are a supplement, never a backbone  | Coverage is inversely correlated with failure rate -- the only containers observed crashing, dumphfdl and hfdlobserver, ship no healthcheck. cAdvisor also cannot distinguish `starting` from `unhealthy`, so the rule needs a start-time gate longer than the fleet's longest `start_period`. |
+| Migrated ntfy to Pushover                                  | Acknowledgement was the deciding factor: Pushover priority 2 re-alerts until acked, so an unseen critical is not lost. Also removes the unmonitored `alertmanager-ntfy` bridge from the critical path and moves credentials into sops.                                                         |
+| Grafana OnCall OSS excluded permanently                    | Archived 2026-03-24; Cloud Connection for mobile push, SMS, and voice is disabled. Recorded so it is not re-evaluated.                                                                                                                                                                         |

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -12,10 +12,10 @@ This is a living reference, not a changelog. Three kinds of content live here:
 
 ### Deployment status
 
-A ticked checkbox in this document means **the code is committed and verified by
-eval, promtool and live query -- not that it is running in production.** The
-work landed on the `fix/monitoring-alerting-overhaul` branch; nothing has been
-applied to the fleet yet.
+A ticked checkbox means the change is **committed, verified by eval and
+promtool, and deployed to the fleet** unless the item says otherwise. Where a
+behaviour was confirmed against live Prometheus or Loki after deploying, the
+numbers are recorded alongside it.
 
 Deployed and verified in production:
 
@@ -59,8 +59,8 @@ applies the ACL explicitly via a oneshot ordered before the exporter.
 
 ### Maintenance rules
 
-- Tick a checkbox when the change is committed and verified by eval, promtool
-  and live query. Note separately if it has not yet been deployed.
+- Tick a checkbox when the change is committed, verified by eval and promtool,
+  and deployed. If it is committed but not yet deployed, say so on the item.
 - When a defect is fixed, leave the entry with its box ticked. The evidence is why the fix exists.
 - If a claim here is contradicted by the live stack, re-verify with the commands in [Verification commands](#verification-commands) and correct the document in the same commit as the code change.
 
@@ -107,7 +107,8 @@ their own modules rather than here: `scrapeConfigs` and `ruleFiles` are both
 | alertmanager            | 127.0.0.1:9093                          | hostname, role           |
 | loki                    | 127.0.0.1:5678                          | hostname, role           |
 | grafana                 | 127.0.0.1:3333                          | hostname, role           |
-| pushgateway             | 127.0.0.1:9091 (honor_labels)           | hostname, role           |
+| dump978                 | sdrhub.local:9275                       | hostname, role           |
+| pushgateway             | 127.0.0.1:9091 (honor_labels)           | none, deliberately       |
 | blackbox-exporter       | 127.0.0.1:9115 (the exporter itself)    | none                     |
 | blackbox-https          | 3 public HTTPS endpoints, must be 2xx   | instance, job            |
 | blackbox-https-redirect | 11 apex domains, must be 3xx            | instance, job            |
@@ -116,6 +117,12 @@ their own modules rather than here: `scrapeConfigs` and `ruleFiles` are both
 `dump978` is scraped on 9275, but only because the container now runs the
 `telegraf-*` image variant -- see below. It carries `metric_relabel_configs`,
 which no other job needs.
+
+`pushgateway` deliberately attaches no static labels. `honor_labels = true`
+means static labels act only as a fallback, so a series pushed from another
+machine that omitted `hostname` would silently inherit `hostname="sdrhub"` and
+be attributed to the wrong host. A missing label is easier to notice than a
+wrong one.
 
 Alertmanager routes by severity to three Pushover receivers, plus a `watchdog` receiver that pings healthchecks.io. Alertmanager, Grafana and Loki are all scraped. See [Notification transport](#notification-transport).
 
@@ -273,6 +280,19 @@ This is orthogonal to log shipping, which works correctly on every host includin
 - [ ] Either honour or remove the ignored keys in `mkUnit`
 - [x] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
 - [ ] Move the Grafana `secret_key` into sops
+- [ ] Decide on TLS and access control for the LAN monitoring endpoints.
+      Prometheus (9090), Alertmanager (9093), Loki (5678) and Grafana (3333) are
+      reachable on the LAN without auth or TLS, and Alertmanager in particular
+      is a control plane -- anyone on the LAN can silence every alert. Raised in
+      review on #2125; deliberately not addressed there because it is
+      pre-existing architecture rather than a regression, and rearchitecting it
+      touches every consumer. Karma is already loopback-only for this reason.
+- [ ] Decide whether a fork pull request should be able to pass the required
+      status checks. Every self-hosted job is now gated to same-repository pull
+      requests, so a fork skips them -- but `build-linux-summary` treats a
+      skipped build as a valid outcome, so the summary goes green without
+      anything having been built. Safe today (no forks, and a human reviews),
+      but fork CI status must not be trusted as-is.
 
 ## Signal catalogue
 

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -10,9 +10,35 @@ This is a living reference, not a changelog. Three kinds of content live here:
 - **Verified defects** -- concrete bugs found by querying the live stack, each with evidence and a checkbox.
 - **Work plan** -- phased tasks with checkboxes.
 
-Rules for maintaining it:
+### Deployment status
 
-- Tick a checkbox only when the change is deployed and verified against live Prometheus or Loki, not when the commit lands.
+A ticked checkbox in this document means **the code is committed and verified by
+eval, promtool and live query -- not that it is running in production.** The
+work landed on the `fix/monitoring-alerting-overhaul` branch; nothing has been
+applied to the fleet yet.
+
+Three things are expected on first apply, and none of them is a bug:
+
+- `SDRCannotClaimDevice` will fire immediately and persistently for dump978,
+  which logs roughly 240 `usb_claim_interface` failures an hour. It is a true
+  positive: that receiver genuinely cannot bind its device.
+- `SDRUsbfsBufferExhausted` will fire for vdlmhub until the host reboots and
+  picks up the new `usbcore.usbfs_memory_mb` kernel parameter. The
+  `systemd.tmpfiles` write applies it live, so this should clear on apply
+  without a reboot.
+- Warning and info alerts move to a new ntfy topic, `fred-sdrhub-digest`.
+  **It must be subscribed to** or those tiers will be invisible. Critical
+  deliberately stays on `fred-sdrhub-alerts` so an existing subscription keeps
+  receiving outages.
+
+After applying, re-run `scripts/check-alert-metrics.sh`; the three metrics it
+currently reports MISSING are all produced by changes in this branch and should
+resolve.
+
+### Maintenance rules
+
+- Tick a checkbox when the change is committed and verified by eval, promtool
+  and live query. Note separately if it has not yet been deployed.
 - When a defect is fixed, leave the entry with its box ticked. The evidence is why the fix exists.
 - If a claim here is contradicted by the live stack, re-verify with the commands in [Verification commands](#verification-commands) and correct the document in the same commit as the code change.
 
@@ -70,9 +96,9 @@ Five of the twenty-two rules reference metrics with no active series. Prometheus
 
 `node_systemd_unit_restart_total` requires `--collector.systemd.enable-restarts-metrics`, which `modules/monitoring/agent/node_exporter.nix:278-287` does not pass.
 
-- [ ] Enable the systemd restarts collector, or rewrite `DockerUnitFlapping` against cAdvisor `container_start_time_seconds`
-- [ ] Delete `SDRServiceFailure` and `FeederUpstreamFailure`
-- [ ] Rewrite `sdr-alerts.yaml` against the metric families that actually exist
+- [x] Enable the systemd restarts collector, or rewrite `DockerUnitFlapping` against cAdvisor `container_start_time_seconds`
+- [x] Delete `SDRServiceFailure` and `FeederUpstreamFailure`
+- [x] Rewrite `sdr-alerts.yaml` against the metric families that actually exist
 
 ### PrometheusTargetDown cannot fire
 
@@ -93,7 +119,7 @@ count by (job,instance) (up{role!="desktop"} == 0) > 0 -> 2 series, value 1
 
 The fix is `count` rather than `sum`.
 
-- [ ] Replace `sum` with `count` in `PrometheusTargetDown`
+- [x] Replace `sum` with `count` in `PrometheusTargetDown`
 
 ### Phantom scrape targets
 
@@ -113,8 +139,8 @@ Ultrafeeder's exporter works on 9274 and emits `readsb_aircraft_*`, `readsb_mess
 
 dump978 sets `ENABLE_PROMETHEUS=true` and `PROMETHEUSPORT=9275` but serves metrics through its internal nginx, which currently returns 404 for `/metrics` and logs `open() "/run/readsb/stats.prom" failed`. That is a container configuration problem, tracked separately below.
 
-- [ ] Remove the `sdrhub.local:9273` and `sdrhub.local:9275` targets
-- [ ] Repoint `sdr-alerts.yaml` at the `readsb_aircraft_*` and `readsb_messages_*` families served on 9274
+- [x] Remove the `sdrhub.local:9273` and `sdrhub.local:9275` targets
+- [x] Repoint `sdr-alerts.yaml` at the `readsb_aircraft_*` and `readsb_messages_*` families served on 9274
 - [ ] Decide whether dump978 metrics are wanted; if so fix the container's nginx metrics path
 
 ### Alloy metrics path
@@ -134,7 +160,7 @@ curl 192.168.31.20:12345/metrics -> 000 (refused)
 
 This is orthogonal to log shipping, which works correctly on every host including Daytona. `loki.write` and `prometheus.remote_write` are outbound pushes and need no inbound listener; only a Prometheus pull from Alloy is blocked. The chosen resolution is to move rule evaluation into the Loki ruler and delete this block entirely rather than make Alloy scrapeable -- see [Decisions log](#decisions-log).
 
-- [ ] Delete the `loki.process "docker"` block and the port 12345 firewall opening from `alloy.nix`
+- [x] Delete the `loki.process "docker"` block and the port 12345 firewall opening from `alloy.nix`
 
 ### Smaller correctness defects
 
@@ -148,11 +174,11 @@ This is orthogonal to log shipping, which works correctly on every host includin
 | hardware/rtl-sdr.nix:17         | `lib.mkDefault` on a list option -- see [Kernel parameter merge hazard](#kernel-parameter-merge-hazard) |
 | grafana.nix:74                  | `secret_key` hardcoded in plaintext; the admin password is correctly sops-managed                   |
 
-- [ ] Fix the `Daytona` regex case sensitivity
-- [ ] Add `hostname` and `role` labels to the unlabelled scrape jobs
-- [ ] Update the Alertmanager inhibit list when the dead rules are removed
+- [x] Fix the `Daytona` regex case sensitivity
+- [x] Add `hostname` and `role` labels to the unlabelled scrape jobs
+- [x] Update the Alertmanager inhibit list when the dead rules are removed
 - [ ] Either honour or remove the ignored keys in `mkUnit`
-- [ ] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
+- [x] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
 - [ ] Move the Grafana `secret_key` into sops
 
 ## Signal catalogue
@@ -381,8 +407,8 @@ Because the ceiling is machine-independent and global, **consolidating servers m
 
 What genuinely does depend on hardware: the number of independent USB host controllers (sdrhub exposes four buses, vdlmhub and acarshub two), whether radios are daisy-chained behind a single external hub (three of four hosts currently do this), and CPU available for demodulation. If consolidating, prefer multiple independent host controllers, avoid funnelling every radio through one hub, use powered hubs for bias-tee draw, and account for the RF and thermal cost of co-locating many dongles plus the concentration of the failure domain.
 
-- [ ] Add `modules/hardware/usbfs.nix` exposing `hardware-profile.usbfs.{enable,memoryMB}`
-- [ ] Enable it on sdrhub, acarshub, vdlmhub, hfdlhub1 -- **not** hfdlhub2, which has no USB radios
+- [x] Add `modules/hardware/usbfs.nix` exposing `hardware-profile.usbfs.{enable,memoryMB}`
+- [x] Enable it on sdrhub, acarshub, vdlmhub, hfdlhub1 -- **not** hfdlhub2, which has no USB radios
 - [ ] Set `usbfs_memory_mb` proportionally if hosts are ever consolidated
 
 ## Tuning workflow
@@ -456,59 +482,60 @@ Two independent providers also means a single provider outage does not blind the
 
 No tuning risk; all of these are outright bugs.
 
-- [ ] `PrometheusTargetDown`: `sum` to `count`
-- [ ] Drop the phantom 9273 and 9275 targets
-- [ ] Rewrite `sdr-alerts.yaml` against the families served on 9274
-- [ ] Delete `SDRServiceFailure` and `FeederUpstreamFailure`, update the inhibit list
-- [ ] Fix the `Daytona` regex case, add labels to unlabelled jobs
-- [ ] Add `modules/hardware/usbfs.nix` and enable on the four radio hosts
-- [ ] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
+- [x] `PrometheusTargetDown`: `sum` to `count`
+- [x] Drop the phantom 9273 and 9275 targets
+- [x] Rewrite `sdr-alerts.yaml` against the families served on 9274
+- [x] Delete `SDRServiceFailure` and `FeederUpstreamFailure`, update the inhibit list
+- [x] Fix the `Daytona` regex case, add labels to unlabelled jobs
+- [x] Add `modules/hardware/usbfs.nix` and enable on the four radio hosts
+- [x] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
 
 ### Phase 2 -- severity routing
 
 Prerequisite for anything noisy. **Transport-agnostic** -- this is entirely achievable on the existing ntfy setup and does not depend on the deferred [Notification transport](#notification-transport) proposal.
 
-- [ ] Split ntfy topics by severity; critical to a priority topic, warning and info to a digest
-- [ ] Set a long `repeat_interval` for the tuning tier
-- [ ] Expand inhibit rules: docker daemon down suppresses container alerts; decoder crash suppresses its own throughput alert
+- [x] Split ntfy topics by severity; critical to a priority topic, warning and info to a digest
+- [x] Set a long `repeat_interval` for the tuning tier
+- [x] Expand inhibit rules: docker daemon down suppresses container alerts; decoder crash suppresses its own throughput alert
 
 ### Phase 3 -- traffic-independent signals
 
 Deployable immediately, nothing to tune.
 
-- [ ] Enable the Loki ruler with `remote_write` into Prometheus and Alertmanager wiring
-- [ ] Crash detection on `s6wrap` and `exited with -11`
-- [ ] Heartbeat-absence detection
-- [ ] `container_health_state != 1` at warning severity
-- [ ] Curated error signature rules from the catalogue above
-- [ ] Remove the dead `loki.process "docker"` block from `alloy.nix`
+- [x] Enable the Loki ruler with `remote_write` into Prometheus and Alertmanager wiring
+- [x] Crash detection on `s6wrap` and `exited with -11`
+- [x] Heartbeat-absence detection
+- [x] `container_health_state != 1` at warning severity
+- [x] Curated error signature rules from the catalogue above
+- [x] Remove the dead `loki.process "docker"` block from `alloy.nix`
 
 ### Phase 4 -- monitoring stack resilience
 
 The notification path is currently a single unmonitored point of failure. If Alertmanager, alertmanager-ntfy, or ntfy.sh dies, silence is indistinguishable from health.
 
-- [ ] Deadman's switch: always-firing alert to a separate receiver backed by an external heartbeat monitor
-- [ ] Scrape Alertmanager, Grafana, and Loki
-- [ ] Alert on `alertmanager_notifications_failed_total` and `prometheus_notifications_dropped_total`
-- [ ] Alert on `prometheus_rule_evaluation_failures_total`, `prometheus_tsdb_wal_corruptions_total`
-- [ ] Per-host log-ingestion deadman via `absent_over_time({host="X"}[15m])`
-- [ ] Alert on `docker.service` being down, to avoid a storm of downstream container alerts
+- [x] Deadman's switch: always-firing alert to a separate receiver backed by an external heartbeat monitor
+- [x] Scrape Alertmanager, Grafana, and Loki
+- [x] Alert on `alertmanager_notifications_failed_total` and `prometheus_notifications_dropped_total`
+- [x] Alert on `prometheus_rule_evaluation_failures_total`, `prometheus_tsdb_wal_corruptions_total`
+- [x] Per-host log-ingestion deadman via `absent_over_time({host="X"}[15m])`
+- [x] Alert on `docker.service` being down, to avoid a storm of downstream container alerts
 
 ### Phase 5 -- CI and container hygiene
 
-- [ ] `promtool test rules` wired into `flake/dev/checks.nix`
-- [ ] CI gate asserting every metric referenced in `alert-rules/*.yaml` returns a non-empty result
+- [x] `promtool test rules` wired into `flake/dev/checks.nix`
+- [x] CI gate asserting every metric referenced in `alert-rules/*.yaml` returns a non-empty result
 - [ ] `promtool check rules` in pre-commit
 - [ ] Add `runbook_url` annotations to every alert
 - [ ] Raise dump978's internal `message-monitor` threshold; it currently restarts its own decoder about 20 times a day because UAT is legitimately quiet at this site
 - [ ] Blackbox exporter for certificate expiry and external endpoint probes
-- [ ] smartctl exporter, disk fill-rate prediction, systemd timer staleness
+- [x] Disk fill-rate prediction, systemd timer staleness, network errors, load saturation
+- [ ] smartctl exporter for SMART pre-failure attributes
 
 ### Phase 6 -- throughput baselines
 
 Requires three weeks of recorded history before the `offset 1w` comparison is meaningful. Start recording in Phase 3 so history accumulates while earlier phases land.
 
-- [ ] Record `decoder_msgs` via the Loki ruler
+- [x] Record `decoder_msgs` via the Loki ruler
 - [ ] Self-baseline alerts once three weekly samples exist
 - [ ] Share-of-fleet alerts for the homogeneous acarsdec and dumpvdl2 groups
 - [ ] Sibling-comparison alerts at info severity

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -1,9 +1,9 @@
-# Pre-commit checks, run per supported system.
-# Wired up via precommit-base (FredSystems/pre-commit-checks).
+# Flake checks, run per supported system.
 #
 # Usage:
 #   nix flake check
 #   nix build .#checks.x86_64-linux.pre-commit-check
+#   nix build .#checks.x86_64-linux.prometheus-alert-rules
 {
   inputs,
   self,
@@ -11,16 +11,49 @@
   ...
 }:
 {
-  checks = forAllSystems (system: {
-    pre-commit-check = inputs.precommit-base.lib.mkCheck {
-      inherit system;
+  checks = forAllSystems (
+    system:
+    let
+      pkgs = import inputs.nixpkgs { inherit system; };
+    in
+    {
+      pre-commit-check = inputs.precommit-base.lib.mkCheck {
+        inherit system;
 
-      src = self;
+        src = self;
 
-      extraExcludes = [
-        "secrets.yaml"
-        "tsconfig.json"
-      ];
-    };
-  });
+        extraExcludes = [
+          "secrets.yaml"
+          "tsconfig.json"
+        ];
+      };
+
+      # Alerting rules are configuration, and configuration that is never
+      # executed rots silently. Prometheus reports a rule that matches nothing
+      # as health=ok, so a rule referring to a metric that does not exist, or
+      # one whose expression can never be true, looks identical to a healthy
+      # rule. Five such rules accumulated in this repo before anyone noticed.
+      #
+      # `check rules` catches syntax and template errors. `test rules`
+      # evaluates each alert against synthetic series and asserts what fires,
+      # which is the only thing that catches a rule that is valid but wrong.
+      prometheus-alert-rules =
+        pkgs.runCommand "prometheus-alert-rules-check"
+          {
+            nativeBuildInputs = [ pkgs.prometheus.cli ];
+          }
+          ''
+            cd ${self}/modules/monitoring/master/alert-rules
+
+            echo "==> promtool check rules"
+            promtool check rules ./*.yaml
+
+            echo "==> promtool test rules"
+            cd tests
+            promtool test rules ./*.yaml
+
+            touch "$out"
+          '';
+    }
+  );
 }

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -15,43 +15,103 @@
     system:
     let
       pkgs = import inputs.nixpkgs { inherit system; };
+
+      excludes = [
+        "secrets.yaml"
+        "tsconfig.json"
+      ];
+
+      # Validates the Prometheus alerting rules: `check rules` for syntax and
+      # templates, `test rules` for behaviour.
+      #
+      # Shared by the standalone flake check and the pre-commit hook below so
+      # the two can never diverge.
+      #
+      # Both halves matter. `check rules` catches malformed YAML and bad label
+      # templates. `test rules` is the only thing that catches a rule which is
+      # valid but wrong -- Prometheus reports a rule matching nothing as
+      # health=ok, so an expression that can never be true looks identical to a
+      # healthy rule with nothing to report. Five such rules accumulated here
+      # before anyone noticed.
+      alertRuleCheck = pkgs.writeShellApplication {
+        name = "check-prometheus-alert-rules";
+        runtimeInputs = [ pkgs.prometheus.cli ];
+        text = ''
+          rules_dir="modules/monitoring/master/alert-rules"
+
+          if [ ! -d "$rules_dir" ]; then
+            echo "error: $rules_dir not found (run from the repository root)" >&2
+            exit 1
+          fi
+
+          echo "==> promtool check rules"
+          promtool check rules "$rules_dir"/*.yaml
+
+          echo "==> promtool test rules"
+          # promtool resolves rule_files relative to the test file, so the unit
+          # tests must be run from their own directory.
+          cd "$rules_dir/tests"
+          promtool test rules ./*.yaml
+        '';
+      };
     in
     {
-      pre-commit-check = inputs.precommit-base.lib.mkCheck {
-        inherit system;
-
-        src = self;
-
-        extraExcludes = [
-          "secrets.yaml"
-          "tsconfig.json"
-        ];
-      };
-
-      # Alerting rules are configuration, and configuration that is never
-      # executed rots silently. Prometheus reports a rule that matches nothing
-      # as health=ok, so a rule referring to a metric that does not exist, or
-      # one whose expression can never be true, looks identical to a healthy
-      # rule. Five such rules accumulated in this repo before anyone noticed.
+      # precommit-base exposes composable modules (`{ hooks, excludes,
+      # passthru }`) as well as the `mkCheck` convenience wrapper. mkCheck
+      # takes no extra-hooks argument, so this merges the base hook set with a
+      # repo-local hook and calls git-hooks' `run` directly.
       #
-      # `check rules` catches syntax and template errors. `test rules`
-      # evaluates each alert against synthetic series and asserts what fires,
-      # which is the only thing that catches a rule that is valid but wrong.
+      # git-hooks is reached through precommit-base's own inputs rather than
+      # being added as a new input to this flake. A new input would have to be
+      # classified in four places (the `# CI:` comment, agents.md, ci-linux.yaml
+      # and the impacted-hosts script) per the input-category sync invariant,
+      # which is a lot of ceremony for a build-time-only tool.
+      pre-commit-check =
+        let
+          base = inputs.precommit-base.lib.mkBaseCheck {
+            inherit system;
+            extraExcludes = excludes;
+          };
+
+          gitHooks = inputs.precommit-base.inputs.git-hooks;
+
+          run = gitHooks.lib.${system}.run {
+            src = self;
+            inherit (base) excludes;
+
+            hooks = base.hooks // {
+              prometheus-alert-rules = {
+                enable = true;
+                name = "prometheus alert rules (promtool check + test)";
+                entry = "${pkgs.lib.getExe alertRuleCheck}";
+
+                # Fires when a rule file or its tests change. pass_filenames is
+                # off because the script globs the directory itself: a rule file
+                # and its test file must always be validated together, and
+                # promtool needs the whole set to resolve rule_files.
+                files = "^modules/monitoring/master/alert-rules/.*\\.ya?ml$";
+                pass_filenames = false;
+              };
+            };
+          };
+        in
+        run
+        // {
+          inherit (base) passthru;
+          shellHook = run.shellHook or "";
+          enabledPackages = run.enabledPackages or [ ];
+        };
+
+      # Standalone check, so CI and `nix flake check` can validate the rules
+      # without running the whole hook suite.
       prometheus-alert-rules =
         pkgs.runCommand "prometheus-alert-rules-check"
           {
-            nativeBuildInputs = [ pkgs.prometheus.cli ];
+            nativeBuildInputs = [ alertRuleCheck ];
           }
           ''
-            cd ${self}/modules/monitoring/master/alert-rules
-
-            echo "==> promtool check rules"
-            promtool check rules ./*.yaml
-
-            echo "==> promtool test rules"
-            cd tests
-            promtool test rules ./*.yaml
-
+            cd ${self}
+            check-prometheus-alert-rules
             touch "$out"
           '';
     }

--- a/hosts/linux/acarshub/configuration.nix
+++ b/hosts/linux/acarshub/configuration.nix
@@ -7,9 +7,14 @@
   imports = [
     ./hardware-configuration.nix
     ../../../profiles/adsb-hub.nix
+    ../../../modules/hardware/usbfs.nix
   ];
 
   networking.hostName = "acarshub";
+
+  # This host has USB SDR hardware attached; raise the global usbfs
+  # transfer-buffer ceiling above the 16 MB kernel default.
+  hardware-profile.usbfs.enable = true;
 
   system.stateVersion = stateVersion;
 

--- a/hosts/linux/hfdlhub1/configuration.nix
+++ b/hosts/linux/hfdlhub1/configuration.nix
@@ -7,9 +7,14 @@
   imports = [
     ./hardware-configuration.nix
     ../../../profiles/adsb-hub.nix
+    ../../../modules/hardware/usbfs.nix
   ];
 
   networking.hostName = "hfdlhub1";
+
+  # This host has USB SDR hardware attached; raise the global usbfs
+  # transfer-buffer ceiling above the 16 MB kernel default.
+  hardware-profile.usbfs.enable = true;
 
   system.stateVersion = stateVersion;
 

--- a/hosts/linux/hfdlhub1/configuration.nix
+++ b/hosts/linux/hfdlhub1/configuration.nix
@@ -68,7 +68,6 @@
           "/opt/adsb/data/dumphfdl1-scanner:/opt/scanner"
         ];
 
-        requires = [ "network-online.target" ];
       }
 
       ###############################################################
@@ -81,11 +80,11 @@
         tty = true;
         restart = "always";
 
-        depends_on = {
-          "dumphfdl-1" = {
-            condition = "service_started";
-          };
-        };
+        # Serialise startup against the sibling decoders: all three share
+        # the sdrplay_apiService and three RSP1a devices, and starting in
+        # parallel races for them. Previously written as Compose's
+        # `depends_on`, which this module never read.
+        dependsOn = [ "dumphfdl-1" ];
 
         environmentFiles = [
           config.sops.secrets."docker/hfdlhub1/dumphfdl2.env".path
@@ -118,14 +117,10 @@
         tty = true;
         restart = "always";
 
-        depends_on = {
-          "dumphfdl-1" = {
-            condition = "service_started";
-          };
-          "dumphfdl-2" = {
-            condition = "service_started";
-          };
-        };
+        dependsOn = [
+          "dumphfdl-1"
+          "dumphfdl-2"
+        ];
 
         environmentFiles = [
           config.sops.secrets."docker/hfdlhub1/dumphfdl3.env".path

--- a/hosts/linux/hfdlhub2/configuration.nix
+++ b/hosts/linux/hfdlhub2/configuration.nix
@@ -65,7 +65,6 @@ in
           "/opt/adsb/hfdlobserver:/run/hfdlobserver"
         ];
 
-        requires = [ "network-online.target" ];
       }
 
     ];

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -226,7 +226,6 @@ in
           "9999:8080"
         ];
 
-        requires = [ "network-online.target" ];
         after = [ "network-online.target" ];
       }
 

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -312,7 +312,20 @@ in
       ###############################################################
       {
         name = "dump978";
-        image = "ghcr.io/sdr-enthusiasts/docker-dump978:latest-build-801@sha256:9c04879d1b4003b2586ad63476612b0ec3f80c486a0bdf0861dba86c369f32cc";
+        # telegraf-build-801, not latest-build-801: the same application build,
+        # but the `latest-*` variant does not ship the telegraf binary, and both
+        # the telegraf and telegraf_socat s6 services `sleep infinity` without
+        # it. That made ENABLE_PROMETHEUS / PROMETHEUSPORT / PROMETHEUSPATH
+        # silently inert -- the s6 services reported "up" while nothing listened
+        # on 9275, so the published port accepted connections via docker-proxy
+        # and immediately reset them.
+        #
+        # With the binary present, /etc/s6-overlay/scripts/04-telegraf generates
+        # outputs_prometheus.conf from those same env vars, which are already
+        # set correctly below, so no other change is needed.
+        #
+        # Cost: the telegraf binary is ~310 MB uncompressed.
+        image = "ghcr.io/sdr-enthusiasts/docker-dump978:telegraf-build-801@sha256:9f52599c4651f91ad6b00e4589cd18fc0e6914a20e0c8b6b56a7b0d5884d9fca";
 
         hostname = "dump978";
         restart = "always";

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -49,9 +49,14 @@ in
     ../../../modules/monitoring/master
     ../../../modules/monitoring/agent
     ../../../modules/services/tailscale
+    ../../../modules/hardware/usbfs.nix
   ];
 
   deployment.role = "monitoring-master";
+
+  # This host has USB SDR hardware attached; raise the global usbfs
+  # transfer-buffer ceiling above the 16 MB kernel default.
+  hardware-profile.usbfs.enable = true;
 
   sops_secrets.enable_secrets.enable = true;
 

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -13,6 +13,7 @@ let
     "sdrhub" = "192.168.31.20";
     "ai.sdrhub" = "192.168.31.20";
     "search.sdrhub" = "192.168.31.20";
+    "karma.sdrhub" = "192.168.31.20";
     "tar1090.sdrhub" = "192.168.31.20";
     "dump978.sdrhub" = "192.168.31.20";
     "piaware.sdrhub" = "192.168.31.20";
@@ -735,6 +736,17 @@ in
               return = "302 http://192.168.31.20:8087/";
             };
 
+            # Karma serves its assets from absolute paths, so a sub-path proxy
+            # would break them. Redirect to the dedicated vhost instead, the
+            # same approach used for fr24 and planefinder above.
+            "/karma/" = {
+              return = "302 http://karma.sdrhub.lan/";
+            };
+
+            "/karma" = {
+              return = "302 http://karma.sdrhub.lan/";
+            };
+
             "/planefinder" = {
               return = "302 http://192.168.31.20:8087/";
             };
@@ -788,6 +800,25 @@ in
           serverAliases = [ "search.sdrhub.local" ];
           locations."/" = {
             proxyPass = "http://127.0.0.1:4444";
+          };
+        };
+
+        # Karma alert dashboard. Bound to loopback by
+        # modules/monitoring/master/karma.nix and reached only through here, so
+        # it needs no firewall port of its own. The port is read from the
+        # service definition rather than hardcoded.
+        #
+        # Karma pushes live alert updates over a websocket, hence the upgrade
+        # headers (the $connection_upgrade map is defined in appendHttpConfig).
+        "karma.sdrhub.lan" = {
+          serverAliases = [ "karma.sdrhub.local" ];
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:${toString config.services.karma.settings.listen.port}";
+            extraConfig = ''
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+            '';
           };
         };
       };

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -335,6 +335,22 @@ in
           config.sops.secrets."docker/sdrhub/dump978.env".path
         ];
 
+        # Suppress telegraf's per-aircraft socket listener.
+        #
+        # Without this, telegraf emits 23 metric families keyed on `address`,
+        # `callsign` and `flightplan_id` -- one set per aircraft seen. That is
+        # unbounded cardinality: observed growing from 230 to 286 series within
+        # an hour, and with 90d retention every aircraft ever seen would leave
+        # 23 series behind permanently. It is also useless for monitoring;
+        # per-aircraft state is what tar1090 and skyaware978 are for.
+        #
+        # The aggregate inputs (stats_*, polar_range_*) are unaffected and are
+        # what the scrape job actually wants: total_accepted_messages,
+        # total_tracks, tracks_with_position, avg_accepted_rssi, max_distance_m.
+        environment = {
+          INFLUXDB_SKIP_AIRCRAFT = "true";
+        };
+
         deviceCgroupRules = [
           "c 189:* rwm"
         ];

--- a/hosts/linux/sdrhub/html/index.html
+++ b/hosts/linux/sdrhub/html/index.html
@@ -50,6 +50,16 @@
             font-family: FontAwesome;
             color: #a6e3a1;
           }
+          li.bell::before {
+            content: "\f0f3 "; /* FontAwesome Unicode */
+            font-family: FontAwesome;
+            color: #a6e3a1;
+          }
+          li.chart::before {
+            content: "\e473 "; /* FontAwesome Unicode */
+            font-family: FontAwesome;
+            color: #a6e3a1;
+          }
       }
         }
     </style>
@@ -72,6 +82,12 @@
       </li>
       <li class="history">
         <a href="http://sdrhub.lan/dozzle/">Dozzle</a>
+      </li>
+      <li class="bell">
+        <a href="http://karma.sdrhub.lan/">Karma (alert dashboard)</a>
+      </li>
+      <li class="chart">
+        <a href="http://sdrhub.lan:3333/">Grafana</a>
       </li>
       <li class="ad">
         <a href="http://192.168.31.20:3000">Ad Guard Home</a>

--- a/hosts/linux/vdlmhub/configuration.nix
+++ b/hosts/linux/vdlmhub/configuration.nix
@@ -7,9 +7,14 @@
   imports = [
     ./hardware-configuration.nix
     ../../../profiles/adsb-hub.nix
+    ../../../modules/hardware/usbfs.nix
   ];
 
   networking.hostName = "vdlmhub";
+
+  # This host has USB SDR hardware attached; raise the global usbfs
+  # transfer-buffer ceiling above the 16 MB kernel default.
+  hardware-profile.usbfs.enable = true;
 
   system.stateVersion = stateVersion;
 

--- a/modules/hardware/default.nix
+++ b/modules/hardware/default.nix
@@ -6,5 +6,6 @@
     ./u2f.nix
     ./rtl-sdr.nix
     ./logitech.nix
+    ./usbfs.nix
   ];
 }

--- a/modules/hardware/rtl-sdr.nix
+++ b/modules/hardware/rtl-sdr.nix
@@ -13,8 +13,16 @@
   config = lib.mkIf config.hardware-profile.rtl-sdr.enable {
     hardware.rtl-sdr.enable = lib.mkDefault true;
 
-    # Blacklist the DVB driver to prevent conflicts
-    boot.kernelParams = lib.mkDefault [ "modprobe.blacklist=dvb_usb_rtl28xxu" ];
+    # Blacklist the DVB driver to prevent conflicts.
+    #
+    # Not lib.mkDefault: boot.kernelParams is a list option, and definitions
+    # only merge within a single priority level. A mkDefault list is discarded
+    # outright by any normal-priority definition elsewhere on the same host,
+    # which would silently drop this blacklist. Verified with lib.evalModules:
+    #
+    #   mkDefault [a] + normal [b]  -> [b]        (a lost)
+    #   normal [a]    + normal [b]  -> [b, a]     (merged)
+    boot.kernelParams = [ "modprobe.blacklist=dvb_usb_rtl28xxu" ];
 
     # Add udev rules for RTL-SDR devices
     services.udev.packages = lib.mkDefault [ pkgs.rtl-sdr ];

--- a/modules/hardware/usbfs.nix
+++ b/modules/hardware/usbfs.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.hardware-profile.usbfs;
+in
+{
+  options.hardware-profile.usbfs = {
+    enable = lib.mkEnableOption "raised usbfs buffer ceiling for USB SDR receivers";
+
+    memoryMB = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 1000;
+      example = 2000;
+      description = ''
+        Value for the usbcore.usbfs_memory_mb kernel parameter: the ceiling on
+        memory userspace may pin for USB transfer buffers. This is a limit, not
+        an allocation, so raising it consumes nothing.
+
+        The kernel default is 16 MB, a compile-time constant that does not vary
+        with RAM, chipset, or USB controller. librtlsdr pins roughly 3.75 MB per
+        device (15 transfers of 256 KB), so four RTL-SDRs sit at about 15 MB and
+        exhaust the default ceiling. The symptom is "Failed to submit transfer"
+        and "async read failed" from dumpvdl2.
+
+        The limit is global rather than per-device, so it must scale with the
+        number of radios attached to a host, not with the host's capability.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # usbcore is built into the kernel on these hosts rather than being a
+    # loadable module, so boot.extraModprobeConfig has no effect -- modprobe.d
+    # only applies to modules that are actually loaded. The parameter has to
+    # come from the kernel command line.
+    #
+    # Deliberately not lib.mkDefault: boot.kernelParams is a list option, and
+    # a mkDefault list is discarded outright (not merged) by any
+    # normal-priority definition elsewhere.
+    boot.kernelParams = [ "usbcore.usbfs_memory_mb=${toString cfg.memoryMB}" ];
+
+    # Apply on activation as well, so the setting takes effect without waiting
+    # for a reboot. The kernel parameter above remains authoritative from boot.
+    systemd.tmpfiles.rules = [
+      "w /sys/module/usbcore/parameters/usbfs_memory_mb - - - - ${toString cfg.memoryMB}"
+    ];
+  };
+}

--- a/modules/monitoring/agent/alloy.nix
+++ b/modules/monitoring/agent/alloy.nix
@@ -1,21 +1,28 @@
 # modules/monitoring/agent/alloy.nix
 #
-# Grafana Alloy log/metric shipper.  Replaces promtail, which was removed
-# from nixpkgs in 25.11 → 26.05 (upstream EOL).
+# Grafana Alloy log shipper.  Replaces promtail, which was removed from
+# nixpkgs in 25.11 → 26.05 (upstream EOL).
 #
-# Feature parity with the prior promtail config:
 #   * Tails the systemd journal at /var/log/journal.
 #   * Forwards to the Loki master at 192.168.31.20:5678 (tenant: default).
 #   * Relabels journal `_SYSTEMD_UNIT` → `unit`,
 #     `_CONTAINER_NAME` → `container`, `_CONTAINER_ID` → `container_id`.
-#   * For unit=docker-*, regex-matches "device not found" → counter
-#     `sdr_service_failure_total`, and "connect ... fail" → counter
-#     `feeder_upstream_failure_total`.
 #
-# Alloy default HTTP listener is 12345 (was 9080 on promtail); preserved
-# in the firewall opening below in case a master ever scrapes the agent's
-# own metrics.  No prometheus scrape job exists for it today
-# (modules/monitoring/master/prometheus.nix has no agent self-scrape).
+# Alloy is deliberately a dumb shipper: it extracts no metrics and exposes
+# nothing for Prometheus to scrape.  Log-derived alerting is evaluated
+# centrally by the Loki ruler on sdrhub
+# (modules/monitoring/master/loki-ruler.nix), so that tuning a pattern is a
+# one-host deploy rather than a fleet-wide one.
+#
+# This module previously carried a `loki.process "docker"` block that
+# incremented `sdr_service_failure_total` and `feeder_upstream_failure_total`
+# counters.  Those counters were unreachable in three independent ways:
+# Alloy's HTTP listener binds 127.0.0.1:12345 only, no Prometheus scrape job
+# for Alloy ever existed, and the alert rules referred to them by their old
+# `promtail_custom_` prefix.  The block and its firewall opening are removed
+# rather than repaired.  Note that log shipping itself was never affected --
+# `loki.write` is an outbound push and needs no inbound listener, which is
+# why the roaming laptop works the same way.
 {
   config,
   pkgs,
@@ -26,7 +33,7 @@ let
     // Journal source: tail systemd journal and emit Loki entries.
     loki.source.journal "journal" {
       path          = "/var/log/journal"
-      forward_to    = [loki.process.docker.receiver]
+      forward_to    = [loki.write.default.receiver]
       relabel_rules = loki.relabel.journal.rules
       labels        = {
         job      = "journal",
@@ -53,36 +60,6 @@ let
       }
     }
 
-    // For docker container units, regex-match known failure patterns and
-    // emit counter metrics.  Counters are exposed on the Alloy /metrics
-    // endpoint (default :12345) for prometheus to scrape if/when added.
-    loki.process "docker" {
-      forward_to = [loki.write.default.receiver]
-
-      stage.match {
-        selector = "{unit=~\"docker-.*\"}"
-
-        stage.regex {
-          expression = "(?P<sdr_err>device not found)|(?P<upstream_err>connect.*fail)"
-        }
-
-        stage.metrics {
-          metric.counter {
-            name        = "sdr_service_failure_total"
-            description = "SDR-related USB/init failures"
-            source      = "sdr_err"
-            action      = "inc"
-          }
-          metric.counter {
-            name        = "feeder_upstream_failure_total"
-            description = "Upstream connection failures"
-            source      = "upstream_err"
-            action      = "inc"
-          }
-        }
-      }
-    }
-
     // Push to the central Loki master.
     loki.write "default" {
       endpoint {
@@ -95,12 +72,8 @@ in
 {
   # Alloy module uses DynamicUser=true + StateDirectory=alloy +
   # SupplementaryGroups=["systemd-journal"], so the user, state dir, and
-  # journal access are all handled by the upstream module.  Nothing extra
-  # to declare beyond the firewall port and the service itself.
-
-  networking.firewall.allowedTCPPorts = [
-    12345 # alloy HTTP / metrics
-  ];
+  # journal access are all handled by the upstream module.  No firewall port
+  # is opened: nothing needs to reach Alloy inbound.
 
   services.alloy = {
     enable = true;

--- a/modules/monitoring/agent/default.nix
+++ b/modules/monitoring/agent/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./cadvisor.nix
     ./node_exporter.nix
+    ./smartctl.nix
     ./alloy.nix
   ];
 }

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -289,7 +289,7 @@
       extraFlags = [
         "--collector.textfile.directory=/var/lib/node_exporter/textfiles"
 
-        # The systemd collector does not emit node_systemd_unit_restart_total
+        # The systemd collector does not emit node_systemd_service_restart_total
         # unless this is set. Without it the DockerUnitFlapping alert selects
         # a metric that does not exist and silently never fires.
         "--collector.systemd.enable-restarts-metrics"

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -288,6 +288,11 @@
 
       extraFlags = [
         "--collector.textfile.directory=/var/lib/node_exporter/textfiles"
+
+        # The systemd collector does not emit node_systemd_unit_restart_total
+        # unless this is set. Without it the DockerUnitFlapping alert selects
+        # a metric that does not exist and silently never fires.
+        "--collector.systemd.enable-restarts-metrics"
       ];
     };
   };

--- a/modules/monitoring/agent/smartctl.nix
+++ b/modules/monitoring/agent/smartctl.nix
@@ -45,6 +45,7 @@
 {
   config,
   lib,
+  pkgs,
   agentNodes,
   agentScrapeMap,
   ...
@@ -101,6 +102,53 @@ in
       networking.firewall.allowedTCPPorts = [
         port # smartctl_exporter
       ];
+
+      # The nixpkgs module ships a udev rule that setfacl's
+      # g:smartctl-exporter-access:rw onto /dev/nvme[0-9]*, but it is gated on
+      # ACTION=="add". That fires when the kernel creates the device node at
+      # boot, and never again -- so deploying this module to a running system
+      # leaves /dev/nvme0 as crw------- root root, the exporter gets EACCES,
+      # and it serves `smartctl_devices 1` with no device metrics at all while
+      # its scrape target still reports up.
+      #
+      # Capabilities do not help: the unit has CAP_SYS_RAWIO and CAP_SYS_ADMIN,
+      # but neither bypasses DAC permission checks (only CAP_DAC_OVERRIDE
+      # would, which is a far bigger grant than an ACL on one device node).
+      #
+      # So apply the ACL explicitly, ordered before the exporter. Idempotent,
+      # and it makes the exporter work on the deploy that enables it rather
+      # than only after the next reboot.
+      systemd.services.smartctl-exporter-device-acl = {
+        description = "Grant smartctl_exporter read access to NVMe control devices";
+        wantedBy = [ "multi-user.target" ];
+        before = [ "prometheus-smartctl-exporter.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+
+        script = ''
+          shopt -s nullglob
+          for dev in /dev/nvme[0-9]*; do
+            # Only the controller character devices (/dev/nvme0). The namespace
+            # block devices (/dev/nvme0n1) are a different subsystem and are
+            # not what smartctl opens.
+            [ -c "$dev" ] || continue
+            ${pkgs.acl}/bin/setfacl -m g:smartctl-exporter-access:rw "$dev"
+          done
+        '';
+      };
+
+      # Ordering alone is not enough on a live deploy: without an explicit
+      # dependency the exporter unit is unchanged and systemd has no reason to
+      # restart it, so it keeps its cached "device not found" state. Requiring
+      # the ACL unit changes the exporter's definition, which makes activation
+      # restart it after the ACL is in place.
+      systemd.services.prometheus-smartctl-exporter = {
+        requires = [ "smartctl-exporter-device-acl.service" ];
+        after = [ "smartctl-exporter-device-acl.service" ];
+      };
     })
 
     (lib.mkIf isMaster {

--- a/modules/monitoring/agent/smartctl.nix
+++ b/modules/monitoring/agent/smartctl.nix
@@ -1,0 +1,143 @@
+# modules/monitoring/agent/smartctl.nix
+#
+# SMART disk pre-failure monitoring via prometheus-smartctl-exporter.
+#
+# WHY
+#
+# node_exporter's diskstats collector reports throughput and latency, and the
+# filesystem collector reports free space. Neither reports the drive's own
+# assessment of whether it is about to die. Every host in this fleet runs a
+# single NVMe SSD with no redundancy, and the decoders write continuously
+# (37.8 TB written on sdrhub), so endurance exhaustion is a realistic failure
+# mode that nothing currently observes.
+#
+# WHAT THE FLEET ACTUALLY EXPOSES (verified 2026-08-03 with smartctl 7.5)
+#
+#   host      device      %used  spare  spare_thresh  media_err  power_on_h
+#   sdrhub    nvme0          54    100            10          0      24,878
+#   hfdlhub1  nvme0           5    100            10          0      22,593
+#   hfdlhub2  nvme0           5    100            10          0      22,590
+#   acarshub  nvme0           1    100            50          0       9,376
+#   vdlmhub   nvme0           1    100            50          0       9,289
+#   fredhub   nvme0           2    100            10          0         200
+#
+# Two things to note, because they drive decisions below:
+#
+#   1. sdrhub's Lexar NM620 is already at 54% of its rated write endurance.
+#      This is the reason this module exists.
+#   2. acarshub and vdlmhub report an Available Spare Threshold of 50%, not
+#      the 10% the other four report. A hardcoded "spare < 10%" alert would
+#      be wrong for those two, so the critical spare rule in
+#      ../master/alert-rules/smart-alerts.yaml compares against the drive's
+#      own reported threshold rather than a constant.
+#
+# PRIVILEGES
+#
+# Nothing is added here. The nixpkgs module already grants exactly what
+# smartctl needs and no more:
+#   - AmbientCapabilities  = CAP_SYS_RAWIO, CAP_SYS_ADMIN
+#   - DeviceAllow          = block-blkext, block-sd, char-nvme (rw)
+#   - SupplementaryGroups  = disk, smartctl-exporter-access
+#   - PrivateDevices       = false (forced off, it would hide the disks)
+# It also creates the smartctl-exporter-access group and installs a udev rule
+# that setfacl's g:smartctl-exporter-access:rw onto /dev/nvme[0-9]*, so the
+# exporter runs as an unprivileged system user rather than root.
+{
+  config,
+  lib,
+  agentNodes,
+  agentScrapeMap,
+  ...
+}:
+let
+  # 9633 is the exporter's upstream default. Confirmed unused elsewhere in
+  # this repo (the taken set is 80, 443, 2269, 3333, 4567, 5432, 5678, 6379,
+  # 8078, 9090, 9093, 9100).
+  port = 9633;
+
+  # fredvps is a QEMU guest. Its virtual disk answers:
+  #   Product: QEMU HARDDISK
+  #   SMART support is: Unavailable - device lacks SMART capability.
+  # There is no SMART data to collect, so enabling a CAP_SYS_RAWIO /
+  # CAP_SYS_ADMIN service there adds attack surface for zero signal. It is
+  # excluded from both the exporter and the scrape job.
+  hostsWithoutSmart = [ "fredvps" ];
+
+  hasSmart = !builtins.elem config.networking.hostName hostsWithoutSmart;
+
+  smartAgents = builtins.filter (h: !builtins.elem h hostsWithoutSmart) agentNodes;
+
+  # This module is imported by every agent (via profiles/adsb-hub.nix) and by
+  # sdrhub, which is also the master. scrapeConfigs is a listOf and merges
+  # across modules, so the master-side scrape job can be defined here instead
+  # of in ../master/prometheus.nix. Gating on services.prometheus.enable is
+  # what makes that safe: only sdrhub enables Prometheus, so only sdrhub
+  # contributes the job. No mkDefault anywhere -- a mkDefault list is
+  # discarded wholesale by any normal-priority definition rather than merged.
+  isMaster = config.services.prometheus.enable;
+in
+{
+  config = lib.mkMerge [
+    (lib.mkIf hasSmart {
+      services.prometheus.exporters.smartctl = {
+        enable = true;
+
+        # The master scrapes this across the LAN, so it cannot bind loopback.
+        listenAddress = "0.0.0.0";
+        inherit port;
+
+        # Each collection forks smartctl once per device. maxInterval caches
+        # the result, so this is the real query rate against the drive; the
+        # scrape job below uses a matching 60s interval so a scrape does not
+        # simply re-serve a cached sample four times.
+        maxInterval = "60s";
+
+        # devices is left at its default of [ ], which autodiscovers via
+        # `smartctl --scan`. On this fleet that yields exactly
+        # "/dev/nvme0 -d nvme", labelled device="nvme0" by the exporter
+        # (it strips /dev/ and replaces / with _).
+      };
+
+      networking.firewall.allowedTCPPorts = [
+        port # smartctl_exporter
+      ];
+    })
+
+    (lib.mkIf isMaster {
+      # hostname and role are attached here because the exporter's own
+      # metrics carry only a `device` label. Alerts template
+      # {{ $labels.hostname }}, which is empty unless the scrape job
+      # supplies it -- the same defect that has been fixed elsewhere in this
+      # stack. Mirrors the node and cadvisor jobs in ../master/prometheus.nix.
+      services.prometheus.scrapeConfigs = [
+        {
+          job_name = "smartctl";
+          scrape_interval = "60s";
+          static_configs =
+            (map (h: {
+              targets = [ "${agentScrapeMap.${h}}:${toString port}" ];
+              labels = {
+                hostname = h;
+                role = "agent";
+                exporter = "smartctl";
+              };
+            }) smartAgents)
+            ++ [
+              {
+                targets = [ "sdrhub.local:${toString port}" ];
+                labels = {
+                  hostname = "sdrhub";
+                  role = "master";
+                  exporter = "smartctl";
+                };
+              }
+            ];
+        }
+      ];
+
+      services.prometheus.ruleFiles = [
+        ../master/alert-rules/smart-alerts.yaml
+      ];
+    })
+  ];
+}

--- a/modules/monitoring/master/alert-rules/alert-rules.yaml
+++ b/modules/monitoring/master/alert-rules/alert-rules.yaml
@@ -113,7 +113,11 @@ groups:
     rules:
       - alert: PrometheusTargetDown
         # Desktops sleep regularly; exclude their scrape targets from this alert.
-        expr: sum by (job, instance) (up{role!="desktop"} == 0) > 0
+        #
+        # Must be count(), not sum(). `up == 0` filters to series whose value
+        # is zero, so summing them always yields zero and `> 0` can never be
+        # true. count() yields the number of matching series instead.
+        expr: count by (job, instance) (up{role!="desktop"} == 0) > 0
         for: 2m
         labels:
           severity: critical

--- a/modules/monitoring/master/alert-rules/blackbox-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/blackbox-alerts.yaml
@@ -1,0 +1,123 @@
+# Alerting rules for the prometheus-blackbox-exporter probes defined in
+# modules/monitoring/master/blackbox.nix.
+#
+# SCOPE
+#
+# Three probe jobs feed these rules:
+#
+#   blackbox-https           public HTTPS vhosts on fredvps that must answer 2xx
+#   blackbox-https-redirect  public HTTPS vhosts that must answer 3xx
+#   blackbox-http-internal   LAN-only nginx vhosts on sdrhub
+#
+# LABELS AVAILABLE HERE -- read this before adding an annotation
+#
+# Blackbox series are labelled `instance` (the probed URL, set by the job's
+# relabel_configs) and `job`. They do NOT carry `hostname` or `role`, because
+# the thing being probed is a URL, not one of our nodes. Templating
+# `{{ $labels.hostname }}` on these series renders empty, which has already
+# produced a useless alert body once in this repo. Only `instance` and `job`
+# are safe below.
+#
+# The absence of `hostname` also means Alertmanager's NodeDown inhibit rule
+# (`equal: [hostname]`) never suppresses these. That is correct: a probe of
+# fredvps from sdrhub is not a consequence of any node being down.
+#
+# EXPECTED "MISSING METRIC" REPORT
+#
+# scripts/check-alert-metrics.sh will report probe_success,
+# probe_ssl_earliest_cert_expiry and probe_duration_seconds as MISSING until
+# this configuration is actually deployed to sdrhub and the exporter has been
+# scraped at least once. That is expected and not a defect -- the script only
+# knows what Prometheus has series for, and it explains this in its own header.
+# Re-run it after deploying; the metrics must resolve then.
+#
+# Unit tests: alert-rules/tests/blackbox-alerts-test.yaml
+groups:
+  - name: blackbox-availability
+    rules:
+      - alert: BlackboxProbeFailed
+        # probe_success is 0 when the prober ran and the target did not
+        # satisfy the module (connection refused, DNS failure, TLS chain
+        # rejected, or a status code outside the module's valid set).
+        #
+        # This is distinct from `up == 0` on this job, which would mean the
+        # exporter itself is unreachable -- that case is covered by the
+        # existing PrometheusTargetDown rule via the blackbox-exporter job.
+        #
+        # 5m at a 60s scrape_interval is five consecutive failed probes.
+        # Enough to ride out a single nginx reload or an ACME renewal
+        # restart; short enough to be actionable.
+        expr: probe_success == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Endpoint {{ $labels.instance }} is failing its probe"
+          description: "Blackbox job {{ $labels.job }} has been unable to get a valid response from {{ $labels.instance }} for 5 minutes."
+
+      - alert: BlackboxSlowProbe
+        # Measured baseline from sdrhub (connect + TLS handshake + response):
+        #
+        #   public HTTPS vhosts     ~0.20s
+        #   flipaholics.pro         ~0.62s  (slowest backend; consistently so)
+        #   LAN nginx vhosts        0.007s - 0.03s
+        #
+        # Worst single observation across all 20 targets was 1.03s, on a cold
+        # first probe. 5s is roughly a 5x margin over that and an 8x margin
+        # over the slowest steady-state target, so this cannot fire on normal
+        # variance -- only on genuine degradation.
+        #
+        # Deliberately below the module timeout (10s) and the job's
+        # scrape_timeout (15s), so a slow-but-working endpoint surfaces here
+        # as a warning rather than eventually flipping BlackboxProbeFailed.
+        #
+        # 15m, not 5m: a slow endpoint is not an outage and does not warrant
+        # the faster pacing.
+        expr: probe_duration_seconds > 5
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Endpoint {{ $labels.instance }} is responding slowly"
+          description: "Blackbox job {{ $labels.job }} has taken more than 5s to probe {{ $labels.instance }} for 15 minutes. Measured baseline is 0.007s-0.03s for LAN vhosts and 0.20s-0.62s for the public HTTPS vhosts."
+
+  - name: blackbox-tls
+    rules:
+      # probe_ssl_earliest_cert_expiry is an absolute unix timestamp, so the
+      # remaining lifetime is `metric - time()` in seconds. Thresholds are
+      # written as arithmetic rather than as magic seconds so they can be read.
+      #
+      # The two rules are mutually exclusive by construction: the warning
+      # carries a >= 7d floor. Without it both would fire below 7 days and
+      # Alertmanager would deliver the same certificate twice on two different
+      # severities and two different repeat intervals.
+      - alert: BlackboxCertExpiringSoon
+        # 21 days. All of these are ACME certs on a 90-day lifetime, which the
+        # NixOS acme module renews at 30 days remaining. 21 days therefore
+        # means renewal has already been attempted and has not succeeded --
+        # there is a real fault, with three weeks of slack to fix it.
+        expr: |
+          (probe_ssl_earliest_cert_expiry - time()) < (21 * 24 * 60 * 60)
+          and
+          (probe_ssl_earliest_cert_expiry - time()) >= (7 * 24 * 60 * 60)
+        # 1h: cert expiry is a slowly-moving fact, not an event. A long `for`
+        # costs nothing here and makes the alert immune to a single bad scrape.
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS certificate for {{ $labels.instance }} expires in under 21 days"
+          description: "The certificate served by {{ $labels.instance }} has less than 21 days of validity left, so ACME renewal (which should have run at 30 days) is not succeeding. Check acme-*.service on the host terminating this vhost."
+
+      - alert: BlackboxCertExpiryCritical
+        # 7 days. Past this point renewal has been failing for three weeks and
+        # the remaining margin is smaller than a weekend plus a work week.
+        # Fires for already-expired certificates too, since the difference
+        # simply goes negative.
+        expr: (probe_ssl_earliest_cert_expiry - time()) < (7 * 24 * 60 * 60)
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "TLS certificate for {{ $labels.instance }} expires in under 7 days"
+          description: "The certificate served by {{ $labels.instance }} has less than 7 days of validity left. Browsers will start refusing this endpoint. Fix ACME renewal on the host terminating this vhost now."

--- a/modules/monitoring/master/alert-rules/capacity-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/capacity-alerts.yaml
@@ -1,0 +1,190 @@
+# Capacity / saturation alerts.
+#
+# Every metric and every threshold in this file was verified against the live
+# Prometheus at http://192.168.31.20:9090 before being committed. Thresholds
+# are not guesses -- each one is annotated with the empirical fleet baseline
+# (30 days of retained data) that justifies it.
+#
+# Fleet shape that these thresholds assume:
+#   - 7 servers: mini PCs, 15 GB RAM, 3-8 CPUs (fredhub is the outlier at 32)
+#   - 2 desktops (Daytona, maranello) which sleep and shut down regularly and
+#     are therefore excluded from anything that measures sustained behaviour.
+groups:
+  - name: capacity-alerts
+    rules:
+      # Predictive disk alert. Complements the static NodeDiskLow (10%) and
+      # NodeDiskWarning (20%) rules in alert-rules.yaml by catching a fast
+      # linear fill *before* it crosses those floors.
+      #
+      # Two halves, ANDed:
+      #   1. predict_linear over a 6h window projects avail_bytes 24h ahead and
+      #      fires if the projection goes negative.
+      #   2. A guard requiring free space to already be under 30%.
+      #
+      # The guard is the important part. predict_linear alone is a false-
+      # positive generator: a 6h window that happens to catch a container image
+      # pull or a Prometheus snapshot on an otherwise 90%-free 1 TB disk
+      # produces a steep negative slope and "fills in 24h" is technically true
+      # but operationally meaningless. Requiring <30% free means the disk must
+      # genuinely be running out AND trending the wrong way.
+      #
+      # 30% was chosen because the fullest real filesystem in the fleet today
+      # is fredvps / at 34.0% free, so the guard sits just below the current
+      # high-water mark: it is armed for the host that is actually closest to
+      # trouble, and gives runway above the existing 20% warning threshold.
+      #
+      # fstype exclusions match the existing disk rules so that tmpfs, overlay
+      # and friends (which "fill" constantly and harmlessly) are ignored.
+      #
+      # Labels preserved by the AND: device, fstype, hostname, instance, job,
+      # mountpoint, role. Verified live -- hostname and mountpoint are both
+      # safe to template.
+      - alert: DiskFillPredicted
+        expr: |
+          predict_linear(
+            node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs", role!="desktop"}[6h],
+            24 * 3600
+          ) < 0
+          and
+          (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs", role!="desktop"}
+           / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs", role!="desktop"}) < 0.30
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk predicted to fill within 24h on {{ $labels.hostname }} ({{ $labels.mountpoint }})"
+          description: "Filesystem {{ $labels.mountpoint }} on {{ $labels.hostname }} is below 30% free and, at its current 6h fill rate, is projected to run out of space within 24 hours."
+
+      # A systemd timer that has stopped triggering. Silent timer failure is
+      # invisible otherwise: the timer unit stays "active (waiting)", so
+      # SystemdUnitFailed never fires, yet backups/GC/cert renewal have
+      # quietly stopped.
+      #
+      # node_systemd_timer_last_trigger_seconds is confirmed present in live
+      # Prometheus (116 series across 8 hosts). It does NOT need an extra
+      # node_exporter flag -- it ships with the default systemd collector.
+      #
+      # The `> 0` guard is mandatory, not cosmetic. node_exporter reports 0 for
+      # a timer that has not triggered since boot. Without the guard, `time() -
+      # 0` is ~56 years of "staleness" and every freshly-booted host instantly
+      # pages for logrotate.timer, systemd-tmpfiles-clean.timer and friends.
+      # This was confirmed in the retained data: those timers show a max
+      # observed staleness of 496033h, which is exactly the epoch artefact.
+      #
+      # Threshold: 72h. Empirical max staleness per timer over 30 days, after
+      # discarding the epoch artefact, is:
+      #   fstrim.timer                  168.9h  (weekly)
+      #   ollama-model-updater.timer    169.9h  (weekly)
+      #   acme-renew-*.timer          <= 36.7h  (daily + jitter/backoff)
+      #   nix-optimise / fwupd-refresh   34.4h
+      #   everything else              <= 24.0h
+      # The two weekly timers are excluded by name; every remaining timer in
+      # the fleet is daily-or-faster with a worst observed gap of 36.7h, so 72h
+      # is ~2x the real high-water mark. That is enough headroom for
+      # RandomizedDelaySec and post-reboot catch-up, while still catching a
+      # genuinely dead daily timer within three days.
+      #
+      # Desktops are excluded: they sleep and power off, so their timers
+      # legitimately go long stretches without triggering.
+      #
+      # Labels preserved: exporter, hostname, instance, job, name, role.
+      # Verified live -- hostname and name are both safe to template.
+      - alert: SystemdTimerStale
+        expr: |
+          (
+            time() - (node_systemd_timer_last_trigger_seconds{
+              role!="desktop",
+              name!~"fstrim\\.timer|ollama-model-updater\\.timer"
+            } > 0)
+          ) > 72 * 3600
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Systemd timer {{ $labels.name }} is stale on {{ $labels.hostname }}"
+          description: "The timer {{ $labels.name }} on {{ $labels.hostname }} has not triggered in over 72 hours. Every non-weekly timer in this fleet runs at least every 36 hours, so this timer has almost certainly stopped firing."
+
+      # Rising error counters on a physical NIC -- bad cable, dying port,
+      # duplex mismatch, or a failing wifi link.
+      #
+      # Only *_errs_total is used, deliberately NOT *_drop_total. Drops are
+      # routine on this fleet and would make the rule useless: over 30 days the
+      # peak 15m rx_drop increase was 103530 on hfdlhub2 enp1s0, with nonzero
+      # drops on 7 of the 15 physical interfaces. Errors, by contrast, are
+      # exactly 0 across every physical interface for the entire 30-day
+      # retention window, so a nonzero error rate is genuinely anomalous.
+      #
+      # Threshold: >10 errors in 15m, sustained 10m. Given a fleet baseline of
+      # flat zero, 10 is simply a floor that ignores a lone transient CRC error
+      # while a real link fault (which produces errors continuously, in the
+      # thousands) trips it immediately.
+      #
+      # Interface exclusions cover the virtual devices: lo, docker0, veth*,
+      # br-* (docker user bridges), tailscale0, and virbr* (libvirt). That
+      # narrows 57 devices down to the 7 real ones. virbr* is included in the
+      # exclusion list because it is a virtual bridge like br-*; error counters
+      # on it do not correspond to any physical link.
+      #
+      # Note on `or`: if a device somehow had both rx and tx errors rising, the
+      # `or` yields a single series for it rather than two, because both sides
+      # carry identical label sets. That is the desired behaviour -- one alert
+      # per faulty interface -- which is why the wording below does not claim a
+      # direction.
+      #
+      # Labels preserved: device, exporter, hostname, instance, job, role.
+      # Verified live -- hostname and device are both safe to template.
+      - alert: NodeNetworkErrors
+        expr: |
+          increase(node_network_receive_errs_total{device!~"lo|docker.*|veth.*|br-.*|tailscale.*|virbr.*"}[15m]) > 10
+          or
+          increase(node_network_transmit_errs_total{device!~"lo|docker.*|veth.*|br-.*|tailscale.*|virbr.*"}[15m]) > 10
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Network errors on {{ $labels.hostname }} ({{ $labels.device }})"
+          description: "Interface {{ $labels.device }} on {{ $labels.hostname }} has recorded more than 10 receive or transmit errors in 15 minutes. Fleet baseline for this counter is zero, so this indicates a cable, port, or link-layer fault."
+
+      # Sustained run-queue saturation, normalised by CPU count so that a
+      # 3-core VPS and a 32-core box use the same threshold.
+      #
+      # The division needs `on (hostname) group_left ()` because the left side
+      # (node_load15) carries exporter/instance/job/role while the right side,
+      # after `count by (hostname)`, carries only hostname. Without explicit
+      # matching the two sides share no common label set and the division
+      # returns empty -- a rule that can never fire. group_left keeps the left
+      # side's labels, so hostname and instance both survive. Verified live.
+      #
+      # node_cpu_seconds_total is filtered to mode="idle" so that count()
+      # yields one series per core rather than one per core-per-mode.
+      #
+      # Threshold: 4x CPU count. This is set from measured fleet behaviour, not
+      # from the textbook "load > cores" rule, because hfdlhub1 runs multiple
+      # dumphfdl decoders on 4 cores and its *normal* state is oversubscribed.
+      # Load15/cores over 30 days on hfdlhub1: avg 2.53, p95 3.19, max 3.73.
+      # Fraction of the last 30 days spent above each candidate threshold:
+      #   >2    89.7% of the time   (would be permanently firing -- useless)
+      #   >3    16.7% of the time   (still far too noisy)
+      #   >3.5   0.4% of the time
+      #   >4     0.0% of the time
+      # 4 is the first threshold with zero false positives against real fleet
+      # data while remaining a genuine saturation signal: a 15-minute load
+      # average at 4x core count means work is queueing faster than it drains.
+      #
+      # node_load15 is already a 15-minute average, so `for: 15m` requires the
+      # condition to hold across two independent windows before alerting.
+      #
+      # Desktops are excluded: interactive workloads (compiles, games) spike
+      # load legitimately and nobody needs to be told.
+      - alert: NodeHighLoad
+        expr: |
+          node_load15{role!="desktop"}
+            / on (hostname) group_left ()
+          count by (hostname) (node_cpu_seconds_total{mode="idle", role!="desktop"})
+          > 4
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Sustained high load on {{ $labels.hostname }}"
+          description: "The 15-minute load average on {{ $labels.hostname }} has been more than 4x its CPU count for 15 minutes. The run queue is growing faster than the host can drain it."

--- a/modules/monitoring/master/alert-rules/docker-rules.yaml
+++ b/modules/monitoring/master/alert-rules/docker-rules.yaml
@@ -12,3 +12,29 @@ groups:
         annotations:
           summary: "Docker systemd unit {{ $labels.name }} is restarting repeatedly"
           description: "Systemd restarted {{ $labels.name }} more than 3 times in 10 minutes."
+
+      # cAdvisor exposes the health state produced by the image's own
+      # HEALTHCHECK. The value encoding matters:
+      #
+      #   1  healthy
+      #  -1  no healthcheck defined in the image
+      #
+      # A naive `!= 1` therefore fires for every container that simply has no
+      # healthcheck -- currently 17 of them, including acars_router, sdrmap
+      # and all the dozzle agents. Both clauses are required.
+      #
+      # This is a supplementary signal only. Coverage is inversely correlated
+      # with failure rate: dumphfdl and hfdlobserver are the containers
+      # actually observed crashing and neither ships a healthcheck, so they
+      # are covered by the Loki ruler's s6wrap detection instead.
+      - alert: ContainerUnhealthy
+        expr: |
+          container_health_state{name!=""} != 1
+            and
+          container_health_state{name!=""} != -1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container {{ $labels.name }} on {{ $labels.hostname }} reports unhealthy"
+          description: "The container's own HEALTHCHECK has been failing for 10 minutes."

--- a/modules/monitoring/master/alert-rules/docker-rules.yaml
+++ b/modules/monitoring/master/alert-rules/docker-rules.yaml
@@ -1,6 +1,9 @@
 groups:
   - name: docker-alerts
     rules:
+      # Requires --collector.systemd.enable-restarts-metrics on node_exporter,
+      # without which this metric does not exist. See
+      # modules/monitoring/agent/node_exporter.nix.
       - alert: DockerUnitFlapping
         expr: increase(node_systemd_unit_restart_total{name=~"docker-.*"}[10m]) > 3
         for: 5m
@@ -9,21 +12,3 @@ groups:
         annotations:
           summary: "Docker systemd unit {{ $labels.name }} is restarting repeatedly"
           description: "Systemd restarted {{ $labels.name }} more than 3 times in 10 minutes."
-
-      - alert: SDRServiceFailure
-        expr: rate(promtail_custom_sdr_service_failure_total[10m]) > 0
-        for: 5m
-        labels:
-          severity: critical
-        annotations:
-          summary: "SDR-related service failure on {{ $labels.host }}"
-          description: "Repeated SDR initialization or USB errors detected (unit {{ $labels.unit }})."
-
-      - alert: FeederUpstreamFailure
-        expr: rate(promtail_custom_feeder_upstream_failure_total[10m]) > 0
-        for: 10m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Feeder upstream connectivity issue on {{ $labels.host }}"
-          description: "Repeated upstream connection failures for at least 10 minutes."

--- a/modules/monitoring/master/alert-rules/docker-rules.yaml
+++ b/modules/monitoring/master/alert-rules/docker-rules.yaml
@@ -5,7 +5,7 @@ groups:
       # without which this metric does not exist. See
       # modules/monitoring/agent/node_exporter.nix.
       - alert: DockerUnitFlapping
-        expr: increase(node_systemd_unit_restart_total{name=~"docker-.*"}[10m]) > 3
+        expr: increase(node_systemd_service_restart_total{name=~"docker-.*"}[10m]) > 3
         for: 5m
         labels:
           severity: critical

--- a/modules/monitoring/master/alert-rules/docker-rules.yaml
+++ b/modules/monitoring/master/alert-rules/docker-rules.yaml
@@ -14,27 +14,47 @@ groups:
           description: "Systemd restarted {{ $labels.name }} more than 3 times in 10 minutes."
 
       # cAdvisor exposes the health state produced by the image's own
-      # HEALTHCHECK. The value encoding matters:
+      # HEALTHCHECK. The value encoding matters, and has two traps:
       #
       #   1  healthy
       #  -1  no healthcheck defined in the image
+      #   0  unhealthy  OR  still inside its start_period
       #
-      # A naive `!= 1` therefore fires for every container that simply has no
-      # healthcheck -- currently 17 of them, including acars_router, sdrmap
-      # and all the dozzle agents. Both clauses are required.
+      # Trap 1: a naive `!= 1` fires for every container that simply has no
+      # healthcheck -- 34 of them, including acars_router, sdrmap and all the
+      # dozzle agents. Hence the second clause.
       #
-      # This is a supplementary signal only. Coverage is inversely correlated
-      # with failure rate: dumphfdl and hfdlobserver are the containers
-      # actually observed crashing and neither ships a healthcheck, so they
-      # are covered by the Loki ruler's s6wrap detection instead.
+      # Trap 2: cAdvisor does not distinguish Docker's "starting" from
+      # "unhealthy" -- both are 0. These images use long start periods, because
+      # their healthchecks assert on message counts over the past hour or two:
+      #
+      #   piaware, dump978                       2h
+      #   acarsdec, dumpvdl2, acarshub, feeders  1h
+      #   ultrafeeder, fr24                      10m
+      #
+      # So without the start-time gate this fires ~10 minutes after every
+      # restart and stays firing for up to two hours, i.e. on every single
+      # deploy. Observed doing exactly that on piaware. The gate is 2h30m, a
+      # margin over the longest start_period in the fleet; anything still
+      # reporting 0 by then is genuinely unhealthy rather than starting.
+      #
+      # A slow gate is acceptable because this is a supplementary signal. The
+      # fast detectors are elsewhere and do not depend on healthchecks:
+      # DecoderHeartbeatMissing (20m), the Loki s6wrap crash rules,
+      # DockerUnitFlapping and ContainerRestarting. Coverage here is in fact
+      # inversely correlated with failure rate -- dumphfdl and hfdlobserver are
+      # the containers actually observed crashing and neither ships a
+      # healthcheck at all.
       - alert: ContainerUnhealthy
         expr: |
           container_health_state{name!=""} != 1
             and
           container_health_state{name!=""} != -1
+            and
+          (time() - container_start_time_seconds{name!=""}) > 9000
         for: 10m
         labels:
           severity: warning
         annotations:
           summary: "Container {{ $labels.name }} on {{ $labels.hostname }} reports unhealthy"
-          description: "The container's own HEALTHCHECK has been failing for 10 minutes."
+          description: "The container's own HEALTHCHECK has been failing for 10 minutes, and it started long enough ago that this is not its start_period."

--- a/modules/monitoring/master/alert-rules/meta-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/meta-alerts.yaml
@@ -1,0 +1,118 @@
+groups:
+  # Alerts about the monitoring stack itself. Everything else in this
+  # directory assumes Prometheus, Alertmanager and the notification bridge are
+  # working; these are the rules that notice when they are not.
+  - name: monitoring-pipeline
+    rules:
+      # Deadman switch. Always firing by construction, so its ARRIVAL at an
+      # external heartbeat monitor is the signal. If Prometheus stops
+      # evaluating, Alertmanager stops dispatching, or the host dies, the
+      # heartbeat stops and the external monitor raises the alarm through a
+      # path that shares no infrastructure with this stack.
+      #
+      # severity: none keeps it out of the critical/warning/info ntfy routes.
+      # It is dispatched by a dedicated Alertmanager route -- see the
+      # watchdog receiver in prometheus.nix. Until a heartbeat URL is
+      # configured that receiver blackholes it, so this rule is inert but
+      # harmless.
+      - alert: Watchdog
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: "Alerting pipeline is alive"
+          description: "This alert always fires. Its absence downstream means Prometheus or Alertmanager has stopped."
+
+      - alert: AlertmanagerNotificationsFailing
+        expr: rate(alertmanager_notifications_failed_total[15m]) > 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Alertmanager cannot deliver notifications"
+          description: "Delivery to {{ $labels.integration }} has been failing for 10 minutes. Alerts are being raised but not reaching a phone."
+
+      - alert: PrometheusNotificationsDropped
+        expr: rate(prometheus_notifications_dropped_total[15m]) > 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus is dropping alert notifications"
+          description: "Prometheus cannot hand alerts to Alertmanager."
+
+      - alert: PrometheusRuleEvaluationFailing
+        expr: rate(prometheus_rule_evaluation_failures_total[15m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus rule evaluation failing in group {{ $labels.rule_group }}"
+          description: "A recording or alerting rule is erroring. Alerts derived from it are not being evaluated."
+
+      - alert: PrometheusTSDBWALCorruption
+        expr: increase(prometheus_tsdb_wal_corruptions_total[1h]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus TSDB write-ahead log corruption"
+          description: "The WAL reported corruption in the last hour. Metric history may be incomplete."
+
+      - alert: PrometheusScrapeNearTimeout
+        expr: |
+          scrape_duration_seconds > 8
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Scrape of {{ $labels.job }} on {{ $labels.instance }} is slow"
+          description: "Scrape duration has exceeded 8s against a 10s timeout for 15 minutes. The target is about to start failing."
+
+  - name: log-pipeline
+    rules:
+      # Whole-pipeline stoppage. loki_distributor_lines_received_total is
+      # labelled by tenant only, with no per-source-host dimension, so this
+      # can only detect that ingestion has stopped entirely. Per-host
+      # detection is done by the Loki ruler's HostLogsMissing rules, which
+      # can use absent_over_time against a host-scoped stream selector.
+      - alert: LogIngestionStopped
+        expr: rate(loki_distributor_lines_received_total[15m]) == 0
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Loki has stopped receiving any log lines"
+          description: "No log lines have reached Loki for 30 minutes. Every log-derived alert is inoperative. Alloy has failed fleet-wide, or the network path to Loki is broken."
+
+      - alert: LokiDown
+        expr: up{job="loki"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Loki is down"
+          description: "All log-derived alerting, including decoder crash and heartbeat detection, is inoperative while Loki is down."
+
+      - alert: AlertmanagerDown
+        expr: up{job="alertmanager"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Alertmanager is down"
+          description: "Prometheus is still evaluating rules but no alert can be delivered."
+
+  - name: docker-daemon
+    rules:
+      # A dockerd failure otherwise produces one alert per container. This
+      # fires first so the cause is visible, and the inhibit rule keyed on it
+      # suppresses the downstream noise.
+      - alert: DockerDaemonDown
+        expr: node_systemd_unit_state{state="active", name="docker.service"} == 0
+        for: 3m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Docker daemon is not running on {{ $labels.hostname }}"
+          description: "dockerd is not active. Every container on this host is down."

--- a/modules/monitoring/master/alert-rules/meta-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/meta-alerts.yaml
@@ -59,15 +59,24 @@ groups:
           summary: "Prometheus TSDB write-ahead log corruption"
           description: "The WAL reported corruption in the last hour. Metric history may be incomplete."
 
+      # Thresholds are 80% of each job's scrape_timeout, so this means "about to
+      # start failing" rather than an arbitrary number of seconds. The blackbox
+      # jobs set scrape_timeout: 15s because a probe includes DNS, TCP, TLS and
+      # HTTP against a remote endpoint; 8s there is barely half their budget and
+      # would fire on healthy probes.
+      #
+      # Everything else inherits the global 10s scrape_timeout.
       - alert: PrometheusScrapeNearTimeout
         expr: |
-          scrape_duration_seconds > 8
+          scrape_duration_seconds{job!~"blackbox-.*"} > 8
+            or
+          scrape_duration_seconds{job=~"blackbox-.*"} > 12
         for: 15m
         labels:
           severity: warning
         annotations:
           summary: "Scrape of {{ $labels.job }} on {{ $labels.instance }} is slow"
-          description: "Scrape duration has exceeded 8s against a 10s timeout for 15 minutes. The target is about to start failing."
+          description: "Scrape duration has reached 80% of this job's scrape_timeout for 15 minutes. The target is about to start failing."
 
   - name: log-pipeline
     rules:

--- a/modules/monitoring/master/alert-rules/sdr-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/sdr-alerts.yaml
@@ -1,8 +1,17 @@
 groups:
   - name: sdr-alerts
     rules:
+      # The readsb exporter on sdrhub.local:9274 emits the readsb_aircraft_*,
+      # readsb_messages_* and readsb_position_count_* families. It does NOT
+      # emit readsb_stats_*, which these rules previously selected on; those
+      # names exist only in Loki's historical label index, so both rules
+      # evaluated to an empty vector and were reported healthy by Prometheus.
+      #
+      # Both metrics are gauges reporting a recent window, not counters --
+      # they oscillate rather than increasing monotonically -- so == 0 is the
+      # correct comparison and rate() would be wrong.
       - alert: UltrafeederNoAircraft
-        expr: readsb_stats_aircraft_with_pos{job="ultrafeeder"} == 0
+        expr: readsb_aircraft_with_position{job="ultrafeeder"} == 0
         for: 30m
         labels:
           severity: warning
@@ -11,10 +20,10 @@ groups:
           description: "No aircraft with position have been tracked for 30 minutes. Possible SDR hardware failure, antenna issue, or decoder problem."
 
       - alert: UltrafeederNotReceiving
-        expr: readsb_stats_messages{job="ultrafeeder"} == 0
+        expr: readsb_messages_valid{job="ultrafeeder"} == 0
         for: 15m
         labels:
           severity: critical
         annotations:
           summary: "Ultrafeeder receiving no RF messages on {{ $labels.hostname }}"
-          description: "readsb has processed zero messages for 15 minutes. The SDR hardware is likely disconnected, crashed, or the decoder has stopped."
+          description: "readsb has processed zero valid messages for 15 minutes. The SDR hardware is likely disconnected, crashed, or the decoder has stopped."

--- a/modules/monitoring/master/alert-rules/smart-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/smart-alerts.yaml
@@ -1,0 +1,133 @@
+# SMART disk health alerts.
+#
+# Metric names verified against the smartctl_exporter source rather than
+# guessed: prometheus-community/smartctl_exporter exposes
+# smartctl_device_{smart_status,critical_warning,media_errors,percentage_used,
+# available_spare,available_spare_threshold,temperature,smartctl_exit_status}.
+#
+# Fleet baseline, read off the drives with smartctl 7.5 on 2026-08-03:
+#
+#   host      device   %used  spare  spare_thresh  media_err  TB written
+#   sdrhub    nvme0       54    100            10          0        37.8
+#   hfdlhub1  nvme0        5    100            10          0
+#   hfdlhub2  nvme0        5    100            10          0
+#   acarshub  nvme0        1    100            50          0
+#   vdlmhub   nvme0        1    100            50          0
+#   fredhub   nvme0        2    100            10          0
+#
+# Two facts drive the thresholds below, both verified directly:
+#
+#   1. sdrhub is at 54% of its rated write endurance with 37.8 TB written.
+#      Every host runs a single NVMe with no redundancy and the decoders write
+#      continuously, so endurance exhaustion is the realistic failure mode.
+#   2. acarshub and vdlmhub report an Available Spare Threshold of 50%, not the
+#      10% the other four report. A hardcoded "spare < 10%" rule would be
+#      wrong for those two, so SmartAvailableSpareLow compares against the
+#      drive's own reported threshold instead of a constant.
+#
+# fredvps is excluded at the exporter level: it is a QEMU guest whose virtual
+# disk reports "SMART support is: Unavailable - device lacks SMART capability".
+#
+# scripts/check-alert-metrics.sh will report every metric here as MISSING until
+# the exporter is deployed. That is expected, and the script's own failure text
+# says so.
+groups:
+  - name: smart-alerts
+    rules:
+      # The drive's own overall verdict. 1 is passing, 0 is failing. When a
+      # drive says it is failing, that is not a threshold to tune.
+      - alert: SmartDeviceFailing
+        expr: smartctl_device_smart_status == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SMART self-assessment FAILED on {{ $labels.hostname }} ({{ $labels.device }})"
+          description: "The drive reports its own overall health as failing. Replace it. This host has a single NVMe with no redundancy."
+
+      # NVMe critical warning is a bitfield: spare below threshold, temperature
+      # excursion, degraded reliability, read-only mode, failed volatile memory
+      # backup. Any bit set is actionable, so alert on non-zero rather than
+      # decoding individual bits.
+      - alert: SmartCriticalWarning
+        expr: smartctl_device_critical_warning > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "NVMe critical warning on {{ $labels.hostname }} ({{ $labels.device }})"
+          description: "The controller has raised a critical warning bitfield (value {{ $value }}). Causes include available spare below threshold, temperature excursion, degraded reliability, or the drive having gone read-only."
+
+      # Uncorrectable data-integrity errors. Fleet baseline is exactly 0 on
+      # every drive, so any increase is genuinely anomalous rather than a
+      # threshold that needs tuning.
+      - alert: SmartMediaErrors
+        expr: increase(smartctl_device_media_errors[1h]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Media errors increasing on {{ $labels.hostname }} ({{ $labels.device }})"
+          description: "The drive has recorded new uncorrectable data-integrity errors in the last hour. Fleet baseline for this counter is zero across all drives."
+
+      # Spare blocks compared against the DRIVE'S OWN reported threshold, not a
+      # constant -- acarshub and vdlmhub report 50% where the others report 10%.
+      # Crossing the manufacturer's own threshold is what sets the
+      # corresponding critical_warning bit, so this is a pre-failure signal.
+      - alert: SmartAvailableSpareLow
+        expr: |
+          smartctl_device_available_spare
+            <= on (hostname, device) group_left ()
+          smartctl_device_available_spare_threshold
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Spare blocks exhausted on {{ $labels.hostname }} ({{ $labels.device }})"
+          description: "Available spare has fallen to or below the drive's own reported threshold. The controller is running out of blocks to remap failures onto."
+
+      # Write endurance. percentage_used is the controller's own estimate of
+      # rated lifetime consumed; 100 means the endurance rating is spent, and
+      # it can exceed 100.
+      #
+      # Warning at 80: sdrhub is at 54% after 24878 power-on hours (2.8 years),
+      # so it is tracking toward roughly 19 bytes per byte of remaining life.
+      # 80 gives many months of notice at that rate -- long enough to order a
+      # replacement without urgency.
+      #
+      # Critical at 95 rather than 100, because the point is to replace the
+      # drive before the rating is exhausted, not after.
+      - alert: SmartWearoutWarning
+        expr: smartctl_device_percentage_used >= 80 and smartctl_device_percentage_used < 95
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk wear at {{ $value }}% on {{ $labels.hostname }} ({{ $labels.device }})"
+          description: "The drive reports {{ $value }}% of its rated write endurance consumed. Plan a replacement. Single NVMe, no redundancy."
+
+      - alert: SmartWearoutCritical
+        expr: smartctl_device_percentage_used >= 95
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk endurance nearly exhausted on {{ $labels.hostname }} ({{ $labels.device }})"
+          description: "The drive reports {{ $value }}% of its rated write endurance consumed. Replace it now."
+
+      # The exporter forks smartctl per device; a non-zero exit means it could
+      # not read the drive. Without this the SMART rules above would go quiet
+      # rather than firing, which is the silent-failure mode this whole
+      # alerting overhaul exists to eliminate.
+      #
+      # Bit 0 (value 1) means a command-line or device-open failure. The higher
+      # bits are SMART status flags that the dedicated rules above already
+      # cover, so this deliberately matches only the low bit.
+      - alert: SmartctlCannotReadDevice
+        expr: (smartctl_device_smartctl_exit_status % 2) == 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "smartctl cannot read {{ $labels.device }} on {{ $labels.hostname }}"
+          description: "The exporter's smartctl invocation is failing to open the device, so no SMART data is being collected for it. Every SMART alert for this drive is inoperative until this is resolved."

--- a/modules/monitoring/master/alert-rules/system-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/system-alerts.yaml
@@ -2,7 +2,12 @@ groups:
   - name: nixos-alerts
     rules:
       - alert: NixOSNotOnMain
-        expr: nixos_branch{host!~"daytona|maranello"} == 0
+        # Desktops track feature branches routinely, so they are excluded.
+        # This previously matched host!~"daytona|maranello", which never
+        # excluded Daytona: the host label is "Daytona" and PromQL regexes
+        # are case-sensitive. Selecting on role is both correct and
+        # consistent with NixOSRevisionBehind below.
+        expr: nixos_branch{role!="desktop"} == 0
         for: 6h
         labels:
           severity: warning

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -1,0 +1,249 @@
+# promtool unit tests for the Prometheus alerting rules.
+#
+# Run with:
+#   nix build .#checks.x86_64-linux.prometheus-alert-rules
+#
+# These exist because every defect found in this rule set was of the same
+# shape: a rule that is syntactically valid, is reported health=ok by
+# Prometheus, and can never fire. An empty result is not an error, so nothing
+# surfaced them. Only evaluating a rule against known input catches that.
+#
+# When adding an alert, add a case here that proves it fires on the condition
+# it claims to detect. A rule with no test is a rule nobody has verified.
+rule_files:
+  - ../alert-rules.yaml
+  - ../docker-rules.yaml
+  - ../meta-alerts.yaml
+  - ../sdr-alerts.yaml
+  - ../system-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Regression test for the sum()/count() defect.
+  #
+  # The rule was `sum by (job, instance) (up{...} == 0) > 0`. The `== 0`
+  # filter keeps only series valued zero, so the sum is always zero and
+  # `> 0` is never true. Two targets were down in production for an extended
+  # period and this alert never fired.
+  - interval: 1m
+    name: PrometheusTargetDown fires when a target is down
+    input_series:
+      - series: 'up{job="ultrafeeder", instance="sdrhub.local:9274", role="master"}'
+        values: "0+0x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTargetDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: ultrafeeder
+              instance: sdrhub.local:9274
+            exp_annotations:
+              summary: "Targets for ultrafeeder are DOWN"
+              description: "Prometheus cannot scrape sdrhub.local:9274 for >2 minutes."
+
+  - interval: 1m
+    name: PrometheusTargetDown stays silent when targets are up
+    input_series:
+      - series: 'up{job="ultrafeeder", instance="sdrhub.local:9274", role="master"}'
+        values: "1+0x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTargetDown
+        exp_alerts: []
+
+  # Desktops sleep, so they must never trigger this.
+  - interval: 1m
+    name: PrometheusTargetDown ignores desktops
+    input_series:
+      - series: 'up{job="node", instance="maranello.local:9100", role="desktop"}'
+        values: "0+0x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PrometheusTargetDown
+        exp_alerts: []
+
+  # container_health_state uses -1 for "image defines no HEALTHCHECK". A
+  # naive `!= 1` fires for all 17 such containers in the fleet.
+  - interval: 1m
+    name: ContainerUnhealthy ignores containers with no healthcheck
+    input_series:
+      - series: 'container_health_state{name="acars_router", hostname="sdrhub"}'
+        values: "-1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ContainerUnhealthy
+        exp_alerts: []
+
+  - interval: 1m
+    name: ContainerUnhealthy fires on a genuinely unhealthy container
+    input_series:
+      - series: 'container_health_state{name="ultrafeeder", hostname="sdrhub"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ContainerUnhealthy
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              name: ultrafeeder
+              hostname: sdrhub
+            exp_annotations:
+              summary: "Container ultrafeeder on sdrhub reports unhealthy"
+              description: "The container's own HEALTHCHECK has been failing for 10 minutes."
+
+  - interval: 1m
+    name: ContainerUnhealthy stays silent on a healthy container
+    input_series:
+      - series: 'container_health_state{name="ultrafeeder", hostname="sdrhub"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ContainerUnhealthy
+        exp_alerts: []
+
+  # These selected readsb_stats_* names, which the exporter does not emit.
+  - interval: 1m
+    name: UltrafeederNotReceiving fires on zero valid messages
+    input_series:
+      - series: 'readsb_messages_valid{job="ultrafeeder", hostname="sdrhub"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 18m
+        alertname: UltrafeederNotReceiving
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: ultrafeeder
+              hostname: sdrhub
+            exp_annotations:
+              summary: "Ultrafeeder receiving no RF messages on sdrhub"
+              description: "readsb has processed zero valid messages for 15 minutes. The SDR hardware is likely disconnected, crashed, or the decoder has stopped."
+
+  - interval: 1m
+    name: UltrafeederNoAircraft fires when nothing is tracked
+    input_series:
+      - series: 'readsb_aircraft_with_position{job="ultrafeeder", hostname="sdrhub"}'
+        values: "0+0x40"
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: UltrafeederNoAircraft
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: ultrafeeder
+              hostname: sdrhub
+            exp_annotations:
+              summary: "Ultrafeeder tracking no aircraft on sdrhub"
+              description: "No aircraft with position have been tracked for 30 minutes. Possible SDR hardware failure, antenna issue, or decoder problem."
+
+  - interval: 1m
+    name: Ultrafeeder alerts stay silent under normal traffic
+    input_series:
+      - series: 'readsb_messages_valid{job="ultrafeeder", hostname="sdrhub"}'
+        values: "9000+100x40"
+      - series: 'readsb_aircraft_with_position{job="ultrafeeder", hostname="sdrhub"}'
+        values: "220+1x40"
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: UltrafeederNotReceiving
+        exp_alerts: []
+      - eval_time: 35m
+        alertname: UltrafeederNoAircraft
+        exp_alerts: []
+
+  # Requires --collector.systemd.enable-restarts-metrics on node_exporter.
+  - interval: 1m
+    name: DockerUnitFlapping fires on a restart loop
+    input_series:
+      - series: 'node_systemd_unit_restart_total{name="docker-dumpvdl2-3.service", hostname="vdlmhub"}'
+        values: "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19"
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: DockerUnitFlapping
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              name: docker-dumpvdl2-3.service
+              hostname: vdlmhub
+            exp_annotations:
+              summary: "Docker systemd unit docker-dumpvdl2-3.service is restarting repeatedly"
+              description: "Systemd restarted docker-dumpvdl2-3.service more than 3 times in 10 minutes."
+
+  - interval: 1m
+    name: DockerUnitFlapping stays silent for a stable unit
+    input_series:
+      - series: 'node_systemd_unit_restart_total{name="docker-ultrafeeder.service", hostname="sdrhub"}'
+        values: "2+0x20"
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: DockerUnitFlapping
+        exp_alerts: []
+
+  # The Watchdog must fire unconditionally; the deadman depends on it.
+  - interval: 1m
+    name: Watchdog always fires
+    input_series:
+      - series: 'up{job="prometheus"}'
+        values: "1+0x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: Watchdog
+        exp_alerts:
+          - exp_labels:
+              severity: none
+            exp_annotations:
+              summary: "Alerting pipeline is alive"
+              description: "This alert always fires. Its absence downstream means Prometheus or Alertmanager has stopped."
+
+  - interval: 1m
+    name: DockerDaemonDown fires when dockerd is inactive
+    input_series:
+      - series: 'node_systemd_unit_state{state="active", name="docker.service", hostname="vdlmhub"}'
+        values: "0+0x10"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: DockerDaemonDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              state: active
+              name: docker.service
+              hostname: vdlmhub
+            exp_annotations:
+              summary: "Docker daemon is not running on vdlmhub"
+              description: "dockerd is not active. Every container on this host is down."
+
+  # NixOSNotOnMain previously matched host!~"daytona|maranello", which never
+  # excluded Daytona because the host label is "Daytona" and PromQL regexes
+  # are case-sensitive.
+  - interval: 1m
+    name: NixOSNotOnMain ignores desktops regardless of hostname casing
+    input_series:
+      - series: 'nixos_branch{host="Daytona", hostname="Daytona", role="desktop"}'
+        values: "0+0x500"
+      - series: 'nixos_branch{host="maranello", hostname="maranello", role="desktop"}'
+        values: "0+0x500"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: NixOSNotOnMain
+        exp_alerts: []
+
+  - interval: 1m
+    name: NixOSNotOnMain fires for a server off main
+    input_series:
+      - series: 'nixos_branch{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "0+0x500"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: NixOSNotOnMain
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              host: vdlmhub
+              hostname: vdlmhub
+              role: agent
+            exp_annotations:
+              summary: "NixOS repo not on main branch"
+              description: "The NixOS configuration on vdlmhub is not checked out on main for more than 6 hours."

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -71,18 +71,24 @@ tests:
     input_series:
       - series: 'container_health_state{name="acars_router", hostname="sdrhub"}'
         values: "-1+0x20"
+      - series: 'container_start_time_seconds{name="acars_router", hostname="sdrhub"}'
+        values: "0+0x20"
     alert_rule_test:
       - eval_time: 15m
         alertname: ContainerUnhealthy
         exp_alerts: []
 
-  - interval: 1m
+  # start_time 0 against an eval_time of 3h means the container has been up
+  # longer than the 2h30m gate, so the state is genuinely unhealthy.
+  - interval: 5m
     name: ContainerUnhealthy fires on a genuinely unhealthy container
     input_series:
       - series: 'container_health_state{name="ultrafeeder", hostname="sdrhub"}'
-        values: "0+0x20"
+        values: "0+0x60"
+      - series: 'container_start_time_seconds{name="ultrafeeder", hostname="sdrhub"}'
+        values: "0+0x60"
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 3h
         alertname: ContainerUnhealthy
         exp_alerts:
           - exp_labels:
@@ -91,15 +97,36 @@ tests:
               hostname: sdrhub
             exp_annotations:
               summary: "Container ultrafeeder on sdrhub reports unhealthy"
-              description: "The container's own HEALTHCHECK has been failing for 10 minutes."
+              description: "The container's own HEALTHCHECK has been failing for 10 minutes, and it started long enough ago that this is not its start_period."
 
-  - interval: 1m
+  - interval: 5m
     name: ContainerUnhealthy stays silent on a healthy container
     input_series:
       - series: 'container_health_state{name="ultrafeeder", hostname="sdrhub"}'
-        values: "1+0x20"
+        values: "1+0x60"
+      - series: 'container_start_time_seconds{name="ultrafeeder", hostname="sdrhub"}'
+        values: "0+0x60"
     alert_rule_test:
-      - eval_time: 15m
+      - eval_time: 3h
+        alertname: ContainerUnhealthy
+        exp_alerts: []
+
+  # Regression test for the start_period false positive. cAdvisor reports 0 for
+  # both "unhealthy" and "still starting", and piaware's start_period is 2h, so
+  # without the start-time gate this fired ~10 minutes after every deploy and
+  # stayed firing for two hours. Observed happening on piaware in production.
+  #
+  # start_time 0 with an eval_time of 1h means the container is 1h old, inside
+  # the 2h30m gate, so a health state of 0 must be treated as "starting".
+  - interval: 5m
+    name: ContainerUnhealthy ignores a container still inside its start_period
+    input_series:
+      - series: 'container_health_state{name="piaware", hostname="sdrhub"}'
+        values: "0+0x30"
+      - series: 'container_start_time_seconds{name="piaware", hostname="sdrhub"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 1h
         alertname: ContainerUnhealthy
         exp_alerts: []
 

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -157,7 +157,7 @@ tests:
   - interval: 1m
     name: DockerUnitFlapping fires on a restart loop
     input_series:
-      - series: 'node_systemd_unit_restart_total{name="docker-dumpvdl2-3.service", hostname="vdlmhub"}'
+      - series: 'node_systemd_service_restart_total{name="docker-dumpvdl2-3.service", hostname="vdlmhub"}'
         values: "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19"
     alert_rule_test:
       - eval_time: 16m
@@ -174,7 +174,7 @@ tests:
   - interval: 1m
     name: DockerUnitFlapping stays silent for a stable unit
     input_series:
-      - series: 'node_systemd_unit_restart_total{name="docker-ultrafeeder.service", hostname="sdrhub"}'
+      - series: 'node_systemd_service_restart_total{name="docker-ultrafeeder.service", hostname="sdrhub"}'
         values: "2+0x20"
     alert_rule_test:
       - eval_time: 16m

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -130,6 +130,34 @@ tests:
         alertname: ContainerUnhealthy
         exp_alerts: []
 
+  # The cases above each use one container, so none of them proves the
+  # start-time gate is applied per series rather than globally. This one has an
+  # old broken container and a freshly started one in the same evaluation: a
+  # correct per-series join alerts on the first and not the second.
+  - interval: 5m
+    name: ContainerUnhealthy start-gate discriminates between containers
+    input_series:
+      - series: 'container_health_state{name="oldbroken", hostname="sdrhub"}'
+        values: "0+0x60"
+      - series: 'container_start_time_seconds{name="oldbroken", hostname="sdrhub"}'
+        values: "0+0x60"
+      - series: 'container_health_state{name="newstarting", hostname="sdrhub"}'
+        values: "0+0x60"
+      # Started at t=10500s, so at eval 3h it is still inside the 2h30m gate.
+      - series: 'container_start_time_seconds{name="newstarting", hostname="sdrhub"}'
+        values: "10500+0x60"
+    alert_rule_test:
+      - eval_time: 3h
+        alertname: ContainerUnhealthy
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              name: oldbroken
+              hostname: sdrhub
+            exp_annotations:
+              summary: "Container oldbroken on sdrhub reports unhealthy"
+              description: "The container's own HEALTHCHECK has been failing for 10 minutes, and it started long enough ago that this is not its start_period."
+
   # These selected readsb_stats_* names, which the exporter does not emit.
   - interval: 1m
     name: UltrafeederNotReceiving fires on zero valid messages

--- a/modules/monitoring/master/alert-rules/tests/blackbox-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/blackbox-alerts-test.yaml
@@ -1,0 +1,246 @@
+# promtool unit tests for the blackbox-exporter alerting rules.
+#
+# Run with:
+#   cd modules/monitoring/master/alert-rules/tests
+#   promtool test rules blackbox-alerts-test.yaml
+#
+# Modelled on alert-rules-test.yaml, including the relative rule_files paths --
+# promtool resolves them against the directory containing the test file, which
+# is why these tests must be run from this directory.
+#
+# TWO TIMING TRAPS THIS FILE IS BUILT AROUND
+#
+# 1. Rules are evaluated at the top-level `evaluation_interval`, but samples are
+#    laid down at each test's own `interval`. If `interval` exceeds Prometheus'
+#    5m lookback delta, the series is stale at most evaluation points, the
+#    expression yields nothing, and a `for:` clause can never accumulate -- the
+#    test then "passes" for a rule that never fired. Every `interval` below is
+#    therefore <= 5m, and every `input_series` is long enough to cover the
+#    rule's `for:` plus the evaluation time being asserted.
+#
+# 2. `time()` inside a unit test is the test's own clock, which starts at epoch
+#    0. So `probe_ssl_earliest_cert_expiry` values here are "seconds of
+#    remaining validity measured from the start of the test", not real
+#    timestamps. At eval_time 90m the clock reads 5400, so a series valued
+#    864000 has 858600s (~9.94 days) left. The values below were chosen so the
+#    5400s of elapsed test time cannot push any case across a threshold.
+rule_files:
+  - ../blackbox-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  #############################################################
+  # BlackboxProbeFailed
+  #############################################################
+
+  # The core reason blackbox exists: catch an endpoint that is unreachable even
+  # though every exporter on every node reports itself perfectly healthy.
+  - interval: 1m
+    name: BlackboxProbeFailed fires for a public HTTPS endpoint that stops responding
+    input_series:
+      - series: 'probe_success{job="blackbox-https", instance="https://acarshub.app/"}'
+        values: "0+0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BlackboxProbeFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-https
+              instance: https://acarshub.app/
+            exp_annotations:
+              summary: "Endpoint https://acarshub.app/ is failing its probe"
+              description: "Blackbox job blackbox-https has been unable to get a valid response from https://acarshub.app/ for 5 minutes."
+
+  # The internal job must be covered too: this is the only check that exercises
+  # the nginx reverse-proxy layer on sdrhub.
+  - interval: 1m
+    name: BlackboxProbeFailed fires for an internal LAN vhost
+    input_series:
+      - series: 'probe_success{job="blackbox-http-internal", instance="http://tar1090.sdrhub.local/"}'
+        values: "0+0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BlackboxProbeFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-http-internal
+              instance: http://tar1090.sdrhub.local/
+            exp_annotations:
+              summary: "Endpoint http://tar1090.sdrhub.local/ is failing its probe"
+              description: "Blackbox job blackbox-http-internal has been unable to get a valid response from http://tar1090.sdrhub.local/ for 5 minutes."
+
+  - interval: 1m
+    name: BlackboxProbeFailed stays silent while probes succeed
+    input_series:
+      - series: 'probe_success{job="blackbox-https", instance="https://acarshub.app/"}'
+        values: "1+0x15"
+      - series: 'probe_success{job="blackbox-https-redirect", instance="https://sdr-e.org/"}'
+        values: "1+0x15"
+      - series: 'probe_success{job="blackbox-http-internal", instance="http://sdrhub.local/"}'
+        values: "1+0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BlackboxProbeFailed
+        exp_alerts: []
+
+  # A single failed probe must not page. `for: 5m` at a 60s scrape interval
+  # means five consecutive failures; this proves one is absorbed.
+  - interval: 1m
+    name: BlackboxProbeFailed absorbs a single transient failure
+    input_series:
+      - series: 'probe_success{job="blackbox-https", instance="https://fredclausen.com/"}'
+        values: "1 1 0 1 1 1 1 1 1 1 1 1"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BlackboxProbeFailed
+        exp_alerts: []
+
+  #############################################################
+  # BlackboxSlowProbe
+  #############################################################
+
+  - interval: 1m
+    name: BlackboxSlowProbe fires on a sustained slow endpoint
+    input_series:
+      - series: 'probe_duration_seconds{job="blackbox-https", instance="https://fredclausen.com/"}'
+        values: "7.5+0x25"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BlackboxSlowProbe
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: blackbox-https
+              instance: https://fredclausen.com/
+            exp_annotations:
+              summary: "Endpoint https://fredclausen.com/ is responding slowly"
+              description: "Blackbox job blackbox-https has taken more than 5s to probe https://fredclausen.com/ for 15 minutes. Measured baseline is 0.007s-0.03s for LAN vhosts and 0.20s-0.62s for the public HTTPS vhosts."
+
+  # Guards the threshold against the real measured latencies, including the
+  # slowest steady-state target (flipaholics.pro at ~0.62s) and the worst
+  # single cold-probe observation seen while validating this config (1.03s).
+  # If someone lowers the 5s threshold to something like 1s, this test breaks
+  # instead of production paging.
+  - interval: 1m
+    name: BlackboxSlowProbe stays silent at the measured baseline latency
+    input_series:
+      - series: 'probe_duration_seconds{job="blackbox-https", instance="https://fredclausen.com/"}'
+        values: "0.2+0x25"
+      - series: 'probe_duration_seconds{job="blackbox-https", instance="https://flipaholics.pro/"}'
+        values: "0.62+0x25"
+      - series: 'probe_duration_seconds{job="blackbox-http-internal", instance="http://sdrhub.local/"}'
+        values: "0.007+0x25"
+      - series: 'probe_duration_seconds{job="blackbox-https-redirect", instance="https://sdr-e.org/"}'
+        values: "1.03+0x25"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BlackboxSlowProbe
+        exp_alerts: []
+
+  #############################################################
+  # BlackboxCertExpiringSoon (warning, < 21d with a >= 7d floor)
+  #############################################################
+
+  # 864000 = 10 days of remaining validity at test time 0. At eval_time 90m the
+  # test clock reads 5400, leaving 858600s -- comfortably inside the 7d..21d
+  # band, so the arithmetic cannot be the reason this passes or fails.
+  - interval: 5m
+    name: BlackboxCertExpiringSoon fires at 10 days remaining
+    input_series:
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https", instance="https://acarshub.app/"}'
+        values: "864000+0x24"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: BlackboxCertExpiringSoon
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: blackbox-https
+              instance: https://acarshub.app/
+            exp_annotations:
+              summary: "TLS certificate for https://acarshub.app/ expires in under 21 days"
+              description: "The certificate served by https://acarshub.app/ has less than 21 days of validity left, so ACME renewal (which should have run at 30 days) is not succeeding. Check acme-*.service on the host terminating this vhost."
+      # The critical rule must NOT also fire at 10 days.
+      - eval_time: 90m
+        alertname: BlackboxCertExpiryCritical
+        exp_alerts: []
+
+  # 5184000 = 60 days. A freshly renewed ACME cert. Nothing may fire.
+  - interval: 5m
+    name: Cert expiry alerts stay silent on a freshly renewed certificate
+    input_series:
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https", instance="https://acarshub.app/"}'
+        values: "5184000+0x24"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: BlackboxCertExpiringSoon
+        exp_alerts: []
+      - eval_time: 90m
+        alertname: BlackboxCertExpiryCritical
+        exp_alerts: []
+
+  # Boundary: 30 days remaining is exactly when the NixOS acme module renews.
+  # Nothing may fire yet, or every certificate in the fleet alerts on schedule
+  # every 60 days.
+  - interval: 5m
+    name: BlackboxCertExpiringSoon stays silent at the 30 day renewal point
+    input_series:
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https-redirect", instance="https://sdr-e.org/"}'
+        values: "2592000+0x24"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: BlackboxCertExpiringSoon
+        exp_alerts: []
+
+  #############################################################
+  # BlackboxCertExpiryCritical (critical, < 7d)
+  #############################################################
+
+  # 432000 = 5 days remaining. Critical must fire; warning must not, because of
+  # its >= 7d floor. Without that floor Alertmanager would deliver the same
+  # certificate on two severities with two repeat intervals.
+  - interval: 5m
+    name: BlackboxCertExpiryCritical fires at 5 days remaining and suppresses the warning
+    input_series:
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https-redirect", instance="https://sdr-e.org/"}'
+        values: "432000+0x24"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: BlackboxCertExpiryCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-https-redirect
+              instance: https://sdr-e.org/
+            exp_annotations:
+              summary: "TLS certificate for https://sdr-e.org/ expires in under 7 days"
+              description: "The certificate served by https://sdr-e.org/ has less than 7 days of validity left. Browsers will start refusing this endpoint. Fix ACME renewal on the host terminating this vhost now."
+      - eval_time: 90m
+        alertname: BlackboxCertExpiringSoon
+        exp_alerts: []
+
+  # An already-expired certificate. `metric - time()` simply goes negative, so
+  # the same `< 7d` comparison must still catch it. A rule that only handled
+  # positive remaining time would go silent at the exact moment it matters most.
+  - interval: 5m
+    name: BlackboxCertExpiryCritical fires for an already expired certificate
+    input_series:
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https", instance="https://flipaholics.pro/"}'
+        values: "-86400+0x24"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: BlackboxCertExpiryCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-https
+              instance: https://flipaholics.pro/
+            exp_annotations:
+              summary: "TLS certificate for https://flipaholics.pro/ expires in under 7 days"
+              description: "The certificate served by https://flipaholics.pro/ has less than 7 days of validity left. Browsers will start refusing this endpoint. Fix ACME renewal on the host terminating this vhost now."
+      - eval_time: 90m
+        alertname: BlackboxCertExpiringSoon
+        exp_alerts: []

--- a/modules/monitoring/master/alert-rules/tests/capacity-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/capacity-alerts-test.yaml
@@ -1,0 +1,382 @@
+# promtool unit tests for the capacity / saturation alerting rules.
+#
+# Run with:
+#   nix build .#checks.x86_64-linux.prometheus-alert-rules
+#
+# Same rationale as alert-rules-test.yaml: a rule that is syntactically valid
+# and reported health=ok by Prometheus can still be incapable of ever firing,
+# because an empty query result is not an error. Every alert here has both a
+# firing case and a non-firing case, and the non-firing cases are chosen to be
+# the specific false-positive traps that each rule's guards exist to prevent.
+#
+# Note on series length: input_series must extend past eval_time, and far
+# enough to cover the rule's `for:` duration plus its range-vector window,
+# otherwise the series goes stale mid-evaluation and the test fails for
+# reasons unrelated to the rule logic.
+#
+# Note on `interval:`, which cost real debugging time here. Rules are evaluated
+# at the top-level `evaluation_interval` (1m), but input samples are spaced at
+# each test's `interval`. If that spacing exceeds Prometheus' 5m lookback
+# delta, the series is stale at most evaluation steps, so any rule with a
+# `for:` clause never accumulates a continuous pending period and silently
+# fails to fire. The SystemdTimerStale tests originally used `interval: 10m`
+# and failed for exactly this reason -- the expression was correct. Keep every
+# `interval:` here at 5m or below.
+rule_files:
+  - ../capacity-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # ---------------------------------------------------------------------------
+  # DiskFillPredicted
+  # ---------------------------------------------------------------------------
+
+  # 100 GB filesystem, 25 GB free (25%), losing 25 MB/min. That trend empties
+  # the disk in well under 24h, and it is already below the 30% guard.
+  - interval: 5m
+    name: DiskFillPredicted fires on a disk that is low and draining
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="/dev/nvme0n1p2", fstype="ext4", mountpoint="/", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "25000000000-125000000x100"
+      - series: 'node_filesystem_size_bytes{device="/dev/nvme0n1p2", fstype="ext4", mountpoint="/", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "100000000000+0x100"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: DiskFillPredicted
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              device: /dev/nvme0n1p2
+              fstype: ext4
+              mountpoint: /
+              hostname: vdlmhub
+              instance: vdlmhub.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Disk predicted to fill within 24h on vdlmhub (/)"
+              description: "Filesystem / on vdlmhub is below 30% free and, at its current 6h fill rate, is projected to run out of space within 24 hours."
+
+  # The reason the <30% guard exists. This filesystem is draining fast enough
+  # that predict_linear projects it negative inside 24h, but it still has 33%
+  # free. predict_linear on its own would fire here; that is the exact false
+  # positive we refuse to ship (a write burst on a roomy disk).
+  - interval: 5m
+    name: DiskFillPredicted stays silent when free space is still above the guard
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="/dev/nvme0n1p2", fstype="ext4", mountpoint="/", hostname="sdrhub", instance="sdrhub.local:9100", job="node", role="master"}'
+        values: "50000000000-200000000x100"
+      - series: 'node_filesystem_size_bytes{device="/dev/nvme0n1p2", fstype="ext4", mountpoint="/", hostname="sdrhub", instance="sdrhub.local:9100", job="node", role="master"}'
+        values: "100000000000+0x100"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: DiskFillPredicted
+        exp_alerts: []
+
+  # A healthy, stable filesystem: low on space but not trending anywhere.
+  - interval: 5m
+    name: DiskFillPredicted stays silent on a low but stable filesystem
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="/dev/sda2", fstype="ext4", mountpoint="/", hostname="fredvps", instance="fredvps.tailc21fc7.ts.net:9100", job="node", role="agent"}'
+        values: "25000000000+0x100"
+      - series: 'node_filesystem_size_bytes{device="/dev/sda2", fstype="ext4", mountpoint="/", hostname="fredvps", instance="fredvps.tailc21fc7.ts.net:9100", job="node", role="agent"}'
+        values: "100000000000+0x100"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: DiskFillPredicted
+        exp_alerts: []
+
+  # Desktops are out of scope; they churn disk constantly.
+  - interval: 5m
+    name: DiskFillPredicted ignores desktops
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="/dev/nvme1n1p2", fstype="ext4", mountpoint="/", hostname="maranello", instance="maranello.local:9100", job="node", role="desktop"}'
+        values: "25000000000-125000000x100"
+      - series: 'node_filesystem_size_bytes{device="/dev/nvme1n1p2", fstype="ext4", mountpoint="/", hostname="maranello", instance="maranello.local:9100", job="node", role="desktop"}'
+        values: "100000000000+0x100"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: DiskFillPredicted
+        exp_alerts: []
+
+  # tmpfs "fills" routinely and is excluded by fstype.
+  - interval: 5m
+    name: DiskFillPredicted ignores tmpfs
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="tmpfs", fstype="tmpfs", mountpoint="/run", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "25000000000-125000000x100"
+      - series: 'node_filesystem_size_bytes{device="tmpfs", fstype="tmpfs", mountpoint="/run", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "100000000000+0x100"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: DiskFillPredicted
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # SystemdTimerStale
+  # ---------------------------------------------------------------------------
+
+  # last_trigger pinned at t=1s while the clock runs to 80h, so the timer looks
+  # ~80h stale, comfortably past the 72h threshold.
+  - interval: 5m
+    name: SystemdTimerStale fires on a timer that stopped triggering
+    input_series:
+      - series: 'node_systemd_timer_last_trigger_seconds{name="nix-gc.timer", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "1+0x1000"
+    alert_rule_test:
+      - eval_time: 80h
+        alertname: SystemdTimerStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              name: nix-gc.timer
+              hostname: vdlmhub
+              instance: vdlmhub.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Systemd timer nix-gc.timer is stale on vdlmhub"
+              description: "The timer nix-gc.timer on vdlmhub has not triggered in over 72 hours. Every non-weekly timer in this fleet runs at least every 36 hours, so this timer has almost certainly stopped firing."
+
+  # Regression test for the epoch artefact. node_exporter reports 0 for a timer
+  # that has not triggered since boot, so `time() - 0` looks like ~56 years of
+  # staleness. Without the `> 0` guard every freshly booted host would page for
+  # logrotate.timer and systemd-tmpfiles-clean.timer immediately.
+  - interval: 5m
+    name: SystemdTimerStale ignores timers that have never triggered since boot
+    input_series:
+      - series: 'node_systemd_timer_last_trigger_seconds{name="logrotate.timer", hostname="acarshub", instance="acarshub.local:9100", job="node", role="agent"}'
+        values: "0+0x1000"
+    alert_rule_test:
+      - eval_time: 80h
+        alertname: SystemdTimerStale
+        exp_alerts: []
+
+  # Weekly timers are excluded by name. This also proves the regex escaping in
+  # the rule (`fstrim\\.timer`) survives YAML and PromQL parsing -- if the
+  # escape were wrong the exclusion would silently stop matching and fstrim
+  # would page every week.
+  - interval: 5m
+    name: SystemdTimerStale ignores the known weekly timers
+    input_series:
+      - series: 'node_systemd_timer_last_trigger_seconds{name="fstrim.timer", hostname="hfdlhub1", instance="hfdlhub1.local:9100", job="node", role="agent"}'
+        values: "1+0x1000"
+      - series: 'node_systemd_timer_last_trigger_seconds{name="ollama-model-updater.timer", hostname="fredhub", instance="fredhub.local:9100", job="node", role="agent"}'
+        values: "1+0x1000"
+    alert_rule_test:
+      - eval_time: 80h
+        alertname: SystemdTimerStale
+        exp_alerts: []
+
+  # A daily timer that is merely late (24h since last trigger) is fine; the
+  # fleet's worst legitimate gap is ~36h.
+  - interval: 5m
+    name: SystemdTimerStale stays silent for a timer within its normal period
+    input_series:
+      - series: 'node_systemd_timer_last_trigger_seconds{name="docker-prune.timer", hostname="sdrhub", instance="sdrhub.local:9100", job="node", role="agent"}'
+        values: "1+0x1000"
+    alert_rule_test:
+      - eval_time: 24h
+        alertname: SystemdTimerStale
+        exp_alerts: []
+
+  # Desktops sleep and power off, so their timers legitimately go stale.
+  - interval: 5m
+    name: SystemdTimerStale ignores desktops
+    input_series:
+      - series: 'node_systemd_timer_last_trigger_seconds{name="nix-gc.timer", hostname="maranello", instance="maranello.local:9100", job="node", role="desktop"}'
+        values: "1+0x1000"
+    alert_rule_test:
+      - eval_time: 80h
+        alertname: SystemdTimerStale
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # NodeNetworkErrors
+  # ---------------------------------------------------------------------------
+
+  # 5 receive errors per minute => ~75 per 15m window, far past the >10 floor.
+  - interval: 1m
+    name: NodeNetworkErrors fires on rising receive errors
+    input_series:
+      - series: 'node_network_receive_errs_total{device="enp1s0", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "0+5x60"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeNetworkErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              device: enp1s0
+              hostname: vdlmhub
+              instance: vdlmhub.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Network errors on vdlmhub (enp1s0)"
+              description: "Interface enp1s0 on vdlmhub has recorded more than 10 receive or transmit errors in 15 minutes. Fleet baseline for this counter is zero, so this indicates a cable, port, or link-layer fault."
+
+  # Covers the right-hand side of the `or`, which would otherwise be untested.
+  - interval: 1m
+    name: NodeNetworkErrors fires on rising transmit errors
+    input_series:
+      - series: 'node_network_transmit_errs_total{device="wlo1", hostname="acarshub", instance="acarshub.local:9100", job="node", role="agent"}'
+        values: "0+5x60"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeNetworkErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              device: wlo1
+              hostname: acarshub
+              instance: acarshub.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Network errors on acarshub (wlo1)"
+              description: "Interface wlo1 on acarshub has recorded more than 10 receive or transmit errors in 15 minutes. Fleet baseline for this counter is zero, so this indicates a cable, port, or link-layer fault."
+
+  # The normal fleet state: error counters flat at zero.
+  - interval: 1m
+    name: NodeNetworkErrors stays silent on a clean interface
+    input_series:
+      - series: 'node_network_receive_errs_total{device="enp1s0", hostname="hfdlhub1", instance="hfdlhub1.local:9100", job="node", role="agent"}'
+        values: "0+0x60"
+      - series: 'node_network_transmit_errs_total{device="enp1s0", hostname="hfdlhub1", instance="hfdlhub1.local:9100", job="node", role="agent"}'
+        values: "0+0x60"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeNetworkErrors
+        exp_alerts: []
+
+  # Virtual interfaces are excluded. Without the device filter, docker0, the
+  # veth pairs, the docker user bridges, tailscale0 and virbr0 would all be
+  # eligible -- 50 of the fleet's 57 network devices are virtual.
+  - interval: 1m
+    name: NodeNetworkErrors ignores virtual interfaces
+    input_series:
+      - series: 'node_network_receive_errs_total{device="lo", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "0+50x60"
+      - series: 'node_network_receive_errs_total{device="docker0", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "0+50x60"
+      - series: 'node_network_receive_errs_total{device="veth594c8bd", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "0+50x60"
+      - series: 'node_network_receive_errs_total{device="br-3bd5a620116b", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "0+50x60"
+      - series: 'node_network_receive_errs_total{device="tailscale0", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "0+50x60"
+      - series: 'node_network_transmit_errs_total{device="virbr0", hostname="vdlmhub", instance="vdlmhub.local:9100", job="node", role="agent"}'
+        values: "0+50x60"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeNetworkErrors
+        exp_alerts: []
+
+  # One error every 2 minutes is ~7.5 per 15m, under the >10 floor, so an
+  # isolated transient does not page.
+  - interval: 2m
+    name: NodeNetworkErrors stays silent below the error floor
+    input_series:
+      - series: 'node_network_receive_errs_total{device="enp191s0", hostname="fredhub", instance="fredhub.local:9100", job="node", role="agent"}'
+        values: "0+1x60"
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: NodeNetworkErrors
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # NodeHighLoad
+  # ---------------------------------------------------------------------------
+
+  # 4 cores, load15 of 20 => ratio 5, past the 4x threshold. This case also
+  # proves the `on (hostname) group_left ()` join works at all: with plain `/`
+  # the two sides share no label set and the result is empty, which is the
+  # can-never-fire defect class this branch exists to eliminate.
+  - interval: 1m
+    name: NodeHighLoad fires on sustained saturation
+    input_series:
+      - series: 'node_load15{hostname="hfdlhub1", instance="hfdlhub1.local:9100", job="node", role="agent"}'
+        values: "20+0x40"
+      - series: 'node_cpu_seconds_total{cpu="0", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="1", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="2", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="3", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeHighLoad
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: hfdlhub1
+              instance: hfdlhub1.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Sustained high load on hfdlhub1"
+              description: "The 15-minute load average on hfdlhub1 has been more than 4x its CPU count for 15 minutes. The run queue is growing faster than the host can drain it."
+
+  # hfdlhub1's actual steady state: load15 ~10 on 4 cores, ratio 2.5, which is
+  # its 30-day average. A threshold of 2 would have this host permanently
+  # alerting (89.7% of the last 30 days), so this must stay silent.
+  - interval: 1m
+    name: NodeHighLoad stays silent at the normal HFDL decoder baseline
+    input_series:
+      - series: 'node_load15{hostname="hfdlhub1", instance="hfdlhub1.local:9100", job="node", role="agent"}'
+        values: "10+0x40"
+      - series: 'node_cpu_seconds_total{cpu="0", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="1", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="2", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="3", mode="idle", hostname="hfdlhub1", role="agent"}'
+        values: "100+1x40"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeHighLoad
+        exp_alerts: []
+
+  # Proves the normalisation by core count. An absolute load of 20 is alarming
+  # on a 4-core box and unremarkable on fredhub's 32 cores (ratio 0.625).
+  - interval: 1m
+    name: NodeHighLoad normalises by CPU count on a large host
+    input_series:
+      - series: 'node_load15{hostname="fredhub", instance="fredhub.local:9100", job="node", role="agent"}'
+        values: "20+0x40"
+      - series: 'node_cpu_seconds_total{cpu="0", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="1", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="2", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="3", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="4", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="5", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeHighLoad
+        exp_alerts: []
+
+  # Desktops spike load legitimately (compiles, games) and are excluded.
+  - interval: 1m
+    name: NodeHighLoad ignores desktops
+    input_series:
+      - series: 'node_load15{hostname="maranello", instance="maranello.local:9100", job="node", role="desktop"}'
+        values: "100+0x40"
+      - series: 'node_cpu_seconds_total{cpu="0", mode="idle", hostname="maranello", role="desktop"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="1", mode="idle", hostname="maranello", role="desktop"}'
+        values: "100+1x40"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: NodeHighLoad
+        exp_alerts: []

--- a/modules/monitoring/master/alert-rules/tests/capacity-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/capacity-alerts-test.yaml
@@ -343,7 +343,12 @@ tests:
         exp_alerts: []
 
   # Proves the normalisation by core count. An absolute load of 20 is alarming
-  # on a 4-core box and unremarkable on fredhub's 32 cores (ratio 0.625).
+  # on a 4-core box and unremarkable on fredhub's 32 cores (ratio 0.625, far
+  # below the threshold of 4).
+  #
+  # All 32 core series are supplied deliberately. An earlier version claimed 32
+  # cores in this comment but supplied 6, giving a ratio of 3.33 -- under the
+  # threshold, so the case passed, but by a margin that proved nothing.
   - interval: 1m
     name: NodeHighLoad normalises by CPU count on a large host
     input_series:
@@ -360,6 +365,58 @@ tests:
       - series: 'node_cpu_seconds_total{cpu="4", mode="idle", hostname="fredhub", role="agent"}'
         values: "100+1x40"
       - series: 'node_cpu_seconds_total{cpu="5", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="6", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="7", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="8", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="9", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="10", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="11", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="12", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="13", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="14", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="15", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="16", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="17", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="18", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="19", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="20", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="21", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="22", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="23", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="24", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="25", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="26", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="27", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="28", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="29", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="30", mode="idle", hostname="fredhub", role="agent"}'
+        values: "100+1x40"
+      - series: 'node_cpu_seconds_total{cpu="31", mode="idle", hostname="fredhub", role="agent"}'
         values: "100+1x40"
     alert_rule_test:
       - eval_time: 30m

--- a/modules/monitoring/master/alert-rules/tests/smart-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/smart-alerts-test.yaml
@@ -1,0 +1,237 @@
+# promtool unit tests for the SMART disk health rules.
+#
+# Gotcha, learned the hard way in this directory: rules evaluate at the
+# top-level evaluation_interval, but samples are spaced at each test's own
+# `interval`. If `interval` exceeds Prometheus' 5m lookback delta the series is
+# stale at most evaluation steps and a `for:` clause never accumulates a
+# continuous pending period. Keep every interval <= 5m and make input_series
+# long enough to cover the rule's `for:` plus eval_time.
+rule_files:
+  - ../smart-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    name: SmartDeviceFailing fires when the drive reports failure
+    input_series:
+      - series: 'smartctl_device_smart_status{hostname="sdrhub", device="nvme0", role="master"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartDeviceFailing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: sdrhub
+              device: nvme0
+              role: master
+            exp_annotations:
+              summary: "SMART self-assessment FAILED on sdrhub (nvme0)"
+              description: "The drive reports its own overall health as failing. Replace it. This host has a single NVMe with no redundancy."
+
+  - interval: 1m
+    name: SmartDeviceFailing silent on a passing drive
+    input_series:
+      - series: 'smartctl_device_smart_status{hostname="sdrhub", device="nvme0"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartDeviceFailing
+        exp_alerts: []
+
+  - interval: 1m
+    name: SmartCriticalWarning fires on any bit set
+    input_series:
+      - series: 'smartctl_device_critical_warning{hostname="vdlmhub", device="nvme0"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartCriticalWarning
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: vdlmhub
+              device: nvme0
+            exp_annotations:
+              summary: "NVMe critical warning on vdlmhub (nvme0)"
+              description: "The controller has raised a critical warning bitfield (value 1). Causes include available spare below threshold, temperature excursion, degraded reliability, or the drive having gone read-only."
+
+  - interval: 1m
+    name: SmartCriticalWarning silent when clear
+    input_series:
+      - series: 'smartctl_device_critical_warning{hostname="vdlmhub", device="nvme0"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: SmartCriticalWarning
+        exp_alerts: []
+
+  - interval: 1m
+    name: SmartMediaErrors fires when the counter increases
+    input_series:
+      # Flat at 0 then climbing, so increase() over 1h is positive.
+      - series: 'smartctl_device_media_errors{hostname="hfdlhub1", device="nvme0"}'
+        values: "0+0x30 1+1x40"
+    alert_rule_test:
+      - eval_time: 70m
+        alertname: SmartMediaErrors
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: hfdlhub1
+              device: nvme0
+            exp_annotations:
+              summary: "Media errors increasing on hfdlhub1 (nvme0)"
+              description: "The drive has recorded new uncorrectable data-integrity errors in the last hour. Fleet baseline for this counter is zero across all drives."
+
+  - interval: 1m
+    name: SmartMediaErrors silent at the fleet baseline of zero
+    input_series:
+      - series: 'smartctl_device_media_errors{hostname="hfdlhub1", device="nvme0"}'
+        values: "0+0x80"
+    alert_rule_test:
+      - eval_time: 70m
+        alertname: SmartMediaErrors
+        exp_alerts: []
+
+  # The spare rule compares against the drive's own threshold. acarshub reports
+  # 50 where sdrhub reports 10, so a constant would be wrong for one of them.
+  - interval: 1m
+    name: SmartAvailableSpareLow respects a 50 percent threshold drive
+    input_series:
+      - series: 'smartctl_device_available_spare{hostname="acarshub", device="nvme0"}'
+        values: "50+0x30"
+      - series: 'smartctl_device_available_spare_threshold{hostname="acarshub", device="nvme0"}'
+        values: "50+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartAvailableSpareLow
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: acarshub
+              device: nvme0
+            exp_annotations:
+              summary: "Spare blocks exhausted on acarshub (nvme0)"
+              description: "Available spare has fallen to or below the drive's own reported threshold. The controller is running out of blocks to remap failures onto."
+
+  - interval: 1m
+    name: SmartAvailableSpareLow silent when spare is above a 50 percent threshold
+    input_series:
+      - series: 'smartctl_device_available_spare{hostname="acarshub", device="nvme0"}'
+        values: "51+0x30"
+      - series: 'smartctl_device_available_spare_threshold{hostname="acarshub", device="nvme0"}'
+        values: "50+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartAvailableSpareLow
+        exp_alerts: []
+
+  # 40% spare would trip a naive "< 10" constant check but is healthy for a
+  # drive whose own threshold is 10. This is the case a hardcoded rule gets
+  # wrong in the other direction.
+  - interval: 1m
+    name: SmartAvailableSpareLow silent at 40 percent on a 10 percent threshold drive
+    input_series:
+      - series: 'smartctl_device_available_spare{hostname="sdrhub", device="nvme0"}'
+        values: "40+0x30"
+      - series: 'smartctl_device_available_spare_threshold{hostname="sdrhub", device="nvme0"}'
+        values: "10+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartAvailableSpareLow
+        exp_alerts: []
+
+  # sdrhub's real current value. Must not alert.
+  - interval: 5m
+    name: SmartWearout silent at the current fleet worst case of 54 percent
+    input_series:
+      - series: 'smartctl_device_percentage_used{hostname="sdrhub", device="nvme0"}'
+        values: "54+0x30"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: SmartWearoutWarning
+        exp_alerts: []
+      - eval_time: 90m
+        alertname: SmartWearoutCritical
+        exp_alerts: []
+
+  - interval: 5m
+    name: SmartWearoutWarning fires at 80 percent and does not double up as critical
+    input_series:
+      - series: 'smartctl_device_percentage_used{hostname="sdrhub", device="nvme0"}'
+        values: "80+0x30"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: SmartWearoutWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: sdrhub
+              device: nvme0
+            exp_annotations:
+              summary: "Disk wear at 80% on sdrhub (nvme0)"
+              description: "The drive reports 80% of its rated write endurance consumed. Plan a replacement. Single NVMe, no redundancy."
+      - eval_time: 90m
+        alertname: SmartWearoutCritical
+        exp_alerts: []
+
+  - interval: 5m
+    name: SmartWearoutCritical fires at 95 percent and warning does not
+    input_series:
+      - series: 'smartctl_device_percentage_used{hostname="sdrhub", device="nvme0"}'
+        values: "95+0x30"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: SmartWearoutCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: sdrhub
+              device: nvme0
+            exp_annotations:
+              summary: "Disk endurance nearly exhausted on sdrhub (nvme0)"
+              description: "The drive reports 95% of its rated write endurance consumed. Replace it now."
+      - eval_time: 90m
+        alertname: SmartWearoutWarning
+        exp_alerts: []
+
+  - interval: 1m
+    name: SmartctlCannotReadDevice fires on exit status low bit set
+    input_series:
+      - series: 'smartctl_device_smartctl_exit_status{hostname="fredhub", device="nvme0"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartctlCannotReadDevice
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: fredhub
+              device: nvme0
+            exp_annotations:
+              summary: "smartctl cannot read nvme0 on fredhub"
+              description: "The exporter's smartctl invocation is failing to open the device, so no SMART data is being collected for it. Every SMART alert for this drive is inoperative until this is resolved."
+
+  # Exit status 4 has the low bit clear: those are SMART status flags the
+  # dedicated rules cover, not a device-open failure.
+  - interval: 1m
+    name: SmartctlCannotReadDevice ignores non-open-failure exit codes
+    input_series:
+      - series: 'smartctl_device_smartctl_exit_status{hostname="fredhub", device="nvme0"}'
+        values: "4+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartctlCannotReadDevice
+        exp_alerts: []
+
+  - interval: 1m
+    name: SmartctlCannotReadDevice silent on clean exit
+    input_series:
+      - series: 'smartctl_device_smartctl_exit_status{hostname="fredhub", device="nvme0"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: SmartctlCannotReadDevice
+        exp_alerts: []

--- a/modules/monitoring/master/blackbox.nix
+++ b/modules/monitoring/master/blackbox.nix
@@ -1,0 +1,236 @@
+{ pkgs, ... }:
+let
+  # Blackbox exporter listen address. Deliberately loopback-only.
+  #
+  # Nothing outside this host has any reason to reach the exporter: it is a
+  # probe *driver*, not a source of truth about sdrhub, and the only consumer
+  # is the Prometheus instance running on this same machine. Binding it to
+  # 0.0.0.0 would expose an unauthenticated HTTP fetcher on the LAN --
+  # /probe?target=<anything> turns the exporter into an open SSRF relay that
+  # can reach every LAN service the firewall otherwise protects.
+  #
+  # Consequently there is NO networking.firewall.allowedTCPPorts entry in this
+  # file, and services.prometheus.exporters.blackbox.openFirewall stays at its
+  # default of false. Port 9115 is the upstream default and is unused elsewhere
+  # in this repo (sdrhub already occupies 22, 80, 3000, 3333, 4567, 5432, 5678,
+  # 6379, 8889, 9090, 9093, 9100 and 11434).
+  blackboxHost = "127.0.0.1";
+  blackboxPort = 9115;
+  blackboxAddress = "${blackboxHost}:${toString blackboxPort}";
+
+  # Public HTTPS vhosts on fredvps that terminate TLS with their own ACME
+  # certificate. See hosts/linux/fredvps/nginx.nix -- every one of these is a
+  # separate `enableACME = true` vhost, so every one has an independently
+  # issued certificate that can independently fail to renew. That is precisely
+  # why the whole set is probed rather than a token sample: a per-cert renewal
+  # failure is invisible if only one cert is watched.
+  #
+  # Split by expected response so the probe asserts the *intended* behaviour
+  # instead of accepting any 2xx-or-3xx. Every entry below was verified to
+  # respond as classified, from sdrhub, with a clean chain (ssl_verify_result=0).
+
+  # Vhosts that serve real content and must answer 2xx directly.
+  publicAppEndpoints = [
+    "https://fredclausen.com/" # nginx -> fredsite on 127.0.0.1:4200
+    "https://acarshub.app/" # nginx -> acarshub on 127.0.0.1:8085
+    "https://flipaholics.pro/" # nginx -> 127.0.0.1:8078
+  ];
+
+  # Vhosts whose entire job is a globalRedirect. These must answer 3xx; a 2xx
+  # here would mean the redirect silently stopped working.
+  publicRedirectEndpoints = [
+    "https://acarshub.com/" # -> acarshub.app
+    "https://adsb-pi.com/" # -> fredclausen.com
+    "https://atcfreq.com/" # -> fredclausen.com
+    "https://epicspam.com/" # -> fredclausen.com
+    "https://freminal.com/" # -> fredclausen.com
+    "https://onemorefoot.com/" # -> fredclausen.com
+    "https://politicalpileon.com/" # -> fredclausen.com
+    "https://sdrdockerconfig.com/" # -> fredclausen.com
+    "https://therightradio.com/" # -> fredclausen.com
+    "https://sdr-e.org/" # -> github.com/sdr-enthusiasts
+    "https://sdr-enthusiasts.org/" # -> github.com/sdr-enthusiasts
+  ];
+
+  # LAN-only HTTP vhosts served by nginx on this host (see the virtualHosts
+  # block in hosts/linux/sdrhub/configuration.nix).
+  #
+  # These are NOT redundant with the existing `up` metric. Prometheus scrapes
+  # the backends directly on their container ports; nothing currently exercises
+  # the nginx reverse-proxy layer in front of them. A broken proxyPass, a
+  # dropped serverAlias, or an AdGuard rewrite that stops resolving leaves
+  # every `up` at 1 while the service is unreachable for every human. This is
+  # the only check that covers that path.
+  #
+  # Each was verified 200 from sdrhub itself (dump978 after following its
+  # single redirect to /skyaware978/, which is why the internal module follows
+  # redirects and the public ones do not).
+  internalEndpoints = [
+    "http://sdrhub.local/" # landing page
+    "http://tar1090.sdrhub.local/" # -> 192.168.31.20:8080
+    "http://dump978.sdrhub.local/" # -> 192.168.31.20:8083
+    "http://piaware.sdrhub.local/" # -> 192.168.31.20:8084
+    "http://ai.sdrhub.local/" # -> fredhub 192.168.31.14:8889
+    "http://search.sdrhub.local/" # -> 127.0.0.1:4444
+  ];
+
+  # The relabel dance is the entire trick of a blackbox scrape job, and it is
+  # silently wrong if any step is missing:
+  #
+  #   1. __address__ (the URL to probe) is copied into __param_target, which
+  #      Prometheus renders as the ?target= query parameter on /probe.
+  #   2. instance is set from __param_target so the resulting series are
+  #      labelled with the probed URL rather than with the exporter.
+  #   3. ONLY THEN is __address__ overwritten with the exporter's own
+  #      host:port, which is what Prometheus actually connects to.
+  #
+  # Omit step 3 and Prometheus tries to scrape /probe on the target itself.
+  # Omit steps 1-2 and the exporter receives no target, returns its own
+  # metrics, and every series is labelled with the exporter -- a job that looks
+  # perfectly healthy while probing nothing. Order matters: step 2 reads the
+  # label step 1 writes, and step 3 must come last.
+  probeRelabelConfigs = [
+    {
+      source_labels = [ "__address__" ];
+      target_label = "__param_target";
+    }
+    {
+      source_labels = [ "__param_target" ];
+      target_label = "instance";
+    }
+    {
+      target_label = "__address__";
+      replacement = blackboxAddress;
+    }
+  ];
+
+  mkProbeJob = name: module: targets: {
+    job_name = name;
+    metrics_path = "/probe";
+    params.module = [ module ];
+    # Probes are far more expensive than a metrics fetch and TLS expiry moves
+    # on a scale of days, so override the 15s global interval.
+    scrape_interval = "60s";
+    # Must exceed the module timeout below, or Prometheus gives up before the
+    # exporter can report a failure and the result is `up == 0` instead of the
+    # much more informative `probe_success == 0`.
+    scrape_timeout = "15s";
+    static_configs = [ { inherit targets; } ];
+    relabel_configs = probeRelabelConfigs;
+  };
+
+  # preferred_ip_protocol must be ip4 on every module: upstream defaults to
+  # ip6, and this network has no IPv6 route at all (`ip -6 route get` returns
+  # "Network is unreachable" on sdrhub, and fredvps' A records only resolve to
+  # v4-mapped addresses). Leaving the default would make every probe fail, or
+  # at best add a pointless timeout before ip_protocol_fallback kicks in.
+  #
+  # fail_if_not_ssl on the HTTPS modules guards against a target being
+  # downgraded to plain HTTP without anyone noticing -- with
+  # follow_redirects disabled it cannot happen via a redirect, but it can
+  # happen by editing a target URL here.
+  blackboxConfig = {
+    modules = {
+      # follow_redirects = false so probe_ssl_earliest_cert_expiry describes
+      # THIS host's certificate. The exporter reads TLS state off the *final*
+      # response in the chain (prober/http.go sets the gauge from `resp.TLS`),
+      # so following redirects on acarshub.com would silently report
+      # acarshub.app's expiry, and sdr-e.org would report github.com's. The
+      # cert-expiry alerts would then be watching the wrong certificates.
+      https_2xx = {
+        prober = "http";
+        timeout = "10s";
+        http = {
+          method = "GET";
+          valid_status_codes = [ ]; # empty = any 2xx
+          follow_redirects = false;
+          fail_if_not_ssl = true;
+          preferred_ip_protocol = "ip4";
+        };
+      };
+
+      https_redirect = {
+        prober = "http";
+        timeout = "10s";
+        http = {
+          method = "GET";
+          valid_status_codes = [
+            301
+            302
+            307
+            308
+          ];
+          follow_redirects = false;
+          fail_if_not_ssl = true;
+          preferred_ip_protocol = "ip4";
+        };
+      };
+
+      # Internal LAN vhosts. Redirects are followed here because dump978's
+      # container redirects / -> /skyaware978/ and the end state is what
+      # matters; there is no certificate to attribute to the wrong host.
+      http_2xx = {
+        prober = "http";
+        timeout = "10s";
+        http = {
+          method = "GET";
+          valid_status_codes = [ ];
+          follow_redirects = true;
+          fail_if_ssl = true;
+          preferred_ip_protocol = "ip4";
+        };
+      };
+    };
+  };
+
+  blackboxConfigFile = (pkgs.formats.yaml { }).generate "blackbox-exporter.yml" blackboxConfig;
+in
+{
+  services.prometheus = {
+    exporters.blackbox = {
+      enable = true;
+      listenAddress = blackboxHost;
+      port = blackboxPort;
+      configFile = blackboxConfigFile;
+    };
+
+    # Plain assignment, never lib.mkDefault.
+    #
+    # ruleFiles and scrapeConfigs are list options, and a mkDefault list is not
+    # merged with normal-priority definitions -- it is discarded wholesale by
+    # them. Wrapping either of these in mkDefault would delete every rule file
+    # and scrape job declared in prometheus.nix the moment this module loaded.
+    # That exact bug was just fixed in modules/hardware/rtl-sdr.nix. Normal
+    # priority makes the module system concatenate instead, which is verified
+    # by asserting the pre-existing job names survive:
+    #
+    #   nix eval --json '.#nixosConfigurations.sdrhub.config.services.prometheus.scrapeConfigs'
+    ruleFiles = [
+      ./alert-rules/blackbox-alerts.yaml
+    ];
+
+    scrapeConfigs = [
+      (mkProbeJob "blackbox-https" "https_2xx" publicAppEndpoints)
+      (mkProbeJob "blackbox-https-redirect" "https_redirect" publicRedirectEndpoints)
+      (mkProbeJob "blackbox-http-internal" "http_2xx" internalEndpoints)
+
+      # The exporter's own operational metrics -- not a probe, a normal scrape.
+      # Without this, a dead exporter yields no probe_success series at all,
+      # and "no series" never fires an alert. This job gives the existing
+      # PrometheusTargetDown rule something to notice.
+      {
+        job_name = "blackbox-exporter";
+        static_configs = [
+          {
+            targets = [ blackboxAddress ];
+            labels = {
+              hostname = "sdrhub";
+              role = "master";
+              exporter = "blackbox";
+            };
+          }
+        ];
+      }
+    ];
+  };
+}

--- a/modules/monitoring/master/dashboards/fleet-overview.json
+++ b/modules/monitoring/master/dashboards/fleet-overview.json
@@ -31,7 +31,7 @@
       "type": "stat",
       "title": "Nodes Up",
       "description": "Number of nodes currently reachable by Prometheus",
-      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 1 },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -74,7 +74,7 @@
       "type": "stat",
       "title": "Nodes Down",
       "description": "Number of nodes not reachable by Prometheus",
-      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 1 },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -122,7 +122,7 @@
       "type": "stat",
       "title": "Nodes Needing Reboot",
       "description": "Nodes with /run/reboot-required present",
-      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 1 },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -170,7 +170,7 @@
       "type": "stat",
       "title": "Nodes Behind Main",
       "description": "Nodes whose deployed commit is behind GitHub main",
-      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 1 },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -218,7 +218,7 @@
       "type": "stat",
       "title": "Failed Systemd Units",
       "description": "Total count of failed systemd units across all nodes",
-      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 1 },
+      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -265,8 +265,8 @@
       "id": 7,
       "type": "stat",
       "title": "Active Alerts",
-      "description": "Number of currently firing Alertmanager alerts",
-      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 1 },
+      "description": "Currently firing Alertmanager alerts, excluding the Watchdog deadman, which fires permanently by design -- see the Alerting Pipeline panel",
+      "gridPos": { "h": 4, "w": 4, "x": 5, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -303,7 +303,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "count(ALERTS{alertstate=\"firing\"}) or vector(0)",
+          "expr": "count(ALERTS{alertstate=\"firing\", alertname!=\"Watchdog\"}) or vector(0)",
           "legendFormat": "Firing",
           "instant": true
         }
@@ -314,7 +314,7 @@
       "type": "stat",
       "title": "Firmware Updates",
       "description": "Total firmware updates available across the fleet (fwupd)",
-      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 1 },
+      "gridPos": { "h": 4, "w": 5, "x": 14, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -362,7 +362,7 @@
       "type": "stat",
       "title": "Critical Firmware",
       "description": "Devices with critical- or high-urgency firmware updates pending",
-      "gridPos": { "h": 4, "w": 3, "x": 21, "y": 1 },
+      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "reduceOptions": {
@@ -406,18 +406,77 @@
       ]
     },
     {
+      "id": 12,
+      "type": "stat",
+      "title": "Alerting Pipeline",
+      "description": "Inverted deadman. The Watchdog alert fires permanently by design, so FIRING is the healthy state and DOWN means Prometheus has stopped evaluating it. This CANNOT detect Prometheus or Grafana themselves being down -- it would show NO DATA. The authoritative deadman is external (healthchecks.io), because a monitor sharing infrastructure with what it watches cannot report that infrastructure failing.",
+      "gridPos": { "h": 4, "w": 5, "x": 9, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": { "text": "NO DATA", "color": "red", "index": 0 }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "DOWN", "color": "red", "index": 1 },
+                "1": { "text": "OK", "color": "green", "index": 2 }
+              }
+            }
+          ],
+          "noValue": "NO DATA",
+          "unit": "none",
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "count(ALERTS{alertstate=\"firing\", alertname=\"Watchdog\"}) or vector(0)",
+          "legendFormat": "Watchdog",
+          "instant": true
+        }
+      ]
+    },
+    {
       "id": 10,
       "type": "row",
       "title": "Per-Node Build & Deployment Info",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
     },
     {
       "id": 11,
       "type": "table",
       "title": "Node Deployment Status",
       "description": "Per-node: deployed SHA, deploy time, commits behind main, reboot needed, and node up status",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 10 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "showHeader": true,
@@ -642,14 +701,14 @@
       "type": "row",
       "title": "Per-Node Resource Health",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }
     },
     {
       "id": 21,
       "type": "table",
       "title": "Node Resource Summary",
       "description": "CPU, memory, disk, and load average per node",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 15 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 19 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "showHeader": true,
@@ -866,14 +925,14 @@
       "type": "row",
       "title": "Failed Systemd Units",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }
     },
     {
       "id": 31,
       "type": "table",
       "title": "Currently Failed Units",
       "description": "All systemd units currently in a failed state across the fleet",
-      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 24 },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 28 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "showHeader": true,
@@ -957,14 +1016,14 @@
       "type": "row",
       "title": "Pending Firmware Updates",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 }
     },
     {
       "id": 36,
       "type": "table",
       "title": "Firmware Updates by Device",
       "description": "Devices across the fleet with firmware updates available (fwupd). Run `fwupdmgr update` on the affected host to apply.",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 31 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 35 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "showHeader": true,
@@ -1103,13 +1162,13 @@
       "type": "row",
       "title": "Resource Trends",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 }
     },
     {
       "id": 41,
       "type": "timeseries",
       "title": "CPU Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1155,7 +1214,7 @@
       "id": 42,
       "type": "timeseries",
       "title": "Memory Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 44 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1201,7 +1260,7 @@
       "id": 43,
       "type": "timeseries",
       "title": "Network Receive — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1238,7 +1297,7 @@
       "id": 44,
       "type": "timeseries",
       "title": "Network Transmit — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1275,7 +1334,7 @@
       "id": 45,
       "type": "timeseries",
       "title": "System Load (1m) — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 60 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1312,7 +1371,7 @@
       "id": 46,
       "type": "timeseries",
       "title": "Root Disk Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 56 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 60 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },

--- a/modules/monitoring/master/dashboards/fleet-overview.json
+++ b/modules/monitoring/master/dashboards/fleet-overview.json
@@ -409,7 +409,7 @@
       "id": 12,
       "type": "stat",
       "title": "Alerting Pipeline",
-      "description": "Inverted deadman. The Watchdog alert fires permanently by design, so FIRING is the healthy state and DOWN means Prometheus has stopped evaluating it. This CANNOT detect Prometheus or Grafana themselves being down -- it would show NO DATA. The authoritative deadman is external (healthchecks.io), because a monitor sharing infrastructure with what it watches cannot report that infrastructure failing.",
+      "description": "Inverted deadman. The Watchdog alert fires permanently by design, so FIRING is the healthy state and DOWN means Prometheus has stopped evaluating it. This CANNOT detect a failure downstream of rule evaluation: if Alertmanager, the Pushover receiver, or delivery itself breaks while Prometheus keeps evaluating Watchdog, this panel still reads OK. Nor can it detect Prometheus or Grafana being down, where it would show NO DATA. The authoritative deadman is external (healthchecks.io), because a monitor sharing infrastructure with what it watches cannot report that infrastructure failing.",
       "gridPos": { "h": 4, "w": 5, "x": 9, "y": 5 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {

--- a/modules/monitoring/master/default.nix
+++ b/modules/monitoring/master/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./blackbox.nix
     ./grafana.nix
+    ./karma.nix
     ./loki.nix
     ./loki-ruler.nix
     ./prometheus.nix

--- a/modules/monitoring/master/default.nix
+++ b/modules/monitoring/master/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./blackbox.nix
     ./grafana.nix
     ./loki.nix
     ./loki-ruler.nix

--- a/modules/monitoring/master/default.nix
+++ b/modules/monitoring/master/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./grafana.nix
     ./loki.nix
+    ./loki-ruler.nix
     ./prometheus.nix
   ];
 }

--- a/modules/monitoring/master/karma.nix
+++ b/modules/monitoring/master/karma.nix
@@ -12,7 +12,8 @@
 # EXPOSURE
 #
 # Bound to 127.0.0.1 and reached through the existing nginx reverse proxy, so
-# it is available on the LAN as http://karma.sdrhub.lan/ without opening a
+# it is available on the LAN as http://karma.sdrhub.lan/ (and the .local
+# alias) without opening a
 # port of its own. No `openFirewall`.
 #
 # This matters more than for a read-only dashboard: Karma creates and expires

--- a/modules/monitoring/master/karma.nix
+++ b/modules/monitoring/master/karma.nix
@@ -1,0 +1,76 @@
+# modules/monitoring/master/karma.nix
+#
+# Karma: an alert dashboard for Alertmanager.
+#
+# WHY
+#
+# Pushover is a feed of events. It tells you what happened, in order, and is
+# useless for answering "what is wrong right now" or "what did I already
+# acknowledge". Karma provides current state instead: alerts grouped by
+# label, with silence management.
+#
+# EXPOSURE
+#
+# Bound to 127.0.0.1 and reached through the existing nginx reverse proxy, so
+# it is available on the LAN as http://karma.sdrhub.lan/ without opening a
+# port of its own. No `openFirewall`.
+#
+# This matters more than for a read-only dashboard: Karma creates and expires
+# silences, which makes it a control plane. Anyone who reaches the UI can
+# silence every alert in the fleet, and the result is indistinguishable from a
+# healthy quiet fleet. Keeping it behind nginx on the LAN, rather than exposed
+# or published to the internet, is deliberate. If it is ever published, it
+# needs auth in front of it (Karma has `authentication.basicAuth`, and
+# `authorization.acl` for silences) or the Alertmanager entry set to
+# `readonly = true`.
+#
+# The listen port is read back by the nginx vhost in
+# hosts/linux/sdrhub/configuration.nix via
+# config.services.karma.settings.listen.port, so the proxy target cannot drift
+# out of sync with the service.
+{
+  services.karma = {
+    enable = true;
+
+    settings = {
+      listen = {
+        address = "127.0.0.1";
+        # Upstream default is 8080, which ultrafeeder already publishes here.
+        # 8090 is unused: sdrhub's containers occupy 8080-8087, and nothing
+        # else in the repo references it.
+        port = 8090;
+      };
+
+      alertmanager = {
+        # Alertmanager's own evaluation is 15s; polling faster than that just
+        # adds load without surfacing anything sooner.
+        interval = "30s";
+
+        servers = [
+          {
+            name = "sdrhub";
+            uri = "http://127.0.0.1:9093";
+            timeout = "10s";
+          }
+        ];
+      };
+
+      # The Watchdog deadman fires permanently by design, so without this it
+      # would sit at the top of the UI forever and train the eye to ignore a
+      # non-empty dashboard. The filter is a default, not a restriction --
+      # clearing it in the UI still shows the Watchdog, which is occasionally
+      # what you want when checking the alerting pipeline itself.
+      filters.default = [ "alertname!=Watchdog" ];
+
+      ui = {
+        refresh = "30s";
+        hideFiltersWhenIdle = true;
+        colorTitlebar = true;
+        theme = "dark";
+        minimalGroupWidth = 420;
+        alertsPerGroup = 5;
+        collapseGroups = "collapsedOnMobile";
+      };
+    };
+  };
+}

--- a/modules/monitoring/master/loki-ruler.nix
+++ b/modules/monitoring/master/loki-ruler.nix
@@ -1,0 +1,330 @@
+# modules/monitoring/master/loki-ruler.nix
+#
+# Log-derived alerting and recording rules, evaluated by Loki's ruler on the
+# monitoring master.
+#
+# Rules live here rather than in Alloy's `loki.process` stages because these
+# patterns need frequent tuning against real decoder behaviour, and a change
+# here is a single-host deploy instead of a six-host colmena run. It also means
+# Alloy never has to be scrapeable by Prometheus.
+#
+# Alerting rules are delivered to Alertmanager directly. Recording rules are
+# remote-written into Prometheus so the derived series are usable in Grafana
+# and in ordinary PromQL alongside cAdvisor and node_exporter data.
+#
+# IMPORTANT -- two LogQL behaviours shape every rule below:
+#
+#   * `count_over_time` with a line filter returns NO SERIES when nothing
+#     matches, rather than zero. Any rule of the form `count_over_time(...) == 0`
+#     is therefore dead on arrival. Absence must be expressed with
+#     `absent_over_time`, which does return 1 and preserves the selector labels.
+#   * Consequently every "something bad happened" rule here is `> N`, which only
+#     needs matching lines to exist, and every "something stopped" rule uses
+#     `absent_over_time` against an explicit selector.
+{
+  pkgs,
+  ...
+}:
+let
+  yamlFormat = pkgs.formats.yaml { };
+
+  # Decoder containers that emit a periodic liveness line. The heartbeat
+  # cadence is five minutes, and over a 48h sample it arrived 575 times out of
+  # 576, so a 20 minute absence window is ~4 missed beats and is not noisy.
+  #
+  # `pattern` null means "any log line at all" -- used for hfdlobserver, which
+  # has no single stable heartbeat string but logs continuously.
+  #
+  # This list must track the services.adsb.containers definitions in
+  # hosts/linux/*/configuration.nix.
+  decoderUnits = [
+    {
+      host = "acarshub";
+      unit = "docker-acarsdec-1.service";
+      pattern = "\\[STATS\\] Total in the last";
+    }
+    {
+      host = "acarshub";
+      unit = "docker-acarsdec-2.service";
+      pattern = "\\[STATS\\] Total in the last";
+    }
+    {
+      host = "acarshub";
+      unit = "docker-acarsdec-3.service";
+      pattern = "\\[STATS\\] Total in the last";
+    }
+    {
+      host = "vdlmhub";
+      unit = "docker-dumpvdl2-1.service";
+      pattern = "\\[STATS\\] Total in the last";
+    }
+    {
+      host = "vdlmhub";
+      unit = "docker-dumpvdl2-2.service";
+      pattern = "\\[STATS\\] Total in the last";
+    }
+    {
+      host = "vdlmhub";
+      unit = "docker-dumpvdl2-3.service";
+      pattern = "\\[STATS\\] Total in the last";
+    }
+    {
+      host = "vdlmhub";
+      unit = "docker-dumpvdl2-4.service";
+      pattern = "\\[STATS\\] Total in the last";
+    }
+    {
+      host = "hfdlhub1";
+      unit = "docker-dumphfdl-1.service";
+      pattern = "hfdl messages received in last";
+    }
+    {
+      host = "hfdlhub1";
+      unit = "docker-dumphfdl-2.service";
+      pattern = "hfdl messages received in last";
+    }
+    {
+      host = "hfdlhub1";
+      unit = "docker-dumphfdl-3.service";
+      pattern = "hfdl messages received in last";
+    }
+    {
+      host = "hfdlhub2";
+      unit = "docker-hfdlobserver.service";
+      pattern = null;
+    }
+  ];
+
+  # absent_over_time returns 1 only when the selector matched nothing in the
+  # window, and carries the selector's labels through, so each unit needs its
+  # own rule to be individually identifiable.
+  heartbeatRules = map (d: {
+    alert = "DecoderHeartbeatMissing";
+    expr =
+      if d.pattern == null then
+        ''absent_over_time({host="${d.host}", unit="${d.unit}"}[20m])''
+      else
+        ''absent_over_time({host="${d.host}", unit="${d.unit}"} |~ `${d.pattern}` [20m])'';
+    for = "5m";
+    labels = {
+      severity = "critical";
+      inherit (d) host unit;
+    };
+    annotations = {
+      summary = "Decoder ${d.unit} on ${d.host} has stopped logging";
+      description = "No heartbeat line for 20 minutes. The container is running but wedged, or its journal has stopped reaching Loki. This is independent of how much traffic the receiver should be decoding.";
+    };
+  }) decoderUnits;
+
+  rules = {
+    groups = [
+      {
+        name = "decoder-liveness";
+        interval = "1m";
+        rules = heartbeatRules;
+      }
+
+      {
+        name = "decoder-process-health";
+        interval = "1m";
+        rules = [
+          {
+            # Emitted by the SDRE base image's s6wrap for any supervised
+            # program that dies. The only signal that is consistent across
+            # the whole container family, and it covers dumphfdl and
+            # hfdlobserver, neither of which ships a HEALTHCHECK.
+            alert = "SDRDecoderCrashed";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `[s6wrap] !!! CAUTION !!!` [15m])) > 0'';
+            for = "0m";
+            labels.severity = "critical";
+            annotations = {
+              summary = "Decoder process crashed in {{ $labels.unit }} on {{ $labels.host }}";
+              description = "s6wrap reported a supervised program terminating on a signal in the last 15 minutes.";
+            };
+          }
+
+          {
+            # hfdlobserver supervises its own children and reports their exit
+            # status itself. Exit 0 is routine rotation; negative values are
+            # signal deaths. Threshold allows for occasional restarts.
+            alert = "HFDLObserverChildCrashing";
+            expr = ''sum by (host, unit) (count_over_time({unit="docker-hfdlobserver.service"} |~ `exited with -(11|6|9)` [30m])) > 2'';
+            for = "5m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "hfdlobserver child processes crashing on {{ $labels.host }}";
+              description = "More than two signal deaths of IQDecoderProcess or KiwiClientProcess in 30 minutes.";
+            };
+          }
+        ];
+      }
+
+      {
+        name = "sdr-hardware";
+        interval = "1m";
+        rules = [
+          {
+            alert = "SDRCannotClaimDevice";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `usb_claim_interface error` [30m])) > 10'';
+            for = "10m";
+            labels.severity = "critical";
+            annotations = {
+              summary = "{{ $labels.unit }} on {{ $labels.host }} cannot claim its SDR";
+              description = "Repeated usb_claim_interface failures. The device is held by another process, has disappeared from the bus, or is resetting.";
+            };
+          }
+
+          {
+            # Symptom of the global usbfs ceiling being exhausted. Expected to
+            # fire on vdlmhub until the usbfs kernel parameter is deployed --
+            # see modules/hardware/usbfs.nix.
+            alert = "SDRUsbfsBufferExhausted";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |~ `(Failed to submit transfer|async read failed)` [15m])) > 5'';
+            for = "5m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "USB transfer failures in {{ $labels.unit }} on {{ $labels.host }}";
+              description = "librtlsdr could not submit USB transfers. Usually the usbcore.usbfs_memory_mb ceiling is too low for the number of attached radios.";
+            };
+          }
+
+          {
+            alert = "SDRPlayApiUnresponsive";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `sdrplay_api_ServiceNotResponding` [30m])) > 0'';
+            for = "0m";
+            labels.severity = "critical";
+            annotations = {
+              summary = "SDRplay API unresponsive on {{ $labels.host }}";
+              description = "sdrplay_apiService is not answering. The decoder in {{ $labels.unit }} cannot acquire its radio until the service is restarted.";
+            };
+          }
+
+          {
+            # The dump978 image restarts its own decoder when it sees no
+            # messages. At this site UAT is genuinely quiet, so it has been
+            # bouncing the decoder roughly twenty times a day. Alert on the
+            # container giving up rather than on the staleness warning.
+            alert = "ContainerSelfRestartingReceiver";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `[message-monitor]` |= `Restarting the` [2h])) > 3'';
+            for = "10m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "{{ $labels.unit }} on {{ $labels.host }} keeps restarting its own receiver";
+              description = "The container's built-in message monitor has restarted the decoder more than three times in two hours. Either the receiver is failing or the container's staleness threshold is wrong for this site.";
+            };
+          }
+        ];
+      }
+
+      {
+        name = "feeder-connectivity";
+        interval = "1m";
+        rules = [
+          {
+            alert = "MlatNotSynchronized";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |~ `Server status: +(not synchronized|clock unstable)` [30m])) > 0'';
+            for = "10m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "MLAT not synchronized on {{ $labels.host }}";
+              description = "mlat-client reports no synchronization with nearby receivers, or an unstable clock, in {{ $labels.unit }}.";
+            };
+          }
+
+          {
+            alert = "FeederUpstreamRetrying";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `Connection retries will continue` [30m])) > 2'';
+            for = "10m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "Feeder upstream unreachable from {{ $labels.unit }} on {{ $labels.host }}";
+              description = "Repeated connection retries to an upstream aggregator.";
+            };
+          }
+
+          {
+            # Matches on the module path, not the log level. In acars_router
+            # sdre_stubborn_io indicates genuine connectivity loss, whereas
+            # message_handler errors are malformed upstream JSON and are noise.
+            alert = "AcarsRouterUpstreamFlapping";
+            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |~ `sdre_stubborn_io.*(Disconnect occurred|Write while disconnected)` [30m])) > 20'';
+            for = "15m";
+            labels.severity = "warning";
+            annotations = {
+              summary = "acars_router upstream connection flapping on {{ $labels.host }}";
+              description = "Sustained disconnect or back-pressure events against an upstream feed from {{ $labels.unit }}.";
+            };
+          }
+        ];
+      }
+
+      {
+        # Recording rules only. These build the history that the seasonal
+        # baseline alerts need; they do not alert on their own. The
+        # comparison rules cannot be written until roughly three weeks of
+        # this series exists -- see agent-docs/MONITORING.md, Phase 6.
+        name = "decoder-throughput-recording";
+        interval = "1m";
+        rules = [
+          {
+            record = "decoder:messages:last5m";
+            expr = ''sum by (host, unit) (last_over_time({unit=~"docker-(acarsdec|dumpvdl2)-.*"} | regexp `Total in the last \d+ minutes: (?P<msgs>\d+)` | unwrap msgs [10m]))'';
+          }
+          {
+            record = "decoder:messages:last5m";
+            expr = ''sum by (host, unit) (last_over_time({unit=~"docker-dumphfdl-.*"} | regexp `(?P<msgs>\d+) hfdl messages received` | unwrap msgs [10m]))'';
+          }
+        ];
+      }
+    ];
+  };
+
+  ruleFile = yamlFormat.generate "decoder-logs.yaml" rules;
+
+  # Loki's local ruler storage expects <directory>/<tenant>/<file>.yaml.
+  # auth_enabled is false, so the tenant is "fake" -- confirmed by the
+  # on-disk layout at /var/lib/loki/chunks/fake.
+  rulesDir = pkgs.runCommand "loki-rules" { } ''
+    mkdir -p "$out/fake"
+    cp ${ruleFile} "$out/fake/decoder-logs.yaml"
+  '';
+in
+{
+  # The ruler needs a writable scratch directory for rule evaluation state.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/loki/rules-temp 0750 loki loki -"
+  ];
+
+  services.loki.configuration.ruler = {
+    storage = {
+      type = "local";
+      local.directory = "${rulesDir}";
+    };
+
+    rule_path = "/var/lib/loki/rules-temp";
+
+    alertmanager_url = "http://127.0.0.1:9093";
+    enable_alertmanager_v2 = true;
+
+    # Single-binary deployment; no ring coordination needed.
+    ring.kvstore.store = "inmemory";
+
+    # Recording rule output is pushed into Prometheus, which already runs with
+    # --web.enable-remote-write-receiver (see prometheus.nix extraFlags).
+    remote_write = {
+      enabled = true;
+      clients.prometheus = {
+        url = "http://127.0.0.1:9090/api/v1/write";
+        remote_timeout = "30s";
+        queue_config = {
+          capacity = 2500;
+          max_shards = 10;
+          min_shards = 1;
+        };
+      };
+    };
+  };
+
+  # Keep the generated rule file inspectable on the host for debugging.
+  environment.etc."loki/rules/decoder-logs.yaml".source = ruleFile;
+}

--- a/modules/monitoring/master/loki-ruler.nix
+++ b/modules/monitoring/master/loki-ruler.nix
@@ -21,6 +21,15 @@
 #   * Consequently every "something bad happened" rule here is `> N`, which only
 #     needs matching lines to exist, and every "something stopped" rule uses
 #     `absent_over_time` against an explicit selector.
+#
+# EVERY HOST-SCOPED RULE MUST EMIT `hostname`, not just `host`.
+#
+# Alertmanager's route groups on [alertname, hostname] and both inhibit rules
+# match with `equal: [hostname]`. A rule that only carries `host` -- which is
+# what `sum by (host, ...)` yields, since that is the Loki stream label -- is
+# therefore never suppressed by NodeDown for the same machine, and all of its
+# instances collapse into a single group with an empty hostname. Alloy sets
+# `host` and `hostname` identically, so aggregations here carry both.
 {
   pkgs,
   ...
@@ -137,6 +146,11 @@ let
       labels = {
         severity = "critical";
         inherit (d) host unit;
+        # Alertmanager groups on and inhibits by `hostname`, not `host`, so a
+        # rule carrying only `host` is never suppressed by NodeDown for the
+        # same machine and groups across hosts. Alloy sets both labels to the
+        # same value, so this is simply the name Alertmanager expects.
+        hostname = d.host;
       };
       annotations = {
         summary = "Decoder ${d.unit} on ${d.host} has stopped logging";
@@ -200,7 +214,7 @@ let
             # the whole container family, and it covers dumphfdl and
             # hfdlobserver, neither of which ships a HEALTHCHECK.
             alert = "SDRDecoderCrashed";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `[s6wrap] !!! CAUTION !!!` [15m])) > 0'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `[s6wrap] !!! CAUTION !!!` [15m])) > 0'';
             for = "0m";
             labels.severity = "critical";
             annotations = {
@@ -214,7 +228,7 @@ let
             # status itself. Exit 0 is routine rotation; negative values are
             # signal deaths. Threshold allows for occasional restarts.
             alert = "HFDLObserverChildCrashing";
-            expr = ''sum by (host, unit) (count_over_time({unit="docker-hfdlobserver.service"} |~ `exited with -(11|6|9)` [30m])) > 2'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit="docker-hfdlobserver.service"} |~ `exited with -(11|6|9)` [30m])) > 2'';
             for = "5m";
             labels.severity = "warning";
             annotations = {
@@ -231,7 +245,7 @@ let
         rules = [
           {
             alert = "SDRCannotClaimDevice";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `usb_claim_interface error` [30m])) > 10'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `usb_claim_interface error` [30m])) > 10'';
             for = "10m";
             labels.severity = "critical";
             annotations = {
@@ -245,7 +259,7 @@ let
             # fire on vdlmhub until the usbfs kernel parameter is deployed --
             # see modules/hardware/usbfs.nix.
             alert = "SDRUsbfsBufferExhausted";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |~ `(Failed to submit transfer|async read failed)` [15m])) > 5'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |~ `(Failed to submit transfer|async read failed)` [15m])) > 5'';
             for = "5m";
             labels.severity = "warning";
             annotations = {
@@ -256,7 +270,7 @@ let
 
           {
             alert = "SDRPlayApiUnresponsive";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `sdrplay_api_ServiceNotResponding` [30m])) > 0'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `sdrplay_api_ServiceNotResponding` [30m])) > 0'';
             for = "0m";
             labels.severity = "critical";
             annotations = {
@@ -281,7 +295,7 @@ let
             # ceiling fix: 0 restarts in 12h, against 54 in the preceding 3
             # days, and the monitor now reports OK more often than stale.
             alert = "ContainerSelfRestartingReceiver";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `[message-monitor]` |= `Restarting the` [2h])) > 3'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `[message-monitor]` |= `Restarting the` [2h])) > 3'';
             for = "10m";
             labels.severity = "warning";
             annotations = {
@@ -298,7 +312,7 @@ let
         rules = [
           {
             alert = "MlatNotSynchronized";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |~ `Server status: +(not synchronized|clock unstable)` [30m])) > 0'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |~ `Server status: +(not synchronized|clock unstable)` [30m])) > 0'';
             for = "10m";
             labels.severity = "warning";
             annotations = {
@@ -309,7 +323,7 @@ let
 
           {
             alert = "FeederUpstreamRetrying";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `Connection retries will continue` [30m])) > 2'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `Connection retries will continue` [30m])) > 2'';
             for = "10m";
             labels.severity = "warning";
             annotations = {
@@ -323,7 +337,7 @@ let
             # sdre_stubborn_io indicates genuine connectivity loss, whereas
             # message_handler errors are malformed upstream JSON and are noise.
             alert = "AcarsRouterUpstreamFlapping";
-            expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |~ `sdre_stubborn_io.*(Disconnect occurred|Write while disconnected)` [30m])) > 20'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |~ `sdre_stubborn_io.*(Disconnect occurred|Write while disconnected)` [30m])) > 20'';
             for = "15m";
             labels.severity = "warning";
             annotations = {
@@ -344,11 +358,11 @@ let
         rules = [
           {
             record = "decoder:messages:last5m";
-            expr = ''sum by (host, unit) (last_over_time({unit=~"docker-(acarsdec|dumpvdl2)-.*"} | regexp `Total in the last \d+ minutes: (?P<msgs>\d+)` | unwrap msgs [10m]))'';
+            expr = ''sum by (host, hostname, unit) (last_over_time({unit=~"docker-(acarsdec|dumpvdl2)-.*"} | regexp `Total in the last \d+ minutes: (?P<msgs>\d+)` | unwrap msgs [10m]))'';
           }
           {
             record = "decoder:messages:last5m";
-            expr = ''sum by (host, unit) (last_over_time({unit=~"docker-dumphfdl-.*"} | regexp `(?P<msgs>\d+) hfdl messages received` | unwrap msgs [10m]))'';
+            expr = ''sum by (host, hostname, unit) (last_over_time({unit=~"docker-dumphfdl-.*"} | regexp `(?P<msgs>\d+) hfdl messages received` | unwrap msgs [10m]))'';
           }
         ];
       }

--- a/modules/monitoring/master/loki-ruler.nix
+++ b/modules/monitoring/master/loki-ruler.nix
@@ -116,12 +116,49 @@ let
     };
   }) decoderUnits;
 
+  # Hosts that ship journal logs to Loki. Desktops are excluded: maranello
+  # runs no Alloy, and Daytona is a roaming laptop that is legitimately
+  # offline for long stretches.
+  loggingHosts = [
+    "sdrhub"
+    "fredhub"
+    "fredvps"
+    "acarshub"
+    "vdlmhub"
+    "hfdlhub1"
+    "hfdlhub2"
+  ];
+
+  # Per-host log-shipping deadman. Prometheus cannot express this: the
+  # distributor's ingestion counter is labelled by tenant only, with no
+  # per-source dimension. Here the host label exists on the stream itself.
+  hostLogRules = map (h: {
+    alert = "HostLogsMissing";
+    expr = ''absent_over_time({host="${h}"}[30m])'';
+    for = "10m";
+    labels = {
+      severity = "warning";
+      host = h;
+      hostname = h;
+    };
+    annotations = {
+      summary = "No logs received from ${h} for 30 minutes";
+      description = "Alloy on ${h} has stopped shipping, or the host is unreachable. Every log-derived alert for this host is silently inoperative until it returns.";
+    };
+  }) loggingHosts;
+
   rules = {
     groups = [
       {
         name = "decoder-liveness";
         interval = "1m";
         rules = heartbeatRules;
+      }
+
+      {
+        name = "log-shipping-liveness";
+        interval = "1m";
+        rules = hostLogRules;
       }
 
       {

--- a/modules/monitoring/master/loki-ruler.nix
+++ b/modules/monitoring/master/loki-ruler.nix
@@ -28,12 +28,21 @@
 let
   yamlFormat = pkgs.formats.yaml { };
 
-  # Decoder containers that emit a periodic liveness line. The heartbeat
-  # cadence is five minutes, and over a 48h sample it arrived 575 times out of
-  # 576, so a 20 minute absence window is ~4 missed beats and is not noisy.
+  # Decoder containers that emit a periodic liveness line.
   #
   # `pattern` null means "any log line at all" -- used for hfdlobserver, which
   # has no single stable heartbeat string but logs continuously.
+  #
+  # `window` defaults to 20m, which suits the five-minute heartbeat that the
+  # acarsdec/dumpvdl2/dumphfdl containers emit (over a 48h sample it arrived 575
+  # times out of 576, so 20m is ~4 missed beats). dump978 is on a different
+  # mechanism with a 30 minute cadence and overrides it.
+  #
+  # These rules are traffic-independent by construction: they check that the
+  # heartbeat line exists, not what value it carries. A receiver sitting on a
+  # genuinely silent frequency still emits its heartbeat, so no quiet-hours
+  # scoping is needed here. Scoping only matters for throughput rules, which are
+  # deliberately not in this file yet -- see the Phase 6 baselines.
   #
   # This list must track the services.adsb.containers definitions in
   # hosts/linux/*/configuration.nix.
@@ -93,28 +102,48 @@ let
       unit = "docker-hfdlobserver.service";
       pattern = null;
     }
+    {
+      # dump978 has no decoder stats line. Its liveness signal is the built-in
+      # message monitor, which logs every 30 minutes -- verified emitting
+      # 10-13 lines in every one of the 24 hours across a 5 day sample, so it
+      # is genuinely round-the-clock and its absence means the container is
+      # wedged rather than the band being quiet.
+      #
+      # 90m is three missed runs. Anything tighter would false-positive on a
+      # single skipped cycle.
+      host = "sdrhub";
+      unit = "docker-dump978.service";
+      pattern = "\\[message-monitor\\]";
+      window = "90m";
+    }
   ];
 
   # absent_over_time returns 1 only when the selector matched nothing in the
   # window, and carries the selector's labels through, so each unit needs its
   # own rule to be individually identifiable.
-  heartbeatRules = map (d: {
-    alert = "DecoderHeartbeatMissing";
-    expr =
-      if d.pattern == null then
-        ''absent_over_time({host="${d.host}", unit="${d.unit}"}[20m])''
-      else
-        ''absent_over_time({host="${d.host}", unit="${d.unit}"} |~ `${d.pattern}` [20m])'';
-    for = "5m";
-    labels = {
-      severity = "critical";
-      inherit (d) host unit;
-    };
-    annotations = {
-      summary = "Decoder ${d.unit} on ${d.host} has stopped logging";
-      description = "No heartbeat line for 20 minutes. The container is running but wedged, or its journal has stopped reaching Loki. This is independent of how much traffic the receiver should be decoding.";
-    };
-  }) decoderUnits;
+  heartbeatRules = map (
+    d:
+    let
+      window = d.window or "20m";
+    in
+    {
+      alert = "DecoderHeartbeatMissing";
+      expr =
+        if d.pattern == null then
+          ''absent_over_time({host="${d.host}", unit="${d.unit}"}[${window}])''
+        else
+          ''absent_over_time({host="${d.host}", unit="${d.unit}"} |~ `${d.pattern}` [${window}])'';
+      for = "5m";
+      labels = {
+        severity = "critical";
+        inherit (d) host unit;
+      };
+      annotations = {
+        summary = "Decoder ${d.unit} on ${d.host} has stopped logging";
+        description = "No heartbeat line for ${window}. The container is running but wedged, or its journal has stopped reaching Loki. This is independent of how much traffic the receiver should be decoding, so it is not a quiet-band false positive.";
+      };
+    }
+  ) decoderUnits;
 
   # Hosts that ship journal logs to Loki. Desktops are excluded: maranello
   # runs no Alloy, and Daytona is a roaming laptop that is legitimately
@@ -238,9 +267,19 @@ let
 
           {
             # The dump978 image restarts its own decoder when it sees no
-            # messages. At this site UAT is genuinely quiet, so it has been
-            # bouncing the decoder roughly twenty times a day. Alert on the
-            # container giving up rather than on the staleness warning.
+            # messages, and alerting on that rather than on the staleness
+            # warning gets quiet-hours scoping for free: the container only
+            # restarts inside its own 0800-1800 "Adjustment Timeframe", and
+            # outside it logs "No action is taken" instead. Verified over a 5
+            # day sample -- "Restarting the" appears only in hours 08-17, and
+            # the no-action line only in 00-07 and 18-23, an exact complement.
+            # So this fires only during hours when UAT traffic is expected,
+            # with no time functions in the query.
+            #
+            # Was running at roughly twenty restarts a day, caused by the
+            # receiver being unable to claim its device. After the usbfs
+            # ceiling fix: 0 restarts in 12h, against 54 in the preceding 3
+            # days, and the monitor now reports OK more often than stale.
             alert = "ContainerSelfRestartingReceiver";
             expr = ''sum by (host, unit) (count_over_time({unit=~"docker-.*"} |= `[message-monitor]` |= `Restarting the` [2h])) > 3'';
             for = "10m";

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   agentNodes,
@@ -16,6 +17,19 @@ in
 {
   environment.systemPackages = [
     pkgs.prometheus.cli
+  ];
+
+  #######################################
+  # Deadman heartbeat endpoint
+  #######################################
+  # The healthchecks.io ping URL. Left owned by root: the alertmanager unit
+  # runs with DynamicUser=yes, so there is no stable uid to chown to, and
+  # LoadCredential below is the systemd-native way to hand a root-owned file
+  # to such a service.
+  sops.secrets."healthchecks.io/endpoint" = { };
+
+  systemd.services.alertmanager.serviceConfig.LoadCredential = [
+    "hc-endpoint:${config.sops.secrets."healthchecks.io/endpoint".path}"
   ];
 
   system.activationScripts.prometheus_activation = {
@@ -479,19 +493,41 @@ in
               ];
             }
 
-            # Deadman sink. Intentionally has no notification config, so the
-            # permanently-firing Watchdog alert is dispatched here and
-            # discarded instead of reaching ntfy.
+            # Deadman sink.
             #
-            # TO ACTIVATE THE DEADMAN: add a webhook_configs entry pointing at
-            # an external heartbeat monitor that lives outside this stack --
-            # a healthchecks.io ping URL, or an Uptime Kuma push URL hosted on
-            # fredvps, which is off-site and would survive a whole-house
-            # outage. The monitor alarms when the heartbeat stops, which is
-            # the only way to distinguish "nothing is wrong" from "the
-            # alerting pipeline is dead". Until then this rule is inert.
+            # The Watchdog alert fires permanently by design, so its ARRIVAL at
+            # healthchecks.io is the signal, not its content. healthchecks.io
+            # expects a ping on a schedule and alarms when one stops arriving,
+            # over infrastructure and a network path that share nothing with
+            # this stack.
+            #
+            # This is the only check that covers the delivery path itself. A
+            # successful ping proves Prometheus is evaluating rules, can reach
+            # Alertmanager, that Alertmanager is dispatching and its routing
+            # tree resolves, and that this host has working outbound DNS and
+            # network. Every other alert in this repo assumes all of that.
+            #
+            # It cannot be done from inside: AlertmanagerDown and friends are
+            # evaluated by Prometheus and delivered by Alertmanager, so they
+            # catch partial failure but never total failure -- the component
+            # that would report it is the one that is broken.
+            #
+            # url_file rather than url keeps the ping URL out of the Nix store.
+            # It reads from the systemd credential directory rather than
+            # /run/secrets directly because the alertmanager unit runs with
+            # DynamicUser=yes, so there is no static uid for sops to chown to.
+            # LoadCredential (below) copies it in as root at unit start and
+            # exposes it to the service user at a deterministic path.
             {
               name = "watchdog";
+
+              webhook_configs = [
+                {
+                  url_file = "/run/credentials/alertmanager.service/hc-endpoint";
+                  # Watchdog never resolves, so there is nothing to send.
+                  send_resolved = false;
+                }
+              ];
             }
           ];
         };

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -158,24 +158,19 @@ in
       ];
 
       scrapeConfigs = [
+        # Only :9274 serves metrics.  Docker publishes 9273 and 9275 but no
+        # process inside the ultrafeeder / dump978 containers listens on them,
+        # so docker-proxy accepts the connection and immediately resets it.
+        # Both were permanently down targets.  dump978 exposes its metrics
+        # through the container's own nginx, which currently 404s on /metrics
+        # (it reads /run/readsb/stats.prom, which does not exist), so there is
+        # nothing to scrape for it at all until that is fixed container-side.
         {
           job_name = "ultrafeeder";
           static_configs = [
             {
               targets = [
-                "sdrhub.local:9273"
                 "sdrhub.local:9274"
-              ];
-            }
-          ];
-        }
-
-        {
-          job_name = "dump978";
-          static_configs = [
-            {
-              targets = [
-                "sdrhub.local:9275"
               ];
             }
           ];

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -382,12 +382,21 @@ in
 
           inhibit_rules = [
             {
-              # When a node is completely down, suppress all the downstream alerts
-              # it would otherwise generate (unit failures, container restarts, etc.)
-              source_matchers = [ "alertname = \"NodeDown\"" ];
-              target_matchers = [
-                "alertname =~ \"SystemdUnitFailed|SystemdUnitFlapping|GithubRunnerCrashLoop|ContainerRestarting|ContainerOOM|DockerUnitFlapping|UltrafeederNoAircraft|UltrafeederNotReceiving|AdGuardHomeDown|AtticServerDown\""
-              ];
+              # When a node is down, everything else observed on that node is a
+              # consequence, so suppress all of it and page once for the cause.
+              #
+              # Matching on "not NodeDown" rather than an explicit alertname
+              # list is deliberate: the previous list had to be edited by hand
+              # for every new alert, and had already gone stale, still naming
+              # two rules that no longer exist. It also omitted
+              # PrometheusTargetDown, which a downed node always triggers.
+              #
+              # Alerts with no hostname label (the Watchdog deadman, for
+              # example) are never inhibited by this rule: `equal` requires the
+              # label to match, and NodeDown always carries a non-empty
+              # hostname from the node job.
+              source_matchers = [ ''alertname="NodeDown"'' ];
+              target_matchers = [ ''alertname!="NodeDown"'' ];
               equal = [ "hostname" ];
             }
           ];

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -172,6 +172,10 @@ in
               targets = [
                 "sdrhub.local:9274"
               ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
             }
           ];
         }
@@ -183,6 +187,10 @@ in
               targets = [
                 "sdrhub.local:8085"
               ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
             }
           ];
         }
@@ -244,14 +252,28 @@ in
         {
           job_name = "prometheus";
           static_configs = [
-            { targets = [ "127.0.0.1:9090" ]; }
+            {
+              targets = [ "127.0.0.1:9090" ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
+            }
           ];
         }
         {
           job_name = "pushgateway";
+          # honor_labels lets pushed metrics keep their own hostname/role if
+          # they carry them; the static labels below are only a fallback.
           honor_labels = true;
           static_configs = [
-            { targets = [ "127.0.0.1:9091" ]; }
+            {
+              targets = [ "127.0.0.1:9091" ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
+            }
           ];
         }
       ];

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -155,6 +155,7 @@ in
         ./alert-rules/firmware-alerts.yaml
         ./alert-rules/system-alerts.yaml
         ./alert-rules/sdr-alerts.yaml
+        ./alert-rules/meta-alerts.yaml
       ];
 
       scrapeConfigs = [
@@ -261,6 +262,48 @@ in
             }
           ];
         }
+
+        # The monitoring stack monitored everything except itself. Without
+        # these, a failure of Alertmanager or Loki produces silence, which is
+        # indistinguishable from health.
+        {
+          job_name = "alertmanager";
+          static_configs = [
+            {
+              targets = [ "127.0.0.1:9093" ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
+            }
+          ];
+        }
+
+        {
+          job_name = "loki";
+          static_configs = [
+            {
+              targets = [ "127.0.0.1:5678" ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
+            }
+          ];
+        }
+
+        {
+          job_name = "grafana";
+          static_configs = [
+            {
+              targets = [ "127.0.0.1:3333" ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
+            }
+          ];
+        }
         {
           job_name = "pushgateway";
           # honor_labels lets pushed metrics keep their own hostname/role if
@@ -354,6 +397,18 @@ in
             # the alertmanager-ntfy expressions above. Splitting here controls
             # how insistently each tier repeats.
             routes = [
+              # The deadman must never reach ntfy: it fires permanently by
+              # design. It is dispatched to its own receiver, which is a
+              # blackhole until an external heartbeat URL is configured.
+              # Matched first so it cannot fall through to a severity route
+              # or to the parent receiver.
+              {
+                matchers = [ ''alertname="Watchdog"'' ];
+                receiver = "watchdog";
+                group_wait = "0s";
+                group_interval = "1m";
+                repeat_interval = "1m";
+              }
               {
                 matchers = [ ''severity="critical"'' ];
                 receiver = "ntfy";
@@ -399,6 +454,16 @@ in
               target_matchers = [ ''alertname!="NodeDown"'' ];
               equal = [ "hostname" ];
             }
+            {
+              # A dockerd failure otherwise produces one alert per container
+              # on the host -- eighteen of them on sdrhub. Page for the cause
+              # and suppress the consequences.
+              source_matchers = [ ''alertname="DockerDaemonDown"'' ];
+              target_matchers = [
+                ''alertname=~"ContainerRestarting|ContainerOOM|ContainerUnhealthy|DockerUnitFlapping|SDRDecoderCrashed|DecoderHeartbeatMissing|UltrafeederNoAircraft|UltrafeederNotReceiving"''
+              ];
+              equal = [ "hostname" ];
+            }
           ];
 
           receivers = [
@@ -411,6 +476,21 @@ in
                   send_resolved = true;
                 }
               ];
+            }
+
+            # Deadman sink. Intentionally has no notification config, so the
+            # permanently-firing Watchdog alert is dispatched here and
+            # discarded instead of reaching ntfy.
+            #
+            # TO ACTIVATE THE DEADMAN: add a webhook_configs entry pointing at
+            # an external heartbeat monitor that lives outside this stack --
+            # a healthchecks.io ping URL, or an Uptime Kuma push URL hosted on
+            # fredvps, which is off-site and would survive a whole-house
+            # outage. The monitor alarms when the heartbeat stops, which is
+            # the only way to distinguish "nothing is wrong" from "the
+            # alerting pipeline is dead". Until then this rule is inert.
+            {
+              name = "watchdog";
             }
           ];
         };

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -402,8 +402,21 @@ in
                 matchers = [ ''alertname="Watchdog"'' ];
                 receiver = "watchdog";
                 group_wait = "0s";
+
+                # Effective ping cadence is 2 minutes, and stating
+                # repeat_interval = 2m makes the config match what actually
+                # happens rather than looking like it produces 1m.
+                #
+                # Alertmanager only re-evaluates whether to notify on each
+                # group_interval tick, and its dedup stage sends only when
+                # `lastNotify < now - repeat_interval`. With repeat_interval
+                # equal to group_interval, the tick at exactly one interval
+                # fails that test by a hair and the notification slips to the
+                # next tick. So any repeat_interval >= group_interval yields a
+                # real cadence of 2 x group_interval. Measured against the
+                # healthchecks.io ping log: 09:25, 09:27, 09:29.
                 group_interval = "1m";
-                repeat_interval = "1m";
+                repeat_interval = "2m";
               }
               {
                 matchers = [ ''severity="critical"'' ];

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -156,6 +156,7 @@ in
         ./alert-rules/system-alerts.yaml
         ./alert-rules/sdr-alerts.yaml
         ./alert-rules/meta-alerts.yaml
+        ./alert-rules/capacity-alerts.yaml
       ];
 
       scrapeConfigs = [

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -388,17 +388,19 @@ in
         }
         {
           job_name = "pushgateway";
-          # honor_labels lets pushed metrics keep their own hostname/role if
-          # they carry them; the static labels below are only a fallback.
+
+          # honor_labels keeps whatever labels the pusher supplied. Deliberately
+          # NO static hostname/role here: with honor_labels those are only a
+          # fallback, so a series pushed from another machine that omitted
+          # hostname would silently inherit hostname="sdrhub", role="master" and
+          # be attributed to the wrong host. A missing hostname is easier to
+          # notice than a wrong one.
+          #
+          # Nothing pushes to the gateway today; whatever starts doing so should
+          # set its own hostname.
           honor_labels = true;
           static_configs = [
-            {
-              targets = [ "127.0.0.1:9091" ];
-              labels = {
-                hostname = "sdrhub";
-                role = "master";
-              };
-            }
+            { targets = [ "127.0.0.1:9091" ]; }
           ];
         }
       ];
@@ -429,11 +431,11 @@ in
             repeat_interval = "4h";
 
             # Per-severity pacing. All three land on the same receiver; the
-            # ntfy topic and priority are chosen from the severity label by
-            # the alertmanager-ntfy expressions above. Splitting here controls
+            # Each severity has its own Pushover receiver, which is where the
+            # priority, sound and retry behaviour is set. Splitting here controls
             # how insistently each tier repeats.
             routes = [
-              # The deadman must never reach ntfy: it fires permanently by
+              # The deadman must never reach Pushover: it fires permanently by
               # design. It is dispatched to its own receiver, which is a
               # blackhole until an external heartbeat URL is configured.
               # Matched first so it cannot fall through to a severity route
@@ -542,8 +544,8 @@ in
 
                   # Priority 2 is emergency: Pushover re-alerts until the
                   # notification is acknowledged, and it bypasses quiet hours.
-                  # This is the capability the ntfy setup did not have -- an
-                  # unseen critical alert was simply lost.
+                  # This is the capability the previous ntfy setup did not
+                  # have -- an unseen critical alert was simply lost.
                   priority = "2";
                   retry = "2m";
                   expire = "1h";

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -341,7 +341,7 @@ in
               # it would otherwise generate (unit failures, container restarts, etc.)
               source_matchers = [ "alertname = \"NodeDown\"" ];
               target_matchers = [
-                "alertname =~ \"SystemdUnitFailed|SystemdUnitFlapping|GithubRunnerCrashLoop|ContainerRestarting|ContainerOOM|DockerUnitFlapping|SDRServiceFailure|FeederUpstreamFailure|UltrafeederNoAircraft|UltrafeederNotReceiving|AdGuardHomeDown|AtticServerDown\""
+                "alertname =~ \"SystemdUnitFailed|SystemdUnitFlapping|GithubRunnerCrashLoop|ContainerRestarting|ContainerOOM|DockerUnitFlapping|UltrafeederNoAircraft|UltrafeederNotReceiving|AdGuardHomeDown|AtticServerDown\""
               ];
               equal = [ "hostname" ];
             }

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -201,13 +201,10 @@ in
       ];
 
       scrapeConfigs = [
-        # Only :9274 serves metrics.  Docker publishes 9273 and 9275 but no
-        # process inside the ultrafeeder / dump978 containers listens on them,
-        # so docker-proxy accepts the connection and immediately resets it.
-        # Both were permanently down targets.  dump978 exposes its metrics
-        # through the container's own nginx, which currently 404s on /metrics
-        # (it reads /run/readsb/stats.prom, which does not exist), so there is
-        # nothing to scrape for it at all until that is fixed container-side.
+        # Ultrafeeder serves metrics on :9274 only. Docker also publishes 9273,
+        # but nothing inside the container listens on it, so docker-proxy
+        # accepts the connection and immediately resets it -- it was a
+        # permanently down target and is not scraped.
         {
           job_name = "ultrafeeder";
           static_configs = [
@@ -219,6 +216,49 @@ in
                 hostname = "sdrhub";
                 role = "master";
               };
+            }
+          ];
+        }
+
+        # dump978 UAT decoder. Serves telegraf's prometheus_client output on
+        # 9275, which only works on the `telegraf-*` image variant -- the
+        # `latest-*` variant omits the telegraf binary and its s6 services
+        # silently sleep, which is why this target was previously down.
+        {
+          job_name = "dump978";
+          static_configs = [
+            {
+              targets = [
+                "sdrhub.local:9275"
+              ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
+            }
+          ];
+
+          metric_relabel_configs = [
+            # Belt and braces against the per-aircraft cardinality bomb.
+            # INFLUXDB_SKIP_AIRCRAFT=true on the container stops telegraf
+            # collecting these at all, which is the real fix; this drop means
+            # that if the env var is ever lost or a future image ignores it,
+            # Prometheus still refuses to ingest 23 unbounded families keyed on
+            # aircraft address, callsign and flightplan id.
+            {
+              source_labels = [ "__name__" ];
+              regex = "aircraft_.*";
+              action = "drop";
+            }
+
+            # telegraf tags everything with host=<container id>, which changes
+            # every time the container is recreated. Left in place it would
+            # churn the series set on each restart and break continuity of the
+            # very counters this job exists to watch. hostname comes from the
+            # static labels above instead.
+            {
+              regex = "host";
+              action = "labeldrop";
             }
           ];
         }

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -13,6 +13,19 @@ let
   agentHosts = agentNodes;
   desktopHosts = builtins.filter (h: h != "Daytona") desktopNodes;
 
+  # Shared Pushover message body.
+  #
+  # Iterates .Alerts rather than using .CommonAnnotations: group_by is
+  # [alertname, hostname], so a group can contain several alerts that differ
+  # only by unit or device -- DecoderHeartbeatMissing across four dumpvdl2
+  # instances, or the SMART rules across devices. Those have no common
+  # description, and .CommonAnnotations.description would render empty.
+  #
+  # Pushover truncates at 1024 characters. Grouping by alertname and hostname
+  # keeps groups small enough that this is not a practical concern.
+  pushoverMessage = ''
+    {{ range .Alerts }}{{ .Annotations.description }}
+    {{ end }}'';
 in
 {
   environment.systemPackages = [
@@ -26,10 +39,24 @@ in
   # runs with DynamicUser=yes, so there is no stable uid to chown to, and
   # LoadCredential below is the systemd-native way to hand a root-owned file
   # to such a service.
-  sops.secrets."healthchecks.io/endpoint" = { };
+  # Alertmanager requires BOTH pushover values: it calls api.pushover.net
+  # directly rather than being a hosted "Pushover-powered service", so it
+  # supplies the application identity (api_token) as well as the recipient
+  # (user_key).
+  sops.secrets = {
+    "healthchecks.io/endpoint" = { };
+    "pushover/api_token" = { };
+    "pushover/user_key" = { };
+  };
 
+  # The alertmanager unit runs with DynamicUser=yes, so there is no stable uid
+  # for sops to chown these to. LoadCredential reads them as root at unit
+  # start and exposes them to the service user under a deterministic path,
+  # which is exactly what it exists for.
   systemd.services.alertmanager.serviceConfig.LoadCredential = [
     "hc-endpoint:${config.sops.secrets."healthchecks.io/endpoint".path}"
+    "pushover-token:${config.sops.secrets."pushover/api_token".path}"
+    "pushover-user-key:${config.sops.secrets."pushover/user_key".path}"
   ];
 
   system.activationScripts.prometheus_activation = {
@@ -336,53 +363,6 @@ in
         }
       ];
 
-      alertmanager-ntfy = {
-        enable = true;
-        settings = {
-          http = {
-            addr = "127.0.0.1:8000";
-          };
-          ntfy = {
-            baseurl = "https://ntfy.sh";
-            notification = {
-              # Both topic and priority accept gval expressions; the evaluation
-              # context exposes the alert's `status`, `labels` and `annotations`.
-              #
-              # Critical alerts keep the pre-existing topic so an already
-              # subscribed device continues to receive them without any action.
-              # Everything else moves to a separate digest topic, which can be
-              # muted independently while decoder thresholds are being tuned.
-              #
-              # NOTE: on public ntfy.sh a topic name is effectively a password.
-              # Both names are in git history and should move to sops-backed
-              # extraConfigFiles -- tracked in agent-docs/MONITORING.md.
-              topic = ''
-                labels["severity"] == "critical" ? "fred-sdrhub-alerts" : "fred-sdrhub-digest"
-              '';
-              priority = ''
-                status == "resolved" ? "default" :
-                labels["severity"] == "critical" ? "urgent" :
-                labels["severity"] == "warning" ? "default" : "low"
-              '';
-              tags = [
-                {
-                  tag = "+1";
-                  condition = ''status == "resolved"'';
-                }
-                {
-                  tag = "rotating_light";
-                  condition = ''status == "firing"'';
-                }
-              ];
-              templates = {
-                title = ''{{ if eq .Status "resolved" }}Resolved: {{ end }}{{ index .Annotations "summary" }}'';
-                description = ''{{ index .Annotations "description" }}'';
-              };
-            };
-          };
-        };
-      };
-
       #######################################
       # Alertmanager
       #######################################
@@ -398,7 +378,8 @@ in
           };
 
           route = {
-            receiver = "ntfy";
+            # Fallback for any alert without a matching severity child route.
+            receiver = "pushover-warning";
             group_by = [
               "alertname"
               "hostname"
@@ -426,14 +407,14 @@ in
               }
               {
                 matchers = [ ''severity="critical"'' ];
-                receiver = "ntfy";
+                receiver = "pushover-critical";
                 group_wait = "30s";
                 group_interval = "5m";
                 repeat_interval = "1h";
               }
               {
                 matchers = [ ''severity="warning"'' ];
-                receiver = "ntfy";
+                receiver = "pushover-warning";
                 group_wait = "2m";
                 group_interval = "30m";
                 repeat_interval = "12h";
@@ -442,7 +423,7 @@ in
                 # Informational tier. Deliberately slow: this is where decoder
                 # throughput alerts land while their thresholds are unproven.
                 matchers = [ ''severity="info"'' ];
-                receiver = "ntfy";
+                receiver = "pushover-info";
                 group_wait = "5m";
                 group_interval = "1h";
                 repeat_interval = "24h";
@@ -482,13 +463,87 @@ in
           ];
 
           receivers = [
+            # Pushover, one receiver per severity rather than one receiver with
+            # a templated priority. Pushover's emergency priority requires
+            # retry/expire, and each tier wants a different sound and repeat
+            # behaviour, so separate receivers are clearer than nested
+            # conditionals in a template.
+            #
+            # Both credentials come from sops via LoadCredential: the
+            # alertmanager unit runs DynamicUser=yes so there is no stable uid
+            # to chown to, and *_file keeps the secrets out of the Nix store
+            # while preserving build-time amtool validation.
+            #
+            # Alertmanager requires BOTH token and user_key. It talks to
+            # api.pushover.net directly rather than being a hosted
+            # "Pushover-powered service", so it supplies the application
+            # identity as well as the recipient.
             {
-              name = "ntfy";
+              name = "pushover-critical";
 
-              webhook_configs = [
+              pushover_configs = [
                 {
-                  url = "http://127.0.0.1:8000/hook";
+                  token_file = "/run/credentials/alertmanager.service/pushover-token";
+                  user_key_file = "/run/credentials/alertmanager.service/pushover-user-key";
                   send_resolved = true;
+
+                  # Priority 2 is emergency: Pushover re-alerts until the
+                  # notification is acknowledged, and it bypasses quiet hours.
+                  # This is the capability the ntfy setup did not have -- an
+                  # unseen critical alert was simply lost.
+                  priority = "2";
+                  retry = "2m";
+                  expire = "1h";
+                  sound = "siren";
+
+                  title = ''{{ if eq .Status "resolved" }}RESOLVED: {{ end }}{{ .CommonLabels.alertname }}{{ if .CommonLabels.hostname }} on {{ .CommonLabels.hostname }}{{ end }}'';
+                  message = pushoverMessage;
+                  url = "{{ (index .Alerts 0).GeneratorURL }}";
+                  url_title = "Open in Prometheus";
+                }
+              ];
+            }
+
+            {
+              name = "pushover-warning";
+
+              pushover_configs = [
+                {
+                  token_file = "/run/credentials/alertmanager.service/pushover-token";
+                  user_key_file = "/run/credentials/alertmanager.service/pushover-user-key";
+                  send_resolved = true;
+
+                  # Normal priority: notifies, respects quiet hours, no retry.
+                  priority = "0";
+
+                  title = ''{{ if eq .Status "resolved" }}RESOLVED: {{ end }}{{ .CommonLabels.alertname }}{{ if .CommonLabels.hostname }} on {{ .CommonLabels.hostname }}{{ end }}'';
+                  message = pushoverMessage;
+                  url = "{{ (index .Alerts 0).GeneratorURL }}";
+                  url_title = "Open in Prometheus";
+                }
+              ];
+            }
+
+            {
+              name = "pushover-info";
+
+              pushover_configs = [
+                {
+                  token_file = "/run/credentials/alertmanager.service/pushover-token";
+                  user_key_file = "/run/credentials/alertmanager.service/pushover-user-key";
+                  # Informational alerts do not need a resolved notification;
+                  # this is the tier decoder throughput lands in while its
+                  # thresholds are unproven and it would double the volume.
+                  send_resolved = false;
+
+                  # Priority -1 is low: delivered silently, no sound or
+                  # vibration. Visible when the phone is picked up.
+                  priority = "-1";
+
+                  title = "{{ .CommonLabels.alertname }}{{ if .CommonLabels.hostname }} on {{ .CommonLabels.hostname }}{{ end }}";
+                  message = pushoverMessage;
+                  url = "{{ (index .Alerts 0).GeneratorURL }}";
+                  url_title = "Open in Prometheus";
                 }
               ];
             }

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -287,9 +287,24 @@ in
           ntfy = {
             baseurl = "https://ntfy.sh";
             notification = {
-              topic = "fred-sdrhub-alerts";
+              # Both topic and priority accept gval expressions; the evaluation
+              # context exposes the alert's `status`, `labels` and `annotations`.
+              #
+              # Critical alerts keep the pre-existing topic so an already
+              # subscribed device continues to receive them without any action.
+              # Everything else moves to a separate digest topic, which can be
+              # muted independently while decoder thresholds are being tuned.
+              #
+              # NOTE: on public ntfy.sh a topic name is effectively a password.
+              # Both names are in git history and should move to sops-backed
+              # extraConfigFiles -- tracked in agent-docs/MONITORING.md.
+              topic = ''
+                labels["severity"] == "critical" ? "fred-sdrhub-alerts" : "fred-sdrhub-digest"
+              '';
               priority = ''
-                status == "firing" ? "high" : "default"
+                status == "resolved" ? "default" :
+                labels["severity"] == "critical" ? "urgent" :
+                labels["severity"] == "warning" ? "default" : "low"
               '';
               tags = [
                 {
@@ -333,6 +348,36 @@ in
             group_wait = "30s";
             group_interval = "5m";
             repeat_interval = "4h";
+
+            # Per-severity pacing. All three land on the same receiver; the
+            # ntfy topic and priority are chosen from the severity label by
+            # the alertmanager-ntfy expressions above. Splitting here controls
+            # how insistently each tier repeats.
+            routes = [
+              {
+                matchers = [ ''severity="critical"'' ];
+                receiver = "ntfy";
+                group_wait = "30s";
+                group_interval = "5m";
+                repeat_interval = "1h";
+              }
+              {
+                matchers = [ ''severity="warning"'' ];
+                receiver = "ntfy";
+                group_wait = "2m";
+                group_interval = "30m";
+                repeat_interval = "12h";
+              }
+              {
+                # Informational tier. Deliberately slow: this is where decoder
+                # throughput alerts land while their thresholds are unproven.
+                matchers = [ ''severity="info"'' ];
+                receiver = "ntfy";
+                group_wait = "5m";
+                group_interval = "1h";
+                repeat_interval = "24h";
+              }
+            ];
           };
 
           inhibit_rules = [

--- a/modules/secrets/secrets.yaml
+++ b/modules/secrets/secrets.yaml
@@ -74,6 +74,11 @@ github_api: ENC[AES256_GCM,data:T/VDBFTz3gJ13UaOdz7TXPGGNKgVoAbSpu9SXfD6X0DvwRHR
 tailscale:
     authkey: ENC[AES256_GCM,data:G31ZTeT2Cn6KdKrqWodWtm4qlaU5i6ID0Zvdr1mzhr4L+KF/Sl3iM3A4zc1xty+fuRY5A7QZHoD1UlKzog==,iv:LQnM1DKa5fXshBELNeg1HFe0aYMxF3vbhzJiqPgmb9Y=,tag:xnRzHVVSYnHbMEgk9Dk6Sg==,type:str]
 github_pat: ENC[AES256_GCM,data:WmtzUTOfpmRIcSzlwx2GEom4yJw/4kb1gSoA9fqrWJZZCsYMzyPgfA==,iv:1EAHDrIf6etXhw5wEZONZlstN9pIUbQxC3KR0ENELBU=,tag:LV8OiTthl9C6i8+bW1z2pg==,type:str]
+pushover:
+    user_key: ENC[AES256_GCM,data:wHtH4wa3G/PrrTJCJ79/GGy0sr24rKuRVWnxlfx9,iv:VbG9YM00rhiv6e5f3XToCkgOUOhWi7NxPZaK4Q4c2NA=,tag:0mXDOqAXeJlx2o8hfKdwhg==,type:str]
+    api_token: ENC[AES256_GCM,data:KUzz6hSpd0gZcd1foN0i53YjscfAB0t62a3BCIzD,iv:h6Y3KZR2YIiytPRkV+0msnKO/LZWtQccyfbDKUSskgM=,tag:2N9BNuLNpepQRIf+KW6mhg==,type:str]
+healthchecks.io:
+    endpoint: ENC[AES256_GCM,data:p8Hg/rGXkJgik2/rzY+WES2oHbpfFq2EQHgFj7Z3kdwyIM20ONXWZHmaEV7wgiGj4a+hVvdkmvM=,iv:zGqsZs3rPGaceSySY1vLVz3xvScm41RQ/r5pyDUQ8wE=,tag:a+oE9rLaAPltB/uh4vyQOQ==,type:str]
 sops:
     age:
         - enc: |
@@ -175,7 +180,7 @@ sops:
             eHvK3JMq9ggZ/p6GB7jxXWCGzbrYY2ecO7l9zkwAWLbeoE7V8s1BNw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1gpd67sr93x3h885cl0pd3rm5ykvxadmyfjmf8u2j0me76mfl3s7scvlp9p
-    lastmodified: "2026-06-10T16:16:46Z"
-    mac: ENC[AES256_GCM,data:MNiKX1zxfH/NHoRHzPmbMY/zJFEoStSdZYyh+pAk0tieOSyQqEKuN5jbdA1fpTXuHY6X09pnLc3vTt0yqAd6f/q/axd8QuSBMf8oYoooCLxrbUws5cxMmZjT3EftNDfuh0gHoHAX/NIDPwFcIiHTgOv6JDshp3aconJuh9Re7m0=,iv:2dmik8ofQD5iEWGSNK7RYnpN/RJPDmDGS1LI50Jfz4s=,tag:hQbkCmucKu0JzAr3UR2bMg==,type:str]
+    lastmodified: "2026-08-03T15:17:49Z"
+    mac: ENC[AES256_GCM,data:11mPN2QmIDQP1zLoZ48Pdx8J8NuErbuBH3YpIyGA3b68SJkKdgGFhbiDy0YV6kYNsh8nhMyc6QOQ9H61xfhqjiObYIAmAc4B2Rqdk9w9UoApk3ngTMXMrAyIxJcuzWZ3/Ce6zHjo+hc0+e1J4yOxoB7MVxNVgBH3qDn5yOUJaGI=,iv:E7G40W9HKa/EdKiBJKd9A8WyfDwT2mK3LHeeRrx6qng=,tag:uyvtvjfZhhJPzS+joFYR8Q==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.13.1
+    version: 3.13.3

--- a/modules/services/adsb-docker-units.nix
+++ b/modules/services/adsb-docker-units.nix
@@ -41,6 +41,26 @@ let
       ttyFlag = if (c.tty or false) then "--tty" else "";
       deviceRuleFlags = mkDeviceCgroupRuleFlags (c.deviceCgroupRules or [ ]);
       deviceFlags = mkDeviceFlags (c.devices or [ ]);
+
+      # Without --hostname a container's hostname is its container id, and
+      # anything inside that self-identifies picks that up. That is not
+      # cosmetic: telegraf in the dump978 container tagged every metric with
+      # host=<container id>, which changes on each recreate, so the Prometheus
+      # job needs a labeldrop to avoid churning its entire series set. Four
+      # containers already set `hostname` expecting it to be honoured.
+      hostnameFlag = lib.optionalString (c ? hostname) ''--hostname "${c.hostname}"'';
+
+      # Ordering against sibling containers. Several entries previously carried
+      # Docker Compose's `depends_on = { name = { condition = ...; }; }`, which
+      # this module never read, so the units started in parallel regardless.
+      # Expressed here as a plain list of container names and translated to
+      # systemd ordering.
+      #
+      # After= on a Type=simple unit waits for the process to be spawned, which
+      # is the same guarantee Compose's `service_started` gives. Ordering only,
+      # deliberately not Requires=: a sibling decoder failing should not stop
+      # the others from running.
+      dependsOnUnits = map (n: "docker-${n}.service") (c.dependsOn or [ ]);
     in
     {
       description = "Docker Container ${c.name}";
@@ -64,7 +84,7 @@ let
             "--network"
             "adsbnet"
           ]
-          + " ${ttyFlag} ${deviceRuleFlags} ${deviceFlags} ${envFlags} ${envFileFlags} ${volumeFlags} ${tmpfsFlags} ${portFlags} "
+          + " ${hostnameFlag} ${ttyFlag} ${deviceRuleFlags} ${deviceFlags} ${envFlags} ${envFileFlags} ${volumeFlags} ${tmpfsFlags} ${portFlags} "
           + (c.extraDockerArgs or "")
           + " ${c.image} ${execCmd}";
 
@@ -77,7 +97,8 @@ let
         "docker.service"
         "network-online.target"
         "docker-create-adsbnet.service"
-      ];
+      ]
+      ++ dependsOnUnits;
       wants = [ "network-online.target" ];
     };
 in
@@ -85,7 +106,29 @@ in
   options.services.adsb.containers = lib.mkOption {
     type = lib.types.listOf lib.types.attrs;
     default = [ ];
-    description = "List of ADS-B/ACARS/SDR containers to run under Docker.";
+    description = ''
+      List of ADS-B/ACARS/SDR containers to run under Docker.
+
+      The type is a freeform `listOf attrs`, so a key that this module does not
+      read is silently ignored rather than rejected. Three keys were being set
+      with no effect before this was documented: `hostname` and `depends_on`
+      (both now honoured, the latter renamed to `dependsOn`) and `requires`,
+      whose intent was already covered by the `wants`/`after` on
+      network-online.target that every unit gets.
+
+      Recognised keys:
+
+      - `name`, `image` (required)
+      - `hostname` -- passed as `docker run --hostname`
+      - `dependsOn` -- list of sibling container names; becomes systemd
+        `After=docker-<name>.service`, ordering only
+      - `environment` (attrset), `environmentFiles` (list of paths)
+      - `volumes`, `tmpfs`, `ports` (lists)
+      - `devices`, `deviceCgroupRules` (lists)
+      - `restart` (default "always"), `exec`, `tty`, `extraDockerArgs`
+
+      Anything else is a no-op. Add it here and to `mkUnit` if it is needed.
+    '';
   };
 
   config = lib.mkIf (cfg.containers != [ ]) {

--- a/scripts/check-alert-metrics.sh
+++ b/scripts/check-alert-metrics.sh
@@ -84,6 +84,10 @@ RESERVED = {
     "and", "if", "atan2",
 }
 
+# Metric names with no underscore. Anything added here must be a real metric,
+# not a label or keyword, or it will produce a spurious MISSING.
+BARE_METRICS = {"up"}
+
 metrics = {}
 
 for name in sorted(os.listdir(rules_dir)):
@@ -148,9 +152,13 @@ for name in sorted(os.listdir(rules_dir)):
             # they may legitimately not exist yet.
             if ":" in ident:
                 continue
-            # A metric name always contains an underscore in this codebase;
-            # bare words are label values or leftover keywords.
-            if "_" not in ident:
+            # Metric names in this codebase contain an underscore, so requiring
+            # one is a cheap way to drop label values and leftover keywords.
+            # `up` is the exception that matters: it has no underscore and is
+            # referenced by NodeDown, PrometheusTargetDown, LokiDown and
+            # AlertmanagerDown, so without this allowlist the script silently
+            # skipped the single most load-bearing metric in the rule set.
+            if "_" not in ident and ident not in BARE_METRICS:
                 continue
             metrics.setdefault(ident, set()).add(name)
 
@@ -206,21 +214,21 @@ while IFS=$'\t' read -r metric files; do
         continue
     fi
 
+    # Any unexpected payload shape must yield "query-error" rather than raise:
+    # this runs under `set -e`, so an uncaught KeyError or IndexError would
+    # abort the whole script and silently skip every remaining metric.
     count="$(printf '%s' "${response}" | python3 -c '
 import json
 import sys
 
 try:
     payload = json.load(sys.stdin)
-except (ValueError, TypeError):
-    print("query-error")
-    sys.exit()
-
-if payload.get("status") != "success":
-    print("query-error")
-else:
+    if payload.get("status") != "success":
+        raise ValueError("non-success status")
     result = payload.get("data", {}).get("result", [])
     print(result[0]["value"][1] if result else "0")
+except Exception:
+    print("query-error")
 ')"
 
     if [[ ${count} == "query-error" ]]; then

--- a/scripts/check-alert-metrics.sh
+++ b/scripts/check-alert-metrics.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#
+# check-alert-metrics.sh -- assert that every metric referenced by a Prometheus
+# alerting rule actually has series in Prometheus.
+#
+# WHY THIS EXISTS
+#
+# Prometheus reports a rule whose expression matches nothing as health=ok. An
+# empty result is not an error. A rule that references a metric which does not
+# exist -- because an exporter was reconfigured, a collector flag was never
+# passed, or an upstream renamed a metric family -- is therefore
+# indistinguishable from a healthy rule that simply has nothing to complain
+# about. It will never fire and nothing will ever say so.
+#
+# Five such rules accumulated in this repository before anyone noticed:
+#
+#   DockerUnitFlapping       node_systemd_unit_restart_total  (collector flag)
+#   SDRServiceFailure        promtail_custom_*                (promtail removed)
+#   FeederUpstreamFailure    promtail_custom_*                (promtail removed)
+#   UltrafeederNoAircraft    readsb_stats_aircraft_with_pos   (renamed upstream)
+#   UltrafeederNotReceiving  readsb_stats_messages            (renamed upstream)
+#
+# promtool check rules will not catch this: the expressions are all valid
+# PromQL. promtool test rules catches it only for rules that have a test. This
+# script is the backstop that catches it for all of them.
+#
+# Usage:
+#   scripts/check-alert-metrics.sh [PROMETHEUS_BASE_URL]
+#
+# Exits 0 if all metrics resolve, or if Prometheus is unreachable (so CI on a
+# runner without LAN access does not fail spuriously). Exits 1 if any
+# referenced metric has no series.
+set -euo pipefail
+
+PROM_URL="${1:-http://192.168.31.20:9090}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RULES_DIR="${REPO_ROOT}/modules/monitoring/master/alert-rules"
+
+if [[ ! -d ${RULES_DIR} ]]; then
+    echo "error: rules directory not found: ${RULES_DIR}" >&2
+    exit 1
+fi
+
+# Reachability probe first. A runner that cannot see the LAN must skip rather
+# than fail, otherwise this check becomes something people learn to ignore.
+if ! curl -sfG --max-time 10 "${PROM_URL}/api/v1/status/buildinfo" >/dev/null 2>&1; then
+    echo "SKIPPED: Prometheus at ${PROM_URL} is unreachable."
+    echo "         This check only runs where the monitoring LAN is reachable."
+    exit 0
+fi
+
+echo "Prometheus: ${PROM_URL}"
+echo "Rules:      ${RULES_DIR}"
+echo
+
+# Extract metric names from every expr: field. Done in python3 with only the
+# standard library, because pyyaml is not available in this repo's dev shell
+# and a regex over the expression text is sufficient for the shapes used here.
+#
+# Emits "metric<TAB>comma,separated,files" per line.
+METRIC_LIST="$(
+    python3 - "${RULES_DIR}" <<'PYEOF'
+import os
+import re
+import sys
+
+rules_dir = sys.argv[1]
+
+# PromQL functions, aggregation operators, keywords and modifiers. These are
+# bare identifiers in an expression but are not metric names.
+RESERVED = {
+    "abs", "absent", "absent_over_time", "avg", "avg_over_time", "bool",
+    "bottomk", "by", "ceil", "changes", "clamp", "clamp_max", "clamp_min",
+    "count", "count_over_time", "count_values", "day_of_month", "day_of_week",
+    "day_of_year", "days_in_month", "delta", "deriv", "exp", "floor", "group",
+    "group_left", "group_right", "histogram_quantile", "hour", "idelta",
+    "ignoring", "increase", "irate", "label_join", "label_replace",
+    "last_over_time", "ln", "log10", "log2", "max", "max_over_time", "min",
+    "min_over_time", "minute", "month", "offset", "on", "or", "predict_linear",
+    "present_over_time", "quantile", "quantile_over_time", "rate", "resets",
+    "round", "scalar", "sgn", "sort", "sort_desc", "sqrt", "stddev",
+    "stddev_over_time", "stdvar", "stdvar_over_time", "sum", "sum_over_time",
+    "time", "timestamp", "topk", "unless", "vector", "without", "year",
+    "and", "if", "atan2",
+}
+
+metrics = {}
+
+for name in sorted(os.listdir(rules_dir)):
+    if not name.endswith((".yaml", ".yml")):
+        continue
+    path = os.path.join(rules_dir, name)
+    if not os.path.isfile(path):
+        continue
+
+    text = open(path, encoding="utf-8").read()
+
+    # Collect expr: values, including YAML block scalars (expr: | ...).
+    exprs = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        m = re.match(r"^(\s*)expr:\s*(.*)$", lines[i])
+        if not m:
+            i += 1
+            continue
+        indent, rest = m.group(1), m.group(2).strip()
+        if rest in ("|", ">", "|-", ">-", "|+", ">+"):
+            block = []
+            i += 1
+            while i < len(lines):
+                if lines[i].strip() == "":
+                    block.append("")
+                    i += 1
+                    continue
+                cur = len(lines[i]) - len(lines[i].lstrip())
+                if cur <= len(indent):
+                    break
+                block.append(lines[i].strip())
+                i += 1
+            exprs.append(" ".join(block))
+        else:
+            # Possibly a multi-line plain scalar continued by deeper indent.
+            buf = [rest]
+            i += 1
+            while i < len(lines):
+                if lines[i].strip() == "":
+                    break
+                cur = len(lines[i]) - len(lines[i].lstrip())
+                if cur <= len(indent) or re.match(r"^\s*\w+:", lines[i]):
+                    break
+                buf.append(lines[i].strip())
+                i += 1
+            exprs.append(" ".join(buf))
+
+    for expr in exprs:
+        # Drop label selectors wholesale: the identifiers inside them are label
+        # names, not metrics. Also drop quoted strings and durations.
+        cleaned = re.sub(r"\{[^{}]*\}", " ", expr)
+        cleaned = re.sub(r'"[^"]*"', " ", cleaned)
+        cleaned = re.sub(r"'[^']*'", " ", cleaned)
+        cleaned = re.sub(r"\[[^\]]*\]", " ", cleaned)
+
+        for ident in re.findall(r"\b[a-zA-Z_][a-zA-Z0-9_:]*\b", cleaned):
+            if ident in RESERVED:
+                continue
+            # Recording rules use a colon and are produced by this stack, so
+            # they may legitimately not exist yet.
+            if ":" in ident:
+                continue
+            # A metric name always contains an underscore in this codebase;
+            # bare words are label values or leftover keywords.
+            if "_" not in ident:
+                continue
+            metrics.setdefault(ident, set()).add(name)
+
+for metric in sorted(metrics):
+    print(f"{metric}\t{','.join(sorted(metrics[metric]))}")
+PYEOF
+)"
+
+if [[ -z ${METRIC_LIST} ]]; then
+    echo "error: no metrics extracted -- the parser is probably broken" >&2
+    exit 1
+fi
+
+# Metrics that legitimately have no series most of the time, because they are
+# emitted only while the condition they describe is true. Their absence is the
+# healthy state, so it must not be reported as a defect.
+#
+# Every entry needs a justification. Do not add a metric here to silence a
+# genuine defect -- that defeats the entire purpose of this script.
+#
+#   fwupd_device_update_info
+#     modules/monitoring/agent/node_exporter.nix emits one series per device
+#     that has a pending firmware release. With no updates outstanding the
+#     jq filter produces nothing. The companion fwupd_updates_available is
+#     always emitted and is checked normally, so a broken exporter is still
+#     caught.
+CONDITIONAL_METRICS=(
+    fwupd_device_update_info
+)
+
+is_conditional() {
+    local needle="$1" entry
+    for entry in "${CONDITIONAL_METRICS[@]}"; do
+        [[ ${entry} == "${needle}" ]] && return 0
+    done
+    return 1
+}
+
+missing=0
+total=0
+conditional=0
+
+while IFS=$'\t' read -r metric files; do
+    [[ -z ${metric} ]] && continue
+    total=$((total + 1))
+
+    response="$(curl -sG --max-time 15 "${PROM_URL}/api/v1/query" \
+        --data-urlencode "query=count(${metric})" || echo '')"
+
+    if [[ -z ${response} ]]; then
+        printf '  %-8s %-52s %s\n' "ERROR" "${metric}" "query failed (${files})"
+        missing=$((missing + 1))
+        continue
+    fi
+
+    count="$(printf '%s' "${response}" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except (ValueError, TypeError):
+    print("query-error")
+    sys.exit()
+
+if payload.get("status") != "success":
+    print("query-error")
+else:
+    result = payload.get("data", {}).get("result", [])
+    print(result[0]["value"][1] if result else "0")
+')"
+
+    if [[ ${count} == "query-error" ]]; then
+        printf '  %-8s %-52s %s\n' "ERROR" "${metric}" "(${files})"
+        missing=$((missing + 1))
+    elif [[ ${count} == "0" ]]; then
+        if is_conditional "${metric}"; then
+            printf '  %-8s %-52s %s\n' "COND" "${metric}" "absent while condition is false (${files})"
+            conditional=$((conditional + 1))
+        else
+            printf '  %-8s %-52s %s\n' "MISSING" "${metric}" "(${files})"
+            missing=$((missing + 1))
+        fi
+    else
+        printf '  %-8s %-52s series=%s\n' "OK" "${metric}" "${count}"
+    fi
+done <<<"${METRIC_LIST}"
+
+echo
+echo "Checked ${total} metric(s); ${missing} unresolved, ${conditional} conditionally absent."
+
+if ((missing > 0)); then
+    cat <<'EOF'
+
+FAILED: at least one alerting rule references a metric with no series.
+
+Such a rule is reported health=ok by Prometheus and will never fire. Either
+fix the metric name, enable the exporter or collector that produces it, or
+delete the rule.
+
+If the metric is produced by a scrape job or collector added in this branch
+and not yet deployed, that is expected -- re-run after deploying.
+EOF
+    exit 1
+fi
+
+echo "All referenced metrics resolve."


### PR DESCRIPTION
## Summary

An audit of the Prometheus/Alertmanager/Loki stack found that a large share of the alerting was silently non-functional, and that the fleet's most likely failure modes were unmonitored. Everything here was found by querying the live stack rather than reading the Nix source — that distinction matters, because every defect was of the same shape: syntactically valid configuration that Prometheus reports as `health=ok` and which can never fire.

The rule set goes from 22 alerts (5 of them dead) to **49 alerts across 9 files, all covered by promtool unit tests**, plus 30 log-derived rules in a new Loki ruler.

All 37 commits are atomic and each leaves `nix eval` and the hook suite green. **Already deployed to the fleet and verified in production.**

## Defects found and fixed

| Defect | Consequence |
| --- | --- |
| `PrometheusTargetDown` used `sum(x == 0) > 0` | Mathematically incapable of firing. Two targets were down with no alert. |
| `sdr-alerts.yaml` selected `readsb_stats_*` | Those names have no active series; both ADS-B alerts were dead. |
| `DockerUnitFlapping` used `node_systemd_unit_restart_total` | Metric is `node_systemd_service_restart_total`, and needed a collector flag. Dead twice over. |
| `SDRServiceFailure` / `FeederUpstreamFailure` | Referenced `promtail_custom_*` after promtail was replaced by Alloy. Deleted. |
| `sdrhub.local:9273` / `:9275` scrape targets | Nothing listened inside the containers; permanently-down phantoms. |
| Alloy's log-to-metric path | Broken in three independent ways at once; replaced by the Loki ruler. |
| `NixOSNotOnMain` excluded `daytona` | Host is `Daytona`; PromQL regexes are case-sensitive. Now selects on `role`. |
| `lib.mkDefault` on `boot.kernelParams` | A `mkDefault` list is discarded, not merged — would have silently dropped the DVB blacklist. |
| `mkUnit` ignored `hostname`/`depends_on`/`requires` | Nine settings across three hosts did nothing. |

## Real faults these surfaced, now resolved

- **`usb_claim_interface error` × 37,948/week on dump978** and **2,095 USB transfer failures on vdlmhub** — both caused by the kernel's 16 MB global usbfs ceiling. Now set declaratively via `boot.kernelParams` (not `modprobe.d`; `usbcore` is built in). Both counters are at **zero**.
- **dump978 was restarting its own decoder ~20×/day** because it couldn't claim its device. Now **0 restarts in 12h**, against 54 in the preceding 3 days.
- **dump978 served no metrics at all** despite correct env vars: the `latest-*` image omits the telegraf binary and its s6 services `sleep infinity` while reporting up. Switched to `telegraf-build-801` — same build, plus the binary.
- **sdrhub's SSD is at 54% of rated write endurance** (37.8 TB written), which nothing was watching. smartctl exporter added.
- **smartctl produced nothing on all 6 hosts after deploy** — the nixpkgs udev rule is `ACTION=="add"`, so it never fires on a live deploy. Capabilities don't help (`CAP_SYS_RAWIO` doesn't bypass DAC). Fixed with an explicit ACL oneshot.

## What's new

**Notification path.** ntfy replaced with Pushover: critical uses emergency priority and re-alerts until acknowledged, which the previous setup could not do. The unmonitored `alertmanager-ntfy` bridge is gone from the critical path, and credentials moved into sops. **Delivery tested end to end** — both tiers received, 0 failures.

**Deadman switch** wired to healthchecks.io. Previously the `Watchdog` alert fired into a receiver with no config and did nothing. This is the only check covering the delivery path itself; it cannot be done from inside the stack, because the component that would report total failure is the one that's broken.

**Loki ruler** with 30 rules: crash detection (`s6wrap`), per-unit heartbeat absence, curated error signatures, and a `decoder:messages:last5m` recording rule accumulating history for future baselines. Rules live centrally so tuning a pattern is a one-host deploy rather than six.

**New exporters:** smartctl (6 hosts) and blackbox (20 endpoints, 14 TLS certs, min 49 days headroom).

**Karma** alert dashboard on sdrhub, loopback-bound behind nginx. Deliberately not exposed: Karma manages silences, so it is a control plane, and a silenced fleet is indistinguishable from a healthy one.

## Guardrails against recurrence

- `promtool check rules` + `test rules` as a **pre-commit hook**, merged into `precommit-base`'s hook set without modifying that repo or adding a flake input.
- **The flake check now actually runs in CI.** It didn't — `lint.yaml` never ran `nix flake check`, so the new tests would have passed by never executing. Same failure mode they exist to catch.
- `scripts/check-alert-metrics.sh` asserts every referenced metric resolves against live Prometheus, distinguishing "broken" from "conditionally absent". **This is what caught the wrong systemd metric name after deploy.**

## Notes for review

Two false-positive sources were found and fixed by deploying, which is worth flagging as the pattern to watch:

1. **`container_health_state` is `0` for both `unhealthy` and `starting`**, and these images use 1–2h `start_period`s. The rule fired on healthy piaware ~10 min after every deploy. Now gated on start time.
2. Thresholds are set from **30 days of measured fleet behaviour**, not defaults. `NodeHighLoad` is 4× cores, because hfdlhub1 normally runs oversubscribed and `> 2` would fire 89.7% of the month.

No throughput alerts on the decoders yet. Traffic here is strongly diurnal with three incompatible archetypes (VHF daytime peak, HF propagation windows, permanently-quiet bands), so any static threshold would be wrong. That needs ~3 weeks of recorded baseline and is tracked as Phase 6 in `agent-docs/MONITORING.md`.

`modules/secrets/secrets.yaml` is included because the config cannot activate without the Pushover and healthchecks keys. All 68 values verified encrypted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Karma alert dashboard access and Grafana navigation from the ADS-B Hub homepage.
  * Added monitoring for endpoint availability, certificate expiry, capacity, container health, disk health, and logging pipeline status.
  * Added SMART disk health monitoring, watchdog checks, and severity-based notifications.

* **Improvements**
  * Updated dashboards to highlight alerting pipeline health.
  * Improved SDR hardware support and service startup reliability.

* **Documentation**
  * Added comprehensive monitoring and operations guidance.

* **Tests**
  * Added automated validation for monitoring rules and referenced metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->