### PR TITLE
chore(flake/niri): `64dee63e` -> `8021817b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -735,11 +735,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1785777405,
-        "narHash": "sha256-CMfZ1bcKBMWnnpIQKpovUrl0K7+dPYEuWXWGV+TNhiw=",
+        "lastModified": 1785898735,
+        "narHash": "sha256-5CjkrKNFlfPxwhISptR+UkkJx/pTKTLUJHmXL565k4Q=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "64dee63e0aac6697435ca21f1d793dbe3d801464",
+        "rev": "8021817b5b809ae8bd8c97a65937d858452c6e32",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1785734586,
-        "narHash": "sha256-ODZkEK9Gy50yg6h98u7KkitZ3oc/uuTFK00bh1CRdNA=",
+        "lastModified": 1785858998,
+        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
+        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
         "type": "github"
       },
       "original": {
@@ -1125,11 +1125,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1785692966,
-        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                        |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`8021817b`](https://github.com/epireyn/niri-flake/commit/8021817b5b809ae8bd8c97a65937d858452c6e32) | `` Update flake.lock ``                        |
| [`4551f7d6`](https://github.com/epireyn/niri-flake/commit/4551f7d6554fcaaa6a5967ac04d326abc46f2ce7) | `` Update flake.lock ``                        |
| [`b3d804ea`](https://github.com/epireyn/niri-flake/commit/b3d804ea6dcfe35ca2fb2052fe68bf79c7fc4cda) | `` feat: Add recent-windows-close animation `` |