### PR TITLE
chore(flake/nixpkgs-stable): `5b4f72e1` -> `531670d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -936,11 +936,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1785491804,
-        "narHash": "sha256-p00vplVOyfKGlhju0+eGGPAxyYYKaY0lpyuoHLFIx2Y=",
+        "lastModified": 1785734586,
+        "narHash": "sha256-ODZkEK9Gy50yg6h98u7KkitZ3oc/uuTFK00bh1CRdNA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b4f72e1705a63aace42900610c4db82cb4af0ec",
+        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`20154259`](https://github.com/NixOS/nixpkgs/commit/201542597fe31268e1f367482f2897ae6eca82ea) | `` zsh-patina: 1.7.0 -> 1.9.0 ``                                                 |
| [`c8cb3e13`](https://github.com/NixOS/nixpkgs/commit/c8cb3e13fa85f823b42035944321b78b08c09554) | `` uptime-kuma: 2.4.0 -> 2.5.0 ``                                                |
| [`8d3ec376`](https://github.com/NixOS/nixpkgs/commit/8d3ec3762a29cf556a7dd80941bbedada8b240b2) | `` cockpit: scrub compiler and -dev store paths from runtime closure ``          |
| [`13a1f080`](https://github.com/NixOS/nixpkgs/commit/13a1f0802e031a1f5df8471cb59503670a249ac1) | `` angie: mark as vulnerable due to insufficient maintainer attention ``         |
| [`746b46a6`](https://github.com/NixOS/nixpkgs/commit/746b46a678539980e16682f95ae7d24dfaba0b4b) | `` buildDubPackage: explicitly set fetchSubmodules ``                            |
| [`950b4ae8`](https://github.com/NixOS/nixpkgs/commit/950b4ae8f89c5bd66d6cb275cddda373c66c8c7f) | `` dub-to-nix: fetch submodules for git dependencies ``                          |
| [`3a243607`](https://github.com/NixOS/nixpkgs/commit/3a24360784b27fe3a14e14868c5f29feb0f6afe9) | `` audiobookshelf: call {pre,post}Install in installPhase ``                     |
| [`d2cdd0b3`](https://github.com/NixOS/nixpkgs/commit/d2cdd0b3b9e182bbe1829e3b404d396a98ee8413) | `` miniupnpd: 2.3.9 -> 2.3.10 ``                                                 |
| [`3b01c114`](https://github.com/NixOS/nixpkgs/commit/3b01c1148f9282efb36b5a43bdf13983b6b83320) | `` libks: 2.0.10 -> 2.0.11 ``                                                    |
| [`c8187c17`](https://github.com/NixOS/nixpkgs/commit/c8187c1719f266c0d5074b79f7b18201efa8a0e0) | `` .github: avoid full checkout on backport ``                                   |
| [`a0c1c5b4`](https://github.com/NixOS/nixpkgs/commit/a0c1c5b495b3c010abcf6ffd9a9edabe245468f5) | `` gammu: 1.43.2 -> 1.43.3 ``                                                    |
| [`d6fb3e88`](https://github.com/NixOS/nixpkgs/commit/d6fb3e88631c45422b4c5627262241857906cc4a) | `` jirafeau: 4.4.0 -> 4.7.2 ``                                                   |
| [`4cf468ac`](https://github.com/NixOS/nixpkgs/commit/4cf468acf47540b7b9848031da17e3f613c50a35) | `` libvncserver: backport CVE-2026-32853 and CVE-2026-32854 fixes ``             |
| [`30e4f93f`](https://github.com/NixOS/nixpkgs/commit/30e4f93f3899123dd2e558fb3b7c1daa4a2fb776) | `` h2o: 2.3.0-rolling-2026-07-21 → 2.3.0-rolling-2026-07-31 ``                   |
| [`aafb117d`](https://github.com/NixOS/nixpkgs/commit/aafb117dc516e22f641e3aef27cb88c6580553ad) | `` h2o: use cmake helpers from lib ``                                            |
| [`57f9002c`](https://github.com/NixOS/nixpkgs/commit/57f9002c4d219a1ab2f2fa23e5af3b8f61401339) | `` h2o: 2.3.0-rolling-2026-06-29 → 2.3.0-rolling-2026-07-21 ``                   |
| [`e63e3c44`](https://github.com/NixOS/nixpkgs/commit/e63e3c448f10ebac24ed508e7878d5b10e4aa9f1) | `` perlPackages.DateManip: fix CVE-2026-60074 and CVE-2026-60075 ``              |
| [`16f7304c`](https://github.com/NixOS/nixpkgs/commit/16f7304c27a14c77e1505eedcb53e1e23c556040) | `` necesse-server: 1.2.0-23522718 -> 1.3.1-24494674 ``                           |
| [`ec8fa554`](https://github.com/NixOS/nixpkgs/commit/ec8fa55405f7e84ae810bf74a18bc4c880415a01) | `` panoply: 5.10.0 -> 5.10.1 ``                                                  |
| [`34a96a23`](https://github.com/NixOS/nixpkgs/commit/34a96a2384f4a55196b948c56f2520683666459c) | `` goaccess: 1.10.2 -> 1.11 ``                                                   |
| [`dbd6ccb0`](https://github.com/NixOS/nixpkgs/commit/dbd6ccb0175da77556187fadcf2d8354a4d50300) | `` tinyproxy: fix CVE-2026-54387, CVE-2026-54388 and CVE-2026-55202 ``           |
| [`61a06010`](https://github.com/NixOS/nixpkgs/commit/61a060108e0c1875b3df5b5b524a57cbfde2bba8) | `` lib60870: 2.3.6 -> 2.4.1 ``                                                   |
| [`f5741312`](https://github.com/NixOS/nixpkgs/commit/f5741312d6da8d9849f1801db3913cb5dfde098e) | `` panoply: 5.9.2 -> 5.10.0 ``                                                   |
| [`e2f80269`](https://github.com/NixOS/nixpkgs/commit/e2f8026940a0a865771f603bcbd5e782e48d4c47) | `` kanidm_1_11: init at 1.11.0 ``                                                |
| [`b187044c`](https://github.com/NixOS/nixpkgs/commit/b187044cafb9be619072b53e3671cd6850aeb96a) | `` zigbee2mqtt: 2.12.1 -> 2.13.0 ``                                              |
| [`9a35d509`](https://github.com/NixOS/nixpkgs/commit/9a35d5091dbde558f92ea9f3853f979a28b16447) | `` nixos/limine: don't read all of /nix/store during installation ``             |
| [`f59cbc3c`](https://github.com/NixOS/nixpkgs/commit/f59cbc3cba018d64cfbcd262c200ea14c074876f) | `` protoc-gen-grpc-java: 1.83.0 -> 1.83.1 ``                                     |
| [`a61a28c5`](https://github.com/NixOS/nixpkgs/commit/a61a28c52f28ff3e7d125f1ead3ef21447572bbc) | `` php84: 8.4.23 -> 8.4.24 ``                                                    |
| [`17c9d3e8`](https://github.com/NixOS/nixpkgs/commit/17c9d3e8038d5ea54ae48b83cebf9269ec748109) | `` php83: 8.3.32 -> 8.3.33 ``                                                    |
| [`8bb66529`](https://github.com/NixOS/nixpkgs/commit/8bb66529dd3f94080b16a4cab6bae988d60ebf3b) | `` php82: 8.2.32 -> 8.2.33 ``                                                    |
| [`ec862f18`](https://github.com/NixOS/nixpkgs/commit/ec862f18a0295f72fc0a111635c9aa08163ccb58) | `` bird3: 3.3.1 -> 3.3.2 ``                                                      |
| [`b20a059b`](https://github.com/NixOS/nixpkgs/commit/b20a059b80657429b9cad8d0d5bb06b6f1a0c491) | `` bird2: 2.19.1 -> 2.19.2 ``                                                    |
| [`644a3c1a`](https://github.com/NixOS/nixpkgs/commit/644a3c1adada32b9eb57a999d7251a9733bcc99c) | `` nodejs: fix cross-compilation ``                                              |
| [`939d0f30`](https://github.com/NixOS/nixpkgs/commit/939d0f3039a001dd0d21e3574c38a78f93ee1032) | `` kanidm_1_10: 1.10.4 -> 1.10.5 ``                                              |
| [`ce0410fa`](https://github.com/NixOS/nixpkgs/commit/ce0410faf3df90534b3d844073217b645d7105c9) | `` ci/github-script/get-pr-commit-details: output file list for merge commits `` |
| [`d8788af2`](https://github.com/NixOS/nixpkgs/commit/d8788af256e6494567b405aa4555db9ad2badf62) | `` audiobookshelf: 2.35.1 -> 2.36.0 ``                                           |
| [`52c120ae`](https://github.com/NixOS/nixpkgs/commit/52c120aeca3277e79aa6cf76599a3715a460f002) | `` mbedtls: fix cross build ``                                                   |
| [`a440bcce`](https://github.com/NixOS/nixpkgs/commit/a440bcce6334599ff6d0a232ac35d956a88d0ffd) | `` mumble: 1.5.901 -> 1.5.915 ``                                                 |
| [`ae9e3fcd`](https://github.com/NixOS/nixpkgs/commit/ae9e3fcd91265c0bdf28c318534e0f1fab83d76f) | `` flatpak-builder: fix building with svg icons ``                               |
| [`4d144d71`](https://github.com/NixOS/nixpkgs/commit/4d144d71b42c982e6da7f8863d9affa9fa0aab0f) | `` andcli: 2.7.0 -> 2.8.0 ``                                                     |
| [`3ba922f9`](https://github.com/NixOS/nixpkgs/commit/3ba922f94a47df5003aaf1351d41426b2e029f61) | `` goupile: 3.12.5 -> 3.12.6 ``                                                  |
| [`252a16d1`](https://github.com/NixOS/nixpkgs/commit/252a16d16dc0d33675c7fce886dcdb71ae3718f9) | `` komikku: 50.10.0 -> 50.11.0 ``                                                |
| [`e158351e`](https://github.com/NixOS/nixpkgs/commit/e158351eed78d108701080d95941e7e0bef2e76a) | `` obsidian: 1.12.7 -> 1.13.4 ``                                                 |
| [`b17bb7d1`](https://github.com/NixOS/nixpkgs/commit/b17bb7d10488acdd296d3871816e759d88d54104) | `` [release-26.05] redmine: Update rails to 7.2.3.2 ``                           |
| [`27eae25e`](https://github.com/NixOS/nixpkgs/commit/27eae25e11bc1b80350acf5cd0f4fafaca0d1fe5) | `` sqlpage: 0.44.1 -> 0.45.0 ``                                                  |
| [`e4a8d5d0`](https://github.com/NixOS/nixpkgs/commit/e4a8d5d0701bfb2ab787173097673308dbbfd47e) | `` cel-go: 0.29.2 -> 0.30.0 ``                                                   |
| [`a55c9f71`](https://github.com/NixOS/nixpkgs/commit/a55c9f719cc7bf356317856b31caa9676e58c7f3) | `` garnet: 1.1.10 -> 2.1.0 ``                                                    |
| [`97e89b2d`](https://github.com/NixOS/nixpkgs/commit/97e89b2d8def7e4465dbd850a15b601d2a93361e) | `` cel-go: 0.28.1 -> 0.29.2 ``                                                   |
| [`ad1b09cc`](https://github.com/NixOS/nixpkgs/commit/ad1b09cc5037b1ddad22a01a73fbc17c6d5f9880) | `` etcd_3_5: 3.5.32 -> 3.5.33 ``                                                 |
| [`ce43934d`](https://github.com/NixOS/nixpkgs/commit/ce43934d812412d6be445b56e193a77d2d670916) | `` tinyauth: 5.1.2 -> 5.1.3 ``                                                   |
| [`a472846c`](https://github.com/NixOS/nixpkgs/commit/a472846c1f749120abdc04b5dcac5c14c6510c19) | `` maintainers: update yarn ``                                                   |
| [`67bb3457`](https://github.com/NixOS/nixpkgs/commit/67bb34578d317d7637e8533856c57c433e57c65a) | `` maintainers: add yarn ``                                                      |
| [`3d5f8ad4`](https://github.com/NixOS/nixpkgs/commit/3d5f8ad4b016654c4c16e31243bb2e3de8c8ed8e) | `` buf: 1.71.0 -> 1.72.0 ``                                                      |
| [`4ebe5a33`](https://github.com/NixOS/nixpkgs/commit/4ebe5a3375cb2fc4cec94185b79e6b330f4d48b2) | `` nixos/tests/predictable-interface-names: Fix systemd reference ``             |
| [`3c8188d7`](https://github.com/NixOS/nixpkgs/commit/3c8188d780bcd206497b1f41fc632c10eb2d2386) | `` nixos/ifstate: Fix systemd package references ``                              |
| [`0ab13a93`](https://github.com/NixOS/nixpkgs/commit/0ab13a93a361a2c038201ca56740a28271a2b8a2) | `` coin3d: unvendor expat ``                                                     |
| [`51d4efac`](https://github.com/NixOS/nixpkgs/commit/51d4efac6d05c35efccd9a1e84f70cc6f1450be8) | `` zoxide: add `nushell` completions ``                                          |
| [`4552d5c5`](https://github.com/NixOS/nixpkgs/commit/4552d5c5c80813e64210dc7e7d3b0500d3582669) | `` starship: add `nushell` completions ``                                        |
| [`3346af0f`](https://github.com/NixOS/nixpkgs/commit/3346af0fa5088b4acac6d097c2f3d07e43bd99ff) | `` jujutsu: add `nushell` completions ``                                         |
| [`743d88e7`](https://github.com/NixOS/nixpkgs/commit/743d88e7e29ca12a6d3e88601e9e31a6ca48e14d) | `` talhelper: 3.1.14 -> 3.1.15 ``                                                |
| [`fd885ec6`](https://github.com/NixOS/nixpkgs/commit/fd885ec6f3f6fcd9c598b4c6d644cb283b8dc794) | `` shogihome: 1.28.0 -> 1.28.1 ``                                                |
| [`c592a3ce`](https://github.com/NixOS/nixpkgs/commit/c592a3ce6226bc64d0fdcdb0e8526428f931cbbb) | `` signal-desktop: 8.18.0 -> 8.21.0 ``                                           |
| [`fa48379b`](https://github.com/NixOS/nixpkgs/commit/fa48379b2d9655495e3951950cc6819e2b9904ff) | `` gn_0-unstable-2026-05-27: init at 0-unstable-2026-05-27 ``                    |
| [`2b739deb`](https://github.com/NixOS/nixpkgs/commit/2b739debfe4694326fbe790e55ae071530f8243c) | `` python3Packages.jupyterlab-git: fix CVE-2026-54527 and CVE-2026-54528 ``      |
| [`71549fb3`](https://github.com/NixOS/nixpkgs/commit/71549fb3008905bf00132e3c92809e2863b54839) | `` python3Package.paho-mqtt: backport fix for flaky tests ``                     |
| [`296ae855`](https://github.com/NixOS/nixpkgs/commit/296ae855c99a30095486f423a48fc83d2108e04d) | `` php85: 8.5.8 -> 8.5.9 ``                                                      |
| [`ef856988`](https://github.com/NixOS/nixpkgs/commit/ef85698897523d3e30085b8e6f74843bcb924c15) | `` warpgate: cleanup ``                                                          |
| [`2379374b`](https://github.com/NixOS/nixpkgs/commit/2379374bb1452c9f316ecbd17aa0cfd2ec961b62) | `` warpgate: add changelog ``                                                    |
| [`cb6cf43f`](https://github.com/NixOS/nixpkgs/commit/cb6cf43fc7841c9962239eb2e3a5462e84f93ba3) | `` warpgate: 0.23.4 -> 0.26.1 ``                                                 |
| [`5db6978e`](https://github.com/NixOS/nixpkgs/commit/5db6978ee28c1c5696fef0a1a3f45ec2b8a28a6b) | `` warpgate: add updateScript ``                                                 |
| [`1c2871c6`](https://github.com/NixOS/nixpkgs/commit/1c2871c6322302093449911b5c60b80677ef16f1) | `` rapidraw: fix CVE-2026-64816 ``                                               |
| [`b20aed42`](https://github.com/NixOS/nixpkgs/commit/b20aed4279d8f2b9cd7e5b1e54eefa0ea68c9cc4) | `` stirling-pdf: 2.10.1 -> 2.14.2 ``                                             |
| [`2c2e0208`](https://github.com/NixOS/nixpkgs/commit/2c2e0208449f5355b0087c1821934b416d7976c7) | `` gleam: 1.17.0 -> 1.18.0 ``                                                    |
| [`b0bca2ec`](https://github.com/NixOS/nixpkgs/commit/b0bca2ecfaef460697653f844f42828ce5ed2fe9) | `` radicle-httpd: 0.26.0 -> 0.27.0 ``                                            |
| [`e3c3cfd5`](https://github.com/NixOS/nixpkgs/commit/e3c3cfd5d7e9ddaa4435d092075ca814a2fc5b84) | `` radicle-explorer: 0-unstable-2026-07-21 -> 0-unstable-2026-07-29 ``           |
| [`0dbdcd74`](https://github.com/NixOS/nixpkgs/commit/0dbdcd744340510c6983d8481645f8d782c0289f) | `` radicle-explorer: 0-unstable-2026-07-16 -> 0-unstable-2026-07-21 ``           |
| [`0dc62fd9`](https://github.com/NixOS/nixpkgs/commit/0dc62fd923ae6f860c700156dc60dc7b109d7b67) | `` olivetin-3k: 3000.17.3 -> 3000.18.1 ``                                        |
| [`c7fcc9ac`](https://github.com/NixOS/nixpkgs/commit/c7fcc9ac0ba771673d3dd3a21e94d96316a28c50) | `` thunderbird-esr-bin-unwrapped: 140.12.1esr -> 153.0.1esr ``                   |
| [`8c056a91`](https://github.com/NixOS/nixpkgs/commit/8c056a9193119cfa24dfd511522823b705eba303) | `` servo: 0.3.0 -> 0.4.0 ``                                                      |
| [`3aff43f2`](https://github.com/NixOS/nixpkgs/commit/3aff43f23ca3b47130c6b6dc4139ae1f028c7d7f) | `` firefox-devedition-unwrapped: 153.0b13 -> 154.0b4 ``                          |
| [`c5fa04bc`](https://github.com/NixOS/nixpkgs/commit/c5fa04bc0e6bb37c7a57863105a6086aa1e3664f) | `` node-red: add adamcstephens as maintainer ``                                  |
| [`765c0624`](https://github.com/NixOS/nixpkgs/commit/765c0624b7116ec3f8983e8d93c4b441c12f18e2) | `` node-red: 4.1.8 -> 4.1.13 ``                                                  |
| [`7da441a7`](https://github.com/NixOS/nixpkgs/commit/7da441a7cd409e34a53fa3cbd26f44f3a28a2997) | `` n8n: 2.31.4 -> 2.32.6 ``                                                      |
| [`27b80e4c`](https://github.com/NixOS/nixpkgs/commit/27b80e4c00ed4454ac12929421ca600f2a3efc67) | `` ungoogled-chromium: 150.0.7871.186-1 -> 151.0.7922.71-1 ``                    |
| [`f3aae3bd`](https://github.com/NixOS/nixpkgs/commit/f3aae3bddd92495d777aea9914bc44e2533b4146) | `` hmcl: 3.16.2 -> 3.16.3 ``                                                     |
| [`ee155a96`](https://github.com/NixOS/nixpkgs/commit/ee155a962ed5a3cea8073b235221e0d8cab9b85e) | `` vivaldi: 8.1.4087.55 -> 8.1.4087.58 ``                                        |
| [`5b327f76`](https://github.com/NixOS/nixpkgs/commit/5b327f76aa593eac23a151746870fca58bbf8e15) | `` vivaldi: 8.1.4087.48 -> 8.1.4087.55 ``                                        |
| [`c5098ddc`](https://github.com/NixOS/nixpkgs/commit/c5098ddc77fd72b564a8c4b801402ec012d25073) | `` linux_5_10: 5.10.261 -> 5.10.262 ``                                           |
| [`1240c092`](https://github.com/NixOS/nixpkgs/commit/1240c09249f3dca5a65283de3b9ddb0e7567e1a7) | `` linux_5_15: 5.15.212 -> 5.15.213 ``                                           |
| [`718d3dfc`](https://github.com/NixOS/nixpkgs/commit/718d3dfcee5a6dbc3f6ef3b8575ebfb0fdf7d82f) | `` linux_6_1: 6.1.178 -> 6.1.180 ``                                              |
| [`c672634e`](https://github.com/NixOS/nixpkgs/commit/c672634e384a7b7e6199d3dc52a0330667209da1) | `` linux_6_6: 6.6.145 -> 6.6.147 ``                                              |
| [`d59a7523`](https://github.com/NixOS/nixpkgs/commit/d59a7523bb44c32e60d35e4b4de262cc6d01f510) | `` linux_6_12: 6.12.97 -> 6.12.100 ``                                            |
| [`f6115a57`](https://github.com/NixOS/nixpkgs/commit/f6115a574e1d554ee9e822c816c8267db18462fb) | `` linux_6_18: 6.18.40 -> 6.18.41 ``                                             |
| [`38f9ff9a`](https://github.com/NixOS/nixpkgs/commit/38f9ff9abeb32d8530cc2e565968ba61f89a435f) | `` repath-studio: add python to runtime closure ``                               |
| [`933d0d21`](https://github.com/NixOS/nixpkgs/commit/933d0d216bd624af9c086eab2daa8e69bab10994) | `` repath-studio: fix update script ``                                           |
| [`5d3680c3`](https://github.com/NixOS/nixpkgs/commit/5d3680c3eda62607252c92db4562eb0a7d97a751) | `` repath-studio: fix darwin build ``                                            |
| [`1a3bc289`](https://github.com/NixOS/nixpkgs/commit/1a3bc2897c8dae4d4e81914642d0e3d5050aad8a) | `` repath-studio: 0.4.16 -> 0.4.18 ``                                            |
| [`dc47d588`](https://github.com/NixOS/nixpkgs/commit/dc47d588aa49c2a4fda918f3969133799c8319c1) | `` fuse-overlayfs: 1.16 -> 1.17 ``                                               |
| [`2d72f6ac`](https://github.com/NixOS/nixpkgs/commit/2d72f6ac1d87a57fbbfc712b833428b88f0b14f5) | `` fcitx5-with-addons: avoid empty path segment in `LD_LIBRARY_PATH` ``          |
| [`48a49e25`](https://github.com/NixOS/nixpkgs/commit/48a49e25e0bed7560987827a254072d0e7ac210a) | `` microsoft-edge: 150.0.4078.83 -> 150.0.4078.105 ``                            |
| [`db0cbeeb`](https://github.com/NixOS/nixpkgs/commit/db0cbeeb0904610c214a109cd1acc1e3a6219c84) | `` pnpm: 11.17.0 -> 11.18.0 ``                                                   |
| [`a0fe6684`](https://github.com/NixOS/nixpkgs/commit/a0fe6684f1817ab559beec2d1daffa0905501f64) | `` vivaldi: use bundled libffmpeg.so instead of nixpkgs ffmpeg ``                |
| [`593c3ee8`](https://github.com/NixOS/nixpkgs/commit/593c3ee8ccdb0ec738cd718cde5f18f9e6c5be65) | `` elasticsearch: tag with knownVulnerabililities ``                             |
| [`375ef6d4`](https://github.com/NixOS/nixpkgs/commit/375ef6d41aed7d3b6f6d969a2cd34a4e426d2b15) | `` syncthing-relay: 2.1.1 -> 2.1.2 ``                                            |
| [`2d0e1589`](https://github.com/NixOS/nixpkgs/commit/2d0e1589d6689cde0397eb0e9528f30d6093aeb2) | `` rustdesk-server: 1.1.14 -> 1.1.16 ``                                          |
| [`546330e2`](https://github.com/NixOS/nixpkgs/commit/546330e2834c028a94664e97087c6860d86ef3e6) | `` megasync: add tallesCoelho as maintainer ``                                   |
| [`c7a19fc6`](https://github.com/NixOS/nixpkgs/commit/c7a19fc67cbbe608239f5dfbad56d23aae0c3732) | `` maintainers: add tallesCoelho ``                                              |
| [`b2159053`](https://github.com/NixOS/nixpkgs/commit/b215905338dfa4ddad7bdf793544a6ef6738752d) | `` copyparty: 1.20.18 -> 1.20.19 ``                                              |
| [`20226465`](https://github.com/NixOS/nixpkgs/commit/20226465fcb75ff1f06162457f456efc9ddd1a8b) | `` copyparty: 1.20.17 -> 1.20.18 ``                                              |
| [`3af7d915`](https://github.com/NixOS/nixpkgs/commit/3af7d9151d46ed6efa3dad69ce8cc0acead855b1) | `` percona-server: 8.4.8-8 -> 8.4.10-10 ``                                       |
| [`c6a44aa1`](https://github.com/NixOS/nixpkgs/commit/c6a44aa1f413659c5bb37789bb237eb7710bf9af) | `` containerd: 2.3.1 -> 2.3.3 ``                                                 |
| [`c42c1ee1`](https://github.com/NixOS/nixpkgs/commit/c42c1ee1e7068b15d924d755df7af4065becfce3) | `` nixos/test-driver: fix corrupt hosts files ``                                 |
| [`35506e74`](https://github.com/NixOS/nixpkgs/commit/35506e74a1e13eefeec21e80649e2ebb40e86194) | `` omxplayer: drop ``                                                            |
| [`26742f6d`](https://github.com/NixOS/nixpkgs/commit/26742f6d5f63d20b31ea85cf732f29481a156328) | `` modrinth-app-unwrapped: 0.15.7 -> 0.15.11 ``                                  |
| [`9cd3c35b`](https://github.com/NixOS/nixpkgs/commit/9cd3c35b248fccc323dbb4e8b03ef3fa647ee929) | `` brioche: fix eval on unsupported systems ``                                   |
| [`aa6e3ec6`](https://github.com/NixOS/nixpkgs/commit/aa6e3ec6641cb82f073c9c764b6d3e8331c763c0) | `` luau: 0.720 -> 0.725 ``                                                       |