### PR TITLE
chore(flake/freminal): `9dc083d4` -> `e533ed00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1785719485,
-        "narHash": "sha256-4SUOxjdFGgGppTZ0P/XE3zmicLFGSuytjP8kj2m8j+4=",
+        "lastModified": 1785726544,
+        "narHash": "sha256-4I84vqyxrtCUmlqF77v2jZYq2CrqXOVGJ9Jief3UZRU=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "9dc083d45fb42b474f1dd00016af5eecd2e7b0a1",
+        "rev": "e533ed000921f4e54922ea925f2008393fe89e0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`f7f9f2e0`](https://github.com/fredsystems/freminal/commit/f7f9f2e0bd41995f588ef0f6d0d39e07dab147d7) | `` fix: resolve cleanup entries 122.C1-C3 and the PR #472 nitpicks ``             |
| [`d3a90478`](https://github.com/fredsystems/freminal/commit/d3a9047835beb631d87670cf48c4b5244096174d) | `` fix: address PR #472 review, and finish the 122.16 close-out ``                |
| [`cabeee4e`](https://github.com/fredsystems/freminal/commit/cabeee4e57d7dca105a78cd7fbd65782273e549c) | `` docs: 122.16 -- account for cleanup entries and the branch's line growth ``    |
| [`5768bf70`](https://github.com/fredsystems/freminal/commit/5768bf70aeed63a6da47e8c9e07be6f0713d7a0a) | `` docs: 122.16 -- reconcile the documents, closing Task 122 ``                   |
| [`cd0dc0e4`](https://github.com/fredsystems/freminal/commit/cd0dc0e4ba898ffe5b849e0026114163fe3d438b) | `` feat: 122.15 -- publish the per-pane terminal-rect origin ``                   |
| [`ea58d9d3`](https://github.com/fredsystems/freminal/commit/ea58d9d3af7552f7361532018f99582e23deebeb) | `` refactor: 122.13 -- rename gui_scroll_offset / gui_extra_rows ``               |
| [`d20ba94e`](https://github.com/fredsystems/freminal/commit/d20ba94e5d624977d4f2b913a251e3a226add6c7) | `` docs: 121.34-121.36 -- chrome-cache decision gate, waste, and confinement ``   |
| [`82975fbb`](https://github.com/fredsystems/freminal/commit/82975fbb4aed78aa6db9f3b5fc1dfbc128473a35) | `` refactor: 122.12 -- name write_input_to_terminal's parameters and result ``    |
| [`1348b842`](https://github.com/fredsystems/freminal/commit/1348b842a40199848abf73312156c8a7c590108f) | `` docs: record the 122.12 shape decision before pivoting to the tab-click bug `` |
| [`bc9a4592`](https://github.com/fredsystems/freminal/commit/bc9a4592fb7dce60e3d37f8dc6f679bf58eede35) | `` docs: record Task 122 execution state for handoff ``                           |
| [`0fd403af`](https://github.com/fredsystems/freminal/commit/0fd403af7f3dd1e17a655230124341f38136d8ec) | `` refactor: 122.11a -- consolidate the per-frame drains into one module ``       |
| [`f5a12776`](https://github.com/fredsystems/freminal/commit/f5a1277644e24a5eeea08524c485407112720b4d) | `` refactor: 122.11 -- extract show's dirty-tracking decision block ``            |
| [`5b81ef4e`](https://github.com/fredsystems/freminal/commit/5b81ef4e5b552b92c66659dd8dd574943c620fbf) | `` refactor: 122.10 -- extract central_body's chrome-signal staging ``            |
| [`cba0b833`](https://github.com/fredsystems/freminal/commit/cba0b833cabe0af6de9df460d25d7c46d3d32a96) | `` refactor: 122.9 -- extract central_body's frame-damage aggregation ``          |
| [`ab6f382f`](https://github.com/fredsystems/freminal/commit/ab6f382f823af953777fbce5384a6efe61e33a61) | `` refactor: 122.8 -- extract the window-command drain and OSC routing ``         |
| [`4d023728`](https://github.com/fredsystems/freminal/commit/4d0237284b569e66d0cdf9411a054aa44bea2aba) | `` refactor: 122.7 -- extract App::update's two zero-egui blocks ``               |
| [`79ce4dc1`](https://github.com/fredsystems/freminal/commit/79ce4dc1c17025657259545d305b988a83201112) | `` test: 122.6 -- make the CursorMoved dispatch path testable ``                  |
| [`16b5efb9`](https://github.com/fredsystems/freminal/commit/16b5efb93ec7b6a53959fda34122686737145c54) | `` refactor: 122.5a -- give the pointer-motion decision its own module ``         |
| [`c6e584c0`](https://github.com/fredsystems/freminal/commit/c6e584c0c7ff1ca6ff8ae2193504e4e94e68aad7) | `` refactor: 122.5 -- extract the pane-resolution chain as a pure function ``     |
| [`9e82b412`](https://github.com/fredsystems/freminal/commit/9e82b412ff1ad5efdbc6c9323e1224a3dce09e0c) | `` refactor: 122.4 -- give the published frame state a name and a home ``         |
| [`67ab18f2`](https://github.com/fredsystems/freminal/commit/67ab18f281a2daea3403f153cb33fb59aeb1e618) | `` refactor: 122.3a -- SplitBorder::active_in_first becomes a named enum ``       |
| [`cb83143c`](https://github.com/fredsystems/freminal/commit/cb83143cdd24098b6ec3259b1dee91be80ec8e0f) | `` refactor: 122.3 -- move panes geometry onto the neutral types ``               |
| [`d360c897`](https://github.com/fredsystems/freminal/commit/d360c897a1486d7efe70136e0cb2c58e06c570e1) | `` feat: 122.2 -- toolkit-neutral Point/Rect in freminal-common ``                |
| [`be982808`](https://github.com/fredsystems/freminal/commit/be98280874c300cf3b87f72affead3ecdc5b838b) | `` docs: 122.1 -- verify the published-state inventory ``                         |
| [`4e2949d9`](https://github.com/fredsystems/freminal/commit/4e2949d9262c52c25e3170a9004590c5e0a10e21) | `` bench: 122.14 -- baseline for the pane-resolution chain ``                     |