### PR TITLE
Close monitoring gaps: manifest race, probe coverage, imageapi + tailscale expiry, targeted deploys

### DIFF
--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -13,6 +13,7 @@
     ../../../modules/services/python-venv-app.nix
     ./nginx.nix
     ./discord-backup.nix
+    ./imageapi-metrics.nix
   ];
 
   # Tailscale MagicDNS name — fill in your tailnet name, e.g. "fredvps.tail1234.ts.net"

--- a/hosts/linux/fredvps/imageapi-metrics.nix
+++ b/hosts/linux/fredvps/imageapi-metrics.nix
@@ -76,9 +76,10 @@ in
             echo "imageapi_last_updated_seconds{host=\"$HOST\"} $LAST_UPDATED"
 
             # Emitted unconditionally so the age alert can require a successful
-            # scrape. Without it, a container that is down would leave the age
-            # metric at its last value and the alert would describe a stale
-            # update loop when the real fault is that nothing answered.
+            # scrape. When nothing answers, the age metric above is written as 0,
+            # so `time() - 0` reads as an enormous age -- without this flag the
+            # alert would describe a stalled update loop when the real fault is
+            # that the endpoint was unreachable.
             echo "# HELP imageapi_last_updated_scrape_success Whether the last-updated endpoint answered and parsed."
             echo "# TYPE imageapi_last_updated_scrape_success gauge"
             echo "imageapi_last_updated_scrape_success{host=\"$HOST\"} $SCRAPE_OK"

--- a/hosts/linux/fredvps/imageapi-metrics.nix
+++ b/hosts/linux/fredvps/imageapi-metrics.nix
@@ -1,0 +1,104 @@
+# Freshness metric for the imageapi (sdre-image-api) container on this host.
+#
+# WHY THIS IS NOT A BLACKBOX PROBE
+#
+# The blackbox exporter on sdrhub already probes
+# https://fredclausen.com/imageapi/api/v1/last-updated and asserts it answers
+# 2xx, which covers the whole public path: TLS, nginx, the proxy prefix strip,
+# Express, and the database read behind that route. What it cannot do is look at
+# the value: blackbox compares status codes and can regex a body, but it has no
+# way to parse a timestamp and compute an age. A stuck updater returns a
+# perfectly healthy 200 with a week-old timestamp.
+#
+# So availability lives in blackbox and freshness lives here. Splitting them also
+# keeps the failure modes distinguishable -- a TLS or nginx fault trips the probe
+# without implying the update loop is broken, and vice versa.
+#
+# WHY IT PROBES LOOPBACK
+#
+# The container's port is published on 127.0.0.1:3001 (see the imageapi entry in
+# configuration.nix). Reading it directly makes this metric a statement about the
+# service's own update loop rather than about the public edge, which the probe
+# already watches. It also means a certificate or reverse-proxy problem cannot
+# masquerade as stale data.
+{ pkgs, config, ... }:
+let
+  # Matches the `ports = [ "3001:3000" ]` mapping in configuration.nix.
+  imageApiUrl = "http://127.0.0.1:3001/api/v1/last-updated";
+in
+{
+  systemd = {
+    services.imageapi-freshness-metric = {
+      description = "Emit imageapi last-updated freshness metric";
+      after = [ "docker.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "imageapi-freshness-metric.sh" ''
+          set -uo pipefail
+
+          CURL=${pkgs.curl}/bin/curl
+          JQ=${pkgs.jq}/bin/jq
+
+          HOST="${config.networking.hostName}"
+          TEXTFILE_DIR=/var/lib/node_exporter/textfiles
+          OUT="$TEXTFILE_DIR/imageapi_freshness.prom"
+
+          mkdir -p "$TEXTFILE_DIR"
+
+          LAST_UPDATED=0
+          SCRAPE_OK=0
+
+          BODY=$($CURL -sf --max-time 15 "${imageApiUrl}" 2>/dev/null || echo "")
+
+          if [[ -n "$BODY" ]]; then
+            RAW=$($JQ -r '.lastUpdated // ""' <<<"$BODY" 2>/dev/null || echo "")
+            if [[ -n "$RAW" && "$RAW" != "never" ]]; then
+              # The API returns an ISO-8601 instant, e.g.
+              # 2026-08-04T21:18:26.974Z. `date -d` parses that directly.
+              PARSED=$(date -d "$RAW" +%s 2>/dev/null || echo "")
+              if [[ "$PARSED" =~ ^[0-9]+$ ]]; then
+                LAST_UPDATED=$PARSED
+                SCRAPE_OK=1
+              fi
+            elif [[ "$RAW" == "never" ]]; then
+              # The endpoint answered and the table is genuinely empty. That is a
+              # successful scrape reporting a real fault, not a scrape failure --
+              # keeping LAST_UPDATED at 0 lets the age alert fire, which is the
+              # correct outcome for an updater that has never run.
+              SCRAPE_OK=1
+            fi
+          fi
+
+          TMP="$OUT.tmp"
+          {
+            echo "# HELP imageapi_last_updated_seconds Unix time of the newest imageapi lastUpdated row."
+            echo "# TYPE imageapi_last_updated_seconds gauge"
+            echo "imageapi_last_updated_seconds{host=\"$HOST\"} $LAST_UPDATED"
+
+            # Emitted unconditionally so the age alert can require a successful
+            # scrape. Without it, a container that is down would leave the age
+            # metric at its last value and the alert would describe a stale
+            # update loop when the real fault is that nothing answered.
+            echo "# HELP imageapi_last_updated_scrape_success Whether the last-updated endpoint answered and parsed."
+            echo "# TYPE imageapi_last_updated_scrape_success gauge"
+            echo "imageapi_last_updated_scrape_success{host=\"$HOST\"} $SCRAPE_OK"
+          } > "$TMP"
+          mv "$TMP" "$OUT"
+        '';
+      };
+    };
+
+    timers.imageapi-freshness-metric = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        # The update loop reschedules itself an hour after each run completes, so
+        # the value moves at most hourly. Polling every 10 minutes is far more
+        # often than needed but keeps the series responsive after a restart and
+        # costs one loopback request.
+        OnCalendar = "*:0/10";
+        Persistent = true;
+        RandomizedDelaySec = "60";
+      };
+    };
+  };
+}

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -55,12 +55,13 @@ in
       # invocation rather than once per path, but with direnv auto-loading a flake
       # on every `cd` that is once per directory change.
       #
-      # 5s only bounds the TCP handshake (`stalled-download-timeout` covers
-      # stalls mid-transfer), and a handshake to cache.nixos.org or cachix
-      # completes in well under a second even on a high-latency link, so there is
-      # no realistic way for this to turn a working remote cache into a failure.
-      # It cuts the off-LAN stall by two thirds while leaving an order of
-      # magnitude of headroom.
+      # 5s bounds the whole connection phase -- DNS resolution, the TCP handshake
+      # and, for the https substituters, the TLS handshake -- but not the
+      # transfer, which `stalled-download-timeout` already covers. Reaching that
+      # point with cache.nixos.org or cachix takes well under a second on a
+      # healthy link and a small multiple of that on a poor one, so 5s cuts the
+      # off-LAN stall by two thirds while still leaving several times the
+      # realistic worst case.
       #
       # This is a mitigation, not the fix: with Tailscale up and
       # --accept-routes, 192.168.31.14 is genuinely reachable and the timeout

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -44,6 +44,30 @@ in
         "niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA="
       ];
 
