### PR TITLE
feat(daytona): tailscale with location-gated route acceptance

### DIFF
--- a/.github/workflows/fleet-manifest.yaml
+++ b/.github/workflows/fleet-manifest.yaml
@@ -19,6 +19,29 @@ name: Fleet Manifest
 on:
   push:
     branches: [main]
+
+  # Every 6 hours, independently of whether anything merged.
+  #
+  # Hosts derive nixos_manifest_age_seconds from this manifest's generated_at,
+  # and NixOSFleetManifestStale fires when the freshest copy any host can see is
+  # over 24h old. On a push-only trigger that metric actually measures "time
+  # since something was merged", so a quiet weekend would trip the alert and
+  # report fleet-wide drift detection as disabled while everything was in fact
+  # working -- the publisher had simply had nothing to publish.
+  #
+  # Refreshing on a schedule makes the metric mean what the alert claims, and
+  # four runs per day against a 24h threshold leaves three missed runs of slack
+  # before it fires.
+  #
+  # The cost is one commit per run carrying a two-line diff. That is immaterial:
+  # the file is capped at ~50 KiB, hosts fetch it as a single file over raw.
+  # githubusercontent.com, and the workflow clones with --depth 1, so none of the
+  # three consumers pays for branch history. Note this relies on the
+  # changed-hosts report diffing paths rather than matching on revision --
+  # otherwise every scheduled run would claim all nine hosts had changed.
+  schedule:
+    - cron: "17 */6 * * *"
+
   workflow_dispatch:
 
 # Serialise pushes to the manifest branch. Two runs racing would make one of

--- a/hosts/linux/daytona/configuration.nix
+++ b/hosts/linux/daytona/configuration.nix
@@ -8,6 +8,7 @@
   imports = [
     ./hardware-configuration.nix
     ../../../profiles/desktop.nix
+    ./tailscale.nix
   ];
 
   # Hardware profile settings

