### PR TITLE
chore(flake/freminal): `e533ed00` -> `62221287`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1785726544,
-        "narHash": "sha256-4I84vqyxrtCUmlqF77v2jZYq2CrqXOVGJ9Jief3UZRU=",
+        "lastModified": 1785851963,
+        "narHash": "sha256-M8PB/kURu61sJV9l2SkKrxyDw6CDoFcpS/7JzDRZwsY=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "e533ed000921f4e54922ea925f2008393fe89e0f",
+        "rev": "62221287ee87f60f133e3d69569f93c613661ca4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`8e0f2fd4`](https://github.com/fredsystems/freminal/commit/8e0f2fd4587926d96fdc97df1a9740d6b1cad131) | `` fix: MSRV 1.96.0 ``                                                                |
| [`8ba5def0`](https://github.com/fredsystems/freminal/commit/8ba5def036b0eba50d7c3b1fd797aa329893edc5) | `` chore(deps): update rust crate fontdb to 0.24.0 ``                                 |
| [`fe2abe76`](https://github.com/fredsystems/freminal/commit/fe2abe761a5f11d42910ff1a9b7e82af145471d2) | `` chore(deps): update taiki-e/install-action action to v2.85.7 ``                    |
| [`627a8c49`](https://github.com/fredsystems/freminal/commit/627a8c496e83162cc04a85c1fdc0514ec5654b5f) | `` chore(deps): update rust crate vergen to v10.0.2 ``                                |
| [`a065141b`](https://github.com/fredsystems/freminal/commit/a065141b81d06a4bad8cc8d9db9b14a7b2b0f9d8) | `` chore(deps): update rust crate serial2 to v0.2.38 ``                               |
| [`8d867184`](https://github.com/fredsystems/freminal/commit/8d867184535569ac0898da155ed29b8083a48836) | `` chore(deps): update rust crate clap to v4.6.5 ``                                   |
| [`a2a22a96`](https://github.com/fredsystems/freminal/commit/a2a22a96cf061afa2add42e49630b644c54d8ea2) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 61cbfe2 `` |