+      # Nix's default is 15s, which is the wrong shape for a substituter list
+      # whose first entry is a LAN address.
+      #
+      # http://192.168.31.14:8080/fred is unroutable from anywhere but the home
+      # network, and a foreign network typically blackholes 192.168.31.0/24
+      # rather than returning ICMP unreachable -- so the connection does not fail
+      # fast, it sits through the full timeout. Nix stops retrying a cache that
+      # errored for the rest of the process, so the cost is roughly once per nix
+      # invocation rather than once per path, but with direnv auto-loading a flake
+      # on every `cd` that is once per directory change.
+      #
+      # 5s only bounds the TCP handshake (`stalled-download-timeout` covers
+      # stalls mid-transfer), and a handshake to cache.nixos.org or cachix
+      # completes in well under a second even on a high-latency link, so there is
+      # no realistic way for this to turn a working remote cache into a failure.
+      # It cuts the off-LAN stall by two thirds while leaving an order of
+      # magnitude of headroom.
+      #
+      # This is a mitigation, not the fix: with Tailscale up and
+      # --accept-routes, 192.168.31.14 is genuinely reachable and the timeout
+      # stops mattering. It is worth having anyway, for when the tunnel is down
+      # or deliberately off.
+      connect-timeout = 5;
+
       trusted-users = [
         "root"
         "@wheel"

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -195,18 +195,12 @@
             # both a wiped StateDirectory and a reboot.
             #
             # An earlier version tracked this in state: it recorded the running
-            # closure and stamped the clock whenever that changed, seeding from
-            # the superseded metric's file on first run to avoid every host
-            # reporting "deployed just now" at once. That reasoning was wrong.
-            # This unit's first run can only ever happen on a closure that was
-            # just activated, because installing the unit requires activating
-            # one -- so "just now" was the correct answer, and seeding replaced it
-            # with the host's PREVIOUS deploy time. Every host in the fleet
-            # reported a deploy several hours older than the one that had just
-            # happened, and the value then froze there until the next real deploy
-            # because the legacy file it seeded from was deleted on the same run.
-            #
             # Retire the state and textfiles the superseded services left behind.
+            # The deploy timestamp is now derived from the system profile mtime
+            # near the top of this script, so none of these files are read any
+            # more; removing them stops a stale .prom re-exporting withdrawn
+            # metric names forever, since the textfile collector has no concept
+            # of expiry.
             rm -f /var/lib/node_exporter/textfiles/nixos_build_timestamp.val \
                   /var/lib/node_exporter/textfiles/nixos_build_last_sha \
                   "$STATE_DIR/deploy_timestamp_seconds" \

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -85,6 +85,35 @@
 
             RUNNING=$(readlink -f /run/current-system 2>/dev/null || echo "")
 
+            # Deploy timestamp, read straight off the system profile symlink.
+            #
+            # /nix/var/nix/profiles/system is atomically replaced on every
+            # activation that sets a new generation -- by nixos-rebuild switch and
+            # by colmena apply alike -- so its own mtime IS the deploy time. It
+            # needs no state file, is correct on the very first run, and survives
+            # both a wiped StateDirectory and a reboot.
+            #
+            # An earlier version tracked this in state: it recorded the running
+            # closure and stamped the clock whenever that changed, seeding from
+            # the superseded metric's file on first run to avoid every host
+            # reporting "deployed just now" at once. That reasoning was wrong.
+            # This unit's first run can only ever happen on a closure that was
+            # just activated, because installing the unit requires activating
+            # one -- so "just now" was the correct answer, and seeding replaced it
+            # with the host's PREVIOUS deploy time.
+            #
+            # /run/current-system is deliberately NOT used for this: it lives on
+            # tmpfs and is recreated at boot, so its mtime is the last boot time
+            # rather than the last deploy.
+            #
+            # It is read here, before the state machine, because the state
+            # machine needs it to tell "main never produced this closure" apart
+            # from "the manifest is older than this closure".
+            DEPLOY_TS=$(stat -c %Y /nix/var/nix/profiles/system 2>/dev/null || echo 0)
+            if [[ ! "$DEPLOY_TS" =~ ^[0-9]+$ ]]; then
+              DEPLOY_TS=0
+            fi
+
             # Refresh the manifest into a temp file first: a truncated or
             # error-page response must not clobber a good cached copy, or a
             # transient GitHub failure would flip the whole fleet to unknown.
@@ -120,6 +149,26 @@
                 '[.hosts[$h].history[].toplevel] | index($p) != null' "$CACHE" >/dev/null 2>&1; then
                 # A closure main published previously: genuinely a deploy behind.
                 STATE="drifted"
+              elif [[ "$GENERATED_AT" -gt 0 && "$DEPLOY_TS" -gt 0 && "$GENERATED_AT" -lt "$DEPLOY_TS" ]]; then
+                # The manifest was generated BEFORE the running closure was
+                # activated, so it cannot possibly contain that closure and
+                # `unmanaged` is not a conclusion the evidence supports.
+                #
+                # This is the normal state for the first few minutes after any
+                # deploy: the manifest is published by a workflow that runs after
+                # the merge, and each host only refetches on its timer. Reporting
+                # `unmanaged` here blamed the host for the publisher simply not
+                # having caught up yet -- and `unmanaged` has a 2h fuse, so a
+                # deploy racing a slow or failed manifest run would have paged
+                # about a perfectly healthy fleet. That is the same
+                # misattribution NixOSFleetManifestStale uses min() to avoid, one
+                # layer down.
+                #
+                # `unknown` is the honest answer -- deploy state cannot be
+                # determined -- and its 12h fuse is long enough to never fire on
+                # a normal deploy while still catching a genuinely stuck
+                # publisher, which is exactly when this must not stay quiet.
+                STATE="unknown"
               else
                 # Never published by main -- a local, dirty or branch build.
                 # Distinguishing this from "drifted" is the whole point: the old
@@ -157,14 +206,6 @@
             # happened, and the value then froze there until the next real deploy
             # because the legacy file it seeded from was deleted on the same run.
             #
-            # /run/current-system is deliberately NOT used for this: it lives on
-            # tmpfs and is recreated at boot, so its mtime is the last boot time
-            # rather than the last deploy.
-            DEPLOY_TS=$(stat -c %Y /nix/var/nix/profiles/system 2>/dev/null || echo 0)
-            if [[ ! "$DEPLOY_TS" =~ ^[0-9]+$ ]]; then
-              DEPLOY_TS=0
-            fi
-
             # Retire the state and textfiles the superseded services left behind.
             rm -f /var/lib/node_exporter/textfiles/nixos_build_timestamp.val \
                   /var/lib/node_exporter/textfiles/nixos_build_last_sha \
@@ -375,4 +416,29 @@
   networking.firewall.allowedTCPPorts = [
     9100 # node_exporter
   ];
+
+  # Re-evaluate deploy state immediately after every activation.
+  #
+  # The metric's timer runs every 10 minutes (plus up to 2 minutes of jitter),
+  # so without this a freshly deployed host keeps reporting against the manifest
+  # it cached BEFORE the deploy for up to ~12 minutes. That window is what makes
+  # the whole fleet look wrong right after a deploy, which is confusing even
+  # though the paired state-machine guard now downgrades it from `unmanaged` to
+  # `unknown`. Kicking the unit here shrinks the window to however long the
+  # manifest publish itself takes.
+  #
+  # --no-block is required: activation must not wait on a network fetch, and a
+  # blocking start would also deadlock when activation is itself being run by
+  # systemd. Failure is ignored for the same reason -- this is an optimisation,
+  # and the timer remains the thing that guarantees the metric is emitted.
+  #
+  # No revision or other flake metadata is embedded here, so this does not
+  # reintroduce the closure-churn problem documented in flake/lib/mk-system.nix.
+  system.activationScripts.refreshDeployStateMetric = {
+    text = ''
+      ${config.systemd.package}/bin/systemctl start --no-block \
+        nixos-deploy-state-metric.service || true
+    '';
+    deps = [ ];
+  };
 }

--- a/modules/monitoring/master/alert-rules/blackbox-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/blackbox-alerts.yaml
@@ -78,10 +78,19 @@ groups:
         #   flipaholics.pro         ~0.62s  (slowest backend; consistently so)
         #   LAN nginx vhosts        0.007s - 0.03s
         #
-        # Worst single observation across all 20 targets was 1.03s, on a cold
-        # first probe. 5s is roughly a 5x margin over that and an 8x margin
-        # over the slowest steady-state target, so this cannot fire on normal
-        # variance -- only on genuine degradation.
+        # Worst single observation was 1.03s, on a cold first probe. 5s is
+        # roughly a 5x margin over that and an 8x margin over the slowest
+        # steady-state target, so this cannot fire on normal variance -- only on
+        # genuine degradation.
+        #
+        # That baseline was measured across the 20 targets that existed when it
+        # was taken. The 16 `-secondary` targets added later were verified to
+        # respond as classified but were NOT separately timed. They are not
+        # expected to shift it: the www aliases are the same nginx vhosts and
+        # certificates as their apex, and the two sub-path targets proxy to
+        # loopback backends on the same host as an already-measured vhost. If a
+        # future target is added that is not in one of those classes, re-measure
+        # rather than assuming this margin still holds.
         #
         # Deliberately below the module timeout (10s) and the job's
         # scrape_timeout (15s), so a slow-but-working endpoint surfaces here

--- a/modules/monitoring/master/alert-rules/blackbox-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/blackbox-alerts.yaml
@@ -5,9 +5,25 @@
 #
 # Three probe jobs feed these rules:
 #
-#   blackbox-https           public HTTPS vhosts on fredvps that must answer 2xx
-#   blackbox-https-redirect  public HTTPS vhosts that must answer 3xx
-#   blackbox-http-internal   LAN-only nginx vhosts on sdrhub
+#   blackbox-https                     public HTTPS vhosts on fredvps that
+#                                      must answer 2xx -- one per certificate
+#   blackbox-https-redirect            public HTTPS vhosts that must answer 3xx
+#                                      -- one per certificate
+#   blackbox-https-secondary           www aliases and sub-path apps that must
+#                                      answer 2xx, sharing a cert with a primary
+#   blackbox-https-redirect-secondary  www aliases that must answer 3xx,
+#                                      sharing a cert with a primary
+#   blackbox-http-internal             LAN-only nginx vhosts on sdrhub
+#
+# THE `-secondary` JOBS AND TLS
+#
+# Availability rules below apply to every job. The TLS rules deliberately do
+# NOT: a `-secondary` target shares its certificate with a primary one (a www
+# alias is folded into the apex's ACME cert, and a sub-path is the same vhost),
+# so including them would report a single renewal failure once per probed URL
+# instead of once per certificate. Each `-secondary` selector below is therefore
+# `job!~".*-secondary"`, and the primary lists in blackbox.nix must stay
+# one-target-per-certificate for that to remain true.
 #
 # LABELS AVAILABLE HERE -- read this before adding an annotation
 #
@@ -97,9 +113,9 @@ groups:
         # means renewal has already been attempted and has not succeeded --
         # there is a real fault, with three weeks of slack to fix it.
         expr: |
-          (probe_ssl_earliest_cert_expiry - time()) < (21 * 24 * 60 * 60)
+          (probe_ssl_earliest_cert_expiry{job!~".*-secondary"} - time()) < (21 * 24 * 60 * 60)
           and
-          (probe_ssl_earliest_cert_expiry - time()) >= (7 * 24 * 60 * 60)
+          (probe_ssl_earliest_cert_expiry{job!~".*-secondary"} - time()) >= (7 * 24 * 60 * 60)
         # 1h: cert expiry is a slowly-moving fact, not an event. A long `for`
         # costs nothing here and makes the alert immune to a single bad scrape.
         for: 1h
@@ -114,7 +130,7 @@ groups:
         # the remaining margin is smaller than a weekend plus a work week.
         # Fires for already-expired certificates too, since the difference
         # simply goes negative.
-        expr: (probe_ssl_earliest_cert_expiry - time()) < (7 * 24 * 60 * 60)
+        expr: (probe_ssl_earliest_cert_expiry{job!~".*-secondary"} - time()) < (7 * 24 * 60 * 60)
         for: 1h
         labels:
           severity: critical

--- a/modules/monitoring/master/alert-rules/sdr-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/sdr-alerts.yaml
@@ -27,3 +27,42 @@ groups:
         annotations:
           summary: "Ultrafeeder receiving no RF messages on {{ $labels.hostname }}"
           description: "readsb has processed zero valid messages for 15 minutes. The SDR hardware is likely disconnected, crashed, or the decoder has stopped."
+
+      # imageapi (sdre-image-api on fredvps) refreshes its image table on a loop
+      # that reschedules itself an hour after each run finishes, so the newest
+      # lastUpdated row should never be much more than an hour old.
+      #
+      # Metric source: hosts/linux/fredvps/imageapi-metrics.nix. The companion
+      # blackbox probe of /imageapi/api/v1/last-updated asserts the endpoint
+      # answers 2xx; it cannot assert the value is recent, because blackbox
+      # compares status codes and has no way to compute an age. A stuck updater
+      # serves a healthy 200 with a week-old timestamp, which is precisely the
+      # failure this rule exists to catch.
+      - alert: ImageApiUpdatesStale
+        # 3h, not 1h: the period is one hour PLUS however long a run takes, and a
+        # run walks a set of GitHub releases, so back-to-back cycles are not
+        # evenly spaced. Three hours tolerates two consecutive missed or slow
+        # cycles before complaining.
+        #
+        # The scrape_success term matters. If the container is down the endpoint
+        # does not answer, the exporter leaves the age metric at 0, and
+        # `time() - 0` is enormous -- this rule would fire and blame a stale
+        # update loop when the real fault is that nothing responded. Requiring a
+        # successful scrape keeps the two distinguishable; the container being
+        # down is reported by the blackbox probe and the docker rules instead.
+        expr: |
+          (
+            time() - imageapi_last_updated_seconds
+          ) > (3 * 60 * 60)
+          and on (host) (imageapi_last_updated_scrape_success == 1)
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "imageapi image data is stale on {{ $labels.host }}"
+          description: >-
+            The newest imageapi lastUpdated row is over 3h old while the endpoint
+            is still answering, so the hourly update loop has stopped making
+            progress. Check the imageapi container logs on {{ $labels.host }} --
+            an expired GitHub token or a failing Octokit call will stall it
+            silently while it keeps serving 200s.

--- a/modules/monitoring/master/alert-rules/system-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/system-alerts.yaml
@@ -291,6 +291,33 @@ groups:
             also removes it from Prometheus. Re-authenticate and then disable key
             expiry for this device.
 
