### PR TITLE
chore(flake/frext): `0f86249a` -> `143a8da7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -517,11 +517,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1785546144,
-        "narHash": "sha256-n7p2jsnSoZJSUdnCJCGRfu6NWsZVPAuTHU0idY+RG/w=",
+        "lastModified": 1785787364,
+        "narHash": "sha256-cVuhp30ziSX84WTZ3rd1FQuf4bLsGPWun9ycF9SGypI=",
         "owner": "FredSystems",
         "repo": "frext",
-        "rev": "0f86249a8761ec2d97b38d2156a1054ba8069573",
+        "rev": "143a8da72a4671075fb9a626f8a4dc64b13c9f45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                                               |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`12f4a82b`](https://github.com/fredsystems/frext/commit/12f4a82b28a9e02002433ad888ccdf10dae89c06) | `` chore(deps): update rust crate fontdb to 0.24.0 ``                                 |
| [`9bee9e04`](https://github.com/fredsystems/frext/commit/9bee9e045921febc8559066e9f580dff403e7d55) | `` chore(deps): update determinatesystems/determinate-nix-action digest to 61cbfe2 `` |
| [`6097b621`](https://github.com/fredsystems/frext/commit/6097b621674760fdb5b63f71cfddb32f83f002f8) | `` chore(deps): update actions/checkout digest to 3d3c42e ``                          |