### PR TITLE
fix(colmena): align colmena closures with nixosConfigurations; correct deploy timestamp

### DIFF
--- a/flake/deployment/colmena.nix
+++ b/flake/deployment/colmena.nix
@@ -80,7 +80,51 @@ let
         ]
         ++ (node.tags or [ ]);
       };
-      imports = c.modules;
+      imports = c.modules ++ [
+        # Restore the flake-derived version metadata that nixpkgs' own
+        # `lib.nixosSystem` injects but Colmena's evaluator does not.
+        #
+        # nixpkgs' flake builds its `lib` as
+        #   (import ./lib).extend (import ./lib/flake-version-info.nix self)
+        # and that overlay rewrites `lib.trivial.versionSuffix` and
+        # `revisionWithDefault` from the flake's own `self`. `lib.nixosSystem`
+        # passes that extended lib into eval-config, so `mkSystem` (which calls
+        # `pkgsInput.lib.nixosSystem`) gets `26.05.<date>.<shortRev>`. Colmena
+        # calls eval-config directly with the plain `pkgs.lib` from
+        # `import nixpkgs { }`, which is NOT flake-extended, so the suffix fell
+        # back to the sentinel `pre-git`.
+        #
+        # The consequence was that `colmena apply` and
+        # `nix eval .#nixosConfigurations.<host>` produced DIFFERENT store paths
+        # for the same host and the same commit. Two things broke as a result:
+        #
+        #   * The fleet manifest is generated from nixosConfigurations, so every
+        #     colmena-deployed server compared as `unmanaged` forever -- its
+        #     running closure was a path the manifest could never contain.
+        #   * ci-linux.yaml builds and pushes
+        #     `.#nixosConfigurations.<host>...toplevel` to Attic, but colmena
+        #     deployed a different path, so the cache never had the closure
+        #     colmena actually wanted. Every `colmena apply` rebuilt the servers
+        #     locally instead of substituting from Attic.
+        #
+        # Setting these three options makes the two evaluation paths produce
+        # byte-identical toplevels (verified for all seven servers), which fixes
+        # both. Keep them in sync with whatever nixpkgs' flake-version-info
+        # overlay does if that upstream mechanism changes.
+        #
+        # NOTE: `system.nixos.revision` here is the NIXPKGS revision, not this
+        # flake's. It only changes when flake.lock's nixpkgs changes, which
+        # already changes the closure, so this does not reintroduce the
+        # "never bake the flake's git rev into a closure" problem documented in
+        # flake/lib/mk-system.nix.
+        {
+          system.nixos.versionSuffix = ".${
+            builtins.substring 0 8 c.nixpkgs.lastModifiedDate
+          }.${c.nixpkgs.shortRev}";
+          system.nixos.revision = c.nixpkgs.rev;
+          nixpkgs.flake.source = c.nixpkgs.outPath;
+        }
+      ];
     };
 
   # The raw colmena hive attrset.  colmenaHive (below) wraps this with

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -78,8 +78,6 @@
 
             STATE_DIR=/var/lib/nixos-deploy-state
             CACHE="$STATE_DIR/manifest.json"
-            TS_FILE="$STATE_DIR/deploy_timestamp_seconds"
-            LAST_TOPLEVEL_FILE="$STATE_DIR/last_toplevel"
             TEXTFILE_DIR=/var/lib/node_exporter/textfiles
             OUT="$TEXTFILE_DIR/nixos_deploy_state.prom"
 
@@ -139,48 +137,40 @@
                 "$CACHE" 2>/dev/null || echo "")
             fi
 
-            # Deploy timestamp: observed locally, keyed on the running closure
-            # changing. Keying on the closure rather than on a git SHA means
-            # redeploying an identical system does not reset it, and a commit
-            # that does not touch this host does not either.
+            # Deploy timestamp, read straight off the system profile symlink.
             #