+      - alert: TailscaleStatusScrapeFailed
+        # Every other rule in this group requires
+        # tailscale_status_scrape_success == 1, because a failed status read
+        # reports expiry 0 and backend_running 0 and would otherwise fire them
+        # spuriously. The consequence is that a persistently failing read
+        # silences all three at once, so without this rule the entire tailscale
+        # section goes quiet exactly when it has stopped being able to see
+        # anything. Nothing else catches it either: the collector times the call
+        # out and still exits 0, so the unit does not fail and
+        # SystemdUnitFailed never fires.
+        #
+        # 30m against a 5-minute collection interval is six consecutive failed
+        # reads -- long enough to ride out a tailscaled restart, short enough to
+        # be actionable.
+        expr: tailscale_status_scrape_success == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Cannot read Tailscale status on {{ $labels.host }}"
+          description: >-
+            tailscale status --json has been unreadable on {{ $labels.host }} for
+            30 minutes, so key expiry and backend state are both unmonitored
+            there. The collector bounds the call at 10s and reports the failure
+            rather than hanging, so this points at tailscaled being wedged or
+            absent rather than at the metric unit.
+
       - alert: TailscaleBackendNotRunning
         # BackendState is not Running. The state after a key expires is
         # NeedsLogin, so this is the signal that the host is actually off the

--- a/modules/monitoring/master/alert-rules/system-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/system-alerts.yaml
@@ -213,3 +213,97 @@ groups:
         annotations:
           summary: "Attic Nix cache server is DOWN on fredhub"
           description: "The Attic binary cache server has been inactive for 5+ minutes. NixOS builds will fall back to cache.nixos.org and be significantly slower."
+
+  # Tailscale node key expiry.
+  #
+  # Metric source: modules/services/tailscale/default.nix, which is imported by
+  # exactly the hosts running tailscale (sdrhub and fredvps today), so these
+  # rules scope themselves automatically as that set changes.
+  #
+  # WHAT EXPIRES. Not the sops auth key -- that is only consulted when a node is
+  # not yet registered, so its expiry cannot disturb a running node. What expires
+  # is each device's NODE key, and rotating the auth key does not renew it: an
+  # expired node key needs `tailscale up` with an interactive login, or a new key
+  # plus --force-reauth. The cost of getting this wrong is concrete: sdrhub
+  # withdraws its advertised 192.168.31.0/24 subnet route, and fredvps loses the
+  # tailnet address Prometheus scrapes it by.
+  #
+  # Thresholds deliberately mirror BlackboxCertExpiringSoon / CertExpiryCritical
+  # (21d warning, 7d critical) so every "credential is running out" alert in this
+  # fleet paces identically.
+  #
+  # Both rules carry two guards that are not optional:
+  #
+  #   tailscale_key_expiry_disabled == 0
+  #     A tagged device, or one with key expiry disabled in the admin console,
+  #     reports no expiry and the metric is 0. Without this guard `0 - time()` is
+  #     hugely negative and the critical rule would fire permanently -- doing the
+  #     right thing upstream would look like a fault.
+  #
+  #   tailscale_status_scrape_success == 1
+  #     If tailscaled cannot be queried the metric is also 0, with the same
+  #     consequence. A daemon fault must be reported as one, not as an expiry.
+  #     TailscaleBackendNotRunning covers that case.
+  #
+  # Already-expired keys need no separate rule: the difference simply goes
+  # negative and TailscaleKeyExpiryCritical fires, exactly as the blackbox cert
+  # rules document for expired certificates.
+  - name: tailscale-alerts
+    rules:
+      - alert: TailscaleKeyExpiringSoon
+        # The >= 7d floor makes this mutually exclusive with the critical rule
+        # below; without it both would fire under 7 days and Alertmanager would
+        # deliver the same host twice on two severities.
+        expr: |
+          (tailscale_key_expiry_seconds - time()) < (21 * 24 * 60 * 60)
+          and
+          (tailscale_key_expiry_seconds - time()) >= (7 * 24 * 60 * 60)
+          and on (host) (tailscale_key_expiry_disabled == 0)
+          and on (host) (tailscale_status_scrape_success == 1)
+        # 1h: expiry is a slowly-moving fact, so a long `for` costs nothing and
+        # makes the rule immune to a single bad scrape.
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Tailscale node key on {{ $labels.host }} expires in under 21 days"
+          description: >-
+            The node key for {{ $labels.host }} expires in less than 21 days,
+            after which the host drops off the tailnet until re-authenticated
+            interactively. Rotating the sops auth key will NOT renew it. Prefer
+            disabling key expiry for this device in the admin console, or making
+            it a tagged device, so this stops recurring.
+
+      - alert: TailscaleKeyExpiryCritical
+        expr: |
+          (tailscale_key_expiry_seconds - time()) < (7 * 24 * 60 * 60)
+          and on (host) (tailscale_key_expiry_disabled == 0)
+          and on (host) (tailscale_status_scrape_success == 1)
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Tailscale node key on {{ $labels.host }} expires in under 7 days"
+          description: >-
+            The node key for {{ $labels.host }} expires in less than 7 days (or
+            has already expired). When it goes, sdrhub stops advertising the LAN
+            subnet route and fredvps becomes unreachable over the tailnet, which
+            also removes it from Prometheus. Re-authenticate and then disable key
+            expiry for this device.
+
+      - alert: TailscaleBackendNotRunning
+        # BackendState is not Running. The state after a key expires is
+        # NeedsLogin, so this is the signal that the host is actually off the
+        # tailnet right now, as opposed to heading that way. Distinct from
+        # SystemdUnitFailed, which only notices tailscaled failing outright --
+        # NeedsLogin is a perfectly healthy process that has stopped working.
+        expr: tailscale_backend_running == 0 and on (host) (tailscale_status_scrape_success == 1)
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Tailscale is not running on {{ $labels.host }}"
+          description: >-
+            tailscaled on {{ $labels.host }} reports a backend state other than
+            Running for 15 minutes. If the node key has expired the state will be
+            NeedsLogin and the host needs interactive re-authentication.

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -558,3 +558,61 @@ tests:
       - eval_time: 2h
         alertname: NixOSManifestFetchStalled
         exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # imageapi freshness. The metric pair exists because blackbox can assert the
+  # endpoint answers but cannot assert the value is recent; these cases pin the
+  # distinction between "data is stale" and "nothing answered".
+  # ---------------------------------------------------------------------------
+
+  - interval: 1m
+    name: ImageApiUpdatesStale fires when data is stale but the endpoint answers
+    input_series:
+      # Timestamp frozen well in the past, so time() - it exceeds 3h during the
+      # evaluation window below.
+      - series: 'imageapi_last_updated_seconds{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "0+0x400"
+      - series: 'imageapi_last_updated_scrape_success{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "1+0x400"
+    alert_rule_test:
+      - eval_time: 4h
+        alertname: ImageApiUpdatesStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              host: fredvps
+              hostname: fredvps
+              role: agent
+            exp_annotations:
+              summary: "imageapi image data is stale on fredvps"
+              description: "The newest imageapi lastUpdated row is over 3h old while the endpoint is still answering, so the hourly update loop has stopped making progress. Check the imageapi container logs on fredvps -- an expired GitHub token or a failing Octokit call will stall it silently while it keeps serving 200s."
+
+  # A container that is down leaves the age metric at 0, which would look
+  # infinitely stale. The scrape_success term is what stops this rule blaming the
+  # update loop for what is actually an unreachable endpoint -- that case belongs
+  # to the blackbox probe and the docker rules.
+  - interval: 1m
+    name: ImageApiUpdatesStale stays silent when the endpoint did not answer
+    input_series:
+      - series: 'imageapi_last_updated_seconds{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "0+0x400"
+      - series: 'imageapi_last_updated_scrape_success{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "0+0x400"
+    alert_rule_test:
+      - eval_time: 4h
+        alertname: ImageApiUpdatesStale
+        exp_alerts: []
+
+  # Fresh data must not fire. The timestamp tracks the clock here, holding the
+  # age near zero throughout.
+  - interval: 1m
+    name: ImageApiUpdatesStale stays silent while updates are fresh
+    input_series:
+      - series: 'imageapi_last_updated_seconds{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "0+60x400"
+      - series: 'imageapi_last_updated_scrape_success{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "1+0x400"
+    alert_rule_test:
+      - eval_time: 4h
+        alertname: ImageApiUpdatesStale
+        exp_alerts: []

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -616,3 +616,124 @@ tests:
       - eval_time: 4h
         alertname: ImageApiUpdatesStale
         exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # Tailscale node key expiry.
+  #
+  # The first case is the most important one in this file's tailscale coverage:
+  # with key expiry disabled -- the desired end state, and the live state of both
+  # tailscale hosts -- the expiry metric is 0. Without the
+  # tailscale_key_expiry_disabled guard, `0 - time()` is hugely negative and
+  # TailscaleKeyExpiryCritical would fire forever, so configuring Tailscale
+  # correctly would page continuously.
+  # ---------------------------------------------------------------------------
+
+  - interval: 1m
+    name: Tailscale expiry alerts stay silent when key expiry is disabled
+    input_series:
+      - series: 'tailscale_key_expiry_seconds{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_key_expiry_disabled{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "1+0x200"
+      - series: 'tailscale_status_scrape_success{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: TailscaleKeyExpiryCritical
+        exp_alerts: []
+      - eval_time: 2h
+        alertname: TailscaleKeyExpiringSoon
+        exp_alerts: []
+
+  # A dead tailscaled also reports expiry 0. That must surface as a daemon fault,
+  # not as an expiry, or the alert would send someone to re-authenticate a key
+  # that is perfectly valid.
+  - interval: 1m
+    name: Tailscale expiry alerts stay silent when the status read failed
+    input_series:
+      - series: 'tailscale_key_expiry_seconds{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_key_expiry_disabled{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_status_scrape_success{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: TailscaleKeyExpiryCritical
+        exp_alerts: []
+
+  # 14 days out: warning fires, critical must not. Proves the >= 7d floor keeps
+  # the two mutually exclusive. time() at eval_time 2h is 7200, so an expiry of
+  # 7200 + 14d lands exactly 14 days ahead.
+  - interval: 1m
+    name: TailscaleKeyExpiringSoon fires at 14 days and critical does not
+    input_series:
+      - series: 'tailscale_key_expiry_seconds{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "1216800+0x200"
+      - series: 'tailscale_key_expiry_disabled{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_status_scrape_success{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: TailscaleKeyExpiringSoon
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              host: sdrhub
+              hostname: sdrhub
+              role: master
+            exp_annotations:
+              summary: "Tailscale node key on sdrhub expires in under 21 days"
+              description: "The node key for sdrhub expires in less than 21 days, after which the host drops off the tailnet until re-authenticated interactively. Rotating the sops auth key will NOT renew it. Prefer disabling key expiry for this device in the admin console, or making it a tagged device, so this stops recurring."
+      - eval_time: 2h
+        alertname: TailscaleKeyExpiryCritical
+        exp_alerts: []
+
+  # 3 days out: critical fires, warning must not.
+  - interval: 1m
+    name: TailscaleKeyExpiryCritical fires at 3 days and warning does not
+    input_series:
+      - series: 'tailscale_key_expiry_seconds{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "266400+0x200"
+      - series: 'tailscale_key_expiry_disabled{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_status_scrape_success{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: TailscaleKeyExpiryCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              host: sdrhub
+              hostname: sdrhub
+              role: master
+            exp_annotations:
+              summary: "Tailscale node key on sdrhub expires in under 7 days"
+              description: "The node key for sdrhub expires in less than 7 days (or has already expired). When it goes, sdrhub stops advertising the LAN subnet route and fredvps becomes unreachable over the tailnet, which also removes it from Prometheus. Re-authenticate and then disable key expiry for this device."
+      - eval_time: 2h
+        alertname: TailscaleKeyExpiringSoon
+        exp_alerts: []
+
+  # NeedsLogin after an expiry is a healthy process that has stopped working, so
+  # SystemdUnitFailed cannot see it. This is the rule that does.
+  - interval: 1m
+    name: TailscaleBackendNotRunning fires when the backend is not Running
+    input_series:
+      - series: 'tailscale_backend_running{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "0+0x200"
+      - series: 'tailscale_status_scrape_success{host="fredvps", hostname="fredvps", role="agent"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: TailscaleBackendNotRunning
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              host: fredvps
+              hostname: fredvps
+              role: agent
+            exp_annotations:
+              summary: "Tailscale is not running on fredvps"
+              description: "tailscaled on fredvps reports a backend state other than Running for 15 minutes. If the node key has expired the state will be NeedsLogin and the host needs interactive re-authentication."

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -737,3 +737,40 @@ tests:
             exp_annotations:
               summary: "Tailscale is not running on fredvps"
               description: "tailscaled on fredvps reports a backend state other than Running for 15 minutes. If the node key has expired the state will be NeedsLogin and the host needs interactive re-authentication."
