### PR TITLE
chore(flake/nixvim): `a19efae6` -> `c7be4930`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1162,11 +1162,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1785527278,
-        "narHash": "sha256-rYFSM491MFFA1V6oax5PngXbevGt6n0o8sKhwFoItE0=",
+        "lastModified": 1785763201,
+        "narHash": "sha256-wA373y/B9orM3HatLu9oS+Ke5lmdZyBl/bdjd2gLMq4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a19efae6c1afe426e8243d79f6dfbab186be6df8",
+        "rev": "c7be49306b23a952c0151cf4bbeacd944ed82f2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`c7be4930`](https://github.com/nix-community/nixvim/commit/c7be49306b23a952c0151cf4bbeacd944ed82f2a) | `` user-configs: add @rbpatt2019's config `` |