-            # Stored and exported in seconds. The superseded metric used
-            # milliseconds implicitly and had to carry a runtime "migrate values
-            # below 1e12" fixup as a result; naming the unit in the metric
-            # removes that class of bug. Grafana wants ms, so the dashboard
-            # multiplies rather than the exporter guessing.
-            LEGACY_TS_FILE=/var/lib/node_exporter/textfiles/nixos_build_timestamp.val
-            LAST_TOPLEVEL=$(cat "$LAST_TOPLEVEL_FILE" 2>/dev/null || echo "")
-            if [[ -n "$RUNNING" && "$RUNNING" != "$LAST_TOPLEVEL" ]]; then
-              SEEDED=0
-              if [[ -z "$LAST_TOPLEVEL" && -s "$LEGACY_TS_FILE" ]]; then
-                # First run after replacing the old services: adopt the previous
-                # deploy timestamp rather than reporting a bogus "deployed just
-                # now" for every host in the fleet simultaneously.
-                #
-                # The legacy file's unit is genuinely ambiguous, which is the
-                # whole reason the replacement names its unit. The old script
-                # wrote milliseconds but carried a runtime fixup that multiplied
-                # any value below 1e12 by 1000, so a host whose timer had not
-                # run since before that fixup shipped can still hold seconds.
-                # Applying the same magnitude test rather than dividing
-                # unconditionally avoids turning such a value into a 1970
-                # timestamp.
-                LEGACY_TS=$(cat "$LEGACY_TS_FILE" 2>/dev/null || echo 0)
-                if [[ "$LEGACY_TS" =~ ^[0-9]+$ && "$LEGACY_TS" -gt 0 ]]; then
-                  if [[ "$LEGACY_TS" -ge 1000000000000 ]]; then
-                    echo $(( LEGACY_TS / 1000 )) > "$TS_FILE"
-                  else
-                    echo "$LEGACY_TS" > "$TS_FILE"
-                  fi
-                  SEEDED=1
-                fi
-              fi
-              [[ "$SEEDED" -eq 0 ]] && date +%s > "$TS_FILE"
-              echo "$RUNNING" > "$LAST_TOPLEVEL_FILE"
+            # /nix/var/nix/profiles/system is atomically replaced on every
+            # activation that sets a new generation -- by nixos-rebuild switch and
+            # by colmena apply alike -- so its own mtime IS the deploy time. It
+            # needs no state file, is correct on the very first run, and survives
+            # both a wiped StateDirectory and a reboot.
+            #
+            # An earlier version tracked this in state: it recorded the running
+            # closure and stamped the clock whenever that changed, seeding from
+            # the superseded metric's file on first run to avoid every host
+            # reporting "deployed just now" at once. That reasoning was wrong.
+            # This unit's first run can only ever happen on a closure that was
+            # just activated, because installing the unit requires activating
+            # one -- so "just now" was the correct answer, and seeding replaced it
+            # with the host's PREVIOUS deploy time. Every host in the fleet
+            # reported a deploy several hours older than the one that had just
+            # happened, and the value then froze there until the next real deploy
+            # because the legacy file it seeded from was deleted on the same run.
+            #
+            # /run/current-system is deliberately NOT used for this: it lives on
+            # tmpfs and is recreated at boot, so its mtime is the last boot time
+            # rather than the last deploy.
+            DEPLOY_TS=$(stat -c %Y /nix/var/nix/profiles/system 2>/dev/null || echo 0)
+            if [[ ! "$DEPLOY_TS" =~ ^[0-9]+$ ]]; then
+              DEPLOY_TS=0
             fi
-            DEPLOY_TS=$(cat "$TS_FILE" 2>/dev/null || echo 0)
-            rm -f "$LEGACY_TS_FILE" /var/lib/node_exporter/textfiles/nixos_build_last_sha
+
+            # Retire the state and textfiles the superseded services left behind.
+            rm -f /var/lib/node_exporter/textfiles/nixos_build_timestamp.val \
+                  /var/lib/node_exporter/textfiles/nixos_build_last_sha \
+                  "$STATE_DIR/deploy_timestamp_seconds" \
+                  "$STATE_DIR/deploy_timestamp_ms" \
+                  "$STATE_DIR/last_toplevel"
 
             MANIFEST_AGE=0
             if [[ "$GENERATED_AT" -gt 0 ]]; then

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -128,6 +128,64 @@ fi
 
 echo "Evaluated $(jq -r 'length' <<<"$PATHS_JSON") host(s)." >&2
 