+
+  # A failed status read suppresses all three other tailscale rules by design,
+  # so the failure itself has to be alertable or the whole section goes quiet
+  # precisely when it can no longer see anything.
+  - interval: 1m
+    name: TailscaleStatusScrapeFailed fires while the expiry rules stay silent
+    input_series:
+      - series: 'tailscale_status_scrape_success{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_key_expiry_seconds{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_key_expiry_disabled{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+      - series: 'tailscale_backend_running{host="sdrhub", hostname="sdrhub", role="master"}'
+        values: "0+0x200"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: TailscaleStatusScrapeFailed
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              host: sdrhub
+              hostname: sdrhub
+              role: master
+            exp_annotations:
+              summary: "Cannot read Tailscale status on sdrhub"
+              description: "tailscale status --json has been unreadable on sdrhub for 30 minutes, so key expiry and backend state are both unmonitored there. The collector bounds the call at 10s and reports the failure rather than hanging, so this points at tailscaled being wedged or absent rather than at the metric unit."
+      # The three suppressed rules must all stay silent on the same input.
+      - eval_time: 1h
+        alertname: TailscaleKeyExpiryCritical
+        exp_alerts: []
+      - eval_time: 1h
+        alertname: TailscaleKeyExpiringSoon
+        exp_alerts: []
+      - eval_time: 1h
+        alertname: TailscaleBackendNotRunning
+        exp_alerts: []

--- a/modules/monitoring/master/alert-rules/tests/blackbox-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/blackbox-alerts-test.yaml
@@ -244,3 +244,74 @@ tests:
       - eval_time: 90m
         alertname: BlackboxCertExpiringSoon
         exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # The `-secondary` jobs must be invisible to the TLS rules.
+  #
+  # A secondary target shares its certificate with a primary one: a www alias is
+  # folded into the apex's ACME cert, and a sub-path is the same vhost. Including
+  # them would report one renewal failure once per probed URL instead of once per
+  # certificate. The job-name suffix is therefore load-bearing rather than
+  # cosmetic, and these cases are what stop a rename or a selector edit quietly
+  # restoring the duplicates.
+  # ---------------------------------------------------------------------------
+
+  - interval: 1m
+    name: Cert expiry alerts ignore -secondary jobs and still fire for the primary
+    input_series:
+      # 3 days of validity: inside the critical threshold for every series here.
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https", instance="https://fredclausen.com/"}'
+        values: "259200+0x200"
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https-secondary", instance="https://www.fredclausen.com/"}'
+        values: "259200+0x200"
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https-redirect-secondary", instance="https://www.acarshub.com/"}'
+        values: "259200+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: BlackboxCertExpiryCritical
+        # Exactly one alert: the primary. Both secondary series share a
+        # certificate with a primary target and must not add a second report.
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-https
+              instance: https://fredclausen.com/
+            exp_annotations:
+              summary: "TLS certificate for https://fredclausen.com/ expires in under 7 days"
+              description: "The certificate served by https://fredclausen.com/ has less than 7 days of validity left. Browsers will start refusing this endpoint. Fix ACME renewal on the host terminating this vhost now."
+
+  - interval: 1m
+    name: The 21-day warning also ignores -secondary jobs
+    input_series:
+      # 14 days: inside the warning band, above the 7d critical floor.
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https-secondary", instance="https://www.acarshub.app/"}'
+        values: "1209600+0x200"
+      - series: 'probe_ssl_earliest_cert_expiry{job="blackbox-https-redirect-secondary", instance="https://www.sdr-e.org/"}'
+        values: "1209600+0x200"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: BlackboxCertExpiringSoon
+        exp_alerts: []
+      - eval_time: 2h
+        alertname: BlackboxCertExpiryCritical
+        exp_alerts: []
+
+  # Availability rules, by contrast, DO apply to secondary jobs -- that is the
+  # entire reason those targets were added. A www alias broken by a dropped
+  # serverAlias must be caught.
+  - interval: 1m
+    name: BlackboxProbeFailed fires for a -secondary target
+    input_series:
+      - series: 'probe_success{job="blackbox-https-secondary", instance="https://fredclausen.com/tar1090/"}'
+        values: "0+0x15"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: BlackboxProbeFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-https-secondary
+              instance: https://fredclausen.com/tar1090/
+            exp_annotations:
+              summary: "Endpoint https://fredclausen.com/tar1090/ is failing its probe"
+              description: "Blackbox job blackbox-https-secondary has been unable to get a valid response from https://fredclausen.com/tar1090/ for 5 minutes."

--- a/modules/monitoring/master/blackbox.nix
+++ b/modules/monitoring/master/blackbox.nix
@@ -30,10 +30,57 @@ let
   # respond as classified, from sdrhub, with a clean chain (ssl_verify_result=0).
 
   # Vhosts that serve real content and must answer 2xx directly.
+  #
+  # PRIMARY endpoints: exactly one per TLS certificate. The cert-expiry rules in
+  # alert-rules/blackbox-alerts.yaml select on these jobs alone, so this list and
+  # publicRedirectEndpoints below must stay one-target-per-certificate. Anything
+  # sharing a cert with an entry here belongs in the *Secondary lists.
   publicAppEndpoints = [
     "https://fredclausen.com/" # nginx -> fredsite on 127.0.0.1:4200
     "https://acarshub.app/" # nginx -> acarshub on 127.0.0.1:8085
     "https://flipaholics.pro/" # nginx -> 127.0.0.1:8078
+  ];
+
+  # Additional 2xx targets that share a certificate with a primary endpoint
+  # above, so they are probed for availability but excluded from the cert-expiry
+  # rules. Without that split every shared cert would be reported twice, on two
+  # instance labels, for one renewal fault.
+  #
+  # Two groups:
+  #
+  #   * www aliases. Every vhost in fredvps/nginx.nix carries
+  #     `serverAliases = [ "www.<domain>" ]`, and the nginx module folds those
+  #     into the same ACME cert -- so expiry is already covered by the apex, but
+  #     *availability* is not. A dropped or typo'd serverAlias breaks www.* while
+  #     the apex stays green and nothing notices. This file already justifies the
+  #     internal probes with exactly that reasoning; the public set was
+  #     inconsistent with it.
+  #
+  #   * Sub-path applications on fredclausen.com. The apex probe only exercises
+  #     `/` (fredsite on :4200). Two further backends hang off path prefixes on
+  #     that same vhost and had no availability coverage at all: nothing scrapes
+  #     them, so either could be down while `https://fredclausen.com/` still
+  #     answered 200. `/acarshub/` is deliberately omitted -- it proxies to the
+  #     same :8085 the acarshub.app probe already covers.
+  #
+  # Verified as classified: every entry below answers 200, and every www alias
+  # answers exactly as its apex does.
+  publicAppSecondaryEndpoints = [
+    "https://www.fredclausen.com/"
+    "https://www.acarshub.app/"
+    "https://www.flipaholics.pro/"
+
+    # tar1090 container on 127.0.0.1:8081.
+    "https://fredclausen.com/tar1090/"
+
+    # imageapi (sdre-image-api) on 127.0.0.1:3001. Probes a real route rather
+    # than the prefix root: the app is an Express API with no `/` handler, so
+    # `/imageapi/` answers 404 by design and a 2xx probe there would fire
+    # permanently. This route also exercises the app's database, since it reads
+    # the newest lastUpdated row. Freshness of that value is a separate concern
+    # and is covered by the sdre_image_api_last_updated_seconds metric on
+    # fredvps -- blackbox can assert a status code but cannot compute an age.
+    "https://fredclausen.com/imageapi/api/v1/last-updated"
   ];
 
   # Vhosts whose entire job is a globalRedirect. These must answer 3xx; a 2xx
@@ -50,6 +97,23 @@ let
     "https://therightradio.com/" # -> fredclausen.com
     "https://sdr-e.org/" # -> github.com/sdr-enthusiasts
     "https://sdr-enthusiasts.org/" # -> github.com/sdr-enthusiasts
+  ];
+
+  # www aliases of the redirect vhosts. Same rationale as
+  # publicAppSecondaryEndpoints: shared certificate, so availability-only.
+  # All eleven were verified to answer 301, identically to their apex.
+  publicRedirectSecondaryEndpoints = [
+    "https://www.acarshub.com/"
+    "https://www.adsb-pi.com/"
+    "https://www.atcfreq.com/"
+    "https://www.epicspam.com/"
+    "https://www.freminal.com/"
+    "https://www.onemorefoot.com/"
+    "https://www.politicalpileon.com/"
+    "https://www.sdrdockerconfig.com/"
+    "https://www.therightradio.com/"
+    "https://www.sdr-e.org/"
+    "https://www.sdr-enthusiasts.org/"
   ];
 
   # LAN-only HTTP vhosts served by nginx on this host (see the virtualHosts
