### PR TITLE
fix(monitoring): detect deploy drift by closure comparison, not commit distance

### DIFF
--- a/.github/workflows/fleet-manifest.yaml
+++ b/.github/workflows/fleet-manifest.yaml
@@ -45,6 +45,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # No step in this job needs the checkout's credential: the eval is
+          # local, and every remote git operation below authenticates through
+          # REMOTE_URL. Leaving it at the default would write the write-scoped
+          # token into .git/config for the duration of the job for nothing.
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22

--- a/.github/workflows/fleet-manifest.yaml
+++ b/.github/workflows/fleet-manifest.yaml
@@ -1,0 +1,127 @@
+---
+name: Fleet Manifest
+
+# Publishes the fleet deploy manifest: a map from host -> the
+# `system.build.toplevel` store path that main currently expects for that host.
+# Hosts compare it against `readlink -f /run/current-system` to decide whether
+# they genuinely need a deploy (see modules/monitoring/agent/node_exporter.nix).
+#
+# Why this exists as its own workflow rather than a job in ci-linux.yaml:
+# ci-linux.yaml runs on `merge_group` / `pull_request` / `workflow_dispatch` and
+# has no push-to-main trigger, so it has nowhere to hang a post-merge step. The
+# manifest must describe main's HEAD specifically, so it needs `push: [main]`.
+#
+# Commits reaching main have already passed the merge queue's ci-linux run, so
+# this does not re-gate on builds. It evaluates rather than builds, and it
+# deliberately evaluates EVERY host instead of reusing the impacted-hosts path
+# filter -- see the rationale block in scripts/gen-fleet-manifest.sh.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Serialise pushes to the manifest branch. Two runs racing would make one of
+# them lose its carry-forward history to a non-fast-forward rejection.
+# cancel-in-progress must stay false: a cancelled run would skip publishing a
+# commit's manifest entirely, and the next run would attribute that commit's
+# closure changes to a later revision.
+concurrency:
+  group: fleet-manifest
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish fleet manifest
+    runs-on: [self-hosted, Linux]
+    # Skip on forks: they have neither the substituters nor a manifest branch
+    # worth writing, and the push would fail on permissions anyway.
+    if: github.repository == 'fredsystems/nixos'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          trust-runner-user: true
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
+            substituters = http://192.168.31.14/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
+
+      - name: Generate and publish manifest
+        shell: bash
+        env:
+          # Actions masks GITHUB_TOKEN in log output, so embedding it in the
+          # remote URL does not leak it. Nothing here echoes the URL regardless.
+          REMOTE_URL: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+          BRANCH: fleet-manifest
+        run: |
+          set -euo pipefail
+
+          REV="$(git rev-parse HEAD)"
+          WORK="${RUNNER_TEMP}/fleet-manifest"
+          rm -rf "$WORK"
+
+          # The manifest lives on an orphan branch so it never appears in a
+          # source diff and never triggers ci-linux's path filter. Bootstrap it
+          # on first run.
+          if git ls-remote --exit-code --heads "$REMOTE_URL" "$BRANCH" >/dev/null 2>&1; then
+            git clone --quiet --depth 1 --branch "$BRANCH" --single-branch "$REMOTE_URL" "$WORK"
+          else
+            echo "Branch '$BRANCH' does not exist yet -- bootstrapping it."
+            mkdir -p "$WORK"
+            git -C "$WORK" init --quiet --initial-branch="$BRANCH"
+            git -C "$WORK" remote add origin "$REMOTE_URL"
+          fi
+
+          git -C "$WORK" config user.name  "github-actions[bot]"
+          git -C "$WORK" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # `--inputs-from .` resolves nixpkgs# against this flake's LOCKED
+          # nixpkgs input rather than the runner's flake registry, so the jq
+          # used here is pinned and already in the store from the eval above.
+          # This mirrors how ci-linux.yaml obtains attic-client.
+          nix shell --inputs-from . nixpkgs#jq --command \
+            ./scripts/gen-fleet-manifest.sh "$WORK/manifest.json" "$REV"
+
+          # Heredoc body sits at this script's base indentation on purpose: the
+          # YAML block scalar strips only the block's own indent, and <<'EOF'
+          # (deliberately not <<-'EOF', which would also eat tabs only) keeps
+          # whatever remains. Indenting it further would emit a README whose
+          # every line began with stray spaces.
+          cat >"$WORK/README.md" <<'EOF'
+          # Fleet manifest branch
+
+          Generated content. Do not edit by hand, and do not merge this branch
+          into `main` -- it is an orphan branch with no shared history.
+
+          `manifest.json` maps each host in `nixosConfigurations` to the
+          `system.build.toplevel` store path that `main` expects for it. Hosts
+          fetch this file and compare it against
+          `readlink -f /run/current-system` to determine their deploy state.
+
+          Produced by `.github/workflows/fleet-manifest.yaml` on every push to
+          `main`. The generator, the manifest schema and the reasoning behind
+          the design live in `scripts/gen-fleet-manifest.sh` on `main`.
+          EOF
+
+          git -C "$WORK" add manifest.json README.md
+
+          if git -C "$WORK" diff --cached --quiet; then
+            echo "Manifest unchanged -- no host's expected closure moved at ${REV}."
+            exit 0
+          fi
+
+          git -C "$WORK" commit --quiet \
+            -m "chore(fleet-manifest): update for ${REV}"
+          git -C "$WORK" push --quiet origin "HEAD:${BRANCH}"
+
+          echo "Published manifest for ${REV}."

--- a/agents.md
+++ b/agents.md
@@ -75,6 +75,7 @@ and HFDL decoders.
     │   ├── ci-linux.yaml        # Linux CI
     │   ├── ci-darwin.yaml       # macOS CI
     │   ├── ci-lint.yaml         # Pre-commit / linting
+    │   ├── fleet-manifest.yaml  # Publishes per-host expected closure paths
     │   └── update-flakes.yaml   # Per-input flake update (1 PR per input)
     ├── merge-queue-ci-skipper/  # Composite action: skip redundant merge-queue builds
     └── renovate.json5           # Renovate Bot config
@@ -202,6 +203,16 @@ would change their derivation hashes and force local source builds.
   hack) -> register it in `.github/tracked-upstream-fixes.json` so the
   `track-upstream-fixes.yaml` workflow flags it for removal once the fix
   lands; load `nixos-track-upstream-fix`.
+- **Never put the flake's git revision into a host's closure.** No
+  `self.rev` in `system.activationScripts`, no `environment.etc` entry
+  holding it, no `system.configurationRevision`. Anything reachable from
+  `system.build.toplevel` that embeds the commit SHA makes every commit
+  change every host's store path, which destroys the fleet's only exact
+  "does this host need a deploy?" signal. Deploy state is derived by
+  comparing `/run/current-system` against the manifest published by
+  `fleet-manifest.yaml`; the revision is recovered by reverse lookup.
+  See the note in `flake/lib/mk-system.nix` and
+  `scripts/gen-fleet-manifest.sh`.
 
 ---
 

--- a/flake/lib/mk-system.nix
+++ b/flake/lib/mk-system.nix
@@ -137,20 +137,24 @@ let
     ./../../modules/base/deployment-meta.nix
     ./../../hosts/linux/${hostName}/configuration.nix
     ./../../modules/base/system.nix