+# Assert that what colmena would deploy matches what this manifest publishes.
+#
+# This is a regression guard for a bug that made the entire server fleet report
+# `unmanaged`. The manifest is generated from `nixosConfigurations`, but servers
+# are deployed by colmena, and the two used to evaluate to DIFFERENT store paths
+# for the same host at the same commit: nixpkgs' `lib.nixosSystem` passes a
+# flake-extended `lib` into eval-config, colmena calls eval-config directly with
+# the plain `pkgs.lib`, and `system.nixos.versionSuffix` consequently came out as
+# `pre-git` instead of `.<date>.<shortRev>`. The manifest therefore described
+# paths that no server would ever be running. See the comment in
+# flake/deployment/colmena.nix.
+#
+# Nothing else in CI evaluates colmenaHive, so without this check the two paths
+# can silently diverge again -- a nixpkgs change to that lib overlay, or a
+# colmena bump, would be enough. Publishing a manifest that describes
+# undeployable paths is worse than not publishing: it marks every server
+# unmanaged. So divergence is fatal here rather than a warning.
+echo "Verifying colmena and nixosConfigurations agree..." >&2
+
+COLMENA_STDERR="$(mktemp)"
+trap 'rm -f "$EVAL_STDERR" "$COLMENA_STDERR"' EXIT
+
+if ! COLMENA_JSON="$(
+    nix eval --json '.#colmenaHive.nodes' \
+        --apply 'ns: builtins.mapAttrs (_: n: n.config.system.build.toplevel.outPath) ns' \
+        2>"$COLMENA_STDERR"
+)"; then
+    printf 'error: failed to evaluate colmenaHive nodes:\n%s\n' "$(cat "$COLMENA_STDERR")" >&2
+    echo "       Cannot confirm the manifest describes deployable paths; refusing to publish." >&2
+    exit 1
+fi
+
+MISMATCHED="$(
+    jq -rn \
+        --argjson a "$PATHS_JSON" \
+        --argjson b "$COLMENA_JSON" \
+        '$b | to_entries
+         | map(select($a[.key] != null and $a[.key] != .value)
+               | "  \(.key)\n    nixosConfigurations: \($a[.key])\n    colmena:             \(.value)")
+         | join("\n")'
+)"
+
+if [[ -n "$MISMATCHED" ]]; then
+    cat >&2 <<EOF
+error: colmena would deploy different closures than this manifest publishes.
+
+$MISMATCHED
+
+Every affected host would report deploy state 'unmanaged' forever, because its
+running closure is a path the manifest can never contain. Refusing to publish.
+
+Fix the divergence (see flake/deployment/colmena.nix) rather than this check.
+EOF
+    exit 1
+fi
+
+echo "colmena and nixosConfigurations agree for $(jq -r 'length' <<<"$COLMENA_JSON") server(s)." >&2
+
 # Previous manifest, if any. A malformed existing file is treated as absent
 # rather than fatal so a corrupted manifest self-heals on the next run.
 #

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -160,13 +160,37 @@ if ! COLMENA_JSON="$(
     exit 1
 fi
 
+# Same warnings-are-fatal policy the nixosConfigurations eval above applies.
+# This is the only place it can ever be enforced for the colmena evaluator:
+# nothing in CI evaluates colmenaHive, so a warning introduced by a nixpkgs or
+# colmena bump would otherwise never surface anywhere.
+if grep -q 'evaluation warning:' "$COLMENA_STDERR"; then
+    printf 'error: colmena evaluation produced warnings:\n%s\n' "$(cat "$COLMENA_STDERR")" >&2
+    exit 1
+fi
+
+# An empty or non-object node set would make the comparison below vacuous and
+# report "agree for 0 servers" on its way to publishing an unverified manifest.
+# Mirrors the identical guard applied to PATHS_JSON above.
+if [[ "$(jq -r 'type' <<<"$COLMENA_JSON")" != "object" ]] ||
+    [[ "$(jq -r 'length' <<<"$COLMENA_JSON")" -eq 0 ]]; then
+    echo "error: colmena evaluation produced no nodes -- refusing to publish" >&2
+    exit 1
+fi
+
+# A colmena node with no nixosConfigurations entry counts as a mismatch rather
+# than being skipped. Such a node should be unreachable -- mkNode dereferences
+# `self.nixosConfigurations.<name>._colmena`, so a missing entry throws during
+# evaluation and is caught above -- but suppressing the case would hide exactly
+# the failure this guard exists to report: a host colmena deploys that the
+# manifest has no path for, which reports `unmanaged` forever.
 MISMATCHED="$(
     jq -rn \
         --argjson a "$PATHS_JSON" \
         --argjson b "$COLMENA_JSON" \
         '$b | to_entries
-         | map(select($a[.key] != null and $a[.key] != .value)
-               | "  \(.key)\n    nixosConfigurations: \($a[.key])\n    colmena:             \(.value)")
+         | map(select($a[.key] != .value)
+               | "  \(.key)\n    nixosConfigurations: \($a[.key] // "<missing>")\n    colmena:             \(.value)")
          | join("\n")'
 )"
 


### PR DESCRIPTION
Follow-up to #2137. Two bugs found after deploying it, both mine.

## 1. Whole server fleet reported `unmanaged`

`colmena apply` and `nix eval .#nixosConfigurations.<host>` produced
**different store paths** for the same host at the same commit:

```
running  (colmena)             …-nixos-system-vdlmhub-26.05pre-git
expected (manifest)            …-nixos-system-vdlmhub-26.05.20260803.531670d
maranello (nixos-rebuild)      running == expected  ✓
```