@@ -212,6 +276,15 @@ in
     scrapeConfigs = [
       (mkProbeJob "blackbox-https" "https_2xx" publicAppEndpoints)
       (mkProbeJob "blackbox-https-redirect" "https_redirect" publicRedirectEndpoints)
+
+      # The `-secondary` suffix is load-bearing, not cosmetic: the cert-expiry
+      # rules in alert-rules/blackbox-alerts.yaml exclude `job=~".*-secondary"`
+      # so a certificate shared with a primary target is reported once rather
+      # than once per probed URL. Renaming these jobs without updating those
+      # rules would silently restore the duplicate cert alerts.
+      (mkProbeJob "blackbox-https-secondary" "https_2xx" publicAppSecondaryEndpoints)
+      (mkProbeJob "blackbox-https-redirect-secondary" "https_redirect" publicRedirectSecondaryEndpoints)
+
       (mkProbeJob "blackbox-http-internal" "http_2xx" internalEndpoints)
 
       # The exporter's own operational metrics -- not a probe, a normal scrape.

--- a/modules/monitoring/master/blackbox.nix
+++ b/modules/monitoring/master/blackbox.nix
@@ -78,7 +78,7 @@ let
     # `/imageapi/` answers 404 by design and a 2xx probe there would fire
     # permanently. This route also exercises the app's database, since it reads
     # the newest lastUpdated row. Freshness of that value is a separate concern
-    # and is covered by the sdre_image_api_last_updated_seconds metric on
+    # and is covered by the imageapi_last_updated_seconds metric on
     # fredvps -- blackbox can assert a status code but cannot compute an age.
     "https://fredclausen.com/imageapi/api/v1/last-updated"
   ];
@@ -278,7 +278,7 @@ in
       (mkProbeJob "blackbox-https-redirect" "https_redirect" publicRedirectEndpoints)
 
       # The `-secondary` suffix is load-bearing, not cosmetic: the cert-expiry
-      # rules in alert-rules/blackbox-alerts.yaml exclude `job=~".*-secondary"`
+      # rules in alert-rules/blackbox-alerts.yaml select `job!~".*-secondary"`
       # so a certificate shared with a primary target is reported once rather
       # than once per probed URL. Renaming these jobs without updating those
       # rules would silently restore the duplicate cert alerts.

--- a/modules/services/tailscale/default.nix
+++ b/modules/services/tailscale/default.nix
@@ -66,7 +66,13 @@
           # STATUS_OK=0, which is the honest report and is what
           # TailscaleBackendNotRunning and the expiry guards expect. Matches the
           # --max-time already used by the imageapi metric on fredvps.
-          STATUS=$(${pkgs.coreutils}/bin/timeout 10 "$TAILSCALE" status --json 2>/dev/null || echo "")
+          # --kill-after matters as much as the timeout itself: a plain `timeout`
+          # sends TERM and then waits indefinitely for a process that ignores it,
+          # which would leave the oneshot active and the previous .prom in place
+          # -- the exact silently-frozen-metrics outcome the bound exists to
+          # prevent. SIGKILL five seconds later guarantees the fall-through.
+          STATUS=$(${pkgs.coreutils}/bin/timeout --kill-after=5 10 \
+            "$TAILSCALE" status --json 2>/dev/null || echo "")
 
           if [[ -n "$STATUS" ]] && $JQ -e . <<<"$STATUS" >/dev/null 2>&1; then
             STATUS_OK=1

--- a/modules/services/tailscale/default.nix
+++ b/modules/services/tailscale/default.nix
@@ -58,7 +58,15 @@
           RUNNING=0
           STATUS_OK=0
 
-          STATUS=$("$TAILSCALE" status --json 2>/dev/null || echo "")
+          # Bounded deliberately. `tailscale status` talks to tailscaled's local
+          # API, which blocks if the daemon is wedged -- and an unbounded read
+          # would hang this oneshot until systemd's start timeout killed it,
+          # leaving the previous .prom in place and the metrics silently frozen
+          # at their last values. Timing out instead falls through to
+          # STATUS_OK=0, which is the honest report and is what
+          # TailscaleBackendNotRunning and the expiry guards expect. Matches the
+          # --max-time already used by the imageapi metric on fredvps.
+          STATUS=$(${pkgs.coreutils}/bin/timeout 10 "$TAILSCALE" status --json 2>/dev/null || echo "")
 
           if [[ -n "$STATUS" ]] && $JQ -e . <<<"$STATUS" >/dev/null 2>&1; then
             STATUS_OK=1

--- a/modules/services/tailscale/default.nix
+++ b/modules/services/tailscale/default.nix
@@ -119,11 +119,28 @@
     timers.tailscale-expiry-metric = {
       wantedBy = [ "timers.target" ];
       timerConfig = {
-        # Expiry moves on a scale of months; hourly is ample and keeps the series
-        # responsive enough to notice tailscaled dying.
-        OnCalendar = "hourly";
+        # Every 5 minutes, paced by the backend-state metric rather than by
+        # expiry.
+        #
+        # Expiry alone would be happy with an hourly run -- it moves on a scale
+        # of months. But this unit also emits tailscale_backend_running, and
+        # TailscaleBackendNotRunning claims to fire after 15 minutes. On an
+        # hourly timer that claim was false: up to 65 minutes to write the 0,
+        # plus the 15 minute `for`, is roughly 80 minutes before a node that has
+        # dropped to NeedsLogin is reported. An alert whose stated window is five
+        # times shorter than reality is worse than one with an honest longer
+        # window.
+        #
+        # Raising the frequency of the whole unit rather than splitting
+        # backend-state into a second service and timer: the work is a single
+        # local API call against tailscaled, so there is nothing to gain by
+        # collecting the two halves separately, and a second unit would be more
+        # moving parts for the same result.
+        OnCalendar = "*:0/5";
         Persistent = true;
-        RandomizedDelaySec = "300";
+        # Small relative to the interval; enough to keep the two tailnet hosts
+        # off the same instant without eating into the detection window.
+        RandomizedDelaySec = "30";
       };
     };
   };

--- a/modules/services/tailscale/default.nix
+++ b/modules/services/tailscale/default.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 {
   sops.secrets."tailscale/authkey" = {
     mode = "0400";
@@ -8,5 +8,115 @@
     enable = true;
     authKeyFile = config.sops.secrets."tailscale/authkey".path;
     openFirewall = true;
+  };
+
+  # Node key expiry metric.
+  #
+  # WHAT ACTUALLY EXPIRES, AND WHY THIS IS NOT ABOUT THE SOPS AUTH KEY
+  #
+  # Two different Tailscale credentials are easy to conflate:
+  #
+  #   * The auth key above (tskey-auth-...). Used ONCE to register a device.
+  #     `services.tailscale` only invokes it when the node is not already
+  #     authenticated, so an expired auth key does not disturb a running node --
+  #     it only blocks a fresh registration or a forced re-auth.
+  #
+  #   * Each device's NODE key, which has its own expiry and is the one that
+  #     takes a working node off the tailnet. Rotating the sops auth key does not
+  #     renew it; an expired node key needs `tailscale up` with an interactive
+  #     login URL, or a new key plus --force-reauth.
+  #
+  # This metric watches the second one, because that is the failure that costs
+  # something: on sdrhub it also withdraws the advertised 192.168.31.0/24 subnet
+  # route, and on fredvps it removes the tailnet address Prometheus scrapes it by.
+  #
+  # Tagged devices have key expiry disabled by default, so on a correctly tagged
+  # fleet KeyExpiry is absent and this reports `expiry_disabled`. That is the
+  # healthy end state, and the alerts treat it as such rather than as missing
+  # data -- otherwise doing the right thing upstream would look like a fault.
+  systemd = {
+    services.tailscale-expiry-metric = {
+      description = "Emit Tailscale node key expiry metrics";
+      after = [ "tailscaled.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript "tailscale-expiry-metric.sh" ''
+          set -uo pipefail
+
+          TAILSCALE=${config.services.tailscale.package}/bin/tailscale
+          JQ=${pkgs.jq}/bin/jq
+
+          HOST="${config.networking.hostName}"
+          TEXTFILE_DIR=/var/lib/node_exporter/textfiles
+          OUT="$TEXTFILE_DIR/tailscale_expiry.prom"
+
+          mkdir -p "$TEXTFILE_DIR"
+
+          EXPIRY=0
+          EXPIRY_DISABLED=0
+          EXPIRED=0
+          RUNNING=0
+          STATUS_OK=0
+
+          STATUS=$("$TAILSCALE" status --json 2>/dev/null || echo "")
+
+          if [[ -n "$STATUS" ]] && $JQ -e . <<<"$STATUS" >/dev/null 2>&1; then
+            STATUS_OK=1
+
+            [[ "$($JQ -r '.BackendState // ""' <<<"$STATUS")" == "Running" ]] && RUNNING=1
+            [[ "$($JQ -r '.Self.Expired // false' <<<"$STATUS")" == "true" ]] && EXPIRED=1
+
+            RAW=$($JQ -r '.Self.KeyExpiry // ""' <<<"$STATUS")
+            if [[ -n "$RAW" && "$RAW" != "null" ]]; then
+              PARSED=$(date -d "$RAW" +%s 2>/dev/null || echo "")
+              [[ "$PARSED" =~ ^[0-9]+$ ]] && EXPIRY=$PARSED
+            else
+              # No expiry reported: key expiry is disabled for this device, which
+              # is the desired configuration for an always-on server.
+              EXPIRY_DISABLED=1
+            fi
+          fi
+
+          TMP="$OUT.tmp"
+          {
+            echo "# HELP tailscale_key_expiry_seconds Unix time this node's Tailscale node key expires (0 if none)."
+            echo "# TYPE tailscale_key_expiry_seconds gauge"
+            echo "tailscale_key_expiry_seconds{host=\"$HOST\"} $EXPIRY"
+
+            echo "# HELP tailscale_key_expiry_disabled Whether key expiry is disabled for this node."
+            echo "# TYPE tailscale_key_expiry_disabled gauge"
+            echo "tailscale_key_expiry_disabled{host=\"$HOST\"} $EXPIRY_DISABLED"
+
+            echo "# HELP tailscale_node_expired Whether this node's key has already expired."
+            echo "# TYPE tailscale_node_expired gauge"
+            echo "tailscale_node_expired{host=\"$HOST\"} $EXPIRED"
+
+            echo "# HELP tailscale_backend_running Whether tailscaled reports BackendState=Running."
+            echo "# TYPE tailscale_backend_running gauge"
+            echo "tailscale_backend_running{host=\"$HOST\"} $RUNNING"
+
+            # Emitted unconditionally so the expiry alerts can require a
+            # successful status read. Without it, a tailscaled that will not
+            # answer leaves expiry at 0, which reads as "expires at the epoch"
+            # and would fire the expiry alerts for what is really a daemon fault.
+            echo "# HELP tailscale_status_scrape_success Whether tailscale status --json was read successfully."
+            echo "# TYPE tailscale_status_scrape_success gauge"
+            echo "tailscale_status_scrape_success{host=\"$HOST\"} $STATUS_OK"
+          } > "$TMP"
+          mv "$TMP" "$OUT"
+        '';
+      };
+    };
+
+    timers.tailscale-expiry-metric = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        # Expiry moves on a scale of months; hourly is ample and keeps the series
+        # responsive enough to notice tailscaled dying.
+        OnCalendar = "hourly";
+        Persistent = true;
+        RandomizedDelaySec = "300";
+      };
+    };
   };
 }

