### PR TITLE
chore(flake/nixpkgs): `148bab9c` -> `64380905`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1785571196,
-        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "lastModified": 1785692966,
+        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                    |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`ef3a9736`](https://github.com/NixOS/nixpkgs/commit/ef3a9736aa216af5ecb0c9119ee7c284bc0b568c) | `` nixos/nextcloud: add test verifying that bind-mounts and special places of /var/lib/nextcloud are OK `` |
| [`3dd00f8e`](https://github.com/NixOS/nixpkgs/commit/3dd00f8ea070ecfb124277b5a9172a46184d68aa) | `` nginxModules.video-thumbextractor: mark as broken ``                                                    |
| [`436ee95f`](https://github.com/NixOS/nixpkgs/commit/436ee95f2c7f845e917ee91daa6b0ed3d7b41593) | `` nginxModules.push-stream: mark as broken ``                                                             |
| [`25988867`](https://github.com/NixOS/nixpkgs/commit/25988867542449ea009e00fc51553a2090b4c732) | `` nginxModules.aws-auth: mark as broken ``                                                                |
| [`bd6a0be6`](https://github.com/NixOS/nixpkgs/commit/bd6a0be6fdad4b32682126bfbc5192e42de3fd5b) | `` nginxModules.lua-upstream: mark as broken ``                                                            |
| [`aa39d2aa`](https://github.com/NixOS/nixpkgs/commit/aa39d2aaa79eafddbd5b68429c44917c9ff29f32) | `` pike: restrict to x86_64-linux ``                                                                       |
| [`e5a2cc86`](https://github.com/NixOS/nixpkgs/commit/e5a2cc86eb4ec3faa564f7e208bc0faaab20ec8e) | `` kazumi: 2.2.3 -> 2.2.6 ``                                                                               |
| [`f06bc88e`](https://github.com/NixOS/nixpkgs/commit/f06bc88ebb8ed29aee58f0d45987e88adb61734c) | `` secp256k1-jdk: add nix-update-script ``                                                                 |
| [`c504cb46`](https://github.com/NixOS/nixpkgs/commit/c504cb466e947f8549dc4c861b54b4aabaddbf94) | `` evcc: 0.313.0 -> 0.313.1 ``                                                                             |
| [`6ed597fc`](https://github.com/NixOS/nixpkgs/commit/6ed597fc7979c8cb6c7ae07c640afd885d2cfa7f) | `` all-the-package-names: 2.0.2511 -> 2.0.2520 ``                                                          |
| [`b5a373cb`](https://github.com/NixOS/nixpkgs/commit/b5a373cb2f831dd88f29e63359245da097082fac) | `` nginxModules.fancyindex: 0.5.2 -> 0.6.0 ``                                                              |
| [`9c511e82`](https://github.com/NixOS/nixpkgs/commit/9c511e822ddcaf01f0a634b86d7f2fab52f80b60) | `` nginxModules.cache-purge: 2.5.1 -> 3.0.2 ``                                                             |
| [`74cc0a6c`](https://github.com/NixOS/nixpkgs/commit/74cc0a6c9d734b6bbe47c45d92713bd417296772) | `` nginxModules.vts: 0.2.2 -> 0.2.6 ``                                                                     |
| [`e5628830`](https://github.com/NixOS/nixpkgs/commit/e56288309931f810588d0f63768fd004675d3373) | `` bootmac: init at 0.7.1 ``                                                                               |
| [`04a3452b`](https://github.com/NixOS/nixpkgs/commit/04a3452b944657d5e4ffe1fe3001b27924d580aa) | `` msm-modem: init at 13 ``                                                                                |
| [`b0067f4d`](https://github.com/NixOS/nixpkgs/commit/b0067f4d586d08ac7f8b07eb2f8354dd113b502c) | `` nginxModules.develkit: 0.3.3 -> 0.3.4 ``                                                                |
| [`f3dced00`](https://github.com/NixOS/nixpkgs/commit/f3dced00971eef97a88b53ea0a55bd69aacc07bc) | `` nginxModules.njs: 0.9.4 -> 1.0.0 ``                                                                     |
| [`bdb1f1c1`](https://github.com/NixOS/nixpkgs/commit/bdb1f1c194eaa65129ecd7b1fd5cfde7c9a4a832) | `` zigbee2mqtt: 2.12.1 -> 2.13.0 ``                                                                        |
| [`205fb105`](https://github.com/NixOS/nixpkgs/commit/205fb105e846a6182084052e3b42a3af7eb9a246) | `` panoply: 5.10.0 -> 5.10.1 ``                                                                            |
| [`7e09d372`](https://github.com/NixOS/nixpkgs/commit/7e09d3726c5850ddb11930780212eb14776e704e) | `` perlPackages.DateManip: fix CVE-2026-60074 and CVE-2026-60075 ``                                        |
| [`9b7ecae5`](https://github.com/NixOS/nixpkgs/commit/9b7ecae5a1700c3465584f53c93421de6b008d3f) | `` mark: 16.6.0 -> 16.8.9 ``                                                                               |
| [`d1b0abba`](https://github.com/NixOS/nixpkgs/commit/d1b0abbadf97279b258a35becfc8166408906aff) | `` _1password-gui-beta: 8.12.26-31.BETA -> 8.12.32-26.BETA ``                                              |
| [`764a4ebd`](https://github.com/NixOS/nixpkgs/commit/764a4ebdf25b051f3e937840e1c60526c9f0a0ea) | `` nixos/limine: don't read all of /nix/store during installation ``                                       |
| [`6cd3e717`](https://github.com/NixOS/nixpkgs/commit/6cd3e717ef7308ab7759a6b0d042e45387cedc97) | `` catgirldownloader: init at 0.5 ``                                                                       |
| [`c2d890f4`](https://github.com/NixOS/nixpkgs/commit/c2d890f46320fd8ce5f6c84bb2b426c719a7ecb8) | `` kanidm_1_11: init at 1.11.0 ``                                                                          |
| [`553fb879`](https://github.com/NixOS/nixpkgs/commit/553fb879c3f8d84396b45e1b322924086356173e) | `` fetchNpmDeps: assert fetcherVersion is not higher than latest version ``                                |
| [`84261cd0`](https://github.com/NixOS/nixpkgs/commit/84261cd0c2ff34daaecdb3b497118e4b16bc23a9) | `` nginxModules.naxsi: remove ``                                                                           |
| [`9525c348`](https://github.com/NixOS/nixpkgs/commit/9525c348d4c1ec01784ac3ed0b16f53400877121) | `` nginxModules.fluentd: remove ``                                                                         |
| [`0b7688d3`](https://github.com/NixOS/nixpkgs/commit/0b7688d3e00c60914ff06062133e25d0f332702e) | `` nginxModules.pagespeed: remove ``                                                                       |
| [`c67586f7`](https://github.com/NixOS/nixpkgs/commit/c67586f7d32c945ea0209731d118cee2ebbcf029) | `` unity-test: fix unstable patch hashes ``                                                                |
| [`34c6c83c`](https://github.com/NixOS/nixpkgs/commit/34c6c83c75deed2f309a56ada0a0520260f673d6) | `` crush: 0.86.0 -> 0.88.0 ``                                                                              |
| [`8df090e0`](https://github.com/NixOS/nixpkgs/commit/8df090e0c0478ffaa7fe72eeade10b3e222d8c99) | `` srsran: pin standard version to c++17 ``                                                                |
| [`cb097223`](https://github.com/NixOS/nixpkgs/commit/cb097223d57eadb1893c000642aa61e1926327b3) | `` srsran: use lib.cmakeBool for WERROR ``                                                                 |
| [`c57ca822`](https://github.com/NixOS/nixpkgs/commit/c57ca822a5438b4aca969399d0ede5f7423235f1) | `` rs-lxmf: 1.0.1 -> 1.1.0 ``                                                                              |
| [`457c6bff`](https://github.com/NixOS/nixpkgs/commit/457c6bff3c6ff96ea6f222e36f66870e85677fe0) | `` cedar: 4.11.2 -> 4.12.0 ``                                                                              |
| [`4f4a3725`](https://github.com/NixOS/nixpkgs/commit/4f4a3725384e0343d0446c75db5873d680d4439f) | `` python3Packages.daft: use fetchCargoVendor ``                                                           |
| [`c321a2d6`](https://github.com/NixOS/nixpkgs/commit/c321a2d68d2856cc46e98275d12b90052ac6c762) | `` lib60870: 2.3.6 -> 2.4.1 ``                                                                             |
| [`e4f54e30`](https://github.com/NixOS/nixpkgs/commit/e4f54e30793a5bb16638840c1601ec4331f6cc31) | `` qogir-theme: Revert removal and remove GTK2 ``                                                          |
| [`5e0e35c6`](https://github.com/NixOS/nixpkgs/commit/5e0e35c6dd85f29474c565d9feb1f62506d06ed9) | `` home-assistant-custom-components.powercalc: 1.23.0 -> 1.23.2 ``                                         |
| [`b83827cc`](https://github.com/NixOS/nixpkgs/commit/b83827cc3785311a74550adc5b050c97009a350a) | `` kloak: 0.8.6-1 -> 0.8.9-1 ``                                                                            |
| [`b208bae1`](https://github.com/NixOS/nixpkgs/commit/b208bae1f7b9961abddb56bf74b1af177272c242) | `` sdl_gamecontrollerdb: 0-unstable-2026-07-23 -> 0-unstable-2026-07-31 ``                                 |
| [`877fad91`](https://github.com/NixOS/nixpkgs/commit/877fad91b00647d3ea75fde72a138fb22c9d7439) | `` python3Packages.environs: 15.0.1 -> 15.1.0 ``                                                           |
| [`6f2ec629`](https://github.com/NixOS/nixpkgs/commit/6f2ec629d6934aa8c3e452a8bcfc6701d8522b64) | `` home-assistant-custom-components.elegoo_printer: 2.11.0 -> 2.12.0 ``                                    |
| [`6a562ec3`](https://github.com/NixOS/nixpkgs/commit/6a562ec3208185e0ca8952baec54838b3c6ec59a) | `` copilot-language-server: 1.526.0 -> 1.527.1 ``                                                          |
| [`939e08d6`](https://github.com/NixOS/nixpkgs/commit/939e08d6b09bdd5227df161c6540444ab900c20f) | `` mate-themes: Revert removal and remove GTK2 ``                                                          |
| [`feada5b8`](https://github.com/NixOS/nixpkgs/commit/feada5b8ffb64704f719021d81dc727786575f3d) | `` protoc-gen-grpc-java: 1.83.0 -> 1.83.1 ``                                                               |
| [`db58556d`](https://github.com/NixOS/nixpkgs/commit/db58556d0c4516f8670d529958c53ce017c1405d) | `` vimPlugins.d2-vim: move repository to d2lang ``                                                         |
| [`7302ffa7`](https://github.com/NixOS/nixpkgs/commit/7302ffa7a0f494bf842669dcbec5cf737ef030a7) | `` d2: move repository to d2lang ``                                                                        |
| [`3f70ca37`](https://github.com/NixOS/nixpkgs/commit/3f70ca3778027f3715fd3514d4836c90cb14bc92) | `` python3Packages.wassima: 2.1.2 -> 2.1.3 ``                                                              |
| [`1bb58b27`](https://github.com/NixOS/nixpkgs/commit/1bb58b274f3d0067bb462b1fb42e8c844f0b4712) | `` kanidm_1_10: 1.10.4 -> 1.10.5 ``                                                                        |
| [`c3d60be7`](https://github.com/NixOS/nixpkgs/commit/c3d60be7739fd7e6c71002cbcb3486b4c523c8d0) | `` dcp: 0.25.9 -> 0.25.10 ``                                                                               |
| [`e3be7da9`](https://github.com/NixOS/nixpkgs/commit/e3be7da9c5be6098e537c29a4c70acd40eecdf0a) | `` openobserve: 0.91.3 -> 0.91.5 ``                                                                        |
| [`32db8d6e`](https://github.com/NixOS/nixpkgs/commit/32db8d6e993b9021d60c51f8166f3268a63f6891) | `` nixos/doc/rl-2611: add sing-box naive outbound ``                                                       |
| [`5ebe7da9`](https://github.com/NixOS/nixpkgs/commit/5ebe7da9ffb840c6e2f9981cc5212dca5b5434dc) | `` doc/rl-2611: add sing-box naive outbound ``                                                             |
| [`e99be1b2`](https://github.com/NixOS/nixpkgs/commit/e99be1b21f7e78caf6d3853f94f650f52752e1bd) | `` sing-box: support naive outbound ``                                                                     |
| [`726b971e`](https://github.com/NixOS/nixpkgs/commit/726b971e891919d3c8788ec84fd9abeb94c79477) | `` cronet-go: init at 148.0.7778.96-1-unstable-2026-07-12 ``                                               |
| [`ea321667`](https://github.com/NixOS/nixpkgs/commit/ea32166774a540633378b877fe65c4befb9220a2) | `` kdePackages.ktextaddons: 2.1.1 -> 2.1.2 ``                                                              |
| [`b306f58e`](https://github.com/NixOS/nixpkgs/commit/b306f58e91aa81116d5b1e8ba677b28b878db5e4) | `` sgdboop: 1.3.2 -> 1.4.2 ``                                                                              |
| [`e7804286`](https://github.com/NixOS/nixpkgs/commit/e7804286db15fd0b296b58e64ed3f181a03f4b44) | `` ci/github-script/get-pr-commit-details: output file list for merge commits ``                           |
| [`539e8169`](https://github.com/NixOS/nixpkgs/commit/539e81699027a2e5d0133a50a353dbb60c734dc0) | `` normcap: relax zxing-cpp dependency constraint ``                                                       |
| [`5e900f31`](https://github.com/NixOS/nixpkgs/commit/5e900f31fe3c5f96d9dd17de0c81a2a1d7a7e8a4) | `` python3Packages.gradio-client: 2.5.0 -> 2.6.0 ``                                                        |
| [`4b614e61`](https://github.com/NixOS/nixpkgs/commit/4b614e611898fda3f93e41015507c9067ef3ec28) | `` fzf-zsh-plugin: 1.0.0-unstable-2026-07-09 -> 1.0.0-unstable-2026-08-01 ``                               |
| [`f9e63804`](https://github.com/NixOS/nixpkgs/commit/f9e63804f2a59d84e3a1c3cf7dc7781ed95b2aa7) | `` containeryard: init at 0.3.12 ``                                                                        |
| [`7db2041c`](https://github.com/NixOS/nixpkgs/commit/7db2041cfc436069b9c99702de1c8ab568ff682c) | `` maintainers: add mcmah309 ``                                                                            |
| [`f1d75022`](https://github.com/NixOS/nixpkgs/commit/f1d7502238aa168bbe9ed4400271c35570a38f7f) | `` cudaPackages.cutlass: 4.5.2 -> 4.6.1 ``                                                                 |
| [`1309adc7`](https://github.com/NixOS/nixpkgs/commit/1309adc7f34a903769edfe175ae7d95544b13073) | `` modular-services: only emit `ExecReload` when there is a reload command ``                              |
| [`6a07f687`](https://github.com/NixOS/nixpkgs/commit/6a07f687f7fbd26fb5b95de6cb64486ff3404642) | `` treewide: follow some GitHub redirects for fetchFromGitHub ``                                           |
| [`d31247c4`](https://github.com/NixOS/nixpkgs/commit/d31247c4481e75052134a4d80b4c328560907382) | `` exo: enable __structuredAttrs, fix build ``                                                             |
| [`350b7cf0`](https://github.com/NixOS/nixpkgs/commit/350b7cf07b06ec666d1ef2d889ee8f17aba14e45) | `` goaccess: 1.10.2 -> 1.11 ``                                                                             |
| [`cb08bcb4`](https://github.com/NixOS/nixpkgs/commit/cb08bcb4018e13379407cd13a546d9b94192244d) | `` python3Packages.types-aiobotocore-*: disable obsolete modules ``                                        |
| [`51c4bb92`](https://github.com/NixOS/nixpkgs/commit/51c4bb92a331d902e9023a3c30be8c99c0028b85) | `` python3Packages.types-aiobotocore-*: 3.7.0 -> 3.8.0 ``                                                  |
| [`da86323a`](https://github.com/NixOS/nixpkgs/commit/da86323a0594762ec496572c41151f904a0ce444) | `` slack-term: use tag instead of rev ``                                                                   |
| [`c034289d`](https://github.com/NixOS/nixpkgs/commit/c034289df5d979e75073a5cb3f3f33389f7163c0) | `` synergy: fix tag ``                                                                                     |
| [`91fe351a`](https://github.com/NixOS/nixpkgs/commit/91fe351a20401bc46c049724f017371510bd9b65) | `` ci/OWNERS: add whole qt-kde team as owner ``                                                            |
| [`443a4343`](https://github.com/NixOS/nixpkgs/commit/443a4343930787c9a100f4c959e566944dce4de6) | `` python3Packages.yalexs-ble: 3.4.2 -> 4.0.0 ``                                                           |
| [`f1a92323`](https://github.com/NixOS/nixpkgs/commit/f1a92323bb55427efd8950e0f005f2cef4ca4348) | `` dovi-tool: 2.3.2 → 2.3.3 ``                                                                             |
| [`202d59a5`](https://github.com/NixOS/nixpkgs/commit/202d59a50e585a591922bf7d5c0c7508c6e6477f) | `` dovi-tool: fix `updateScript` ``                                                                        |
| [`e9a44549`](https://github.com/NixOS/nixpkgs/commit/e9a44549b911e121d47ecf0971ee482e007b5c0a) | `` treewide: follow some GitHub redirects for fetchFromGitHub ``                                           |
| [`1037fd44`](https://github.com/NixOS/nixpkgs/commit/1037fd44944776b979fb51d91af55734af185071) | `` cryptop: fetch from GitHub upstream ``                                                                  |
| [`1d387153`](https://github.com/NixOS/nixpkgs/commit/1d387153a7899fc828d7524a80963dcd8c551d73) | `` modular-services: fix description on mainExecReload ``                                                  |
| [`db3bf894`](https://github.com/NixOS/nixpkgs/commit/db3bf894acb6b72c755fa4a49d8efba309c462f3) | `` tpnote: 1.26.7 -> 1.27.0 ``                                                                             |
| [`a8367698`](https://github.com/NixOS/nixpkgs/commit/a83676982d18cd8ec810a0a5dfbc3f3e89f5bd02) | `` cryptop: set __structuredAttrs ``                                                                       |
| [`3d403677`](https://github.com/NixOS/nixpkgs/commit/3d4036773fb20369229ebc79129564db44020a9c) | `` crossplane: set __structuredAttrs ``                                                                    |
| [`25b6ff7e`](https://github.com/NixOS/nixpkgs/commit/25b6ff7efe7e2fe5f2678db2072a73faeb2bd4e8) | `` python3Packages.boto3-stubs: 1.43.59 -> 1.43.62 ``                                                      |
| [`0202ffc9`](https://github.com/NixOS/nixpkgs/commit/0202ffc91dc599b5f2c220e9eb016a378b065cf1) | `` python3Packages.mypy-boto3-sagemaker: 1.43.57 -> 1.43.60 ``                                             |
| [`b42f595f`](https://github.com/NixOS/nixpkgs/commit/b42f595f950915c989e5d58c0f197b31733cc6a4) | `` python3Packages.mypy-boto3-rds: 1.43.51 -> 1.43.62 ``                                                   |
| [`6982a71d`](https://github.com/NixOS/nixpkgs/commit/6982a71dd95b38bf3c4ef3689c12c486bc3df263) | `` python3Packages.mypy-boto3-quicksight: 1.43.57 -> 1.43.62 ``                                            |
| [`e9e2429d`](https://github.com/NixOS/nixpkgs/commit/e9e2429dca81956f71f9a75c0c3dd32c9a7d2097) | `` python3Packages.mypy-boto3-outposts: 1.43.40 -> 1.43.62 ``                                              |
| [`c8b25a3a`](https://github.com/NixOS/nixpkgs/commit/c8b25a3a85a09c8b01ec573569bebf546adb6bfd) | `` python3Packages.mypy-boto3-network-firewall: 1.43.38 -> 1.43.62 ``                                      |
| [`cfb101c2`](https://github.com/NixOS/nixpkgs/commit/cfb101c2e5fa5de959d96bfeb5f696a99026ff7a) | `` python3Packages.mypy-boto3-marketplace-catalog: 1.43.42 -> 1.43.62 ``                                   |
| [`b59546d5`](https://github.com/NixOS/nixpkgs/commit/b59546d5a5a674a8b697580c68dfa7f2756209b2) | `` python3Packages.mypy-boto3-logs: 1.43.41 -> 1.43.62 ``                                                  |
| [`80be7580`](https://github.com/NixOS/nixpkgs/commit/80be7580140127ca52a0bacbe13a73431de769cc) | `` python3Packages.mypy-boto3-lambda: 1.43.48 -> 1.43.60 ``                                                |
| [`938badaf`](https://github.com/NixOS/nixpkgs/commit/938badaf074f95ae4694657277aed1ab8eb7b69c) | `` python3Packages.mypy-boto3-kafka: 1.43.36 -> 1.43.60 ``                                                 |
| [`70de290b`](https://github.com/NixOS/nixpkgs/commit/70de290b29e61a9d823945f7495908e03893f37b) | `` python3Packages.mypy-boto3-iam: 1.43.29 -> 1.43.60 ``                                                   |
| [`3c7e0a59`](https://github.com/NixOS/nixpkgs/commit/3c7e0a59feba6303c3e199436f80c2e8c324e76f) | `` python3Packages.mypy-boto3-cloudformation: 1.43.38 -> 1.43.62 ``                                        |
| [`082815ca`](https://github.com/NixOS/nixpkgs/commit/082815cacad35ad0855811af0a345bc88e01c8c8) | `` python3Packages.mypy-boto3-amp: 1.43.54 -> 1.43.62 ``                                                   |
| [`e0e2c9b5`](https://github.com/NixOS/nixpkgs/commit/e0e2c9b5048d9062e92f2f4c099f0557e2850394) | `` android-studio: 2026.1.2.11 -> 2026.1.3.7 ``                                                            |
| [`ac8a2ab1`](https://github.com/NixOS/nixpkgs/commit/ac8a2ab1a8fd71babdee1368a82fae59bfc3aacc) | `` vaultwarden: use npmDepsFetcherVersion 2 ``                                                             |
| [`9e6b8222`](https://github.com/NixOS/nixpkgs/commit/9e6b82223843022cb9575f66a1a3d0c198db0d2b) | `` snyk: use npmDepsFetcherVersion 2 ``                                                                    |
| [`780b418f`](https://github.com/NixOS/nixpkgs/commit/780b418f01fa0664f380fbde52bbcdf9a5f9a792) | `` qwen-code: use npmDepsFetcherVersion 2 ``                                                               |
| [`d3edf45a`](https://github.com/NixOS/nixpkgs/commit/d3edf45a0723454799c6a090b1903186ddb26b69) | `` glitchtip: use npmDepsFetcherVersion 2 ``                                                               |
| [`cf8c0c8f`](https://github.com/NixOS/nixpkgs/commit/cf8c0c8fc9f579c62c38694279395b51ac4e406c) | `` ghui: use npmDepsFetcherVersion 2 ``                                                                    |
| [`a6b66388`](https://github.com/NixOS/nixpkgs/commit/a6b663885c7883299516293db5a62e752054f0cb) | `` garmin-grafana: add pyprojectVersionPatchHook ``                                                        |
| [`c97d2b54`](https://github.com/NixOS/nixpkgs/commit/c97d2b5476b90cb8217927612d97d2f66f11c15f) | `` exo: use npmDepsFetcherVersion 2 ``                                                                     |
| [`f35b695c`](https://github.com/NixOS/nixpkgs/commit/f35b695c4d7119358205739d1aebe782e6cfa8fa) | `` cdncheck: 1.2.45 -> 1.2.46 ``                                                                           |
| [`4c482de9`](https://github.com/NixOS/nixpkgs/commit/4c482de9b9f18ee7e8486624cd22ba6e3de90be7) | `` bitwarden-desktop: use npmDepsFetcherVersion 2 ``                                                       |
| [`d88f1e8d`](https://github.com/NixOS/nixpkgs/commit/d88f1e8dd05f928dffb3c502b7879687e3c6b1a2) | `` simple64-netplay-server: 2025.03.1 -> 1.0.39, renamed to gopher64-netplay-server ``                     |
| [`e91e6acd`](https://github.com/NixOS/nixpkgs/commit/e91e6acd668f3e1113fef67b673f5763e2a291a3) | `` wlc: 2.1.0 -> 2.1.1 ``                                                                                  |
| [`ce5334a3`](https://github.com/NixOS/nixpkgs/commit/ce5334a3a5311baaf93e32c84355e0ac0c6ee00d) | `` python3Packages.pyenphase: 3.0.1 -> 3.1.0 ``                                                            |
| [`786b0862`](https://github.com/NixOS/nixpkgs/commit/786b0862612ffb28d44ae8ead53e3aba4be37bd0) | `` python3Packages.plugwise: 1.14.1 -> 1.14.3 ``                                                           |
| [`c5a0c210`](https://github.com/NixOS/nixpkgs/commit/c5a0c210929df9cae2c2c9dff4f01e2be4fcbaec) | `` python3Packages.playwrightcapture: 1.40.2 -> 1.40.3 ``                                                  |
| [`e742a0d9`](https://github.com/NixOS/nixpkgs/commit/e742a0d94afdc5a8e47ffa3596d5c143b30069c5) | `` python3Packages.lookyloo-models: 0.2.9 -> 0.3.0 ``                                                      |
| [`e7b0f88c`](https://github.com/NixOS/nixpkgs/commit/e7b0f88c94ef6b89b78d4ea95dd4a659ec689f03) | `` sage: patch for doctest numeric tolerance ``                                                            |
| [`d143de61`](https://github.com/NixOS/nixpkgs/commit/d143de613b9b0a6e1a54b627e5b294a852568b3f) | `` python3Packages.json-stream-rs-tokenizer: 0.4.32 -> 0.5.1 ``                                            |
| [`6c763c8d`](https://github.com/NixOS/nixpkgs/commit/6c763c8d060c07381af513204f6e021a08a24705) | `` python3Packages.garminconnect: 0.3.6 -> 0.3.8 ``                                                        |
| [`f575a4c5`](https://github.com/NixOS/nixpkgs/commit/f575a4c55ba787decd1387d3dd29b2189f708b57) | `` python3Packages.gardena-bluetooth: 2.8.1 -> 2.9.0 ``                                                    |
| [`68896dda`](https://github.com/NixOS/nixpkgs/commit/68896ddafe1ed7d351830c24137cac2bb720f716) | `` lxmf-rs: 0.9.6 -> 0.9.7 ``                                                                              |
| [`75c5ccab`](https://github.com/NixOS/nixpkgs/commit/75c5ccabd20c0194e167e4f75a0edb0ecf6709f4) | `` cyclonedx-python: 7.3.0 -> 7.3.1 ``                                                                     |
| [`2cf5e629`](https://github.com/NixOS/nixpkgs/commit/2cf5e62999288257fe1f7293551db1ad81aa0f83) | `` python3Packages.velbus-aio: 2026.4.1 -> 2026.7.25 ``                                                    |
| [`09896ebc`](https://github.com/NixOS/nixpkgs/commit/09896ebc2c1fc413a7bc7b185a49808ebf4b14a9) | `` rs-reticulum: 1.0.1 -> 1.1.0 ``                                                                         |
| [`fd227d64`](https://github.com/NixOS/nixpkgs/commit/fd227d64bd0d3addfe69d2570117341e20f9ef2a) | `` python3Packages.whoisdomain: 1.20260326.1 -> 2.20260709.1 ``                                            |
| [`100ac15c`](https://github.com/NixOS/nixpkgs/commit/100ac15c493d24724ed41d2a5b0dd45912e2997a) | `` python3Packages.nixpkgs-plugin-update: fix ruff checks ``                                               |
| [`1dea0a8c`](https://github.com/NixOS/nixpkgs/commit/1dea0a8c760c7c847661d82e792fb7cf0e0fc2f3) | `` leviculum: 0.7.0 -> 0.8.0 ``                                                                            |
| [`36f3ea4f`](https://github.com/NixOS/nixpkgs/commit/36f3ea4f02b059a1897c7667aef8d83daac54440) | `` vale: 3.15.2 -> 3.17.0 ``                                                                               |
| [`2da37730`](https://github.com/NixOS/nixpkgs/commit/2da3773043ef47c6b30d85bea44478c39be7d895) | `` python3Packages.async-substrate-interface: drop ``                                                      |
| [`5a683af5`](https://github.com/NixOS/nixpkgs/commit/5a683af5fafc103489902fd5b5ccc634be6379af) | `` python3Packages.bittensor-drand: drop ``                                                                |
| [`b57ec6cc`](https://github.com/NixOS/nixpkgs/commit/b57ec6cc858ede21532f12d79623b7238fed5acc) | `` python3Packages.bittensor-wallet: drop ``                                                               |
| [`88c5858b`](https://github.com/NixOS/nixpkgs/commit/88c5858be070443df695fe12718a09bfeb140b73) | `` python3Packages.bittensor-cli: drop ``                                                                  |
| [`d31a6ef3`](https://github.com/NixOS/nixpkgs/commit/d31a6ef395e9e651570820eef76ec56f234e5df7) | `` btcli: provide from python3Packages.bittensor ``                                                        |
| [`680a7392`](https://github.com/NixOS/nixpkgs/commit/680a7392f4f366fe7e2c706727aecff2d61d6907) | `` python3Packages.bittensor: 10.5.0 -> 11.0.1 ``                                                          |
| [`241fa740`](https://github.com/NixOS/nixpkgs/commit/241fa7403c354c6a1bfe10cc4be602ca0a5062eb) | `` python3Packages.bittensor-core: init at 0.1.1 ``                                                        |
| [`906787f9`](https://github.com/NixOS/nixpkgs/commit/906787f99e507f7918371361749c7daae52a7990) | `` flexget: 3.19.30 -> 3.19.31 ``                                                                          |
| [`8401cfc7`](https://github.com/NixOS/nixpkgs/commit/8401cfc7a166bf6ff79f321bceccea2b61162f53) | `` ani-cli: 4.14 -> 5.0 ``                                                                                 |
| [`ae4f0e4e`](https://github.com/NixOS/nixpkgs/commit/ae4f0e4e31d50ce76646f7a8391df8b3f129afef) | `` projecteur: fix hash ``                                                                                 |
| [`7747e77a`](https://github.com/NixOS/nixpkgs/commit/7747e77a6f90ebc20714e5fb54bcc632f47c356b) | `` treewide: follow some GitHub redirects for fetchFromGitHub ``                                           |
| [`92af1399`](https://github.com/NixOS/nixpkgs/commit/92af1399c27b0d037f919ca3b8e8e634741380d7) | `` python3Packages.homematicip: 2.13.2 -> 2.13.4 ``                                                        |
| [`20eb3b9d`](https://github.com/NixOS/nixpkgs/commit/20eb3b9da7536ee5bd9d5f07492d14baec7dc2ad) | `` nixos/meilisearch: fix dumpless upgrade config field name ``                                            |
| [`dc65281e`](https://github.com/NixOS/nixpkgs/commit/dc65281ef2c6af51202770a1d14b78a8ac7ba321) | `` python3Packages.anova-wifi: 1.0.1 -> 1.0.2 ``                                                           |
| [`a3d32f24`](https://github.com/NixOS/nixpkgs/commit/a3d32f24b5a02750d5b4b47aefb90fc6ef965dc8) | `` chef-cli: 6.1.29 -> 6.1.34 ``                                                                           |
| [`75663eb8`](https://github.com/NixOS/nixpkgs/commit/75663eb8e451df351e20eaa803ba710cd805e04b) | `` python3Packages.meraki: 3.0.1 -> 4.3.1 ``                                                               |
| [`900d8263`](https://github.com/NixOS/nixpkgs/commit/900d82632238f27a4277d8aab42090914dddf82e) | `` serverspec: 2.42.2 -> 2.43.0 ``                                                                         |
| [`59087416`](https://github.com/NixOS/nixpkgs/commit/5908741656943ea1ab6f7ce9b1e63fe1c545a6fd) | `` inspec: 7.0.95 -> 7.1.7 ``                                                                              |
| [`5ea3a9a6`](https://github.com/NixOS/nixpkgs/commit/5ea3a9a61c6746baf49b09879302f9b36d754018) | `` python3Packages.pipx: cleanup ``                                                                        |
| [`d9607fa3`](https://github.com/NixOS/nixpkgs/commit/d9607fa32f93b246616fec50497deae9054613f8) | `` home-assistant-custom-components.systemair: 1.0.36 -> 1.0.37 ``                                         |
| [`1bf66701`](https://github.com/NixOS/nixpkgs/commit/1bf6670102b23434e5982dbaedee934fcec11806) | `` python3Packages.pywebtransport: 0.16.1 -> 0.20.1 ``                                                     |
| [`289e7b4d`](https://github.com/NixOS/nixpkgs/commit/289e7b4d373438bd2e69e6f0d9f187c8807c06f0) | `` github-backup: 0.64.2 -> 0.65.0 ``                                                                      |
| [`5807eb21`](https://github.com/NixOS/nixpkgs/commit/5807eb21eea2313092ad4a7a3bcd6146db65f348) | `` nixos/ergohaven-entropy: init module ``                                                                 |
| [`023cd6ad`](https://github.com/NixOS/nixpkgs/commit/023cd6adce56c975539a752e8808a761c2c9cff8) | `` ergohaven-entropy: init at 0.3.1 ``                                                                     |
| [`1bb00516`](https://github.com/NixOS/nixpkgs/commit/1bb0051667c744a4f91bb3a856619e56cd8969df) | `` incus-compose: init at 1.1.0 ``                                                                         |
| [`dcd3a3c1`](https://github.com/NixOS/nixpkgs/commit/dcd3a3c1e80f6d77a7c27d3fb6af1979e618da70) | `` python3Packages.deep-gemm: fix build ``                                                                 |
| [`f6627cca`](https://github.com/NixOS/nixpkgs/commit/f6627ccab6f094c2c7dd33b9bf4379e5383c6a4d) | `` python3Packages.pipx: fix tests on Darwin ``                                                            |
| [`2dfd8499`](https://github.com/NixOS/nixpkgs/commit/2dfd8499fc3541b91a8648a8f0adbf4e83a9f03c) | `` kdePackages.calligra: remove deprecated patch ``                                                        |
| [`227ef6a5`](https://github.com/NixOS/nixpkgs/commit/227ef6a5e1fb046f9fbbf6f1c325b088df405df5) | `` sage: work around gap/flint intermittent failures ``                                                    |
| [`44afdbf0`](https://github.com/NixOS/nixpkgs/commit/44afdbf0176e2e8720960007f943f80a46571930) | `` concord-tui: 2.4.5 -> 2.5.0 ``                                                                          |
| [`9d590feb`](https://github.com/NixOS/nixpkgs/commit/9d590febde3a5eae8a2fbb70a45f5391bde62214) | `` opencode: 1.18.9 -> 1.18.11 ``                                                                          |
| [`2c949267`](https://github.com/NixOS/nixpkgs/commit/2c9492676def2b08db50b1c794fa1c6745586284) | `` whale: 0.1.62 -> 0.1.63 ``                                                                              |
| [`a4d7d24e`](https://github.com/NixOS/nixpkgs/commit/a4d7d24ec56f993680524efdf8b8ece37141712e) | `` dwm: add maintainer gepbird ``                                                                          |
| [`a513c7d5`](https://github.com/NixOS/nixpkgs/commit/a513c7d5e4ff5a902fc8648f654db7b77e2ff256) | `` user-scanner: 1.4.1 -> 1.4.2 ``                                                                         |
| [`0eb399ea`](https://github.com/NixOS/nixpkgs/commit/0eb399ea4829dc6edb046ff24ac9414336595bc7) | `` zed-editor: 1.12.0 -> 1.13.1 ``                                                                         |
| [`9dc55737`](https://github.com/NixOS/nixpkgs/commit/9dc557378de735ccb72a8e1a65b25cd4b9dede25) | `` treewide: follow some GitHub redirects for fetchFromGitHub ``                                           |
| [`53f73068`](https://github.com/NixOS/nixpkgs/commit/53f730689f367a25f0793a3b3aaebd75e77cfacf) | `` vunnel: 0.63.0 -> 0.63.1 ``                                                                             |
| [`6a3f99da`](https://github.com/NixOS/nixpkgs/commit/6a3f99da74a46d8e44058c62748d5f26460cc2ee) | `` rmux: 0.9.0 -> 0.9.1 ``                                                                                 |
| [`f4c8eba5`](https://github.com/NixOS/nixpkgs/commit/f4c8eba535c94fec6366d31b3f375965222e4588) | `` netpeek: 0.3.0 -> 0.3.1 ``                                                                              |
| [`c5e63e23`](https://github.com/NixOS/nixpkgs/commit/c5e63e23845a1ffd16e0bcc425f1bd2d21305b0c) | `` goupile: 3.12.5 -> 3.12.6 ``                                                                            |
| [`b9d058a2`](https://github.com/NixOS/nixpkgs/commit/b9d058a2790e648973d6de03ba63e8a2638c50a7) | `` ollama: 0.32.4 -> 0.32.5 ``                                                                             |
| [`2341bac5`](https://github.com/NixOS/nixpkgs/commit/2341bac55174264ce72f661504ea88c3c6af5f62) | `` brave, brave-origin: 1.92.144 -> 1.93.129 ``                                                            |
| [`4d53f69e`](https://github.com/NixOS/nixpkgs/commit/4d53f69eb7681739a0811914d7f47addd6fac7ff) | `` tinyproxy: fix CVE-2026-54387, CVE-2026-54388 and CVE-2026-55202 ``                                     |
| [`73006fd4`](https://github.com/NixOS/nixpkgs/commit/73006fd49ddff7aa468188c72833e39d2cba61ce) | `` terraform-providers.ovh_ovh: 2.17.0 -> 2.18.0 ``                                                        |
| [`758669cc`](https://github.com/NixOS/nixpkgs/commit/758669cc372258ae578d3a3d2d897beccaa44673) | `` python3Packages.green: add changelog ``                                                                 |
| [`f7991117`](https://github.com/NixOS/nixpkgs/commit/f79911170920d361fd42cc1509748ab2f2d296fa) | `` ustreamer: add test for ustreamer's python package ``                                                   |
| [`f5b181e2`](https://github.com/NixOS/nixpkgs/commit/f5b181e25a205d168b2d0f88f2c21ff6d8b6e6f8) | `` secp256k1-jdk: 0.3.1 ``                                                                                 |
| [`d9188fb0`](https://github.com/NixOS/nixpkgs/commit/d9188fb0b45622823603817398eb1551de0bc198) | `` sage: add OBJC_DISABLE_INITIALIZE_FORK_SAFETY for darwin sage-env ``                                    |
| [`acfd6800`](https://github.com/NixOS/nixpkgs/commit/acfd68005db1e3a67ef758140a4d61f88e2fc7e7) | `` gh-enhance: 0.6.1 -> 0.7.0 ``                                                                           |
| [`0590585b`](https://github.com/NixOS/nixpkgs/commit/0590585b60fe6b331cf918874cc933586b445630) | `` xfce4-settings: 4.20.4 -> 4.20.5 ``                                                                     |
| [`b4d683f8`](https://github.com/NixOS/nixpkgs/commit/b4d683f842aaba9f2771b38513d53671f3716ead) | `` tumbler: 4.20.1 -> 4.20.2 ``                                                                            |
| [`00fd080b`](https://github.com/NixOS/nixpkgs/commit/00fd080b64850295d07a9cc065ac4786a6c11679) | `` xfce4-power-manager: 4.20.0 -> 4.20.1 ``                                                                |
| [`5ba82a9f`](https://github.com/NixOS/nixpkgs/commit/5ba82a9f33d90c987fedee0d11cc46c44b0d67e3) | `` xfce4-panel: 4.20.7 -> 4.20.8 ``                                                                        |
| [`8b81a43f`](https://github.com/NixOS/nixpkgs/commit/8b81a43fd9a0c8e99451bc9ed7f7c91b0ecad445) | `` greybird: Revert removal and remove GTK2 ``                                                             |
| [`abf51656`](https://github.com/NixOS/nixpkgs/commit/abf51656f8ebe2507e99ed49497c298e01696650) | `` vimPlugins.kenjutu: init at 0.2.4 ``                                                                    |
| [`df08405b`](https://github.com/NixOS/nixpkgs/commit/df08405b1a3db2729e1690afee702c54bf64ed59) | `` nixos/sillytavern: remove wrvsrx from maintainers ``                                                    |
| [`34d269f2`](https://github.com/NixOS/nixpkgs/commit/34d269f2742bef0686000457ede97586be7298c2) | `` jetbrains.rider: 2026.2 -> 2026.2.0.1 ``                                                                |
| [`beb44000`](https://github.com/NixOS/nixpkgs/commit/beb44000ca2886493a563498b0fcc345ae5ec329) | `` folo: add jsdom runtime dep ``                                                                          |
| [`907cf345`](https://github.com/NixOS/nixpkgs/commit/907cf345942efa5d237a902aff9aa24bf93e7a84) | `` zvm: 0.8.22 -> 0.8.27 ``                                                                                |
| [`d9ac8c45`](https://github.com/NixOS/nixpkgs/commit/d9ac8c451fbdbb47a4436d885148963b55aef0b8) | `` folo: 0.11.0 -> 0.12.0 ``                                                                               |
| [`20392140`](https://github.com/NixOS/nixpkgs/commit/203921403f2aecf7a25c65f6286afeb6e42ebe46) | `` maintainers: add geekiot-hub ``                                                                         |
| [`b80a6a3d`](https://github.com/NixOS/nixpkgs/commit/b80a6a3d96fc8e82a9ec9b4c5683ea78a7f4805e) | `` komikku: 50.10.0 -> 50.11.0 ``                                                                          |
| [`a93ccd86`](https://github.com/NixOS/nixpkgs/commit/a93ccd86427c1cc28d7c668ed246032903bf1f6e) | `` microscheme: 0.9.3 -> 0.9.4 ``                                                                          |
| [`d4e46396`](https://github.com/NixOS/nixpkgs/commit/d4e46396b65223371de73b4149bd4b59a4671fca) | `` emacs: move propagatedUserEnvPkgs from externalSrc to fix-rtags ``                                      |
| [`e9b2e1cf`](https://github.com/NixOS/nixpkgs/commit/e9b2e1cfb27de0b63fa16c729ded7c973c545c69) | `` emacs.pkgs.rtags: simplify its override with fix-rtags ``                                               |
| [`a4794fc4`](https://github.com/NixOS/nixpkgs/commit/a4794fc468c0aefb0caf1fa1df1a5fdae08a55c5) | `` librevna: fix missing launcher and taskbar icons ``                                                     |
| [`1d838ddc`](https://github.com/NixOS/nixpkgs/commit/1d838ddcdade2bfe022385d915dd1b83e4df082f) | `` sessiond: init at 0.1.1 ``                                                                              |
| [`e008a8fd`](https://github.com/NixOS/nixpkgs/commit/e008a8fd7bdafb069c1a0dda800c58e0c9dfc333) | `` lcalc: fix build ``                                                                                     |
| [`53b89364`](https://github.com/NixOS/nixpkgs/commit/53b893640a0ebcbf59e13ff0585e957ab8a4289a) | `` gram: 3.0.1 -> 3.2.0 ``                                                                                 |
| [`8c173b31`](https://github.com/NixOS/nixpkgs/commit/8c173b31ddd276c463bf76c490cba22d8c60022d) | `` python3Packages.checksumdir: add versionCheckHook ``                                                    |
| [`a6a23415`](https://github.com/NixOS/nixpkgs/commit/a6a23415f0078e3ba2d70148522fc04153a834dc) | `` python3Packages.checksumdir: fix build ``                                                               |
| [`972f5c17`](https://github.com/NixOS/nixpkgs/commit/972f5c17d36da7c0b82ad30d989474d2bae9275d) | `` python3Packages.checksumdir: cleanup ``                                                                 |
| [`a9da17ff`](https://github.com/NixOS/nixpkgs/commit/a9da17ff87f29658d15a5bbe6f36a308d23e1e9e) | `` mpop: 1.4.22 -> 1.4.23 ``                                                                               |
| [`e5c0b921`](https://github.com/NixOS/nixpkgs/commit/e5c0b9217a4a52e70e2b200703e60bbe2ac776a4) | `` maintainers: update yarn ``                                                                             |
| [`4de406f6`](https://github.com/NixOS/nixpkgs/commit/4de406f61f7d9efc30bcf77e5d55ea2580ff0cf5) | `` maintainers: add daneov ``                                                                              |
| [`28b78240`](https://github.com/NixOS/nixpkgs/commit/28b7824006cedcf474663c7e99cd72bbc6f5b368) | `` etcd_3_5: 3.5.32 -> 3.5.33 ``                                                                           |
| [`2219ec2a`](https://github.com/NixOS/nixpkgs/commit/2219ec2a93aaa1f0ed20e5bacfef0593425a2642) | `` kotofetch: 0.2.22 -> 0.2.23 ``                                                                          |
| [`a44c1aa1`](https://github.com/NixOS/nixpkgs/commit/a44c1aa1384e34157077b7f69edf1bc81ac4a117) | `` python3Packages.daft: remove derdennisop to maintainers ``                                              |
| [`ea456eb1`](https://github.com/NixOS/nixpkgs/commit/ea456eb18566deac03dcb5f75361015319eec7d4) | `` python3Packages.daft: add GaetanLepage to maintainers ``                                                |
| [`5e736654`](https://github.com/NixOS/nixpkgs/commit/5e73665472f670cffdec89027b844a54611a2e6a) | `` qcom-diag: init at unstable-2026-04-18 ``                                                               |
| [`f65dd0cf`](https://github.com/NixOS/nixpkgs/commit/f65dd0cf71ced41f57058b3bd132b3121babe70d) | `` python3Packages.mplhep: 0.4.1 -> 1.3.2 ``                                                               |
| [`457c11a9`](https://github.com/NixOS/nixpkgs/commit/457c11a9507eb6c21fca1bbc7197ab557727342c) | `` python3Packages.eheimdigital: 1.7.0 -> 1.7.1 ``                                                         |
| [`f0063617`](https://github.com/NixOS/nixpkgs/commit/f0063617f10be428b11e8110a1a3ddea6a89aa09) | `` rustfs: 1.0.0-beta.11 -> 1.0.0-beta.12 ``                                                               |
| [`755a02d7`](https://github.com/NixOS/nixpkgs/commit/755a02d7e95389d343015e29d8228fdeeabdf3da) | `` python3Packages.finetuning-scheduler: 2.10.0.post0 -> 2.13.0 ``                                         |
| [`83222bdc`](https://github.com/NixOS/nixpkgs/commit/83222bdc4aba539a1801e87c6a61d902441dae91) | `` grok-build: 0.2.111 -> 0.2.118 ``                                                                       |
| [`8263b4f6`](https://github.com/NixOS/nixpkgs/commit/8263b4f6891964bb91595ce3daea3c8c3057a6b8) | `` python3Packages.awkward: 2.11.0 -> 2.12.0 ``                                                            |
| [`8fb92b18`](https://github.com/NixOS/nixpkgs/commit/8fb92b180de84579016de48e9fb72809ea6b099d) | `` python3Packages.awkward-cpp: 54 -> 55 ``                                                                |
| [`8da97382`](https://github.com/NixOS/nixpkgs/commit/8da973827ef660b407ffffb229639fd02d876ee6) | `` sshamble: 0.3.9 -> 0.3.10 ``                                                                            |
| [`7fdcc23d`](https://github.com/NixOS/nixpkgs/commit/7fdcc23daa1e56df9061638a8ae78aaf48cba5f2) | `` emacs.pkgs.evil-ghostel: use same source as ghostel ``                                                  |
| [`9291b15f`](https://github.com/NixOS/nixpkgs/commit/9291b15f286675ea3f22ea88b511e07540c685a1) | `` code-cursor: 3.13.10 -> 3.14.7 ``                                                                       |
| [`168fa98f`](https://github.com/NixOS/nixpkgs/commit/168fa98f9f8e3f8e19df5a589196fa1476ef6c70) | `` python3Packages.daft: 0.7.14 -> 0.7.21 ``                                                               |
| [`6707c51b`](https://github.com/NixOS/nixpkgs/commit/6707c51bb916a843fd2572184e3dbb1c4585c3db) | `` uv: 0.12.0 -> 0.12.1 ``                                                                                 |
| [`e1060cde`](https://github.com/NixOS/nixpkgs/commit/e1060cde30ae73d0ce2f3aedcd1c2e6ace6486a6) | `` coin3d: unvendor expat ``                                                                               |
| [`3d21f579`](https://github.com/NixOS/nixpkgs/commit/3d21f57997155dc91d20de9b2b9ba75a5ee8e819) | `` qrtr: limit lib.platforms to aarch64-linux ``                                                           |
| [`05dfd7c6`](https://github.com/NixOS/nixpkgs/commit/05dfd7c6ef352ab4744d6ea24ac50b20b21caa8d) | `` python3Packages.bambi: 0.18.0 -> 0.19.0 ``                                                              |
| [`4ed1db20`](https://github.com/NixOS/nixpkgs/commit/4ed1db2025813432609d2cc94fcc640c2255b8d3) | `` python3Packages.blackjax: skip failing tests on aarch64-linux ``                                        |
| [`8dad48e0`](https://github.com/NixOS/nixpkgs/commit/8dad48e06a7df8861b7ccb6ba05fbddff4270174) | `` hexagonrpc: add tools output with sscregistrygen ``                                                     |
| [`daca5fbb`](https://github.com/NixOS/nixpkgs/commit/daca5fbb5a792ffa9fcab940f265bb88344ab8cf) | `` postgresqlPackages.pgvector: 0.8.5 -> 0.8.6 ``                                                          |
| [`a449f1ae`](https://github.com/NixOS/nixpkgs/commit/a449f1ae651ad6128c532b7a4689015c0279fdee) | `` flying-carpet: 9.0.10 -> 10.0.2 ``                                                                      |
| [`80a6477d`](https://github.com/NixOS/nixpkgs/commit/80a6477dd85030cc7664cdeb8957bc305b29543a) | `` necesse-server: 1.2.0-23522718 -> 1.3.1-24494674 ``                                                     |
| [`46469d82`](https://github.com/NixOS/nixpkgs/commit/46469d8283eca468d3b4508c4b934c9013b65a26) | `` temporal-cli: 1.8.1 -> 1.8.2 ``                                                                         |
| [`1af7e2fc`](https://github.com/NixOS/nixpkgs/commit/1af7e2fcc0973a85b6cd1649d1464e5f459bde7f) | `` nerva: 1.53.1 -> 1.57.0 ``                                                                              |
| [`3b612b36`](https://github.com/NixOS/nixpkgs/commit/3b612b360681efbac7794e6b9a9bfbc5e5a4199a) | `` vscode-extensions.tombi-toml.tombi: 1.2.4 -> 1.2.5 ``                                                   |
| [`a084cb61`](https://github.com/NixOS/nixpkgs/commit/a084cb6191d82e2dd8d2160c04fbc33df7c05cdf) | `` android-tools: 36.0.1 -> 37.0.0 ``                                                                      |
| [`98e09bd6`](https://github.com/NixOS/nixpkgs/commit/98e09bd60f18c43bd0c223e5ab86f7b6ef247040) | `` vscode-extensions.cuelangorg.vscode-cue: 0.0.19 -> 0.0.21 ``                                            |
| [`bd5e0837`](https://github.com/NixOS/nixpkgs/commit/bd5e08374d85147647507c69e15abf481c818e28) | `` truehdd: 0.4.0 -> 0.5.1 ``                                                                              |
| [`69d37152`](https://github.com/NixOS/nixpkgs/commit/69d3715286395b14992870477577081ef84df4af) | `` beeper: 4.2.985 -> 4.3.0 ``                                                                             |
| [`98e01881`](https://github.com/NixOS/nixpkgs/commit/98e01881ea5e6af53cc2b41c9b6d2235800140e0) | `` code: 0.6.100 -> 0.6.162 ``                                                                             |
| [`e3000cae`](https://github.com/NixOS/nixpkgs/commit/e3000cae3e8e5d68805b4b49d5f7d743d138161a) | `` ulid: 2.1.1 -> 2.1.2 ``                                                                                 |
| [`fb734e82`](https://github.com/NixOS/nixpkgs/commit/fb734e822ab622231302e45a90e30e6e5d8fb3e4) | `` dwm: 6.6 -> 6.8 ``                                                                                      |
| [`6bc461fa`](https://github.com/NixOS/nixpkgs/commit/6bc461fa522f5bbbacb414721d7537d8aac30497) | `` emacs.pkgs.ghostel: further ease overrideAttrs of local bumps ``                                        |
| [`3a0a89a4`](https://github.com/NixOS/nixpkgs/commit/3a0a89a4419c590e7b5c33e98196c34f2e4e22d3) | `` metasploit: 6.4.146 -> 6.5.0 ``                                                                         |
| [`b9fd5dee`](https://github.com/NixOS/nixpkgs/commit/b9fd5dee6ace7f73c50d292ffda4946e38a62945) | `` nvc: 1.22.0 -> 1.22.1 ``                                                                                |
| [`16c0cd5a`](https://github.com/NixOS/nixpkgs/commit/16c0cd5ab31d394fd5d71c04f8be04ed229450d8) | `` terraform-providers.yandex-cloud_yandex: 0.218.0 -> 0.220.0 ``                                          |
| [`f61dc483`](https://github.com/NixOS/nixpkgs/commit/f61dc483711e5a8fcb68dd7522b9ec18d1df68da) | `` qui: 1.23.0 -> 1.24.0 ``                                                                                |
| [`4cd0c3db`](https://github.com/NixOS/nixpkgs/commit/4cd0c3dbfd5fcae1d25a57034aa67f4ef1efd694) | `` liana: 14.0 -> 15.0 ``                                                                                  |
| [`104bfcda`](https://github.com/NixOS/nixpkgs/commit/104bfcda76e65b98e6a0dec08f6a568fcf423689) | `` lianad: 14.0 -> 15.0 ``                                                                                 |
| [`0c27cbdd`](https://github.com/NixOS/nixpkgs/commit/0c27cbdd5cee49da38d4720be1b6a037df622517) | `` nextcloudPackages: add pantry ``                                                                        |
| [`531718e9`](https://github.com/NixOS/nixpkgs/commit/531718e98f4ea379f5b0da66a4b3869ea59eb13a) | `` nextcloudPackages: update apps ``                                                                       |
| [`1a5bd73b`](https://github.com/NixOS/nixpkgs/commit/1a5bd73bec84c5a935c09ba7986c15d65c800047) | `` python3Packages.langchain-aws: 1.6.3 -> 1.6.4 ``                                                        |
| [`17cc1131`](https://github.com/NixOS/nixpkgs/commit/17cc113109ffd255a2568513685fea5086ee1db6) | `` gurk-rs: modernize ``                                                                                   |
| [`6f37c883`](https://github.com/NixOS/nixpkgs/commit/6f37c883441337645849c48019dd381b54ad8cfe) | `` gurk-rs: add faukah to maintainers ``                                                                   |
| [`8eb1d5ef`](https://github.com/NixOS/nixpkgs/commit/8eb1d5efec68ae36cab0b6ce658933482ab7c825) | `` python3Packages.urllib3-future: 2.23.900 -> 2.24.900 ``                                                 |
| [`ee317b61`](https://github.com/NixOS/nixpkgs/commit/ee317b615b0bcaa15ce67032c6039d120ad7aee7) | `` burpsuite: 2026.7 -> 2026.7.2 ``                                                                        |
| [`a8d30d27`](https://github.com/NixOS/nixpkgs/commit/a8d30d27d4fec28159d103098e0cdd82bca8d3db) | `` tinyauth: 5.1.2 -> 5.1.3 ``                                                                             |
| [`91fc8d49`](https://github.com/NixOS/nixpkgs/commit/91fc8d4949658734eb1ab0e16a4f8ea10ed21ba2) | `` zensical: 0.0.51 -> 0.0.52 ``                                                                           |
| [`d12f525d`](https://github.com/NixOS/nixpkgs/commit/d12f525d0d5f50a5fdc48d845703c73897ed7b68) | `` singular: re-enable docs builds on darwin ``                                                            |
| [`cae22cca`](https://github.com/NixOS/nixpkgs/commit/cae22cca058089d705dd522e0372fed2d2fa334b) | `` zsh-forgit: 26.07.0 -> 26.08.0 ``                                                                       |
| [`c222de75`](https://github.com/NixOS/nixpkgs/commit/c222de75c5cf1063e26374084564791b2d3e72ee) | `` fishPlugins.forgit: 26.07.0 -> 26.08.0 ``                                                               |
| [`f8d6e922`](https://github.com/NixOS/nixpkgs/commit/f8d6e92260573ea87c24c17eeb3030c2adaa1848) | `` fluent-gtk-theme: add maintainer stzx ``                                                                |
| [`b16538e8`](https://github.com/NixOS/nixpkgs/commit/b16538e8d70a370864ac3e04994badbb48d514d4) | `` python3Packages.netbox-dns: 1.5.10 -> 1.5.11 ``                                                         |
| [`7abb13d3`](https://github.com/NixOS/nixpkgs/commit/7abb13d34e4616a15bd42acc61cdde33f874cb59) | `` maintainers: add stzx ``                                                                                |
| [`7eba9255`](https://github.com/NixOS/nixpkgs/commit/7eba92554cf8d34c132ffd17e00281790a6b567d) | `` zennotes-desktop: 2.19.0 -> 2.20.2 ``                                                                   |
| [`376264ed`](https://github.com/NixOS/nixpkgs/commit/376264ed871f6cee0d7d4063123202366694850e) | `` zoxide: add `nushell` completions ``                                                                    |
| [`81f9bba8`](https://github.com/NixOS/nixpkgs/commit/81f9bba8b09f66044be8a5c05612e237636b1766) | `` starship: add `nushell` completions ``                                                                  |
| [`9b344f1e`](https://github.com/NixOS/nixpkgs/commit/9b344f1e9488e3f5c0d5f535c0a1e84009df4422) | `` jujutsu: add `nushell` completions ``                                                                   |
| [`ac1af7ea`](https://github.com/NixOS/nixpkgs/commit/ac1af7ea79ed248f59397b39ea3a0fa76924f50b) | `` python3Packages.pure-magic-rs: 0.3.3 -> 0.4.3 ``                                                        |
| [`28da4c21`](https://github.com/NixOS/nixpkgs/commit/28da4c21df962e02bcba474051ef96a4c2e71428) | `` python3Packages.alibabacloud-ecs20140526: 7.9.2 -> 7.9.3 ``                                             |
| [`fb961396`](https://github.com/NixOS/nixpkgs/commit/fb96139603f7e82a948ece76632302ec76ed8f6a) | `` python3Packages.trafilatura: 2.1.0 -> 2.2.0 ``                                                          |
| [`139573ea`](https://github.com/NixOS/nixpkgs/commit/139573eaa676d8659b95c461d54cbe50d26f8ce1) | `` opencommit: 3.3.9 -> 3.3.10 ``                                                                          |
| [`260d761b`](https://github.com/NixOS/nixpkgs/commit/260d761ba03e79883176dbbde653c539400793db) | `` bazel-gazelle: 0.51.3 -> 0.52.2 ``                                                                      |
| [`48830883`](https://github.com/NixOS/nixpkgs/commit/48830883bbb39302c0bb9f579259ae46850d01b2) | `` php84: 8.4.23 -> 8.4.24 ``                                                                              |
| [`cdf784fe`](https://github.com/NixOS/nixpkgs/commit/cdf784fede52ed08784de29b5476e4b997032b3d) | `` php83: 8.3.32 -> 8.3.33 ``                                                                              |
| [`9773f194`](https://github.com/NixOS/nixpkgs/commit/9773f194efe10d861c6542834774644bcb76bd87) | `` php82: 8.2.32 -> 8.2.33 ``                                                                              |
| [`d10c5164`](https://github.com/NixOS/nixpkgs/commit/d10c5164c0ae88007754ffeecd02a531ceb8f691) | `` banjorecomp: 1.0.1 -> 1.0.2 ``                                                                          |
| [`6f074996`](https://github.com/NixOS/nixpkgs/commit/6f074996277234fff040ef1c10173d16f4cff8a8) | `` redmine: Update rails to 8.1.3.1 ``                                                                     |
| [`016d8b0f`](https://github.com/NixOS/nixpkgs/commit/016d8b0f2bfef24863b4f27b44872935e3a25a97) | `` betterleaks: add sshine as maintainer ``                                                                |
| [`801111d9`](https://github.com/NixOS/nixpkgs/commit/801111d984da5acefeb502c04261d2691f28f4d1) | `` ahk_x11: pin crystal version to crystal_1_19 ``                                                         |
| [`eed93d3f`](https://github.com/NixOS/nixpkgs/commit/eed93d3f69e5b42adc16e5688c0f267e85e3db43) | `` neonmodem: 1.0.7 -> 1.1.0 ``                                                                            |
| [`4e45f75b`](https://github.com/NixOS/nixpkgs/commit/4e45f75b8e30b4b177976b5be5b9ddb3e874dea7) | `` bendsql: init at 0.34.2 ``                                                                              |
| [`ba471233`](https://github.com/NixOS/nixpkgs/commit/ba4712332440067ab7d7e09500cb0d387e6ce028) | `` maintainers: add mnixry ``                                                                              |
| [`408da2a8`](https://github.com/NixOS/nixpkgs/commit/408da2a87f956975dfef0c293950e1ca16415574) | `` spotatui: 0.40.2 -> 0.40.3 ``                                                                           |
| [`4beeea71`](https://github.com/NixOS/nixpkgs/commit/4beeea71502079f157e8586ea10d556bdd2cdb02) | `` typstPackages: sync with Typst Universe as of 2026-07-31 ``                                             |
| [`7672ed9a`](https://github.com/NixOS/nixpkgs/commit/7672ed9a5f852e4b950747cbe18eb2853bc1ff6f) | `` nginxModules.njs: fix configure flags ``                                                                |
| [`13642e6f`](https://github.com/NixOS/nixpkgs/commit/13642e6f8c6960230ecf50e51da679c02001c9d3) | `` nginxModules.set-misc: test build with develkit ``                                                      |
| [`6088de61`](https://github.com/NixOS/nixpkgs/commit/6088de614ef178ec3dbf9afa43cd0a92ecc9e364) | `` nginxModules: sort aliases and keep sorted ``                                                           |
| [`5b57f448`](https://github.com/NixOS/nixpkgs/commit/5b57f448c50fe88513eb8e429ce4dd9864a65813) | `` nginxModules.http_proxy_connect_module_v25: drop ``                                                     |
| [`33b28330`](https://github.com/NixOS/nixpkgs/commit/33b28330e73b75d3f02b73074ea3b28e53521be7) | `` nginxModules.http_proxy_connect_module_v24: drop ``                                                     |
| [`8d6d3999`](https://github.com/NixOS/nixpkgs/commit/8d6d3999f98c8c76e5554d869efa3f89c65f0562) | `` nginx: make module source trees writable ``                                                             |
| [`30538743`](https://github.com/NixOS/nixpkgs/commit/30538743b2500a865bfedd5e327754261803569f) | `` nginxModules: test nginx build in passthru ``                                                           |
| [`1af39c19`](https://github.com/NixOS/nixpkgs/commit/1af39c19caef126436c5c89466c79c8b53cd5955) | `` nginxModules.vod: 1.7.0 -> 1.9.1 ``                                                                     |
| [`e2f0c106`](https://github.com/NixOS/nixpkgs/commit/e2f0c106f8e4ea646a94a337410c8a9c0269ae9f) | `` nginxModules: use nix-update-script with stable version policy ``                                       |
| [`ef3a9736`](https://github.com/NixOS/nixpkgs/commit/ef3a9736aa216af5ecb0c9119ee7c284bc0b568c) | `` nixos/nextcloud: add test verifying that bind-mounts and special places of /var/lib/nextcloud are OK `` |
| [`3dd00f8e`](https://github.com/NixOS/nixpkgs/commit/3dd00f8ea070ecfb124277b5a9172a46184d68aa) | `` nginxModules.video-thumbextractor: mark as broken ``                                                    |
| [`436ee95f`](https://github.com/NixOS/nixpkgs/commit/436ee95f2c7f845e917ee91daa6b0ed3d7b41593) | `` nginxModules.push-stream: mark as broken ``                                                             |
| [`25988867`](https://github.com/NixOS/nixpkgs/commit/25988867542449ea009e00fc51553a2090b4c732) | `` nginxModules.aws-auth: mark as broken ``                                                                |
| [`bd6a0be6`](https://github.com/NixOS/nixpkgs/commit/bd6a0be6fdad4b32682126bfbc5192e42de3fd5b) | `` nginxModules.lua-upstream: mark as broken ``                                                            |
| [`aa39d2aa`](https://github.com/NixOS/nixpkgs/commit/aa39d2aaa79eafddbd5b68429c44917c9ff29f32) | `` pike: restrict to x86_64-linux ``                                                                       |
| [`e5a2cc86`](https://github.com/NixOS/nixpkgs/commit/e5a2cc86eb4ec3faa564f7e208bc0faaab20ec8e) | `` kazumi: 2.2.3 -> 2.2.6 ``                                                                               |
| [`f06bc88e`](https://github.com/NixOS/nixpkgs/commit/f06bc88ebb8ed29aee58f0d45987e88adb61734c) | `` secp256k1-jdk: add nix-update-script ``                                                                 |
| [`c504cb46`](https://github.com/NixOS/nixpkgs/commit/c504cb466e947f8549dc4c861b54b4aabaddbf94) | `` evcc: 0.313.0 -> 0.313.1 ``                                                                             |
| [`6ed597fc`](https://github.com/NixOS/nixpkgs/commit/6ed597fc7979c8cb6c7ae07c640afd885d2cfa7f) | `` all-the-package-names: 2.0.2511 -> 2.0.2520 ``                                                          |
| [`b5a373cb`](https://github.com/NixOS/nixpkgs/commit/b5a373cb2f831dd88f29e63359245da097082fac) | `` nginxModules.fancyindex: 0.5.2 -> 0.6.0 ``                                                              |
| [`9c511e82`](https://github.com/NixOS/nixpkgs/commit/9c511e822ddcaf01f0a634b86d7f2fab52f80b60) | `` nginxModules.cache-purge: 2.5.1 -> 3.0.2 ``                                                             |
| [`74cc0a6c`](https://github.com/NixOS/nixpkgs/commit/74cc0a6c9d734b6bbe47c45d92713bd417296772) | `` nginxModules.vts: 0.2.2 -> 0.2.6 ``                                                                     |
| [`e5628830`](https://github.com/NixOS/nixpkgs/commit/e56288309931f810588d0f63768fd004675d3373) | `` bootmac: init at 0.7.1 ``                                                                               |
| [`04a3452b`](https://github.com/NixOS/nixpkgs/commit/04a3452b944657d5e4ffe1fe3001b27924d580aa) | `` msm-modem: init at 13 ``                                                                                |
| [`b0067f4d`](https://github.com/NixOS/nixpkgs/commit/b0067f4d586d08ac7f8b07eb2f8354dd113b502c) | `` nginxModules.develkit: 0.3.3 -> 0.3.4 ``                                                                |
| [`f3dced00`](https://github.com/NixOS/nixpkgs/commit/f3dced00971eef97a88b53ea0a55bd69aacc07bc) | `` nginxModules.njs: 0.9.4 -> 1.0.0 ``                                                                     |
| [`bdb1f1c1`](https://github.com/NixOS/nixpkgs/commit/bdb1f1c194eaa65129ecd7b1fd5cfde7c9a4a832) | `` zigbee2mqtt: 2.12.1 -> 2.13.0 ``                                                                        |
| [`205fb105`](https://github.com/NixOS/nixpkgs/commit/205fb105e846a6182084052e3b42a3af7eb9a246) | `` panoply: 5.10.0 -> 5.10.1 ``                                                                            |
| [`7e09d372`](https://github.com/NixOS/nixpkgs/commit/7e09d3726c5850ddb11930780212eb14776e704e) | `` perlPackages.DateManip: fix CVE-2026-60074 and CVE-2026-60075 ``                                        |
| [`9b7ecae5`](https://github.com/NixOS/nixpkgs/commit/9b7ecae5a1700c3465584f53c93421de6b008d3f) | `` mark: 16.6.0 -> 16.8.9 ``                                                                               |
| [`d1b0abba`](https://github.com/NixOS/nixpkgs/commit/d1b0abbadf97279b258a35becfc8166408906aff) | `` _1password-gui-beta: 8.12.26-31.BETA -> 8.12.32-26.BETA ``                                              |
| [`764a4ebd`](https://github.com/NixOS/nixpkgs/commit/764a4ebdf25b051f3e937840e1c60526c9f0a0ea) | `` nixos/limine: don't read all of /nix/store during installation ``                                       |
| [`6cd3e717`](https://github.com/NixOS/nixpkgs/commit/6cd3e717ef7308ab7759a6b0d042e45387cedc97) | `` catgirldownloader: init at 0.5 ``                                                                       |
| [`c2d890f4`](https://github.com/NixOS/nixpkgs/commit/c2d890f46320fd8ce5f6c84bb2b426c719a7ecb8) | `` kanidm_1_11: init at 1.11.0 ``                                                                          |
| [`553fb879`](https://github.com/NixOS/nixpkgs/commit/553fb879c3f8d84396b45e1b322924086356173e) | `` fetchNpmDeps: assert fetcherVersion is not higher than latest version ``                                |

*... and 58 more commits (truncated)*