### PR TITLE
chore(flake/precommit-base): `01acaa60` -> `01cf5823`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1000,11 +1000,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785692966,
+        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
         "type": "github"
       },
       "original": {
@@ -1216,11 +1216,11 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1785487287,
-        "narHash": "sha256-3eF2bngygCD5mfzUKbXWYFXRSCmHcPnEiHZdbeyGc4k=",
+        "lastModified": 1785798977,
+        "narHash": "sha256-42WzZMi4NtynBZzaMxXi2M+Kt6yihb8Qnn/mWap7PLc=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "01acaa60808b41153970f9b0985ffb142b2ebfe5",
+        "rev": "01cf5823724a9482eb716739e106354e62b14e01",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
         "nixpkgs": "nixpkgs_14"
       },
       "locked": {
-        "lastModified": 1785476452,
-        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
+        "lastModified": 1785736145,
+        "narHash": "sha256-DauSP0ACycrq3MEEmDz/Scsxhs9TPBTexwKbTuE8Bw8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
+        "rev": "292249772330735cb32b90dedf44feddec40e7d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`01cf5823`](https://github.com/fredsystems/pre-commit-checks/commit/01cf5823724a9482eb716739e106354e62b14e01) | `` chore(flake/nixpkgs): e2587cae -> 64380905 ``      |
| [`73eaf96e`](https://github.com/fredsystems/pre-commit-checks/commit/73eaf96e4e293056878278c94ee6063362b282d9) | `` chore(flake/rust-overlay): 6ef009bf -> 29224977 `` |
| [`e9cf4ecf`](https://github.com/fredsystems/pre-commit-checks/commit/e9cf4ecff1f40ae5af7ef49d0db56699ba1a5b9e) | `` switch to tscgo ``                                 |
| [`0bd7d9c7`](https://github.com/fredsystems/pre-commit-checks/commit/0bd7d9c7cec4f68d8ef134ec48be0bac98f4c5fd) | `` switch to tscgo ``                                 |
| [`e211dcc4`](https://github.com/fredsystems/pre-commit-checks/commit/e211dcc41ca3e096a87df068c701423e5c1e5ab3) | `` switch to tscgo ``                                 |
| [`b89aae04`](https://github.com/fredsystems/pre-commit-checks/commit/b89aae04fa1bab38b15b5a2023571eb751cc9e85) | `` switch to tscgo ``                                 |
| [`35e756c3`](https://github.com/fredsystems/pre-commit-checks/commit/35e756c3e429fc8243706b640fc5d3b906e65d04) | `` switch to tscgo ``                                 |