--- a/scripts/colmena-apply-drifted.sh
+++ b/scripts/colmena-apply-drifted.sh
@@ -77,7 +77,11 @@ while [[ $# -gt 0 ]]; do
         --wait) WAIT=1 ;;
         --) shift; COLMENA_ARGS=("$@"); break ;;
         -h | --help)
-            sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'
+            # Print the whole header block by structure rather than by line
+            # number: a hardcoded range silently truncates the moment the header
+            # grows, which it already had -- the `--` passthrough line was being
+            # cut off.
+            awk 'NR > 1 && /^#/ { sub(/^# ?/, ""); print; next } NR > 1 { exit }' "$0"
             exit 0
             ;;
         *)
@@ -222,8 +226,15 @@ for node in "${NODES[@]}"; do
         continue
     fi
 
+    # StrictHostKeyChecking is deliberately left at the user's default rather
+    # than set to accept-new. This script decides whether to deploy, so
+    # silently trusting an unrecognised host key is the wrong default: an
+    # unknown host should be surfaced, not adopted. Under BatchMode an unknown
+    # key simply fails, which lands the node in UNREACHABLE below and is
+    # reported rather than skipped. Every node here is already in known_hosts
+    # because colmena connects to them, so this costs nothing in practice.
     if ! running="$(
-        ssh -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new \
+        ssh -o BatchMode=yes -o ConnectTimeout=10 \
             -p "$port" "${user}@${host}" 'readlink -f /run/current-system' 2>/dev/null
     )"; then
         UNREACHABLE+=("$node ($host)")

