### PR TITLE
chore(flake/colmena): `84d419ad` -> `a156fd91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1785582945,
-        "narHash": "sha256-PI+qji1xkJm3PV7l7/PKJDumFz0fbA4etXE614jRnls=",
+        "lastModified": 1785930890,
+        "narHash": "sha256-QN4Oy1B4Vma9DiMyXiyssrpgMuIPgkNyO8jb6k2H4oY=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "84d419ad080477ed2f31fbf3866551393df647a7",
+        "rev": "a156fd9146e69a577fe6f5542a7c6ed83a6888ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                       |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`117e6946`](https://github.com/nix-community/colmena/commit/117e69468b6b91da31653030742f58aadf27e98a) | `` hive/tests: pin nixpkgs system in tests `` |
| [`6214444a`](https://github.com/nix-community/colmena/commit/6214444a95d5a3dec6348fa9184ac528a5be1f4f) | `` cargo: drop atty ``                        |