Cause: nixpkgs builds its flake `lib` as
`(import ./lib).extend (import ./lib/flake-version-info.nix self)`, and that
overlay rewrites `lib.trivial.versionSuffix` / `revisionWithDefault` from
nixpkgs' own `self`. `lib.nixosSystem` passes that extended lib into
`eval-config`, so `mkSystem` gets the dated suffix. Colmena calls `eval-config`
directly with the plain `pkgs.lib` from `import nixpkgs { }`, which is not
flake-extended, so it fell back to the sentinel `pre-git` and left
`system.nixos.revision` / `nixpkgs.flake.source` unset.

I validated the original mechanism against maranello — a desktop deployed with
`nixos-rebuild` — which matched, and never validated a colmena-built path. That
is the gap that let this ship.

**Second, pre-existing consequence:** `ci-linux.yaml` builds and pushes
`.#nixosConfigurations.<host>...toplevel` to Attic, but colmena deployed a
different path, so the cache never held the closure colmena actually wanted.
Every `colmena apply` has been rebuilding server closures locally instead of
substituting them. This fixes that too, and makes `nixos-rebuild` and `colmena`
interchangeable on a server rather than each forcing a full rebuild of the
other's work.

`system.nixos.revision` here is the **nixpkgs** revision, not this flake's, so it
does not reintroduce the "never bake the flake's git rev into a closure" rule
from `agents.md` — it changes only when `flake.lock`'s nixpkgs changes, which
already changes the closure.

### Regression guard

Nothing in CI evaluates `colmenaHive`, so these paths could silently diverge
again on a nixpkgs or colmena bump. The manifest generator now evaluates both
and refuses to publish on mismatch — publishing a manifest that describes
undeployable paths is worse than not publishing, since it marks every server
`unmanaged`. Costs 35s for all seven nodes in one eval.

Verified it passes on the fix and fails with a per-host diff when the fix is
reverted:

```
  vdlmhub
    nixosConfigurations: /nix/store/892m2flv…-nixos-system-vdlmhub-26.05.20260803.531670d
    colmena:             /nix/store/mh26l917…-nixos-system-vdlmhub-26.05pre-git
```

## 2. Deploy timestamp was hours stale

maranello showed "7 hours ago" for a system activated at 14:46:47.

The seeding branch adopted the timestamp left by the superseded
`nixos-build-info-metric`, which recorded the host's *previous* deploy, then
deleted that legacy file on the same run — freezing the wrong value until the
next real deploy.

The premise was wrong: this unit's first run can only ever happen on a
just-activated closure, because installing the unit requires activating one. So
"just now" was always correct, and the optimisation was avoiding the truth. Both
reviewers commented on that block's *units*, which anchored me on unit handling
and away from the fact that the block shouldn't exist.

Replaced with the mtime of `/nix/var/nix/profiles/system`, atomically replaced
on every activation that sets a generation, by `switch` and `colmena apply`
alike. No state file, no legacy migration, no unit ambiguity — and it deletes
the ms-vs-seconds handling both reviewers flagged.

`/run/current-system` is deliberately not used: `/run` is tmpfs (verified), so
its mtime is the last *boot*, not the last deploy.

Verified on maranello: profile mtime `14:46:47` matches generation 1852 and the
real deploy; the legacy file would have given `08:10` — generation 1851, the
previous deploy.

## Verification

| Check | Result |
|---|---|
| colmena vs nixosConfigurations, all 7 servers | byte-identical |
| Guard passes on fix / fails on revert | both confirmed |
| Deploy timestamp vs real activation time | exact match |
| Four deploy states | all resolve correctly |
| All 9 hosts eval, no warnings | pass |
| `pre-commit run --all-files` | pass |

## Deploy note

Merge, let the manifest publish (~3 min), then `colmena apply`. Servers will
land on the manifest path and report `up_to_date`. The new expected paths are
exactly what the current manifest already publishes, so nothing else is needed.

## Cross-tool safety, since it came up

- `nixos-rebuild` on a **server** now lands on the manifest path — tracking
  intact, and no longer forces a rebuild against colmena's work.
- `colmena` on a **desktop** is impossible: the hive is built from `serverNodes`
  only, so `--on maranello` fails with an unknown node. If desktops are ever
  added there, the `mkNode` fix applies to them automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment monitoring by deriving deployment times directly from the active system profile.
  - Removed obsolete deployment state and legacy metric files.
  - Added validation to ensure published fleet manifests match the corresponding system configurations.
  - Deployments now include clearer NixOS version and revision metadata for improved traceability.
  - Manifest generation reports actionable diagnostics and stops when configuration evaluation or consistency checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->