### PR TITLE
chore(opencode): update overlay to v1.18.12

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -27,18 +27,18 @@
 }:
 opencode.overrideAttrs (
   _finalAttrs: prevAttrs: rec {
-    version = "1.18.11";
+    version = "1.18.12";
 
     src = fetchFromGitHub {
       owner = "anomalyco";
       repo = "opencode";
       tag = "v${version}";
-      hash = "sha256-Rg+NeRLeu0e+WSTZd8oJzV3XMMxXZCZ5LImDcCraX8g=";
+      hash = "sha256-Tf3ublCkl0Jl45ogl8JUhpGFNUe88tU3B6e8pViPuHk=";
     };
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {
       inherit version src;
-      outputHash = "sha256-lHr4g4Kw9CvyDHiuyuCDsyk9vOXzz/My5bI9/zd5aYE=";
+      outputHash = "sha256-mgrSWC89/3N8EQycjMiqc01iwfYMiYZI1uS9gjvXEvc=";
     });
   }
 )


### PR DESCRIPTION
Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated OpenCode to version 1.18.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->