--- a/hosts/linux/daytona/tailscale.nix
+++ b/hosts/linux/daytona/tailscale.nix
@@ -1,0 +1,152 @@
+# Tailscale on the laptop, with LAN route acceptance gated on location.
+#
+# WHY THIS EXISTS
+#
+# The substituter list in modules/base/system.nix starts with
+# http://192.168.31.14:8080/fred (Attic on fredhub), which is unroutable off the
+# home network. Every nix invocation away from home therefore stalls on it before
+# falling back, and with direnv loading a flake on every `cd` that is constantly.
+# `connect-timeout = 5` bounds the stall; this makes the cache actually reachable.
+#
+# sdrhub already advertises 192.168.31.0/24 to the tailnet and fredvps already
+# consumes it -- see the comment on `extraUpFlags` in
+# hosts/linux/fredvps/configuration.nix, which cites the same motivation. This is
+# that arrangement applied to the laptop.
+#
+# Everything here is deliberately scoped to this host rather than added to
+# modules/services/tailscale, so enabling it cannot alter sdrhub's or fredvps'
+# closures.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  # The LAN sdrhub advertises. Kept as a prefix string because the check below is
+  # a substring match against `ip addr` output, not a CIDR computation.
+  homeSubnetPrefix = "192.168.31.";
+
+  # Route acceptance is toggled rather than the tailnet being joined and left.
+  #
+  # Leaving the tailnet at home would also give up remote SSH, MagicDNS and
+  # anything else reachable over it, for no benefit -- the only thing that
+  # interacts badly with being physically on the advertised LAN is accepting a
+  # route for that same LAN. So the node stays up everywhere and only
+  # --accept-routes moves.
+  #
+  # Worth knowing how much this is actually protecting against: the kernel
+  # prefers the directly-connected 192.168.31.0/24 route in the main table, which
+  # Tailscale's policy rules consult before its own table, so accepting the route
+  # at home is usually harmless anyway. This is belt-and-braces that removes the
+  # ambiguity, not a fix for a known breakage.
+  routeGating = pkgs.writeShellApplication {
+    name = "tailscale-route-gating";
+    runtimeInputs = [
+      pkgs.iproute2
+      pkgs.jq
+      config.services.tailscale.package
+    ];
+    text = ''
+      # Presence of an address in the advertised range is the test, rather than
+      # the wifi SSID: it works identically on ethernet and wifi, survives an
+      # SSID rename, and cannot be fooled by a network that merely has a similar
+      # name.
+      if ip -4 -o addr show | grep -q "inet ${homeSubnetPrefix}"; then
+        want=false
+        where="on the home LAN"
+      else
+        want=true
+        where="away from the home LAN"
+      fi
+
+      # tailscale set is idempotent, but reading the current value first keeps
+      # this quiet in the journal and avoids poking the daemon on every
+      # NetworkManager event -- of which a laptop generates plenty.
+      #
+      # `debug prefs` is the only place RouteAll is exposed; `status --json` does
+      # not carry it. If that ever changes shape, the read fails and we fall
+      # through to setting unconditionally, which is correct but chattier.
+      # Deliberately not `.RouteAll // empty`: jq's alternative operator treats
+      # `false` as absent, so that idiom returns nothing for the very state we
+      # most need to recognise -- route acceptance already off. The script would
+      # then think the value was unknown on every run and call `tailscale set`
+      # each time, logging a line every five minutes forever. `// "unknown"` on
+      # the null case keeps false distinguishable from missing.
+      current=""
+      if prefs=$(tailscale debug prefs 2>/dev/null); then
+        current=$(jq -r 'if has("RouteAll") and .RouteAll != null then (.RouteAll | tostring) else "" end' \
+          <<<"$prefs" 2>/dev/null || echo "")
+      fi
+
+      if [ "$current" = "$want" ]; then
+        exit 0
+      fi
+
+      echo "tailscale-route-gating: $where; setting --accept-routes=$want (was ''${current:-unknown})"
+
+      # Not fatal on failure. tailscaled may not be up yet during early boot or a
+      # resume, and this runs again on the next NetworkManager event and on the
+      # backstop timer below. Failing the unit here would only produce noise and,
+      # for the dispatcher, a NetworkManager error.
+      if ! tailscale set --accept-routes="$want"; then
+        echo "tailscale-route-gating: could not set --accept-routes (tailscaled not ready?)" >&2
+      fi
+    '';
+  };
+in
+{
+  imports = [ ../../../modules/services/tailscale ];
+
+  services.tailscale = {
+    # Without this the advertised subnet route is ignored and 192.168.31.14 stays
+    # unreachable even with the tunnel up. Linux clients do not accept advertised
+    # routes by default. The gating script overrides the effective value at
+    # runtime; this is what applies on the very first `tailscale up`.
+    extraUpFlags = [ "--accept-routes" ];
+
+    # Sets networking.firewall.checkReversePath = "loose".
+    #
+    # Daytona currently has strict reverse-path filtering (the NixOS default),
+    # which can silently drop replies arriving over tailscale0 for a subnet
+    # route. fredvps happens to work without this, but a strict-rp_filter drop is
+    # an unpleasant thing to debug -- it looks like the route is missing when it
+    # is not -- so the documented setting for a machine that accepts routes is
+    # used here rather than relying on that.
+    useRoutingFeatures = "client";
+  };
+
+  # Immediate reaction to a network change: connecting, disconnecting, a new
+  # DHCP lease, or a resume that brings an interface back.
+  networking.networkmanager.dispatcherScripts = [
+    {
+      source = lib.getExe routeGating;
+      type = "basic";
+    }
+  ];
+
+  systemd = {
+    services.tailscale-route-gating = {
+      description = "Gate Tailscale route acceptance on being off the home LAN";
+      after = [ "tailscaled.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = lib.getExe routeGating;
+      };
+    };
+
+    # Backstop for events the dispatcher cannot see: tailscaled starting after
+    # the last network event, a resume that does not re-trigger NetworkManager,
+    # or the daemon not yet being ready when the dispatcher fired. Without it a
+    # missed event leaves the wrong setting in place until the next network
+    # change, which on a laptop that stays put could be days.
+    timers.tailscale-route-gating = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";
+        OnUnitActiveSec = "5min";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -303,11 +303,23 @@ mv "${OUT}.tmp" "$OUT"
 
 # Report what moved, so the workflow log answers "which hosts did this commit
 # actually affect?" directly.
-CHANGED="$(jq -r --arg rev "$REV" '
-    .hosts | to_entries
-    | map(select(.value.history[0].rev == $rev))
-    | map(.key) | join(" ")
-' "$OUT")"
+# Computed by diffing against the previous manifest rather than by selecting
+# `history[0].rev == $REV`.
+#
+# That selector answers "whose newest entry carries this revision", which is only
+# the same question when every entry at this revision was created by THIS run. Re-
+# run the generator at an unchanged revision -- a workflow_dispatch, or a retry --
+# and it reports every host as changed, because their entries were created at that
+# same revision the first time round. Diffing the paths is what the sentence
+# actually claims to describe.
+CHANGED="$(
+    jq -rn \
+        --argjson old "$OLD_JSON" \
+        --argjson paths "$PATHS_JSON" \
+        '$paths | to_entries
+         | map(select((($old.hosts // {})[.key].history[0].toplevel // "") != .value) | .key)
+         | join(" ")'
+)"
 
 if [[ -n "$CHANGED" ]]; then
     echo "Hosts whose expected closure changed at ${REV}: ${CHANGED}" >&2


### PR DESCRIPTION
Three commits. The headline change is Daytona-only; two smaller fixes came out
of verifying it.

## 1. Changed-hosts report was matching on revision

`gen-fleet-manifest.sh` selected hosts whose `history[0].rev` equalled the
current revision. That answers "whose newest entry carries this revision",
which only matches the intended question when every entry at that revision was
written by the current run.

Re-running at an unchanged revision therefore claimed **all nine hosts had
changed**. It did that to me mid-verification, which is how it surfaced. Now
diffs the evaluated paths against the previous manifest — revision-independent,
and what the sentence actually claims.

## 2. `NixOSFleetManifestStale` would fire on a quiet weekend

`nixos_manifest_age_seconds` comes from the manifest's `generated_at`, and the
publisher ran **only on push to main**. So the metric measured *"time since
something was merged"*, not *"time since the publisher last worked"*. No merges
for 25h — a weekend — and the alert reports fleet-wide drift detection as
disabled while everything is fine.

Same conflation this work has been correcting elsewhere: a broken publisher and
an idle one are different conditions and must not share a signal. Now refreshed
six-hourly, giving three missed runs of slack.

The cost is one commit per run with a two-line diff, which none of the three
consumers pays for: the file is capped at ~50 KiB (25-entry history cap,
measured), hosts fetch it as a single file over `raw.githubusercontent.com`, and
the workflow clones `--depth 1`.

Depends on commit 1 — with the old report, every scheduled run would have logged
all nine hosts as changed.

## 3. Tailscale on Daytona

Away from home the substituter list still starts with an unroutable
`http://192.168.31.14:8080/fred`, so every nix invocation stalls before falling
back — constantly, with direnv loading a flake on every `cd`. `connect-timeout`
bounded the stall; this makes the cache reachable, by consuming the
`192.168.31.0/24` route sdrhub already advertises and fredvps already accepts
for the same stated reason.

**Route acceptance is toggled rather than the tailnet joined and left**, so
remote SSH and MagicDNS keep working everywhere. The only thing that interacts
badly with being on the advertised LAN is accepting a route for that same LAN.

Location is detected by the presence of an address in the advertised range, not
by SSID — identical behaviour on wifi and ethernet, and survives an SSID rename.

`useRoutingFeatures = "client"` is set even though fredvps works without it:
Daytona has strict reverse-path filtering, and an rp_filter drop on a subnet
route presents as a *missing route*, which is unpleasant to debug.

A NetworkManager dispatcher reacts immediately; a five-minute timer backstops
events the dispatcher cannot see (tailscaled starting after the last network
event, or a resume that doesn't re-trigger NM). Without it a missed event could
leave the wrong setting until the next network change — days, on a laptop that
stays put.

### Bug caught by testing

The prefs read originally used `.RouteAll // empty`. **jq's `//` treats `false`
as absent**, so it returned nothing for route acceptance already being *off* —
the state most in need of recognition. The script then thought the value unknown
every run and called `tailscale set` each time, logging every five minutes
forever. Found by testing all four combinations of location × current setting.

## Verification

| Check | Result |
|---|---|
| Closures changed vs main | **Daytona only**; other 8 byte-identical |
| Gating logic, 4 combinations | all pass, including both no-op cases |
| Changed-hosts report | no-op re-run reports nothing; 1-host change reports 1 host |
| Manifest size at the 25-entry cap | 49.4 KiB (6.6 KiB today) |
| promtool check + test | pass |
| `pre-commit run --all-files` | pass |

## After merge

Daytona is not in the colmena hive, so `colmena-apply-drifted.sh` will correctly
ignore it — deploy with `nixos-rebuild switch`.

Then **disable key expiry for Daytona** in the Tailscale admin console, as done
for sdrhub and fredvps. Otherwise it expires in ~180 days and drops off the
tailnet; the alert added in #2139 would catch it at 21 days, but the permanent
fix is one click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tailscale routing on Daytona now automatically adjusts based on the connected network, improving access to advertised routes when away from the home LAN.
  * Fleet Manifest updates now run automatically every six hours.

* **Bug Fixes**
  * Fleet Manifest change reporting now accurately identifies hosts with changed system closures, including after retries or reruns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->