### PR TITLE
chore(opencode): update overlay to v1.18.13

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -27,18 +27,18 @@
 }:
 opencode.overrideAttrs (
   _finalAttrs: prevAttrs: rec {
-    version = "1.18.12";
+    version = "1.18.13";
 
     src = fetchFromGitHub {
       owner = "anomalyco";
       repo = "opencode";
       tag = "v${version}";
-      hash = "sha256-Tf3ublCkl0Jl45ogl8JUhpGFNUe88tU3B6e8pViPuHk=";
+      hash = "sha256-xjzxTsMN4dMax3rL+2+4og0E7LovwYFvpU7Ea2sh6tM=";
     };
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {
       inherit version src;
-      outputHash = "sha256-mgrSWC89/3N8EQycjMiqc01iwfYMiYZI1uS9gjvXEvc=";
+      outputHash = "sha256-CQGZzD+XP4b452zvocKkdpjGJ2qrnxDhMQ/9846jp9I=";
     });
   }
 )


### PR DESCRIPTION
Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenCode to version 1.18.13.
  * Refreshed bundled source and dependency metadata for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->