-    {
-      # Bake the git revision of the flake that built this system into a
-      # persistent file so node_exporter can compare it against GitHub main
-      # without needing a local git checkout on the node.
-      # self.rev is only set when the flake was built from a clean git tree;
-      # self.dirtyRev is set for dirty trees; fall back to "dirty" if neither.
-      system.activationScripts.configRevision = {
-        text = ''
-          mkdir -p /etc/nixos
-          echo "${self.rev or self.dirtyRev or "dirty"}" > /etc/nixos/configuration-revision
-        '';
-        deps = [ ];
-      };
-    }
+    # NOTE: do NOT bake the flake's git revision into this system.
+    #
+    # An earlier revision of this file wrote `self.rev` to
+    # /etc/nixos/configuration-revision from a `system.activationScripts`
+    # entry. Activation scripts are part of `system.build.toplevel`, so the
+    # 40-character commit SHA ended up inside every host's store path. That
+    # made every commit to main change every host's closure hash, whether or
+    # not the commit touched that host -- which destroyed the only signal
+    # capable of answering "does this host actually need a deploy?".
+    #
+    # Deploy state is now derived by comparing the host's running closure
+    # against the fleet manifest published by .github/workflows/fleet-manifest.yaml
+    # (see modules/monitoring/agent/node_exporter.nix). The manifest maps each
+    # host to the toplevel store path main currently expects, so the git
+    # revision is recovered by reverse lookup instead of being baked in.
+    # Reintroducing a rev-bearing activation script, `environment.etc` entry or
+    # `system.configurationRevision` would silently break drift detection for
+    # the whole fleet.
     hmInput.nixosModules.home-manager
     {
       home-manager = {

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -8,30 +8,6 @@
 {
   systemd = {
     services = {
-      nixos-branch-metric = {
-        description = "Emit NixOS branch metric";
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = pkgs.writeShellScript "nixos-branch-metric.sh" ''
-            # For colmena-managed nodes there is no local git checkout.
-            # A clean build from a known commit written to
-            # /etc/nixos/configuration-revision is treated as "on main"
-            # (value=1). A dirty build or missing file emits 0.
-            REV=$(cat /etc/nixos/configuration-revision 2>/dev/null || echo "")
-
-            if [[ -n "$REV" && "$REV" != "dirty" ]]; then
-              value=1
-            else
-              value=0
-            fi
-
-            mkdir -p /var/lib/node_exporter/textfiles
-            echo "nixos_branch{host=\"${config.networking.hostName}\"} $value" \
-              > /var/lib/node_exporter/textfiles/nixos_branch.prom
-          '';
-        };
-      };
-
       nixos-needs-reboot-metric = {
         description = "Emit reboot-needed metric for Prometheus";
         serviceConfig = {
@@ -56,107 +32,211 @@
         };
       };
 
-      nixos-build-info-metric = {
-        description = "Emit NixOS build SHA and deploy timestamp metrics";
+      # Deploy state relative to the fleet manifest published by
+      # .github/workflows/fleet-manifest.yaml.
+      #
+      # This replaces three earlier services (nixos-branch-metric,
+      # nixos-build-info-metric, nixos-revision-metric), all of which keyed off
+      # a git SHA written to /etc/nixos/configuration-revision and asked the
+      # GitHub compare API for a commit distance. That produced three distinct
+      # classes of false alert:
+      #
+      #   * A commit that moved main without changing THIS host's closure still
+      #     counted, so every host alerted on every unrelated commit and the
+      #     "fix" was a rebuild that changed nothing. Commit distance simply is
+      #     not a measure of whether a host needs a deploy.
+      #   * A dirty or branch build recorded the literal string "dirty", and the
+      #     script then hard-coded BEHIND=0 for that case -- so a host built
+      #     from a WIP tree reported healthy no matter how far main moved. The
+      #     one situation most deserving an alert was the one that silenced it.
+      #   * The SHA was written from a system.activationScripts entry, which is
+      #     part of system.build.toplevel. Every commit therefore changed every
+      #     host's store path, poisoning the only exact signal available. See
+      #     the note in flake/lib/mk-system.nix.
+      #
+      # The manifest records the toplevel store path main expects per host, so
+      # the comparison here is exact: identical paths means identical systems,
+      # and a commit that does not alter this host's closure cannot move it.
+      nixos-deploy-state-metric = {
+        description = "Emit NixOS deploy state metrics from the fleet manifest";
+        # Needs the network to refresh the manifest. It degrades to the cached
+        # copy rather than failing, but ordering after the network avoids a
+        # guaranteed-failing fetch on every boot.
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = pkgs.writeShellScript "nixos-build-info-metric.sh" ''
-            HOST="${config.networking.hostName}"
-            SHA=$(cat /etc/nixos/configuration-revision 2>/dev/null || echo "dirty")
-            TS_FILE="/var/lib/node_exporter/textfiles/nixos_build_timestamp.val"
-
-            # Only update the timestamp when the SHA changes (i.e. a new deploy happened).
-            # We persist the last-seen SHA alongside the timestamp so we can detect this.
-            LAST_SHA_FILE="/var/lib/node_exporter/textfiles/nixos_build_last_sha"
-            LAST_SHA=$(cat "$LAST_SHA_FILE" 2>/dev/null || echo "")
-
-            mkdir -p /var/lib/node_exporter/textfiles
-
-            if [[ "$SHA" != "dirty" && "$SHA" != "$LAST_SHA" ]]; then
-              echo $(( $(date +%s) * 1000 )) > "$TS_FILE"
-              echo "$SHA" > "$LAST_SHA_FILE"
-            fi
-
-            TS=$(cat "$TS_FILE" 2>/dev/null || echo "0")
-
-            # Migrate existing values that were written as seconds (< 1e12) to milliseconds
-            if [[ "$TS" -gt 0 && "$TS" -lt 1000000000000 ]]; then
-              TS=$(( TS * 1000 ))
-              echo "$TS" > "$TS_FILE"
-            fi
-            SHORT_SHA=''${SHA:0:7}
-
-            cat > /var/lib/node_exporter/textfiles/nixos_build_info.prom <<EOF
-            # HELP nixos_build_info NixOS build info: SHA label + deploy timestamp
-            # TYPE nixos_build_info gauge
-            nixos_build_info{host="$HOST", sha="$SHA", short_sha="$SHORT_SHA"} $TS
-            EOF
-          '';
-        };
-      };
-
-      nixos-revision-metric = {
-        description = "Emit NixOS upstream revision metrics";
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = pkgs.writeShellScript "nixos-revision-metric.sh" ''
-            set -euo pipefail
+          StateDirectory = "nixos-deploy-state";
+          ExecStart = pkgs.writeShellScript "nixos-deploy-state-metric.sh" ''
+            set -uo pipefail
 
             CURL=${pkgs.curl}/bin/curl
             JQ=${pkgs.jq}/bin/jq
 
-            OWNER="fredsystems"
-            REPO="nixos"
             HOST="${config.networking.hostName}"
+            MANIFEST_URL="https://raw.githubusercontent.com/fredsystems/nixos/fleet-manifest/manifest.json"
 
-            # --- Revision this system was actually built and activated from.
-            # Written persistently by the activationScript in mk-system.nix on
-            # every colmena apply, so it survives reboots and never requires a
-            # local git checkout on the node. ---
-            LOCAL=$(cat /etc/nixos/configuration-revision 2>/dev/null || echo "")
+            STATE_DIR=/var/lib/nixos-deploy-state
+            CACHE="$STATE_DIR/manifest.json"
+            TS_FILE="$STATE_DIR/deploy_timestamp_ms"
+            LAST_TOPLEVEL_FILE="$STATE_DIR/last_toplevel"
+            TEXTFILE_DIR=/var/lib/node_exporter/textfiles
+            OUT="$TEXTFILE_DIR/nixos_deploy_state.prom"
 
-            if [[ -z "$LOCAL" || "$LOCAL" = "dirty" ]]; then
-                # No recorded revision (pre-activation or dirty build) — emit
-                # zeroed metrics so the alert doesn't fire spuriously.
-                BEHIND=0
-                LAG=0
+            mkdir -p "$STATE_DIR" "$TEXTFILE_DIR"
+
+            RUNNING=$(readlink -f /run/current-system 2>/dev/null || echo "")
+
+            # Refresh the manifest into a temp file first: a truncated or
+            # error-page response must not clobber a good cached copy, or a
+            # transient GitHub failure would flip the whole fleet to unknown.
+            FETCH_OK=0
+            TMP="$CACHE.tmp"
+            if $CURL -sfL --max-time 30 -o "$TMP" "$MANIFEST_URL" \
+              && $JQ -e '.schema == 1 and (.hosts | type == "object")' "$TMP" >/dev/null 2>&1; then
+              mv "$TMP" "$CACHE"
+              FETCH_OK=1
             else
-                # --- Remote commit SHA from GitHub (main) ---
-                API_COMMIT="https://api.github.com/repos/$OWNER/$REPO/commits/main"
-                REMOTE=$($CURL -s "$API_COMMIT" | $JQ -r .sha)
-
-                if [[ "$REMOTE" = "null" || -z "$REMOTE" ]]; then
-                    # GitHub API unavailable — don't flip the alert
-                    BEHIND=0
-                    LAG=0
-                else
-                    # Compare LOCAL (base) ... REMOTE (head):
-                    # ahead_by = commits REMOTE has that LOCAL doesn't
-                    #            i.e. how many commits the running system is behind main
-                    API_COMPARE="https://api.github.com/repos/$OWNER/$REPO/compare/$LOCAL...$REMOTE"
-                    COMPARE=$($CURL -s "$API_COMPARE")
-
-                    BEHIND_BY=$(echo "$COMPARE" | $JQ -r .ahead_by)
-
-                    # Default safe values
-                    BEHIND=0
-                    LAG=0
-
-                    if [[ "$BEHIND_BY" != "null" && "$BEHIND_BY" =~ ^[0-9]+$ ]]; then
-                        if [[ "$BEHIND_BY" -gt 0 ]]; then
-                            BEHIND=1
-                            LAG=$BEHIND_BY
-                        fi
-                    fi
-                fi
+              rm -f "$TMP"
             fi
 
-            mkdir -p /var/lib/node_exporter/textfiles
+            STATE="unknown"
+            EXPECTED=""
+            EXPECTED_REV=""
+            CHANGED_AT=0
+            GENERATED_AT=0
 
-            cat > /var/lib/node_exporter/textfiles/nixos_revision.prom <<EOF
-            nixos_revision_behind{host="$HOST"} $BEHIND
-            nixos_revision_lag{host="$HOST"} $LAG
-            EOF
+            if [[ -s "$CACHE" ]]; then
+              GENERATED_AT=$($JQ -r '.generated_at // 0' "$CACHE" 2>/dev/null || echo 0)
+              # history is newest-first and history[0] is the currently
+              # expected closure; see scripts/gen-fleet-manifest.sh.
+              EXPECTED=$($JQ -r --arg h "$HOST" '.hosts[$h].history[0].toplevel // ""' "$CACHE" 2>/dev/null || echo "")
+              EXPECTED_REV=$($JQ -r --arg h "$HOST" '.hosts[$h].history[0].rev // ""' "$CACHE" 2>/dev/null || echo "")
+              CHANGED_AT=$($JQ -r --arg h "$HOST" '.hosts[$h].history[0].at // 0' "$CACHE" 2>/dev/null || echo 0)
+            fi
+
+            if [[ -n "$RUNNING" && -n "$EXPECTED" ]]; then
+              if [[ "$RUNNING" == "$EXPECTED" ]]; then
+                STATE="up_to_date"
+              elif $JQ -e --arg h "$HOST" --arg p "$RUNNING" \
+                '[.hosts[$h].history[].toplevel] | index($p) != null' "$CACHE" >/dev/null 2>&1; then
+                # A closure main published previously: genuinely a deploy behind.
+                STATE="drifted"
+              else
+                # Never published by main -- a local, dirty or branch build.
+                # Distinguishing this from "drifted" is the whole point: the old
+                # script reported it as healthy.
+                STATE="unmanaged"
+              fi
+            fi
+
+            # Revision the running closure came from, recovered by reverse
+            # lookup now that the SHA is deliberately not baked into the system.
+            RUNNING_REV=""
+            if [[ -s "$CACHE" && -n "$RUNNING" ]]; then
+              RUNNING_REV=$($JQ -r --arg h "$HOST" --arg p "$RUNNING" \
+                'first(.hosts[$h].history[] | select(.toplevel == $p) | .rev) // ""' \
+                "$CACHE" 2>/dev/null || echo "")
+            fi
+
+            # Deploy timestamp: observed locally, keyed on the running closure
+            # changing. Keying on the closure rather than on a git SHA means
+            # redeploying an identical system does not reset it, and a commit
+            # that does not touch this host does not either.
+            #
+            # Stored and exported in seconds. The superseded metric used
+            # milliseconds implicitly and had to carry a runtime "migrate values
+            # below 1e12" fixup as a result; naming the unit in the metric
+            # removes that class of bug. Grafana wants ms, so the dashboard
+            # multiplies rather than the exporter guessing.
+            OLD_TS_MS_FILE=/var/lib/node_exporter/textfiles/nixos_build_timestamp.val
+            LAST_TOPLEVEL=$(cat "$LAST_TOPLEVEL_FILE" 2>/dev/null || echo "")
+            if [[ -n "$RUNNING" && "$RUNNING" != "$LAST_TOPLEVEL" ]]; then
+              SEEDED=0
+              if [[ -z "$LAST_TOPLEVEL" && -s "$OLD_TS_MS_FILE" ]]; then
+                # First run after replacing the old services: adopt the previous
+                # deploy timestamp rather than reporting a bogus "deployed just
+                # now" for every host in the fleet simultaneously.
+                OLD_MS=$(cat "$OLD_TS_MS_FILE" 2>/dev/null || echo 0)
+                if [[ "$OLD_MS" =~ ^[0-9]+$ && "$OLD_MS" -gt 0 ]]; then
+                  echo $(( OLD_MS / 1000 )) > "$TS_FILE"
+                  SEEDED=1
+                fi
+              fi
+              [[ "$SEEDED" -eq 0 ]] && date +%s > "$TS_FILE"
+              echo "$RUNNING" > "$LAST_TOPLEVEL_FILE"
+            fi
+            DEPLOY_TS=$(cat "$TS_FILE" 2>/dev/null || echo 0)
+            rm -f "$OLD_TS_MS_FILE" /var/lib/node_exporter/textfiles/nixos_build_last_sha
+
+            MANIFEST_AGE=0
+            if [[ "$GENERATED_AT" -gt 0 ]]; then
+              MANIFEST_AGE=$(( $(date +%s) - GENERATED_AT ))
+              [[ "$MANIFEST_AGE" -lt 0 ]] && MANIFEST_AGE=0
+            fi
+
+            # Store paths are safe as label values (no quotes, backslashes or
+            # newlines are possible in a /nix/store path), so no escaping is
+            # needed here. Basenames only: the /nix/store prefix is noise in a
+            # dashboard and the hash is what identifies the closure.
+            TMP_OUT="$OUT.tmp"
+            {
+              echo "# HELP nixos_deploy_state Deploy state vs the fleet manifest (1 on the active state)."
+              echo "# TYPE nixos_deploy_state gauge"
+              # Every state is emitted on every run, including the zeros. An
+              # alert must never depend on a series being absent: absence is
+              # indistinguishable from a broken exporter, and scripts/
+              # check-alert-metrics.sh exists precisely because a rule matching
+              # nothing is reported healthy.
+              for s in up_to_date drifted unmanaged unknown; do
+                if [[ "$s" == "$STATE" ]]; then v=1; else v=0; fi
+                echo "nixos_deploy_state{host=\"$HOST\",state=\"$s\"} $v"
+              done
+
+              echo "# HELP nixos_expected_change_timestamp_seconds Unix time main last changed this host's expected closure."
+              echo "# TYPE nixos_expected_change_timestamp_seconds gauge"
+              echo "nixos_expected_change_timestamp_seconds{host=\"$HOST\"} $CHANGED_AT"
+
+              # Value is always 1: this is an identity/"info" metric whose
+              # payload is its labels. Keeping the value at 1 is what lets the
+              # NixOSDeployDrift rule pull these labels into its annotations
+              # with `* on (host) group_left (...)` without the join altering
+              # the alert expression's value.
+              echo "# HELP nixos_deploy_info Running and expected closure identity for this host."
+              echo "# TYPE nixos_deploy_info gauge"
+              echo "nixos_deploy_info{host=\"$HOST\",running=\"$(basename "$RUNNING")\",expected=\"$(basename "$EXPECTED")\",rev=\"$RUNNING_REV\",short_rev=\"''${RUNNING_REV:0:7}\",expected_rev=\"$EXPECTED_REV\",short_expected_rev=\"''${EXPECTED_REV:0:7}\"} 1"
+
+              echo "# HELP nixos_deploy_timestamp_seconds Unix time this host's running closure last changed."
+              echo "# TYPE nixos_deploy_timestamp_seconds gauge"
+              echo "nixos_deploy_timestamp_seconds{host=\"$HOST\"} $DEPLOY_TS"
+
+              echo "# HELP nixos_manifest_age_seconds Age of the fleet manifest this host compared against."
+              echo "# TYPE nixos_manifest_age_seconds gauge"
+              echo "nixos_manifest_age_seconds{host=\"$HOST\"} $MANIFEST_AGE"
+
+              echo "# HELP nixos_manifest_fetch_success Whether the last manifest refresh succeeded."
+              echo "# TYPE nixos_manifest_fetch_success gauge"
+              echo "nixos_manifest_fetch_success{host=\"$HOST\"} $FETCH_OK"
+            } > "$TMP_OUT"
+            mv "$TMP_OUT" "$OUT"
+
+            # Retire the files written by the three superseded services so a
+            # stale .prom does not keep re-exporting removed metrics forever.
+            # The textfile collector has no concept of expiry: whatever is in
+            # the directory is exported until the file is deleted.
+            rm -f "$TEXTFILE_DIR/nixos_branch.prom" \
+                  "$TEXTFILE_DIR/nixos_build_info.prom" \
+                  "$TEXTFILE_DIR/nixos_revision.prom"
+
+            # Also retire the baked-in revision file itself. Nothing reads it
+            # any more, and leaving it behind invites someone to trust a value
+            # that is now frozen at whatever commit last deployed with the old
+            # activation script. Cleaning it up from here rather than from a new
+            # system.activationScripts entry is deliberate: the point of this
+            # change was getting rev-bearing state out of the closure, and a
+            # cleanup activation script would be a confusing thing to find
+            # there next to the comment forbidding exactly that.
+            rm -f /etc/nixos/configuration-revision
           '';
         };
       };
@@ -224,13 +304,6 @@
     };
 
     timers = {
-      nixos-branch-metric = {
-        wantedBy = [ "timers.target" ];
-        timerConfig = {
-          OnCalendar = "*:0/10"; # every 10 minutes
-        };
-      };
-
       nixos-needs-reboot-metric = {
         wantedBy = [ "timers.target" ];
         timerConfig = {
@@ -238,19 +311,18 @@
         };
       };
 
-      nixos-build-info-metric = {
+      nixos-deploy-state-metric = {
         wantedBy = [ "timers.target" ];
         timerConfig = {
-          OnCalendar = "*:0/5"; # every 5 minutes — cheap, just reads a file
+          # Every 10 minutes. One conditional-GET-friendly fetch of a small
+          # JSON file per host; raw.githubusercontent.com serves it from a CDN,
+          # so this is far cheaper than the two unauthenticated api.github.com
+          # calls per host per run that this replaces (those were also subject
+          # to a 60/hour/IP rate limit the whole fleet shared behind one NAT).
+          OnCalendar = "*:0/10";
           Persistent = true;
-        };
-      };
-
-      nixos-revision-metric = {
-        wantedBy = [ "timers.target" ];
-        timerConfig = {
-          OnCalendar = "*:0/15"; # every 15 minutes
-          Persistent = true;
+          # Without this the whole fleet fetches on the same wall-clock minute.
+          RandomizedDelaySec = "120";
         };
       };
     }

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -78,7 +78,7 @@
 
             STATE_DIR=/var/lib/nixos-deploy-state
             CACHE="$STATE_DIR/manifest.json"
-            TS_FILE="$STATE_DIR/deploy_timestamp_ms"
+            TS_FILE="$STATE_DIR/deploy_timestamp_seconds"
             LAST_TOPLEVEL_FILE="$STATE_DIR/last_toplevel"
             TEXTFILE_DIR=/var/lib/node_exporter/textfiles
             OUT="$TEXTFILE_DIR/nixos_deploy_state.prom"
@@ -149,17 +149,30 @@
             # below 1e12" fixup as a result; naming the unit in the metric
             # removes that class of bug. Grafana wants ms, so the dashboard
             # multiplies rather than the exporter guessing.
-            OLD_TS_MS_FILE=/var/lib/node_exporter/textfiles/nixos_build_timestamp.val
+            LEGACY_TS_FILE=/var/lib/node_exporter/textfiles/nixos_build_timestamp.val
             LAST_TOPLEVEL=$(cat "$LAST_TOPLEVEL_FILE" 2>/dev/null || echo "")
             if [[ -n "$RUNNING" && "$RUNNING" != "$LAST_TOPLEVEL" ]]; then
               SEEDED=0
-              if [[ -z "$LAST_TOPLEVEL" && -s "$OLD_TS_MS_FILE" ]]; then
+              if [[ -z "$LAST_TOPLEVEL" && -s "$LEGACY_TS_FILE" ]]; then
                 # First run after replacing the old services: adopt the previous
                 # deploy timestamp rather than reporting a bogus "deployed just
                 # now" for every host in the fleet simultaneously.
-                OLD_MS=$(cat "$OLD_TS_MS_FILE" 2>/dev/null || echo 0)
-                if [[ "$OLD_MS" =~ ^[0-9]+$ && "$OLD_MS" -gt 0 ]]; then
-                  echo $(( OLD_MS / 1000 )) > "$TS_FILE"
+                #
+                # The legacy file's unit is genuinely ambiguous, which is the
+                # whole reason the replacement names its unit. The old script
+                # wrote milliseconds but carried a runtime fixup that multiplied
+                # any value below 1e12 by 1000, so a host whose timer had not
+                # run since before that fixup shipped can still hold seconds.
+                # Applying the same magnitude test rather than dividing
+                # unconditionally avoids turning such a value into a 1970
+                # timestamp.
+                LEGACY_TS=$(cat "$LEGACY_TS_FILE" 2>/dev/null || echo 0)
+                if [[ "$LEGACY_TS" =~ ^[0-9]+$ && "$LEGACY_TS" -gt 0 ]]; then
+                  if [[ "$LEGACY_TS" -ge 1000000000000 ]]; then
+                    echo $(( LEGACY_TS / 1000 )) > "$TS_FILE"
+                  else
+                    echo "$LEGACY_TS" > "$TS_FILE"
+                  fi
                   SEEDED=1
                 fi
               fi
@@ -167,7 +180,7 @@
               echo "$RUNNING" > "$LAST_TOPLEVEL_FILE"
             fi
             DEPLOY_TS=$(cat "$TS_FILE" 2>/dev/null || echo 0)
-            rm -f "$OLD_TS_MS_FILE" /var/lib/node_exporter/textfiles/nixos_build_last_sha
+            rm -f "$LEGACY_TS_FILE" /var/lib/node_exporter/textfiles/nixos_build_last_sha
 
             MANIFEST_AGE=0
             if [[ "$GENERATED_AT" -gt 0 ]]; then

--- a/modules/monitoring/master/alert-rules/system-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/system-alerts.yaml
@@ -1,20 +1,16 @@
 groups:
+  # Deploy-state alerts are driven by nixos_deploy_state, emitted by
+  # modules/monitoring/agent/node_exporter.nix from the fleet manifest that
+  # .github/workflows/fleet-manifest.yaml publishes. The manifest records the
+  # system.build.toplevel store path main expects per host, so "needs a deploy"
+  # is decided by comparing closures rather than by counting commits.
+  #
+  # NixOSNotOnMain and NixOSRevisionBehind previously lived here. Both keyed off
+  # a git SHA and a GitHub compare-API commit distance, which meant any commit
+  # touching any host alerted on every host, and a dirty build reported healthy.
+  # They are replaced by NixOSDeployDrift and NixOSUnmanagedSystem below.
   - name: nixos-alerts
     rules:
-      - alert: NixOSNotOnMain
-        # Desktops track feature branches routinely, so they are excluded.
-        # This previously matched host!~"daytona|maranello", which never
-        # excluded Daytona: the host label is "Daytona" and PromQL regexes
-        # are case-sensitive. Selecting on role is both correct and
-        # consistent with NixOSRevisionBehind below.
-        expr: nixos_branch{role!="desktop"} == 0
-        for: 6h
-        labels:
-          severity: warning
-        annotations:
-          summary: "NixOS repo not on main branch"
-          description: "The NixOS configuration on {{ $labels.host }} is not checked out on main for more than 6 hours."
-
       - alert: NixOSNeedsReboot
         expr: nixos_needs_reboot == 1
         for: 1h
@@ -24,15 +20,149 @@ groups:
           summary: "NixOS system requires a reboot"
           description: "Host {{ $labels.host }} has pending upgrades and needs a reboot."
 
-      - alert: NixOSRevisionBehind
-        # Desktops are updated manually on a different cadence than servers.
-        expr: nixos_revision_behind{role!="desktop"} == 1
-        for: 6h
+      - alert: NixOSDeployDrift
+        # Fires only when main has actually changed THIS host's system closure
+        # and the host has not taken it up for six hours.
+        #
+        # The elapsed-time term is the crux. nixos_expected_change_timestamp_seconds
+        # only moves when the host's expected closure changes, so a commit that
+        # does not affect this host never starts the clock -- which is what makes
+        # frequent no-op churn (a nightly overlay bump for a package this host
+        # does not install, a flake input only desktops consume) silent instead
+        # of paging. Using `for: 6h` on a plain boolean could not express this:
+        # the boolean would already be true the moment main moved.
+        #
+        # Desktops are excluded: they are rebuilt by hand on their own cadence
+        # and legitimately run local builds. Selecting on role rather than host
+        # matters -- an earlier rule used host!~"daytona|maranello" and never
+        # excluded Daytona, because the label is "Daytona" and PromQL regexes
+        # are case-sensitive.
+        #
+        # The trailing group_left join pulls the closure/revision labels off
+        # nixos_deploy_info so the annotations can name what is actually stale.
+        # nixos_deploy_info is an identity metric with a constant value of 1,
+        # which is what keeps this a label enrichment rather than an arithmetic
+        # change to the condition.
+        expr: |
+          (
+            nixos_deploy_state{state="drifted", role!="desktop"} == 1
+            and on (host) (
+              (time() - max by (host) (nixos_expected_change_timestamp_seconds)) > 21600
+            )
+          )
+          * on (host) group_left (running, expected, short_rev, short_expected_rev)
+          max by (host, running, expected, short_rev, short_expected_rev) (nixos_deploy_info)
+        # Short: the six-hour grace already lives in the expression above. This
+        # only needs to ride out a scrape gap or an in-flight deploy.
+        for: 15m
         labels:
           severity: warning
         annotations:
-          summary: "NixOS checkout is behind GitHub main"
-          description: "Host {{ $labels.host }} is behind GitHub main."
+          summary: "NixOS host is running an outdated system closure"
+          description: >-
+            {{ $labels.host }} is running {{ $labels.running }} (from
+            {{ $labels.short_rev }}) but main expects {{ $labels.expected }}
+            (from {{ $labels.short_expected_rev }}). This commit range genuinely
+            changes this host's closure, so a deploy is required.
+
+      - alert: NixOSUnmanagedSystem
+        # The running closure is not one the manifest has ever published for
+        # this host: a local, dirty or feature-branch build. The superseded
+        # nixos-revision-metric script reported exactly this case as healthy,
+        # because it hard-coded BEHIND=0 whenever the recorded revision was the
+        # string "dirty" -- so a server left on a WIP build never alerted no
+        # matter how far main moved.
+        #
+        # Same group_left label enrichment as NixOSDeployDrift; see the note
+        # there for why the constant-valued info metric makes this safe.
+        expr: |
+          (nixos_deploy_state{state="unmanaged", role!="desktop"} == 1)
+          * on (host) group_left (running, expected)
+          max by (host, running, expected) (nixos_deploy_info)
+        for: 2h
+        labels:
+          severity: warning
+        annotations:
+          summary: "NixOS host is running an unmanaged system closure"
+          description: >-
+            {{ $labels.host }} is running {{ $labels.running }}, which main has
+            never produced (main expects {{ $labels.expected }}). It was
+            probably deployed from a dirty or feature-branch checkout and will
+            not converge on its own.
+
+      - alert: NixOSDeployStateUnknown
+        # Cannot determine drift at all: no manifest was ever fetched, or this
+        # host is absent from it (newly added and not yet published). Distinct
+        # from the states above because the check itself is blind here, and a
+        # blind check that stays quiet is the failure mode this whole rule set
+        # was rewritten to eliminate.
+        expr: nixos_deploy_state{state="unknown", role!="desktop"} == 1
+        for: 12h
+        labels:
+          severity: warning
+        annotations:
+          summary: "NixOS deploy state cannot be determined"
+          description: >-
+            {{ $labels.host }} could not resolve its expected closure from the
+            fleet manifest for 12 hours. Drift detection is not running on this
+            host. Check the fleet-manifest workflow and the host's egress to
+            raw.githubusercontent.com.
+
+      - alert: NixOSFleetManifestStale
+        # If the publishing workflow breaks, hosts keep fetching the last good
+        # manifest successfully and every one of them keeps reporting
+        # up_to_date. Drift detection silently freezes with no other symptom:
+        # NixOSDeployStateUnknown cannot catch it, because the fetch succeeds
+        # and the host is present in the file. This is the watchdog for that.
+        #
+        # Aggregated with min() and deliberately not `by (host)`: a stale
+        # manifest is one fault in one workflow, so it should page once rather
+        # than once per host. min() also makes the condition specific -- if even
+        # the freshest host in the fleet is looking at a day-old manifest, the
+        # publisher is broken rather than one host's network.
+        expr: min(nixos_manifest_age_seconds{role!="desktop"}) > 86400
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Fleet deploy manifest is stale"
+          description: >-
+            The newest fleet manifest any host can see is over 24h old, so
+            deploy-drift detection is effectively disabled fleet-wide. Check the
+            Fleet Manifest workflow.
+
+      - alert: NixOSManifestFetchStalled
+        # Complements NixOSFleetManifestStale by covering the opposite fault: a
+        # single host that has lost egress (or is being served a stale cached
+        # copy) while the publisher is healthy. Such a host keeps comparing
+        # against its last good manifest, so it happily reports up_to_date
+        # against an expectation that has since moved -- drift goes undetected on
+        # that host and nothing else here would notice. Same class of silent
+        # blindness the commit-distance check suffered from.
+        #
+        # Expressed as a differential against the freshest host in the fleet
+        # rather than an absolute age. An absolute per-host threshold would also
+        # fire on every host during a publisher outage, reintroducing exactly the
+        # seven-notifications-for-one-fault noise this rewrite removes; a
+        # publisher outage raises every host's age together, so the differential
+        # stays near zero and only this rule's true condition can trip it. It
+        # also catches a stale-but-successful fetch, which a
+        # nixos_manifest_fetch_success term would miss.
+        expr: |
+          (
+            nixos_manifest_age_seconds{role!="desktop"}
+            - on () group_left () min(nixos_manifest_age_seconds{role!="desktop"})
+          ) > 43200
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "NixOS host is not refreshing the fleet manifest"
+          description: >-
+            {{ $labels.host }} is comparing against a manifest at least 12h
+            older than the freshest one in the fleet, so its drift detection is
+            stale even though it may report up to date. Check the host's egress
+            to raw.githubusercontent.com.
 
       - alert: AdGuardHomeDown
         expr: node_systemd_unit_state{state="active", name="adguardhome.service", hostname="sdrhub"} == 0

--- a/modules/monitoring/master/alert-rules/system-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/system-alerts.yaml
@@ -131,6 +131,38 @@ groups:
             deploy-drift detection is effectively disabled fleet-wide. Check the
             Fleet Manifest workflow.
 
+      - alert: NixOSDeployStateMetricsMissing
+        # Every rule in this group selects a metric written by a single unit
+        # (nixos-deploy-state-metric.service). If that unit stops producing its
+        # textfile fleet-wide, every one of those selectors matches nothing and
+        # Prometheus reports all of them health=ok -- the "a rule that can never
+        # fire looks identical to a healthy rule" trap that
+        # scripts/check-alert-metrics.sh exists to catch at PR time. This is the
+        # runtime equivalent.
+        #
+        # Selects nixos_deploy_state rather than nixos_manifest_age_seconds
+        # deliberately: it is the metric four alerts in this group depend on, and
+        # both live in the same file, so one rule covers the lot. The four states
+        # are emitted unconditionally on every run, so absence here always means
+        # the exporter is not reporting, never that a condition is false.
+        #
+        # absent() only fires when the vector is completely empty, so this covers
+        # fleet-wide loss. Per-host loss is already covered by the generic
+        # SystemdUnitFailed (alert-rules.yaml) and SystemdTimerStale
+        # (capacity-alerts.yaml), both of which match this unit and timer without
+        # needing to name them.
+        expr: absent(nixos_deploy_state{role!="desktop"})
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "NixOS deploy-state metrics are missing fleet-wide"
+          description: >-
+            No non-desktop host is exporting nixos_deploy_state, so every
+            deploy-drift rule in this group is silently matching nothing. Check
+            nixos-deploy-state-metric.service and the node_exporter textfile
+            collector.
+
       - alert: NixOSManifestFetchStalled
         # Complements NixOSFleetManifestStale by covering the opposite fault: a
         # single host that has lost egress (or is being served a stale cached

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -401,6 +401,27 @@ tests:
               summary: "NixOS host is running an unmanaged system closure"
               description: "vdlmhub is running nixos-system-vdlmhub-wip, which main has never produced (main expects nixos-system-vdlmhub-2). It was probably deployed from a dirty or feature-branch checkout and will not converge on its own."
 
+  # Desktops report `unmanaged` in NORMAL operation: they are rebuilt locally,
+  # frequently from a dirty tree, so their running closure is routinely one main
+  # never published. That makes the role!="desktop" selector on this rule more
+  # load-bearing than on NixOSDeployDrift -- removing it would page for both
+  # desktops permanently rather than occasionally.
+  - interval: 1m
+    name: NixOSUnmanagedSystem ignores desktops, which build locally by design
+    input_series:
+      - series: 'nixos_deploy_state{host="Daytona", hostname="Daytona", role="desktop", state="unmanaged"}'
+        values: "1+0x500"
+      - series: 'nixos_deploy_state{host="maranello", hostname="maranello", role="desktop", state="unmanaged"}'
+        values: "1+0x500"
+      - series: 'nixos_deploy_info{host="Daytona", hostname="Daytona", role="desktop", running="nixos-system-Daytona-local", expected="nixos-system-Daytona-1"}'
+        values: "1+0x500"
+      - series: 'nixos_deploy_info{host="maranello", hostname="maranello", role="desktop", running="nixos-system-maranello-local", expected="nixos-system-maranello-1"}'
+        values: "1+0x500"
+    alert_rule_test:
+      - eval_time: 3h
+        alertname: NixOSUnmanagedSystem
+        exp_alerts: []
+
   # A host that cannot resolve its expected closure has no drift detection at
   # all. A blind check that stays quiet is the exact failure this rule set was
   # rewritten to eliminate, so blindness itself has to be alertable.
@@ -422,6 +443,39 @@ tests:
             exp_annotations:
               summary: "NixOS deploy state cannot be determined"
               description: "vdlmhub could not resolve its expected closure from the fleet manifest for 12 hours. Drift detection is not running on this host. Check the fleet-manifest workflow and the host's egress to raw.githubusercontent.com."
+
+  # Every rule in the nixos-alerts group reads a metric from one unit. If that
+  # unit stops fleet-wide, all of them match nothing and Prometheus calls them
+  # healthy. These two cases assert the absent() backstop both fires on total
+  # loss and stays quiet whenever anything is still reporting.
+  - interval: 1m
+    name: NixOSDeployStateMetricsMissing fires when no host exports the metric
+    input_series:
+      # Some unrelated series must exist, or promtool has no timeline to
+      # evaluate against and the test proves nothing.
+      - series: 'nixos_needs_reboot{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "0+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: NixOSDeployStateMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "NixOS deploy-state metrics are missing fleet-wide"
+              description: "No non-desktop host is exporting nixos_deploy_state, so every deploy-drift rule in this group is silently matching nothing. Check nixos-deploy-state-metric.service and the node_exporter textfile collector."
+
+  # One surviving host is enough to prove the exporter is not universally broken,
+  # and the per-host case belongs to SystemdUnitFailed / SystemdTimerStale.
+  - interval: 1m
+    name: NixOSDeployStateMetricsMissing stays silent while one host reports
+    input_series:
+      - series: 'nixos_deploy_state{host="vdlmhub", hostname="vdlmhub", role="agent", state="up_to_date"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: NixOSDeployStateMetricsMissing
+        exp_alerts: []
 
   # Watchdog for the publisher. If the manifest workflow stops, every host keeps
   # fetching the last good file successfully and keeps reporting up_to_date, so

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -270,29 +270,212 @@ tests:
               summary: "Docker daemon is not running on vdlmhub"
               description: "dockerd is not active. Every container on this host is down."
 
-  # NixOSNotOnMain previously matched host!~"daytona|maranello", which never
-  # excluded Daytona because the host label is "Daytona" and PromQL regexes
-  # are case-sensitive.
+  # ---------------------------------------------------------------------------
+  # Deploy-state alerts.
+  #
+  # These replace NixOSNotOnMain / NixOSRevisionBehind, which counted commits
+  # between the host's recorded git SHA and main. The tests below encode the
+  # three failure modes that motivated the rewrite, so a regression to
+  # commit-distance semantics fails here rather than in production Pushover
+  # notifications.
+  #
+  # promtool has no clock, so `time()` in the drift rule evaluates to the test's
+  # eval_time as a Unix timestamp -- for a test starting at epoch 0, eval_time
+  # 7h means time() == 25200. Expected-change timestamps below are therefore
+  # small absolute numbers chosen relative to that, not real dates.
+  # ---------------------------------------------------------------------------
+
+  # Failure mode (b)/(c): main moves, but the commits do not change this host's
+  # closure. The host reports up_to_date and, critically, its
+  # expected-change timestamp does not move -- so nothing fires. This is the
+  # case that generated recurring false alerts on all seven servers every time
+  # the nightly opencode overlay bump landed.
   - interval: 1m
-    name: NixOSNotOnMain ignores desktops regardless of hostname casing
+    name: NixOSDeployDrift stays silent when main does not change this host
     input_series:
-      - series: 'nixos_branch{host="Daytona", hostname="Daytona", role="desktop"}'
+      - series: 'nixos_deploy_state{host="vdlmhub", hostname="vdlmhub", role="agent", state="up_to_date"}'
+        values: "1+0x500"
+      - series: 'nixos_deploy_state{host="vdlmhub", hostname="vdlmhub", role="agent", state="drifted"}'
         values: "0+0x500"
-      - series: 'nixos_branch{host="maranello", hostname="maranello", role="desktop"}'
-        values: "0+0x500"
+      - series: 'nixos_expected_change_timestamp_seconds{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "100+0x500"
+      - series: 'nixos_deploy_info{host="vdlmhub", hostname="vdlmhub", role="agent", running="nixos-system-vdlmhub-1", expected="nixos-system-vdlmhub-1", short_rev="aaaaaaa", short_expected_rev="aaaaaaa"}'
+        values: "1+0x500"
     alert_rule_test:
       - eval_time: 7h
-        alertname: NixOSNotOnMain
+        alertname: NixOSDeployDrift
         exp_alerts: []
 
+  # Drift within the grace window must not page. The closure genuinely changed,
+  # but only ~1h ago (expected-change timestamp 21000 vs time() == 25200), which
+  # is inside the six-hour allowance for a deploy to happen.
   - interval: 1m
-    name: NixOSNotOnMain fires for a server off main
+    name: NixOSDeployDrift stays silent inside the grace window
     input_series:
-      - series: 'nixos_branch{host="vdlmhub", hostname="vdlmhub", role="agent"}'
-        values: "0+0x500"
+      - series: 'nixos_deploy_state{host="vdlmhub", hostname="vdlmhub", role="agent", state="drifted"}'
+        values: "1+0x500"
+      - series: 'nixos_expected_change_timestamp_seconds{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "21000+0x500"
+      - series: 'nixos_deploy_info{host="vdlmhub", hostname="vdlmhub", role="agent", running="nixos-system-vdlmhub-1", expected="nixos-system-vdlmhub-2", short_rev="aaaaaaa", short_expected_rev="bbbbbbb"}'
+        values: "1+0x500"
     alert_rule_test:
       - eval_time: 7h
-        alertname: NixOSNotOnMain
+        alertname: NixOSDeployDrift
+        exp_alerts: []
+
+  # Legitimate drift: the host's closure changed more than six hours ago and the
+  # host has not taken it up. The annotation must name both closures, which only
+  # works if the group_left join against the constant-valued nixos_deploy_info
+  # is intact.
+  - interval: 1m
+    name: NixOSDeployDrift fires when this host's closure changed long ago
+    input_series:
+      - series: 'nixos_deploy_state{host="vdlmhub", hostname="vdlmhub", role="agent", state="drifted"}'
+        values: "1+0x500"
+      - series: 'nixos_expected_change_timestamp_seconds{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "100+0x500"
+      - series: 'nixos_deploy_info{host="vdlmhub", hostname="vdlmhub", role="agent", running="nixos-system-vdlmhub-1", expected="nixos-system-vdlmhub-2", short_rev="aaaaaaa", short_expected_rev="bbbbbbb"}'
+        values: "1+0x500"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: NixOSDeployDrift
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              host: vdlmhub
+              hostname: vdlmhub
+              role: agent
+              state: drifted
+              running: nixos-system-vdlmhub-1
+              expected: nixos-system-vdlmhub-2
+              short_rev: aaaaaaa
+              short_expected_rev: bbbbbbb
+            exp_annotations:
+              summary: "NixOS host is running an outdated system closure"
+              description: "vdlmhub is running nixos-system-vdlmhub-1 (from aaaaaaa) but main expects nixos-system-vdlmhub-2 (from bbbbbbb). This commit range genuinely changes this host's closure, so a deploy is required."
+
+  # Desktops are excluded by role, not by a host-name regex. The predecessor
+  # rule used host!~"daytona|maranello" and never excluded Daytona, because the
+  # label is "Daytona" and PromQL regexes are case-sensitive. Keeping a
+  # mixed-case desktop in this test preserves that regression guard.
+  - interval: 1m
+    name: NixOSDeployDrift ignores desktops regardless of hostname casing
+    input_series:
+      - series: 'nixos_deploy_state{host="Daytona", hostname="Daytona", role="desktop", state="drifted"}'
+        values: "1+0x500"
+      - series: 'nixos_deploy_state{host="maranello", hostname="maranello", role="desktop", state="drifted"}'
+        values: "1+0x500"
+      - series: 'nixos_expected_change_timestamp_seconds{host="Daytona", hostname="Daytona", role="desktop"}'
+        values: "100+0x500"
+      - series: 'nixos_expected_change_timestamp_seconds{host="maranello", hostname="maranello", role="desktop"}'
+        values: "100+0x500"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: NixOSDeployDrift
+        exp_alerts: []
+
+  # Failure mode (a): a host built from a dirty or feature-branch tree. The
+  # superseded script hard-coded BEHIND=0 whenever the recorded revision was the
+  # string "dirty", so this -- the state most deserving an alert -- was the one
+  # state guaranteed to stay silent. It must now fire.
+  - interval: 1m
+    name: NixOSUnmanagedSystem fires for a server on an unpublished closure
+    input_series:
+      - series: 'nixos_deploy_state{host="vdlmhub", hostname="vdlmhub", role="agent", state="unmanaged"}'
+        values: "1+0x500"
+      - series: 'nixos_deploy_info{host="vdlmhub", hostname="vdlmhub", role="agent", running="nixos-system-vdlmhub-wip", expected="nixos-system-vdlmhub-2"}'
+        values: "1+0x500"
+    alert_rule_test:
+      - eval_time: 3h
+        alertname: NixOSUnmanagedSystem
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              host: vdlmhub
+              hostname: vdlmhub
+              role: agent
+              state: unmanaged
+              running: nixos-system-vdlmhub-wip
+              expected: nixos-system-vdlmhub-2
+            exp_annotations:
+              summary: "NixOS host is running an unmanaged system closure"
+              description: "vdlmhub is running nixos-system-vdlmhub-wip, which main has never produced (main expects nixos-system-vdlmhub-2). It was probably deployed from a dirty or feature-branch checkout and will not converge on its own."
+
+  # A host that cannot resolve its expected closure has no drift detection at
+  # all. A blind check that stays quiet is the exact failure this rule set was
+  # rewritten to eliminate, so blindness itself has to be alertable.
+  - interval: 1m
+    name: NixOSDeployStateUnknown fires when the host cannot resolve state
+    input_series:
+      - series: 'nixos_deploy_state{host="vdlmhub", hostname="vdlmhub", role="agent", state="unknown"}'
+        values: "1+0x900"
+    alert_rule_test:
+      - eval_time: 13h
+        alertname: NixOSDeployStateUnknown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              host: vdlmhub
+              hostname: vdlmhub
+              role: agent
+              state: unknown
+            exp_annotations:
+              summary: "NixOS deploy state cannot be determined"
+              description: "vdlmhub could not resolve its expected closure from the fleet manifest for 12 hours. Drift detection is not running on this host. Check the fleet-manifest workflow and the host's egress to raw.githubusercontent.com."
+
+  # Watchdog for the publisher. If the manifest workflow stops, every host keeps
+  # fetching the last good file successfully and keeps reporting up_to_date, so
+  # nothing else in this rule set can notice. min() means one alert for the whole
+  # fleet rather than one per host, and makes the condition specific: if even the
+  # freshest host is looking at a day-old manifest, the publisher is at fault.
+  - interval: 1m
+    name: NixOSFleetManifestStale fires once for the fleet, not once per host
+    input_series:
+      - series: 'nixos_manifest_age_seconds{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "90000+0x200"
+      - series: 'nixos_manifest_age_seconds{host="acarshub", hostname="acarshub", role="agent"}'
+        values: "95000+0x200"
+      - series: 'nixos_manifest_age_seconds{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "91000+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: NixOSFleetManifestStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "Fleet deploy manifest is stale"
+              description: "The newest fleet manifest any host can see is over 24h old, so deploy-drift detection is effectively disabled fleet-wide. Check the Fleet Manifest workflow."
+
+  # A single host lagging on its fetch must NOT trip the fleet-wide watchdog:
+  # that is a per-host network problem, and min() is what keeps the two apart.
+  # The companion NixOSManifestFetchStalled is what should catch it instead --
+  # asserted in the next two cases.
+  - interval: 1m
+    name: NixOSFleetManifestStale ignores one host with a stale local cache
+    input_series:
+      - series: 'nixos_manifest_age_seconds{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "90000+0x200"
+      - series: 'nixos_manifest_age_seconds{host="acarshub", hostname="acarshub", role="agent"}'
+        values: "600+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: NixOSFleetManifestStale
+        exp_alerts: []
+
+  # The single-stalled-host case the fleet-wide watchdog deliberately ignores.
+  # vdlmhub is 90000s behind while acarshub is at 600s, so the differential is
+  # ~89400s > 43200s.
+  - interval: 1m
+    name: NixOSManifestFetchStalled fires for the one host that stopped refreshing
+    input_series:
+      - series: 'nixos_manifest_age_seconds{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "90000+0x200"
+      - series: 'nixos_manifest_age_seconds{host="acarshub", hostname="acarshub", role="agent"}'
+        values: "600+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: NixOSManifestFetchStalled
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -300,5 +483,24 @@ tests:
               hostname: vdlmhub
               role: agent
             exp_annotations:
-              summary: "NixOS repo not on main branch"
-              description: "The NixOS configuration on vdlmhub is not checked out on main for more than 6 hours."
+              summary: "NixOS host is not refreshing the fleet manifest"
+              description: "vdlmhub is comparing against a manifest at least 12h older than the freshest one in the fleet, so its drift detection is stale even though it may report up to date. Check the host's egress to raw.githubusercontent.com."
+
+  # A publisher outage raises every host's age together. The differential stays
+  # near zero, so this rule must stay silent and leave the single fleet-wide
+  # NixOSFleetManifestStale notification to do the reporting. Without this
+  # guard the alert would page once per host for one fault -- the noise pattern
+  # this whole rewrite exists to remove.
+  - interval: 1m
+    name: NixOSManifestFetchStalled stays silent during a publisher outage
+    input_series:
+      - series: 'nixos_manifest_age_seconds{host="vdlmhub", hostname="vdlmhub", role="agent"}'
+        values: "90000+0x200"
+      - series: 'nixos_manifest_age_seconds{host="acarshub", hostname="acarshub", role="agent"}'
+        values: "91000+0x200"
+      - series: 'nixos_manifest_age_seconds{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "90500+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: NixOSManifestFetchStalled
+        exp_alerts: []

--- a/modules/monitoring/master/dashboards/fleet-overview.json
+++ b/modules/monitoring/master/dashboards/fleet-overview.json
@@ -207,7 +207,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "count(nixos_deploy_state{role!=\"desktop\", state=\"drifted\"} == 1) or vector(0)",
+          "expr": "count(nixos_deploy_state{role!=\"desktop\", state=~\"drifted|unmanaged\"} == 1) or vector(0)",
           "legendFormat": "Needing deploy",
           "instant": true
         }
@@ -553,7 +553,7 @@
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Needs Deploy" },
+            "matcher": { "id": "byName", "options": "Deploy State" },
             "properties": [
               {
                 "id": "mappings",
@@ -561,13 +561,41 @@
                   {
                     "type": "value",
                     "options": {
-                      "0": { "text": "Current", "color": "green", "index": 0 }
+                      "up_to_date": {
+                        "text": "Current",
+                        "color": "green",
+                        "index": 0
+                      }
                     }
                   },
                   {
                     "type": "value",
                     "options": {
-                      "1": { "text": "DEPLOY", "color": "yellow", "index": 1 }
+                      "drifted": {
+                        "text": "DEPLOY",
+                        "color": "yellow",
+                        "index": 1
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "unmanaged": {
+                        "text": "UNMANAGED",
+                        "color": "orange",
+                        "index": 2
+                      }
+                    }
+                  },
+                  {
+                    "type": "value",
+                    "options": {
+                      "unknown": {
+                        "text": "UNKNOWN",
+                        "color": "red",
+                        "index": 3
+                      }
                     }
                   }
                 ]
@@ -576,7 +604,7 @@
                 "id": "custom.cellOptions",
                 "value": { "type": "color-background" }
               },
-              { "id": "custom.width", "value": 100 }
+              { "id": "custom.width", "value": 120 }
             ]
           },
           {
@@ -632,21 +660,22 @@
             "renameByName": {
               "host": "Host",
               "short_rev": "SHA",
+              "state": "Deploy State",
               "Value #build": "Last Deployed",
-              "Value #behind": "Needs Deploy",
               "Value #lag": "Drift Age (h)",
               "Value #reboot": "Reboot Needed",
               "Value #up": "Up"
             },
             "excludeByName": {
-              "Time": true
+              "Time": true,
+              "Value #behind": true
             },
             "indexByName": {
               "Host": 0,
               "Up": 1,
               "SHA": 2,
               "Last Deployed": 3,
-              "Needs Deploy": 4,
+              "Deploy State": 4,
               "Drift Age (h)": 5,
               "Reboot Needed": 6
             }
@@ -665,7 +694,7 @@
         {
           "refId": "behind",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "max by (host) (nixos_deploy_state{state=\"drifted\"})",
+          "expr": "max by (host, state) (nixos_deploy_state == 1)",
           "instant": true,
           "legendFormat": "__auto",
           "format": "table"
@@ -673,7 +702,7 @@
         {
           "refId": "lag",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "(time() - max by (host) (nixos_expected_change_timestamp_seconds)) / 3600 * max by (host) (nixos_deploy_state{state=\"drifted\"})",
+          "expr": "(time() - max by (host) (nixos_expected_change_timestamp_seconds)) / 3600 * max by (host) (nixos_deploy_state{state=~\"drifted|unmanaged\"})",
           "instant": true,
           "legendFormat": "__auto",
           "format": "table"

--- a/modules/monitoring/master/dashboards/fleet-overview.json
+++ b/modules/monitoring/master/dashboards/fleet-overview.json
@@ -168,8 +168,8 @@
     {
       "id": 5,
       "type": "stat",
-      "title": "Nodes Behind Main",
-      "description": "Nodes whose deployed commit is behind GitHub main",
+      "title": "Nodes Needing Deploy",
+      "description": "Nodes whose running system closure differs from the one main expects for them. Counts real deploys, not commit distance: a commit that does not change a node's closure never appears here.",
       "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
@@ -207,8 +207,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "count(nixos_revision_behind{role!=\"desktop\"} == 1) or vector(0)",
-          "legendFormat": "Behind",
+          "expr": "count(nixos_deploy_state{role!=\"desktop\", state=\"drifted\"} == 1) or vector(0)",
+          "legendFormat": "Needing deploy",
           "instant": true
         }
       ]
@@ -475,7 +475,7 @@
       "id": 11,
       "type": "table",
       "title": "Node Deployment Status",
-      "description": "Per-node: deployed SHA, deploy time, commits behind main, reboot needed, and node up status",
+      "description": "Per-node: running closure's source commit, deploy time, whether the running closure differs from the one main expects, how long it has differed, reboot needed, and node up status",
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 10 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
@@ -553,7 +553,7 @@
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Behind Main" },
+            "matcher": { "id": "byName", "options": "Needs Deploy" },
             "properties": [
               {
                 "id": "mappings",
@@ -567,7 +567,7 @@
                   {
                     "type": "value",
                     "options": {
-                      "1": { "text": "BEHIND", "color": "yellow", "index": 1 }
+                      "1": { "text": "DEPLOY", "color": "yellow", "index": 1 }
                     }
                   }
                 ]
@@ -580,16 +580,17 @@
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Commits Behind" },
+            "matcher": { "id": "byName", "options": "Drift Age (h)" },
             "properties": [
+              { "id": "decimals", "value": 1 },
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
                     { "color": "green", "value": null },
-                    { "color": "yellow", "value": 1 },
-                    { "color": "red", "value": 10 }
+                    { "color": "yellow", "value": 6 },
+                    { "color": "red", "value": 72 }
                   ]
                 }
               },
@@ -630,24 +631,23 @@
           "options": {
             "renameByName": {
               "host": "Host",
-              "short_sha": "SHA",
+              "short_rev": "SHA",
               "Value #build": "Last Deployed",
-              "Value #behind": "Behind Main",
-              "Value #lag": "Commits Behind",
+              "Value #behind": "Needs Deploy",
+              "Value #lag": "Drift Age (h)",
               "Value #reboot": "Reboot Needed",
               "Value #up": "Up"
             },
             "excludeByName": {
-              "Time": true,
-              "sha": true
+              "Time": true
             },
             "indexByName": {
               "Host": 0,
               "Up": 1,
               "SHA": 2,
               "Last Deployed": 3,
-              "Behind Main": 4,
-              "Commits Behind": 5,
+              "Needs Deploy": 4,
+              "Drift Age (h)": 5,
               "Reboot Needed": 6
             }
           }
@@ -657,7 +657,7 @@
         {
           "refId": "build",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "max by (host, short_sha) (nixos_build_info)",
+          "expr": "max by (host, short_rev) (nixos_deploy_timestamp_seconds * on (host) group_left (short_rev) nixos_deploy_info) * 1000",
           "instant": true,
           "legendFormat": "__auto",
           "format": "table"
@@ -665,7 +665,7 @@
         {
           "refId": "behind",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "max by (host) (nixos_revision_behind)",
+          "expr": "max by (host) (nixos_deploy_state{state=\"drifted\"})",
           "instant": true,
           "legendFormat": "__auto",
           "format": "table"
@@ -673,7 +673,7 @@
         {
           "refId": "lag",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "max by (host) (nixos_revision_lag)",
+          "expr": "(time() - max by (host) (nixos_expected_change_timestamp_seconds)) / 3600 * max by (host) (nixos_deploy_state{state=\"drifted\"})",
           "instant": true,
           "legendFormat": "__auto",
           "format": "table"

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -460,6 +460,37 @@ in
                 group_interval = "1m";
                 repeat_interval = "2m";
               }
+              # Fleet-wide deploy-state alerts, grouped by alertname ALONE so a
+              # single cause produces a single notification.
+              #
+              # The parent route groups by (alertname, hostname), which is right
+              # for per-host faults but wrong here: one legitimate change to a
+              # shared input (a nixpkgs-stable bump, a modules/ edit) moves every
+              # server's closure at once, and under the parent grouping that
+              # arrives as seven separate Pushover pushes for one action. The
+              # action is fleet-wide -- deploy the servers -- so the
+              # notification should be too.
+              #
+              # Matched before the severity routes below, which would otherwise
+              # claim these on severity="warning". Individual hosts remain
+              # identifiable: each alert instance is still listed in the grouped
+              # notification body, which pushoverMessage renders per-alert.
+              {
+                matchers = [
+                  ''alertname=~"NixOSDeployDrift|NixOSUnmanagedSystem|NixOSDeployStateUnknown|NixOSManifestFetchStalled|NixOSFleetManifestStale"''
+                ];
+                receiver = "pushover-warning";
+                group_by = [ "alertname" ];
+                # Longer than the parent's 30s: a fleet-wide change trips hosts a
+                # few scrape intervals apart, and a short group_wait would split
+                # one cause across two notifications anyway.
+                group_wait = "5m";
+                group_interval = "30m";
+                # Deploy drift is not urgent and self-resolves on the next
+                # deploy. Daily is enough to stay on the radar without becoming
+                # background noise -- the failure mode this rewrite targets.
+                repeat_interval = "24h";
+              }
               {
                 matchers = [ ''severity="critical"'' ];
                 receiver = "pushover-critical";

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -136,6 +136,31 @@ else
     OLD_JSON='{}'
 fi
 
+# Hosts that were published before but are absent now. Reported loudly, but
+# deliberately NOT treated as fatal.
+#
+# A partially-evaluated subset is not reachable here: `nix eval --json` forces
+# the whole attrset, so any single host failing to evaluate fails the command
+# outright and we exit above. The only way this set is non-empty is a deliberate
+# removal from nixosConfigurations, which is a normal operation -- and failing on
+# it would wedge the publisher on every subsequent commit until someone
+# intervened, taking drift detection down for the entire fleet to report one
+# intentional change.
+#
+# The consequence of a genuinely unintended removal is already covered: the
+# dropped host resolves no history, reports `unknown`, and
+# NixOSDeployStateUnknown fires. This message is here so the cause is obvious in
+# the workflow log when that happens.
+DROPPED="$(jq -r --argjson paths "$PATHS_JSON" '
+    ((.hosts // {}) | keys) - ($paths | keys) | join(" ")
+' <<<"$OLD_JSON")"
+
+if [[ -n "$DROPPED" ]]; then
+    echo "WARNING: hosts in the previous manifest are no longer in nixosConfigurations: ${DROPPED}" >&2
+    echo "         They will lose their history and report deploy state 'unknown'." >&2
+    echo "         Expected after an intentional host removal; otherwise investigate." >&2
+fi
+
 NEW_JSON="$(
     jq -n \
         --argjson old "$OLD_JSON" \

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -130,7 +130,20 @@ echo "Evaluated $(jq -r 'length' <<<"$PATHS_JSON") host(s)." >&2
 
 # Previous manifest, if any. A malformed existing file is treated as absent
 # rather than fatal so a corrupted manifest self-heals on the next run.
-if [[ -f "$OUT" ]] && jq -e . "$OUT" >/dev/null 2>&1; then
+#
+# The structure is validated, not just the syntax. A bare `jq -e .` would accept
+# any valid JSON, including shapes this script then indexes as an object --
+# `[]`, `"string"`, or a `history` that is not an array. Those raise a jq error
+# rather than returning null, and under `set -e` that aborts the run instead of
+# self-healing, which would leave the whole fleet without a manifest until
+# someone hand-repaired the branch. Checking the shape up front makes the
+# self-heal claim above actually true for any corruption, not only for invalid
+# JSON.
+if [[ -f "$OUT" ]] && jq -e '
+    type == "object"
+    and ((.hosts // {}) | type == "object")
+    and ((.hosts // {}) | all(.[]; (.history // []) | type == "array"))
+' "$OUT" >/dev/null 2>&1; then
     OLD_JSON="$(cat "$OUT")"
 else
     OLD_JSON='{}'

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# gen-fleet-manifest.sh -- publish the fleet deploy manifest.
+#
+# WHAT THIS IS
+#
+# For every host in `nixosConfigurations`, evaluate the store path of
+# `config.system.build.toplevel` and record it. A host is up to date exactly
+# when `readlink -f /run/current-system` equals the path recorded here. That
+# comparison is the ground truth for "does this host need a deploy?", and it is
+# the only formulation that is immune to all three ways the previous
+# commit-counting check produced false alerts:
+#
+#   1. A host built from a dirty or branch checkout used to report "not behind"
+#      because the recorded revision was the string "dirty" and the old script
+#      hard-coded BEHIND=0 for that case. Here its running closure simply is
+#      not one this manifest ever published, so it is reported as unmanaged.
+#
+#   2. A commit that moves main without changing a given host's closure (an
+#      opencode overlay bump, for instance: overlays are lazy, so a package no
+#      host installs cannot alter any closure) leaves that host's recorded path
+#      untouched. Nothing moves, so nothing alerts, and the rebuild that
+#      "silently changed nothing" is no longer requested.
+#
+#   3. Same mechanism covers commits that are simply irrelevant to a host.
+#
+# WHY THIS EVALUATES EVERY HOST
+#
+# It deliberately does NOT reuse the impacted-hosts path filter from
+# ci-linux.yaml. That filter is intentionally conservative -- `overlays/*` and
+# `modules/*` map to GLOBAL -- because over-building in CI only costs cached
+# CPU. Over-reporting drift, by contrast, is exactly the bug being fixed here.
+# Evaluating all hosts unconditionally (~50s for nine hosts, single eval) keeps
+# the drift signal exact and completely decoupled from the filter's coarseness.
+#
+# MANIFEST SHAPE
+#
+#   {
+#     "schema": 1,
+#     "generated_at": <unix seconds>,
+#     "rev": "<commit this run evaluated>",
+#     "hosts": {
+#       "<host>": {
+#         "history": [
+#           { "toplevel": "/nix/store/...", "rev": "<sha>", "at": <unix seconds> },
+#           ...
+#         ]
+#       }
+#     }
+#   }
+#
+# `history` is newest-first and `history[0]` is always the currently expected
+# closure. Entries are appended only when a host's path actually changes, so
+# `history[0].at` answers "when did main last change this host?" -- the value
+# the drift alert measures elapsed time against. Older entries let a host tell
+# "running a genuinely older managed build" (drifted) apart from "running
+# something main never produced" (unmanaged), and let a running path be mapped
+# back to the commit that introduced it now that the revision is no longer
+# baked into the closure.
+#
+# Usage:
+#   scripts/gen-fleet-manifest.sh <output-path> [rev]
+#
+# `rev` defaults to HEAD of the current checkout. The output file is written
+# atomically; if it already exists it is used as the previous manifest so
+# unchanged hosts carry their history forward.
+
+set -euo pipefail
+
+OUT="${1:?usage: gen-fleet-manifest.sh <output-path> [rev]}"
+REV="${2:-$(git rev-parse HEAD)}"
+
+# Cap on per-host history length. This only needs to be long enough to
+# recognise a host that is a few deploys behind; beyond that the distinction
+# between "very old managed build" and "unmanaged" stops being useful, and an
+# unbounded list would grow the file every host-affecting commit forever.
+MAX_HISTORY=25
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+for tool in nix jq git; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "error: required tool not on PATH: $tool" >&2
+        exit 1
+    }
+done
+
+NOW="$(date +%s)"
+
+# Evaluate every host's toplevel output path in a single eval.
+#
+# stderr is captured to a file rather than merged into stdout: nix prints
+# "Using saved setting for 'extra-substituters = ...'" notices for this flake's
+# nixConfig whenever the invoking user is not a trusted user, and folding those
+# into the JSON would corrupt it. This is the same trap the impacted-hosts
+# script documents.
+EVAL_STDERR="$(mktemp)"
+trap 'rm -f "$EVAL_STDERR"' EXIT
+
+echo "Evaluating system.build.toplevel for every host (rev ${REV})..." >&2
+
+if ! PATHS_JSON="$(
+    nix eval --json .#nixosConfigurations \
+        --apply 'cfgs: builtins.mapAttrs (_: c: c.config.system.build.toplevel.outPath) cfgs' \
+        2>"$EVAL_STDERR"
+)"; then
+    printf 'error: failed to evaluate host toplevels:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
+    exit 1
+fi
+
+# Mirror the CI policy that an evaluation warning is a failure. A warning does
+# not by itself change an output path, but publishing a manifest from a tree
+# that CI would have rejected would advertise paths for a commit that is not
+# actually deployable.
+if grep -q 'evaluation warning:' "$EVAL_STDERR"; then
+    printf 'error: evaluation produced warnings:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
+    exit 1
+fi
+
+# An empty or non-object result means the flake changed shape; publishing it
+# would silently blank the manifest and disable drift detection fleet-wide.
+if [[ "$(jq -r 'type' <<<"$PATHS_JSON")" != "object" ]] ||
+    [[ "$(jq -r 'length' <<<"$PATHS_JSON")" -eq 0 ]]; then
+    echo "error: host evaluation produced no hosts -- refusing to publish" >&2
+    exit 1
+fi
+
+echo "Evaluated $(jq -r 'length' <<<"$PATHS_JSON") host(s)." >&2
+
+# Previous manifest, if any. A malformed existing file is treated as absent
+# rather than fatal so a corrupted manifest self-heals on the next run.
+if [[ -f "$OUT" ]] && jq -e . "$OUT" >/dev/null 2>&1; then
+    OLD_JSON="$(cat "$OUT")"
+else
+    OLD_JSON='{}'
+fi
+
+NEW_JSON="$(
+    jq -n \
+        --argjson old "$OLD_JSON" \
+        --argjson paths "$PATHS_JSON" \
+        --arg rev "$REV" \
+        --argjson now "$NOW" \
+        --argjson maxHistory "$MAX_HISTORY" \
+        '
+        {
+          schema: 1,
+          generated_at: $now,
+          rev: $rev,
+          hosts: (
+            $paths
+            | to_entries
+            | map(
+                .key as $host
+                | .value as $path
+                | (($old.hosts // {})[$host].history // []) as $history
+                | {
+                    key: $host,
+                    value: {
+                      history: (
+                        # Prepend only when the expected closure actually
+                        # changed. This is what keeps history[0].at meaning
+                        # "when main last changed this host" rather than
+                        # "when this workflow last ran".
+                        if ($history | length) > 0 and $history[0].toplevel == $path
+                        then $history
+                        else [ { toplevel: $path, rev: $rev, at: $now } ] + $history
+                        end
+                      )[0:$maxHistory]
+                    }
+                  }
+              )
+            | from_entries
+          )
+        }
+        '
+)"
+
+mkdir -p "$(dirname "$OUT")"
+printf '%s\n' "$NEW_JSON" | jq -S . >"${OUT}.tmp"
+mv "${OUT}.tmp" "$OUT"
+
+# Report what moved, so the workflow log answers "which hosts did this commit
+# actually affect?" directly.
+CHANGED="$(jq -r --arg rev "$REV" '
+    .hosts | to_entries
+    | map(select(.value.history[0].rev == $rev))
+    | map(.key) | join(" ")
+' "$OUT")"
+
+if [[ -n "$CHANGED" ]]; then
+    echo "Hosts whose expected closure changed at ${REV}: ${CHANGED}" >&2
+else
+    echo "No host's expected closure changed at ${REV}." >&2
+fi


### PR DESCRIPTION
## Problem

The fleet's "behind upstream" check compared a git SHA baked into each host
against GitHub `main` and alerted on `.ahead_by > 0`. Commit distance is not a
measure of whether a host needs a deploy, and it produced three distinct classes
of false alert:

1. **Commits that don't touch the host still counted.** Every host alerted on
   every unrelated commit, and the "fix" was a rebuild that changed nothing.
   The nightly opencode overlay bump did this to all seven servers — opencode is
   installed only on Daytona and maranello, and overlays are lazy, so a bump
   cannot alter a server's closure at all.
2. **Dirty builds reported healthy.** A branch/WIP build recorded the literal
   string `"dirty"`, and the script then hard-coded `BEHIND=0` for that case. A
   server left on a WIP build never alerted no matter how far `main` moved — the
   state most deserving an alert was the one state guaranteed to stay silent.
3. **The check had poisoned its own ground truth.** The SHA was written from a
   `system.activationScripts` entry, which is part of `system.build.toplevel`:

   ```
   $ grep -o 'echo "[0-9a-f]\{40\}" > /etc/nixos/configuration-revision' /run/current-system/activate
   echo "5cbb70f76e6815abe0c379ac6d4d725c38ada1e5" > /etc/nixos/configuration-revision
   ```

   Every commit changed every host's store path, whether or not it touched that
   host.

## Approach

Drift is now decided by comparing `readlink -f /run/current-system` against the
`system.build.toplevel` path published for that host in a fleet manifest.
Identical paths means identical systems, so a commit that does not alter a
host's closure cannot move the signal.

Removing the rev from the closure is a **prerequisite**, not a separable change:
without it, every host would compare as drifted on every commit. Hence two
commits — the publisher (inert, additive) and the consumer switch.

The manifest job deliberately does **not** reuse the impacted-hosts path filter
from `ci-linux.yaml`. That filter is intentionally conservative — `overlays/*`
and `modules/*` map to `GLOBAL` — because over-building in CI only costs cached
CPU, whereas over-reporting drift is the bug being fixed. One eval covers all
nine hosts in ~50s, so the signal is exact and fully decoupled from the filter's
coarseness.

## Changes

- **`scripts/gen-fleet-manifest.sh`** + **`.github/workflows/fleet-manifest.yaml`** —
  on push to `main`, evaluate every host's `toplevel` and publish to an orphan
  `fleet-manifest` branch. Per-host history is carried forward and extended only
  when a path actually changes, so `history[0].at` records when `main` last
  changed *that host*.
- **`flake/lib/mk-system.nix`** — remove the rev-bearing activation script, with
  a comment explaining why it must not return.
- **`modules/monitoring/agent/node_exporter.nix`** — three services
  (`nixos-branch-metric`, `nixos-build-info-metric`, `nixos-revision-metric`)
  collapse into one emitting a four-state gauge: `up_to_date` / `drifted` /
  `unmanaged` / `unknown`. Retired `.prom` files and the orphaned
  `/etc/nixos/configuration-revision` are cleaned up; the previous deploy
  timestamp is adopted rather than reset.
- **Alert rules** — `NixOSNotOnMain` and `NixOSRevisionBehind` replaced. The
  drift alert measures elapsed time since `main` last changed *this host's*
  closure, so no-op churn never starts the clock. A `for:` on a boolean could
  not express this, since the boolean is already true the moment `main` moves.
- **Two watchdogs** for the ways the check could go blind: a stalled publisher
  (aggregated with `min()` so one fault pages once) and a single host that
  stopped refreshing (a differential against the freshest host, so a publisher
  outage cannot trip it).
- **`prometheus.nix`** — these alerts group by `alertname` alone, so one
  shared-input change is one notification instead of seven.
- Dashboard panels and `agents.md` updated.

## Verification

| Check | Result |
|-------------------------------------------------|--------|
| All nine hosts eval clean, no eval warnings | pass |
| Different commit, unchanged tree | 0 closures move (was 9/9) |
| Simulated opencode 1.18.13 -> 1.18.14 bump | only Daytona + maranello |
| `.github/*` edit (`GLOBAL` in CI) | 0 closures move |
| `modules/monitoring/master/*` edit (`GLOBAL`) | only sdrhub |
| Four states vs live data | all correct |
| Failed / malformed fetch | cache preserved, no flip to `unknown` |
| `promtool check metrics` on emitted output | pass |
| `promtool check rules` + `test rules` | pass, 8 new cases |
| `pre-commit run --all-files` | pass |

The new promtool cases cover both the false-alert scenarios above and the two
watchdogs. Test harness confirmed non-vacuous by deliberately inverting an
expectation and observing `got:[]`.

## Two things to know before merging

1. **One-time fleet-wide `unmanaged` state.** Removing the rev from the closure
   changes every host's path exactly once (verified: maranello `ijpanm90q…` ->
   `ikzv36k84…`). After merge, servers report `unmanaged` until deployed once.
   Sequence: merge -> manifest publishes -> `colmena apply` -> steady state. The
   2h `for:` gives room.
2. **`check-alert-metrics` will fail on this PR.** It triggers on
   `alert-rules/**` and queries Prometheus for metrics that don't exist until
   deployment. The script already documents this case as expected. The new
   metrics were deliberately *not* added to `CONDITIONAL_METRICS` — that list
   explicitly warns against using it to silence things, and these are
   unconditional once deployed. Goes green after the deploy.

## Follow-up

The manifest now makes `hosts whose closure changed` comparable against `hosts
CI built`, which is an independent audit of the path filter — any host in the
first set but not the second is a filter bug. Separately, auto-deploy is the
natural next step: this identifies precisely which hosts need a deploy and why,
which is exactly the input `colmena apply --on` wants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated fleet deployment manifests, published after changes to the main branch or on demand.
  - Deployment monitoring now compares running systems with expected deployments and reports status, revision, timestamps, and manifest freshness.
  - Added alerts for deployment drift, unmanaged systems, unknown status, stale manifests, and stalled updates.
  - Added fleet-wide alert routing and updated the deployment dashboard to show closure-based drift and age.

- **Bug Fixes**
  - Improved handling of unavailable, outdated, or malformed deployment manifests while preserving previously known state.
  - Removed reliance on embedded Git revision metadata for deployment status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->