### PR TITLE
chore(flake/home-manager): `bf9ce9fe` -> `a7c70cc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -691,11 +691,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785531816,
-        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
+        "lastModified": 1785958398,
+        "narHash": "sha256-5r/JgsoNMTx+qIh83WkxpujEKBR7PF5ssnh5vYCuSAw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
+        "rev": "a7c70cc290290f373f50cd820403833d250459ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`a7c70cc2`](https://github.com/nix-community/home-manager/commit/a7c70cc290290f373f50cd820403833d250459ac) | `` maintainers: update all-maintainers.nix ``                               |
| [`cc51f24b`](https://github.com/nix-community/home-manager/commit/cc51f24b9ba245d4c528dd6210eb095693df9f08) | `` claude-code: allow hooks to accept a path like skills/commands ``        |
| [`44a1a0ab`](https://github.com/nix-community/home-manager/commit/44a1a0ab16b1b6b8e6b673227d870c3a89cab35e) | `` crush: add module ``                                                     |
| [`ff174130`](https://github.com/nix-community/home-manager/commit/ff1741309ec30dce33bc35986045d283333b3e96) | `` maintainers: add vidhanio ``                                             |
| [`c2cef1e7`](https://github.com/nix-community/home-manager/commit/c2cef1e7e07bb6b4c5b9f37184f40afd45097d4f) | `` dprint: add module ``                                                    |
| [`63bd543c`](https://github.com/nix-community/home-manager/commit/63bd543c9eb774a53be7650536a1da9e12bfc657) | `` maintainers: add rachitvrma ``                                           |
| [`c66b595c`](https://github.com/nix-community/home-manager/commit/c66b595cf29f1112954ef5e4fe8375c5b86634ca) | `` easyeffects: support separate startup presets ``                         |
| [`e91d4c16`](https://github.com/nix-community/home-manager/commit/e91d4c16982ae46884463c0bb8f2c86c215c5cd1) | `` easyeffects: support paired presets ``                                   |
| [`95675bc3`](https://github.com/nix-community/home-manager/commit/95675bc36353303f129b83c3b7099f21c20531ce) | `` easyeffects: add global settings option ``                               |
| [`b0ba2580`](https://github.com/nix-community/home-manager/commit/b0ba2580ded6fc1d4998b4ae843fad70e584cd21) | `` texlive: replace deprecated texlive.combine with texlive.withPackages `` |
| [`a9bcd005`](https://github.com/nix-community/home-manager/commit/a9bcd0057073751a54ce5fd4b0dc63a391b6f349) | `` flake-edit: init ``                                                      |
| [`380c55ae`](https://github.com/nix-community/home-manager/commit/380c55aeae9745bc94c010996753850d975b8f59) | `` files: batch link creation and target checks ``                          |