--- a/scripts/colmena-apply-drifted.sh
+++ b/scripts/colmena-apply-drifted.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#
+# colmena-apply-drifted.sh -- deploy only the servers that are actually out of
+# date, and refuse to deploy ahead of the published fleet manifest.
+#
+# WHAT IT DOES
+#
+#   1. Evaluates the toplevel store path colmena would deploy for every node.
+#   2. Checks each of those paths against the published fleet manifest, and
+#      stops if the manifest has not caught up (see THE MANIFEST GUARD below).
+#   3. Asks each node over SSH what it is actually running.
+#   4. Runs `colmena apply --on <nodes>` for just the ones that differ.
+#
+# Topology is read from `colmenaHive.deploymentConfig`, which is the same data
+# colmena itself deploys from, so target hosts, ports and users cannot drift out
+# of sync with the node table in flake/hosts/servers.nix.
+#
+# THE MANIFEST GUARD
+#
+# The fleet manifest is published by a workflow that runs AFTER a merge, and each
+# host only compares itself against the manifest on a timer. Merge and deploy
+# quickly and you land in a window where a host is running a closure the manifest
+# has never heard of. The host cannot tell that apart from a hand-built WIP
+# system on its own, so it reports a deploy state of `unknown` until the manifest
+# publishes and it refetches.
+#
+# That window is harmless when the workflow is simply a couple of minutes behind.
+# It is NOT harmless when the workflow has failed: then the manifest never catches
+# up, drift detection for that host stays blind indefinitely, and the only signal
+# is a NixOSDeployStateUnknown alert twelve hours later. This guard is what tells
+# those two situations apart before you deploy rather than after.
+#
+# The check is per-host closure equality, not a commit comparison. That matters:
+# a commit that does not change a given host's closure leaves the manifest still
+# correct for it, so such a host is safe to deploy even though the manifest's
+# recorded revision is older than HEAD. Comparing revisions would refuse those
+# deploys for no reason.
+#
+# Local evaluation uses colmenaHive while the manifest is generated from
+# nixosConfigurations. Those two are byte-identical by construction, and
+# scripts/gen-fleet-manifest.sh refuses to publish if they ever stop being, so
+# comparing one against the other is sound.
+#
+# WHY SSH RATHER THAN THE PROMETHEUS METRIC
+#
+# nixos_deploy_state would answer "who is drifted" in a single query, but it is
+# only as fresh as each host's last timer run. A stale metric can report a host
+# as current when it is not, and this script would then skip the one host that
+# needed deploying. SSH is ground truth, and colmena needs it anyway.
+#
+# Usage:
+#   scripts/colmena-apply-drifted.sh                 # guard, report, deploy
+#   scripts/colmena-apply-drifted.sh --dry-run       # report only
+#   scripts/colmena-apply-drifted.sh --wait          # poll for the manifest
+#   scripts/colmena-apply-drifted.sh --force         # deploy despite the guard
+#   scripts/colmena-apply-drifted.sh -- --verbose    # pass args to colmena
+
+set -euo pipefail
+
+MANIFEST_URL="https://raw.githubusercontent.com/fredsystems/nixos/fleet-manifest/manifest.json"
+
+# How long --wait will poll for the manifest to catch up. The publishing workflow
+# evaluates every host (~1 minute) on top of runner startup, so a few minutes is
+# the normal case; ten minutes means something is wrong rather than slow.
+WAIT_TIMEOUT=600
+WAIT_INTERVAL=15
+
+DRY_RUN=0
+FORCE=0
+WAIT=0
+COLMENA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        --force) FORCE=1 ;;
+        --wait) WAIT=1 ;;
+        --) shift; COLMENA_ARGS=("$@"); break ;;
+        -h | --help)
+            sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1 (use -- to pass args to colmena)" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+for tool in nix jq git ssh curl colmena; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "error: required tool not on PATH: $tool" >&2
+        exit 1
+    }
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    cat >&2 <<'EOF'
+warning: the working tree is dirty.
+
+  A dirty tree evaluates to closures that no commit produced, so the manifest
+  cannot contain them and every host you deploy will report deploy state
+  'unmanaged' until you deploy again from a clean tree. That is the drift check
+  working correctly, not a false alarm.
+
+EOF
+fi
+
+# stderr is kept out of stdout: nix prints "Using saved setting for
+# 'extra-substituters = ...'" notices for this flake's nixConfig whenever the
+# invoking user is not trusted, and folding those in would corrupt the JSON.
+EVAL_STDERR="$(mktemp)"
+trap 'rm -f "$EVAL_STDERR"' EXIT
+
+echo "Evaluating what colmena would deploy..." >&2
+if ! EXPECTED_JSON="$(
+    nix eval --json '.#colmenaHive.nodes' \
+        --apply 'ns: builtins.mapAttrs (_: n: n.config.system.build.toplevel.outPath) ns' \
+        2>"$EVAL_STDERR"
+)"; then
+    printf 'error: failed to evaluate colmenaHive nodes:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
+    exit 1
+fi
+
+if ! DEPLOY_JSON="$(nix eval --json '.#colmenaHive.deploymentConfig' 2>>"$EVAL_STDERR")"; then
+    printf 'error: failed to evaluate colmenaHive deploymentConfig:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
+    exit 1
+fi
+
+mapfile -t NODES < <(jq -r 'keys[]' <<<"$EXPECTED_JSON")
+if [[ ${#NODES[@]} -eq 0 ]]; then
+    echo "error: colmenaHive has no nodes" >&2
+    exit 1
+fi
+echo "Evaluated ${#NODES[@]} node(s)." >&2
+
+# --- Manifest guard -------------------------------------------------------
+
+# Returns the space-separated list of nodes whose locally-evaluated closure is
+# not the one the published manifest currently expects for them.
+manifest_lagging_nodes() {
+    local manifest
+    manifest="$(curl -sfL --max-time 30 "$MANIFEST_URL" 2>/dev/null || echo "")"
+
+    if [[ -z "$manifest" ]] || ! jq -e '.schema == 1' <<<"$manifest" >/dev/null 2>&1; then
+        echo "__FETCH_FAILED__"
+        return 0
+    fi
+
+    jq -rn --argjson expected "$EXPECTED_JSON" --argjson m "$manifest" '
+        $expected | to_entries
+        | map(select(
+            ($m.hosts[.key].history[0].toplevel // "") != .value
+          ) | .key)
+        | join(" ")
+    '
+}
+
+if [[ $FORCE -eq 1 ]]; then
+    echo "Skipping the manifest guard (--force)." >&2
+else
+    LAGGING="$(manifest_lagging_nodes)"
+
+    if [[ $WAIT -eq 1 && -n "$LAGGING" ]]; then
+        echo "Manifest has not caught up yet; waiting up to ${WAIT_TIMEOUT}s..." >&2
+        WAITED=0
+        while [[ -n "$LAGGING" && "$WAITED" -lt "$WAIT_TIMEOUT" ]]; do
+            sleep "$WAIT_INTERVAL"
+            WAITED=$((WAITED + WAIT_INTERVAL))
+            LAGGING="$(manifest_lagging_nodes)"
+            [[ -z "$LAGGING" ]] && echo "Manifest caught up after ${WAITED}s." >&2
+        done
+    fi
+
+    if [[ "$LAGGING" == "__FETCH_FAILED__" ]]; then
+        cat >&2 <<EOF
+error: could not fetch the fleet manifest.
+
+  Deploying now would leave every host unable to determine its deploy state.
+  Check network access to raw.githubusercontent.com, or pass --force if you
+  accept that consequence.
+EOF
+        exit 1
+    fi
+
+    if [[ -n "$LAGGING" ]]; then
+        cat >&2 <<EOF
+error: the published manifest does not yet describe the closures you are about
+       to deploy, for: $LAGGING
+
+  Either the fleet-manifest workflow has not finished for the current commit, or
+  it failed. Deploying now leaves those hosts reporting deploy state 'unknown'
+  until it publishes; if it failed, that is indefinite.
+
+  Check:  gh run list --workflow=fleet-manifest.yaml --limit 3
+  Wait:   $0 --wait
+  Ignore: $0 --force
+EOF
+        exit 1
+    fi
+
+    echo "Manifest matches the closures to be deployed." >&2
+fi
+
+# --- Determine what each node is actually running -------------------------
+
+DRIFTED=()
+CURRENT=()
+UNREACHABLE=()
+
+for node in "${NODES[@]}"; do
+    expected="$(jq -r --arg n "$node" '.[$n]' <<<"$EXPECTED_JSON")"
+    host="$(jq -r --arg n "$node" '.[$n].targetHost // ""' <<<"$DEPLOY_JSON")"
+    port="$(jq -r --arg n "$node" '.[$n].targetPort // 22' <<<"$DEPLOY_JSON")"
+    user="$(jq -r --arg n "$node" '.[$n].targetUser // "root"' <<<"$DEPLOY_JSON")"
+
+    if [[ -z "$host" ]]; then
+        UNREACHABLE+=("$node (no targetHost)")
+        continue
+    fi
+
+    if ! running="$(
+        ssh -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new \
+            -p "$port" "${user}@${host}" 'readlink -f /run/current-system' 2>/dev/null
+    )"; then
+        UNREACHABLE+=("$node ($host)")
+        continue
+    fi
+
+    if [[ "$running" == "$expected" ]]; then
+        CURRENT+=("$node")
+    else
+        DRIFTED+=("$node")
+    fi
+done
+
+printf '\n%-12s %s\n' "current:" "${CURRENT[*]:-none}"
+printf '%-12s %s\n' "to deploy:" "${DRIFTED[*]:-none}"
+if [[ ${#UNREACHABLE[@]} -gt 0 ]]; then
+    # Reported rather than silently skipped: an unreachable node is one colmena
+    # could not have deployed either, and treating it as "current" would quietly
+    # leave it behind forever.
+    printf '%-12s %s\n' "unreachable:" "${UNREACHABLE[*]}"
+fi
+echo
+
+if [[ ${#DRIFTED[@]} -eq 0 ]]; then
+    echo "Nothing to deploy."
+    exit 0
+fi
+
+TARGETS="$(
+    IFS=,
+    echo "${DRIFTED[*]}"
+)"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "would run: colmena apply --on $TARGETS ${COLMENA_ARGS[*]}"
+    exit 0
+fi
+
+echo "Running: colmena apply --on $TARGETS ${COLMENA_ARGS[*]}"
+exec colmena apply --on "$TARGETS" ${COLMENA_ARGS[@]+"${COLMENA_ARGS[@]}"}

--- a/scripts/colmena-apply-drifted.sh
+++ b/scripts/colmena-apply-drifted.sh
@@ -92,7 +92,7 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-for tool in nix jq git ssh curl colmena; do
+for tool in nix jq git ssh curl colmena timeout; do
     command -v "$tool" >/dev/null 2>&1 || {
         echo "error: required tool not on PATH: $tool" >&2
         exit 1
@@ -119,6 +119,13 @@ fi
 EVAL_STDERR="$(mktemp)"
 trap 'rm -f "$EVAL_STDERR"' EXIT
 
+# Captured before evaluation and re-checked immediately before `colmena apply`,
+# so an edit landing mid-run cannot deploy closures this run never evaluated.
+SOURCE_ID_AT_EVAL="$(
+    git rev-parse HEAD
+    git status --porcelain
+)"
+
 echo "Evaluating what colmena would deploy..." >&2
 if ! EXPECTED_JSON="$(
     nix eval --json '.#colmenaHive.nodes' \
@@ -141,41 +148,143 @@ if [[ ${#NODES[@]} -eq 0 ]]; then
 fi
 echo "Evaluated ${#NODES[@]} node(s)." >&2
 
-# --- Manifest guard -------------------------------------------------------
+# --- Determine what each node is actually running -------------------------
+#
+# Done BEFORE the manifest guard, so the guard can be scoped to the nodes that
+# are actually going to be deployed. Checking every evaluated node instead would
+# refuse the whole run because some node that needs no deploy happens to have an
+# unpublished closure -- blocking a safe deployment for an unrelated host.
 
-# Returns the space-separated list of nodes whose locally-evaluated closure is
-# not the one the published manifest currently expects for them.
+DRIFTED=()
+CURRENT=()
+UNREACHABLE=()
+
+for node in "${NODES[@]}"; do
+    expected="$(jq -r --arg n "$node" '.[$n]' <<<"$EXPECTED_JSON")"
+    host="$(jq -r --arg n "$node" '.[$n].targetHost // ""' <<<"$DEPLOY_JSON")"
+    port="$(jq -r --arg n "$node" '.[$n].targetPort // 22' <<<"$DEPLOY_JSON")"
+    user="$(jq -r --arg n "$node" '.[$n].targetUser // "root"' <<<"$DEPLOY_JSON")"
+
+    if [[ -z "$host" ]]; then
+        UNREACHABLE+=("$node (no targetHost)")
+        continue
+    fi
+
+    # StrictHostKeyChecking is pinned to yes rather than left to the caller's
+    # ssh_config, and certainly not set to accept-new.
+    #
+    # This probe decides whether a host is skipped. An attacker able to spoof DNS
+    # or a route could present their own host key, answer with the expected
+    # closure path, and cause a genuinely drifted host to be classified as
+    # current -- silently withholding a deploy, which is the one failure
+    # direction here that matters. Trust-on-first-use is therefore the wrong
+    # default, and relying on the ambient config is not enough either: a
+    # `StrictHostKeyChecking no` entry in ~/.ssh/config would silently defeat it.
+    #
+    # Every node is already in known_hosts because colmena connects to them, so
+    # an unknown key means something is wrong. It fails, lands the node in
+    # UNREACHABLE, and gets reported rather than skipped.
+    #
+    # The outer timeout bounds the whole session, which ConnectTimeout does not:
+    # it only covers reaching the port. A host that accepts the connection and
+    # then wedges -- full disk, load spike, D-state -- would otherwise block the
+    # loop forever and prevent every later node from being classified.
+    # Retried once. A transient blip -- flaky mDNS for a .local name, a moment of
+    # packet loss -- otherwise demotes a host to UNREACHABLE, and the run then
+    # proceeds without it. That is the one failure direction that matters here:
+    # withholding a deploy from a host that needed one. Observed in practice, so
+    # this is not hypothetical.
+    running=""
+    probe_ok=0
+    for attempt in 1 2; do
+        if running="$(
+            timeout 30 ssh \
+                -o BatchMode=yes \
+                -o ConnectTimeout=10 \
+                -o StrictHostKeyChecking=yes \
+                -p "$port" "${user}@${host}" 'readlink -f /run/current-system' 2>/dev/null
+        )"; then
+            probe_ok=1
+            break
+        fi
+        [[ "$attempt" -eq 1 ]] && sleep 3
+    done
+
+    if [[ "$probe_ok" -eq 0 ]]; then
+        UNREACHABLE+=("$node ($host)")
+        continue
+    fi
+
+    if [[ "$running" == "$expected" ]]; then
+        CURRENT+=("$node")
+    else
+        DRIFTED+=("$node")
+    fi
+done
+
+printf '\n%-12s %s\n' "current:" "${CURRENT[*]:-none}"
+printf '%-12s %s\n' "to deploy:" "${DRIFTED[*]:-none}"
+if [[ ${#UNREACHABLE[@]} -gt 0 ]]; then
+    # Reported rather than silently skipped: an unreachable node is one colmena
+    # could not have deployed either, and treating it as "current" would quietly
+    # leave it behind forever.
+    printf '%-12s %s\n' "unreachable:" "${UNREACHABLE[*]}"
+fi
+echo
+
+if [[ ${#DRIFTED[@]} -eq 0 ]]; then
+    echo "Nothing to deploy."
+    exit 0
+fi
+
+# --- Manifest guard, scoped to the deployment targets ---------------------
+
+# Prints the space-separated subset of the given nodes whose locally-evaluated
+# closure is not the one the published manifest currently expects for them.
+#
+# $1 is the remaining seconds allowed for the fetch, so a --wait loop cannot
+# exceed its deadline by however long curl decides to spend.
 manifest_lagging_nodes() {
-    local manifest
-    manifest="$(curl -sfL --max-time 30 "$MANIFEST_URL" 2>/dev/null || echo "")"
+    local budget="$1" manifest
+    [[ "$budget" -lt 1 ]] && budget=1
+
+    manifest="$(curl -sfL --max-time "$budget" "$MANIFEST_URL" 2>/dev/null || echo "")"
 
     if [[ -z "$manifest" ]] || ! jq -e '.schema == 1' <<<"$manifest" >/dev/null 2>&1; then
         echo "__FETCH_FAILED__"
         return 0
     fi
 
-    jq -rn --argjson expected "$EXPECTED_JSON" --argjson m "$manifest" '
-        $expected | to_entries
+    jq -rn \
+        --argjson expected "$EXPECTED_JSON" \
+        --argjson m "$manifest" \
+        --arg targets "${DRIFTED[*]}" \
+        '
+        ($targets | split(" ")) as $t
+        | $expected | to_entries
         | map(select(
-            ($m.hosts[.key].history[0].toplevel // "") != .value
+            (.key | IN($t[]))
+            and (($m.hosts[.key].history[0].toplevel // "") != .value)
           ) | .key)
         | join(" ")
-    '
+        '
 }
 
 if [[ $FORCE -eq 1 ]]; then
     echo "Skipping the manifest guard (--force)." >&2
 else
-    LAGGING="$(manifest_lagging_nodes)"
+    # Deadline measured with SECONDS, not by summing sleeps: each fetch can also
+    # consume wall-clock time, so accumulating only the sleeps let --wait run for
+    # several times its stated timeout when every fetch was slow.
+    DEADLINE=$((SECONDS + WAIT_TIMEOUT))
+    LAGGING="$(manifest_lagging_nodes "$((DEADLINE - SECONDS))")"
 
     if [[ $WAIT -eq 1 && -n "$LAGGING" ]]; then
         echo "Manifest has not caught up yet; waiting up to ${WAIT_TIMEOUT}s..." >&2
-        WAITED=0
-        while [[ -n "$LAGGING" && "$WAITED" -lt "$WAIT_TIMEOUT" ]]; do
+        while [[ -n "$LAGGING" && "$SECONDS" -lt "$DEADLINE" ]]; do
             sleep "$WAIT_INTERVAL"
-            WAITED=$((WAITED + WAIT_INTERVAL))
-            LAGGING="$(manifest_lagging_nodes)"
-            [[ -z "$LAGGING" ]] && echo "Manifest caught up after ${WAITED}s." >&2
+            LAGGING="$(manifest_lagging_nodes "$((DEADLINE - SECONDS))")"
+            [[ -z "$LAGGING" ]] && echo "Manifest caught up after $((WAIT_TIMEOUT - (DEADLINE - SECONDS)))s." >&2
         done
     fi
 
@@ -209,58 +318,25 @@ EOF
     echo "Manifest matches the closures to be deployed." >&2
 fi
 
-# --- Determine what each node is actually running -------------------------
+# --- Deploy ---------------------------------------------------------------
 
-DRIFTED=()
-CURRENT=()
-UNREACHABLE=()
+# `nix eval` above and `colmena apply` below resolve the flake independently, so
+# a worktree edit landing in between would deploy something this run never
+# evaluated and the guard never checked. Re-checking the source identity closes
+# that window: cheaper than snapshotting the tree, and it catches the realistic
+# case of editing a file while the SSH probing was in progress.
+SOURCE_ID_NOW="$(
+    git rev-parse HEAD
+    git status --porcelain
+)"
+if [[ "$SOURCE_ID_NOW" != "$SOURCE_ID_AT_EVAL" ]]; then
+    cat >&2 <<'EOF'
+error: the working tree changed while this run was in progress.
 
-for node in "${NODES[@]}"; do
-    expected="$(jq -r --arg n "$node" '.[$n]' <<<"$EXPECTED_JSON")"
-    host="$(jq -r --arg n "$node" '.[$n].targetHost // ""' <<<"$DEPLOY_JSON")"
-    port="$(jq -r --arg n "$node" '.[$n].targetPort // 22' <<<"$DEPLOY_JSON")"
-    user="$(jq -r --arg n "$node" '.[$n].targetUser // "root"' <<<"$DEPLOY_JSON")"
-
-    if [[ -z "$host" ]]; then
-        UNREACHABLE+=("$node (no targetHost)")
-        continue
-    fi
-
-    # StrictHostKeyChecking is deliberately left at the user's default rather
-    # than set to accept-new. This script decides whether to deploy, so
-    # silently trusting an unrecognised host key is the wrong default: an
-    # unknown host should be surfaced, not adopted. Under BatchMode an unknown
-    # key simply fails, which lands the node in UNREACHABLE below and is
-    # reported rather than skipped. Every node here is already in known_hosts
-    # because colmena connects to them, so this costs nothing in practice.
-    if ! running="$(
-        ssh -o BatchMode=yes -o ConnectTimeout=10 \
-            -p "$port" "${user}@${host}" 'readlink -f /run/current-system' 2>/dev/null
-    )"; then
-        UNREACHABLE+=("$node ($host)")
-        continue
-    fi
-
-    if [[ "$running" == "$expected" ]]; then
-        CURRENT+=("$node")
-    else
-        DRIFTED+=("$node")
-    fi
-done
-
-printf '\n%-12s %s\n' "current:" "${CURRENT[*]:-none}"
-printf '%-12s %s\n' "to deploy:" "${DRIFTED[*]:-none}"
-if [[ ${#UNREACHABLE[@]} -gt 0 ]]; then
-    # Reported rather than silently skipped: an unreachable node is one colmena
-    # could not have deployed either, and treating it as "current" would quietly
-    # leave it behind forever.
-    printf '%-12s %s\n' "unreachable:" "${UNREACHABLE[*]}"
-fi
-echo
-
-if [[ ${#DRIFTED[@]} -eq 0 ]]; then
-    echo "Nothing to deploy."
-    exit 0
+  The closures checked against the manifest are no longer the ones colmena would
+  build. Re-run so the evaluation, the guard and the deployment all agree.
+EOF
+    exit 1
 fi
 
 TARGETS="$(

--- a/scripts/colmena-apply-drifted.sh
+++ b/scripts/colmena-apply-drifted.sh
@@ -121,10 +121,19 @@ trap 'rm -f "$EVAL_STDERR"' EXIT
 
 # Captured before evaluation and re-checked immediately before `colmena apply`,
 # so an edit landing mid-run cannot deploy closures this run never evaluated.
-SOURCE_ID_AT_EVAL="$(
+#
+# The diff content is hashed, not just the porcelain file list. The list records
+# THAT a file is dirty, not what is in it, so editing an already-dirty file left
+# both identifiers identical -- missing precisely the case this guard exists to
+# catch. `git diff HEAD` covers staged and unstaged changes to tracked files,
+# which is exactly the set a flake evaluation can see; untracked files are
+# invisible to Nix and cannot affect the result.
+source_identity() {
     git rev-parse HEAD
     git status --porcelain
-)"
+    git diff HEAD | sha256sum
+}
+SOURCE_ID_AT_EVAL="$(source_identity)"
 
 echo "Evaluating what colmena would deploy..." >&2
 if ! EXPECTED_JSON="$(
@@ -282,9 +291,18 @@ else
     if [[ $WAIT -eq 1 && -n "$LAGGING" ]]; then
         echo "Manifest has not caught up yet; waiting up to ${WAIT_TIMEOUT}s..." >&2
         while [[ -n "$LAGGING" && "$SECONDS" -lt "$DEADLINE" ]]; do
-            sleep "$WAIT_INTERVAL"
-            LAGGING="$(manifest_lagging_nodes "$((DEADLINE - SECONDS))")"
-            [[ -z "$LAGGING" ]] && echo "Manifest caught up after $((WAIT_TIMEOUT - (DEADLINE - SECONDS)))s." >&2
+            # Sleep no further than the deadline, then only fetch if budget
+            # remains. Sleeping a fixed interval could overshoot and leave a
+            # nonpositive budget, which the fetch clamped to 1s -- letting a
+            # --wait run exceed WAIT_TIMEOUT by an extra request.
+            remaining=$((DEADLINE - SECONDS))
+            [[ "$remaining" -le 0 ]] && break
+            sleep "$(( WAIT_INTERVAL < remaining ? WAIT_INTERVAL : remaining ))"
+
+            remaining=$((DEADLINE - SECONDS))
+            [[ "$remaining" -le 0 ]] && break
+            LAGGING="$(manifest_lagging_nodes "$remaining")"
+            [[ -z "$LAGGING" ]] && echo "Manifest caught up after $((WAIT_TIMEOUT - remaining))s." >&2
         done
     fi
 
@@ -320,15 +338,22 @@ fi
 
 # --- Deploy ---------------------------------------------------------------
 
+# On host-key policy for the deployment itself: colmena opens its own SSH
+# connections and this script cannot inject options into them, so it cannot
+# extend the pinned StrictHostKeyChecking used by the probe above to `colmena
+# apply`. What it does provide is that the target list only ever contains hosts
+# whose key verified against known_hosts moments earlier in this same run -- a
+# host that failed that check is in UNREACHABLE and is never passed on. That
+# narrows the exposure to a key swapped between probe and deploy rather than
+# eliminating it. Closing it properly belongs in ssh_config or an SSH host CA,
+# which would cover every colmena invocation rather than only this wrapper.
+
 # `nix eval` above and `colmena apply` below resolve the flake independently, so
 # a worktree edit landing in between would deploy something this run never
 # evaluated and the guard never checked. Re-checking the source identity closes
 # that window: cheaper than snapshotting the tree, and it catches the realistic
 # case of editing a file while the SSH probing was in progress.
-SOURCE_ID_NOW="$(
-    git rev-parse HEAD
-    git status --porcelain
-)"
+SOURCE_ID_NOW="$(source_identity)"
 if [[ "$SOURCE_ID_NOW" != "$SOURCE_ID_AT_EVAL" ]]; then
     cat >&2 <<'EOF'
 error: the working tree changed while this run was in progress.


### PR DESCRIPTION
Five independent changes, each atomic. Three fix gaps found by running the
previous PRs in production; two close coverage gaps.

## 1. `unmanaged` right after every deploy (fix)

The whole fleet reported `unmanaged` after deploying #2138, including hosts
running exactly the closure the manifest expected. The exporter concluded "main
never produced this closure" from a manifest generated **before** that closure
was activated — maranello's exporter ran at 21:40:50, 41 seconds before the new
manifest existed.

Not just cosmetic: `unmanaged` has a 2h fuse, so deploying while the manifest
workflow is queued or failed would page about a healthy fleet — the same
misattribution `NixOSFleetManifestStale` uses `min()` to avoid, one layer down.

Now reports `unknown` when the manifest predates the running closure (12h fuse:
never fires on a normal deploy, still catches a stuck publisher), plus an
activation hook so a deploy re-evaluates immediately instead of waiting out the
10-minute timer.

Verified all four transitions, including that a manifest *newer* than the deploy
still yields `unmanaged` — genuine dirty-tree builds are still caught.

## 2. www aliases and sub-path apps unprobed (coverage)

- `/tar1090/` (:8081) and `/imageapi/` (:3001) had **no** availability coverage.
  Nothing scrapes fredvps but node_exporter, so either could be down while
  `https://fredclausen.com/` returned 200.
- None of the 14 `www` aliases were probed. A dropped `serverAlias` breaks
  `www.*` while the apex stays green — the exact reasoning this file already
  used to justify its *internal* probes.

Both share a certificate with an existing target, so they go in `-secondary`
jobs excluded from the TLS rules; otherwise one renewal failure would report
once per URL instead of once per certificate.

The imageapi entry probes `/api/v1/last-updated`, not the prefix root: the app
is an Express API with no `/` handler, so `/imageapi/` answers 404 by design and
a 2xx probe there would fire permanently.

20 → 36 probe targets, all verified as classified before committing.

## 3. imageapi update loop (coverage)

Blackbox can assert the endpoint answers but cannot compute an age — a stuck
updater serves a healthy 200 with week-old data. Adds a loopback textfile metric
plus a 3h staleness alert (the loop reschedules 1h *after* each run completes, so
cycles aren't evenly spaced).

The `scrape_success` term is load-bearing: a down container leaves the age at 0,
and without it the rule would blame a stalled update loop for an unreachable
endpoint.

## 4. Tailscale node key expiry (coverage)

Both tailnet hosts were 20 days from expiry with nothing watching. On expiry
sdrhub withdraws its `192.168.31.0/24` subnet route and fredvps loses the address
Prometheus scrapes it by.

Watches the **node** key, not the sops auth key — those behave differently, and
rotating the auth key does *not* renew an expired node key. An alert on the wrong
one would send someone to update sops while both boxes stayed offline.

Thresholds mirror the blackbox cert rules (21d/7d). Two guards are mandatory, not
defensive: a device with expiry disabled — now the live state of both hosts — and
an unqueryable daemon both report 0, so without them `0 - time()` would fire
critical forever and *configuring Tailscale correctly would page continuously*.
The most important test asserts exactly that.

Validated against both live nodes: reproduced sdrhub's expiry to the second while
expiry was enabled, then `expiry_disabled=1` after it was turned off.

## 5. `scripts/colmena-apply-drifted.sh` (feature)

Deploys only the servers that are actually out of date, and refuses to deploy
ahead of the published manifest.

Reads topology from `colmenaHive.deploymentConfig` — the same data colmena
deploys from — so target hosts/ports/users can't drift from the node table.

Uses SSH rather than `nixos_deploy_state` deliberately: a stale metric can report
a host as current when it isn't, which would skip the one host that needed
deploying. That's the only unsafe direction here.

The manifest guard is per-host **closure equality**, not a commit comparison — a
commit that doesn't change a host's closure leaves the manifest correct for it, so
comparing revisions would refuse safe deploys for no reason. `--wait` polls,
`--force` overrides.

## Verification

| Check | Result |
|---|---|
| promtool check + test | pass, 12 new cases |
| All 9 hosts eval, no warnings | pass |
| colmena/nixosConfigurations agreement guard | pass, 7 servers |
| Deploy-state machine, all 4 transitions | correct |
| Blackbox job + target generation on sdrhub | 36 targets, pre-existing jobs intact |
| Tailscale metric vs live nodes | exact, both states |
| imageapi endpoint + cadence vs source | confirmed |
| `pre-commit run --all-files` | pass |

Every firing test asserts exact annotations, so none can pass vacuously — which
matters here because the negative cases would otherwise pass on a typo'd metric
name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for stale Image API updates, including freshness and scrape-success metrics.
  * Added Tailscale monitoring for expiring node keys, scrape failures, and unavailable backends.
  * Added secondary HTTPS availability checks for aliases and sub-path services.
  * Added a tool to identify and deploy only hosts with configuration drift, including dry-run support.
* **Bug Fixes**
  * Improved deployment-state detection and reporting during system activation.
  * Reduced duplicate TLS certificate alerts for secondary probe targets.
  * Limited cache connection delays with a five-second timeout.
* **Tests**
  * Added coverage for Image API, Tailscale, and secondary probe alerting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->