### PR TITLE
chore(flake/nixpkgs-stable): `531670d8` -> `04607e11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -936,11 +936,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1785734586,
-        "narHash": "sha256-ODZkEK9Gy50yg6h98u7KkitZ3oc/uuTFK00bh1CRdNA=",
+        "lastModified": 1785858998,
+        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
+        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`e1797e5b`](https://github.com/NixOS/nixpkgs/commit/e1797e5b3dcd5f9f8db5735fafd309ce64c84d7a) | `` zammad: 7.1.1 -> 7.1.2 ``                                                       |
| [`56bf6801`](https://github.com/NixOS/nixpkgs/commit/56bf6801320ba9296c10966b6072ca945c2415bb) | `` firefox: use ffmpeg 8 for browsers that support it ``                           |
| [`28831ff9`](https://github.com/NixOS/nixpkgs/commit/28831ff9beb9764b47b6a695e763b93296723418) | `` firefox-bin-unwrapped: 153.0.1 -> 153.0.3 ``                                    |
| [`3930f0d9`](https://github.com/NixOS/nixpkgs/commit/3930f0d9c776fb54ab9d06450212074e6d1f4345) | `` firefox-unwrapped: 153.0.1 -> 153.0.3 ``                                        |
| [`6636901c`](https://github.com/NixOS/nixpkgs/commit/6636901cf7dbc34810147c1dfebdf6611ef567a2) | `` maintainers/github-teams.json: Automated sync ``                                |
| [`f8be8fac`](https://github.com/NixOS/nixpkgs/commit/f8be8fac1b345c9d5d4193b3175600ff74eb9bea) | `` sbcl_2_4_6: skip `elf-sans-immobile.test.sh` to avoid ZFS hang ``               |
| [`489a9c07`](https://github.com/NixOS/nixpkgs/commit/489a9c07c7f7e820e213bba35109aad44b5e8835) | `` tengine: mark as vulnerable ``                                                  |
| [`6169108d`](https://github.com/NixOS/nixpkgs/commit/6169108d0bbd658e099c8256dd9e34d8d9c8bec1) | `` xen: 4.20.3 -> 4.20.4 ``                                                        |
| [`b77e18ce`](https://github.com/NixOS/nixpkgs/commit/b77e18ce1d02a8743233574346f18a36537fd9db) | `` proxysql: fix build by adjusting for gcc 15 ``                                  |
| [`c608cc36`](https://github.com/NixOS/nixpkgs/commit/c608cc3678bc3f37db870d312eb0ba9fb9b98462) | `` linux_xanmod_latest: 7.1.5 -> 7.1.6 ``                                          |
| [`286c39c5`](https://github.com/NixOS/nixpkgs/commit/286c39c577eee79a4c733c90c204aa621b4003bc) | `` linux_xanmod: 6.18.41 -> 6.18.42 ``                                             |
| [`ef7fabc1`](https://github.com/NixOS/nixpkgs/commit/ef7fabc18691271d123466a001935e5f43085824) | `` linuxKernel.kernels.linux_zen: 7.1.4 -> 7.1.5 ``                                |
| [`371888e5`](https://github.com/NixOS/nixpkgs/commit/371888e5433c17e4beb06d45581ad227aea61643) | `` weechat: 4.9.5 -> 4.10.0 ``                                                     |
| [`c383ad57`](https://github.com/NixOS/nixpkgs/commit/c383ad57102e347506ba4e2108bb45fda027e8ba) | `` sing-box: 1.13.15 -> 1.13.16 ``                                                 |
| [`70eb9122`](https://github.com/NixOS/nixpkgs/commit/70eb91223666712932bfcc8b6eb4919176e6c5d9) | `` nixos/tabbyapi: sync with upstream options; add assert for deprecated option `` |
| [`a64b5413`](https://github.com/NixOS/nixpkgs/commit/a64b541385660d3cd034156994861dfe43f74f9c) | `` tabbyapi: 0-unstable-2026-07-18 -> 0-unstable-2026-07-31 ``                     |
| [`8bcd5b83`](https://github.com/NixOS/nixpkgs/commit/8bcd5b832a7e5cd201fa540c2b513967ba1eff52) | `` python3Packages.exllamav3: 1.2.1 -> 1.3.0 ``                                    |
| [`854ae233`](https://github.com/NixOS/nixpkgs/commit/854ae2333c30266b9d3e5368da62fac0cf81649a) | `` mpvScripts.videoclip: 0.2-unstable-2026-07-07 -> 26.7.30.0 ``                   |
| [`05c22f8f`](https://github.com/NixOS/nixpkgs/commit/05c22f8fea001fe8d35492937d6216c92d88efc1) | `` vivaldi: 8.1.4087.58 -> 8.1.4087.61 ``                                          |
| [`f91f282d`](https://github.com/NixOS/nixpkgs/commit/f91f282daaef2064e8ac277aac3c269fbec601d6) | `` jocalsend: 1.618033988 -> 1.6180339887 ``                                       |
| [`4849a73a`](https://github.com/NixOS/nixpkgs/commit/4849a73a13279fc482e2b2dee3896033d718525c) | `` boringssl: 0.20260526.0 -> 0.20260803.0 ``                                      |
| [`be280e6d`](https://github.com/NixOS/nixpkgs/commit/be280e6d145524b5534967ff002ea695be6f4f48) | `` llvmPackages_git: 23.0.0-unstable-2026-07-19 -> 24.0.0-unstable-2026-07-26 ``   |
| [`f7db4f96`](https://github.com/NixOS/nixpkgs/commit/f7db4f962dc4ec42ac517b045d08848ebad76c29) | `` llvmPackages_git: 23.0.0-unstable-2026-07-12 -> 24.0.0-unstable-2026-07-19 ``   |
| [`fa73cf44`](https://github.com/NixOS/nixpkgs/commit/fa73cf447b22ad1657be81da59fc3c36f1544692) | `` llvmPackages_23: init from git ``                                               |
| [`0db3e732`](https://github.com/NixOS/nixpkgs/commit/0db3e7324d857358708eee8bc5e26b839fe84760) | `` llvmPackages_git: 23.0.0-unstable-2026-07-12 -> 23.1.0-rc1 ``                   |
| [`c4fa9179`](https://github.com/NixOS/nixpkgs/commit/c4fa917939dce209825fa018949195e67571dedc) | `` nodejs_26: 26.5.1 -> 26.6.0 ``                                                  |
| [`e701b132`](https://github.com/NixOS/nixpkgs/commit/e701b132f0d242c44c76ba08ae88b3fd94ce988c) | `` linux_6_6: 6.6.147 -> 6.6.148 ``                                                |
| [`5caf7d01`](https://github.com/NixOS/nixpkgs/commit/5caf7d017ddff9b547229d7db0e29dc21fda6302) | `` linux_6_12: 6.12.100 -> 6.12.101 ``                                             |
| [`33565191`](https://github.com/NixOS/nixpkgs/commit/33565191d37a96d943b22ff678ca7b923405bffa) | `` linux_6_18: 6.18.41 -> 6.18.42 ``                                               |
| [`7e01d0f5`](https://github.com/NixOS/nixpkgs/commit/7e01d0f57d7ae3030d3db5d19e40f6582703f8a8) | `` linux_7_1: 7.1.5 -> 7.1.6 ``                                                    |
| [`df5a7991`](https://github.com/NixOS/nixpkgs/commit/df5a79912225ecfd2cf2b149123ab61ce20d69a1) | `` linux_testing: 7.2-rc5 -> 7.2-rc6 ``                                            |
| [`dd75ae55`](https://github.com/NixOS/nixpkgs/commit/dd75ae55ca8400272a1fbb892a4d11934b8f6135) | `` opengist: 1.14.0 -> 1.15.0 ``                                                   |
| [`6fc01254`](https://github.com/NixOS/nixpkgs/commit/6fc012547b1535a03100d80699ebe17890ec61db) | `` mpvScripts.videoclip: 0.2-unstable-2026-05-31 -> 0.2-unstable-2026-07-07 ``     |
| [`b4446c36`](https://github.com/NixOS/nixpkgs/commit/b4446c3630e79916327fe92efa729d59eaa5e302) | `` python3Packages.general-sam: 1.0.4.post0 -> 1.0.5 ``                            |
| [`8afb558f`](https://github.com/NixOS/nixpkgs/commit/8afb558f1fd350f9092764364cdaa33f8bdc7e5a) | `` python3Packages.general-sam: 1.0.3 -> 1.0.4.post0 ``                            |
| [`0fbaba76`](https://github.com/NixOS/nixpkgs/commit/0fbaba762359d7b1c23383410aab39f3af37b189) | `` qgis-ltr: 3.44.11 -> 3.44.12 ``                                                 |
| [`df43982d`](https://github.com/NixOS/nixpkgs/commit/df43982d05f92c8caa278cb144444867530c31ef) | `` ani-cli: remove openssl, add curl-impersonate, __structuredAttrs, strictDeps `` |
| [`b7658fa4`](https://github.com/NixOS/nixpkgs/commit/b7658fa48ab24d057dabaca1eeead449013bf036) | `` discord: add Vulkan driver files in wrapper ``                                  |
| [`c6d0d37f`](https://github.com/NixOS/nixpkgs/commit/c6d0d37f0b7de5dd46f55e1916d35aed7028ac3d) | `` discord: add nvenc library path ``                                              |
| [`16442bbe`](https://github.com/NixOS/nixpkgs/commit/16442bbe1dd75509911024a3db1ee9b79b4d89fe) | `` ani-cli: 4.14 -> 5.0 ``                                                         |
| [`5b704eba`](https://github.com/NixOS/nixpkgs/commit/5b704eba19bd6cccf4d164048d52722b4acc6863) | `` weechat: 4.9.4 -> 4.9.5 ``                                                      |
| [`0599c760`](https://github.com/NixOS/nixpkgs/commit/0599c7605ea9fda1d05cd3328970cdb47ef35ac9) | `` python3Packages.gradio-client: 2.5.0 -> 2.6.0 ``                                |
| [`f0310d7b`](https://github.com/NixOS/nixpkgs/commit/f0310d7bdb334a2bdf1a5886f9f17229b67935b7) | `` python3Packages.gradio{,-client}: unbreak ``                                    |
| [`e7b08621`](https://github.com/NixOS/nixpkgs/commit/e7b08621bcb3b4ff5920e951649112f9a32b9478) | `` gelly: 1.9.4 -> 1.9.5 ``                                                        |
| [`53256856`](https://github.com/NixOS/nixpkgs/commit/53256856fa538e2592894958a99be3d19d2ae348) | `` python3Packages.huggingface-hub: 1.23.0 -> 1.16.0 ``                            |
| [`c40566c2`](https://github.com/NixOS/nixpkgs/commit/c40566c21c48257048103f26ba5429f634d4cc6b) | `` python3Packages.huggingface-hub: 1.10.2 -> 1.23.0 ``                            |
| [`05fd3b44`](https://github.com/NixOS/nixpkgs/commit/05fd3b44bd3312c750b0185f6c07c94021e1d9a4) | `` matrix-continuwuity: backport SEC10 ``                                          |
| [`2c6aaa35`](https://github.com/NixOS/nixpkgs/commit/2c6aaa351527afd0b52de6d289e4b68b164f05ce) | `` vencord: 1.14.15 -> 1.15.0 ``                                                   |
| [`7e20c9ec`](https://github.com/NixOS/nixpkgs/commit/7e20c9ec2ee8f8f40d94e7b36c1925ae3590cbfd) | `` nano: 9.1 -> 9.2 ``                                                             |
| [`6648bdd3`](https://github.com/NixOS/nixpkgs/commit/6648bdd302093015e1c29d043b7a5240a4b1ebaa) | `` bind: disable tests on loongarch ``                                             |
| [`e805c711`](https://github.com/NixOS/nixpkgs/commit/e805c71120dac57d940f6904f9b07280b6c42ae6) | `` megasync: 6.1.1.0 -> 6.4.0.2 ``                                                 |
| [`5f404f6d`](https://github.com/NixOS/nixpkgs/commit/5f404f6dd47e405513f32b5a9d56a76eba530931) | `` bind: 9.20.24 -> 9.20.26 ``                                                     |
| [`e145b60c`](https://github.com/NixOS/nixpkgs/commit/e145b60c017819e1170c37939d9c5e93766dad05) | `` bind: add bartoostveen as a maintainer ``                                       |
| [`0a69d765`](https://github.com/NixOS/nixpkgs/commit/0a69d76548af9c7efc4068c8ee1219acb6842cc9) | `` bind: enable structuredAttrs ``                                                 |
| [`0a361c0c`](https://github.com/NixOS/nixpkgs/commit/0a361c0c6a65b8a2f5beef71c1cd84d7972fe7e0) | `` bind: enable tests, always disable time_test partially ``                       |
| [`c67849b1`](https://github.com/NixOS/nixpkgs/commit/c67849b1acfba0d305bd15b21fd16de0ac59927f) | `` bind: 9.20.23 -> 9.20.24 ``                                                     |
| [`b1977b1c`](https://github.com/NixOS/nixpkgs/commit/b1977b1cd8e4bd82f7160c81b4ecf93c4d1833b4) | `` moonfire-nvr: add update script ``                                              |
| [`05866766`](https://github.com/NixOS/nixpkgs/commit/058667664542f5be944102ba41c7bd4785b9d3a2) | `` moonfire-nvr: 0.7.20 -> 0.7.31 ``                                               |
| [`6cf53726`](https://github.com/NixOS/nixpkgs/commit/6cf5372676dff4f71a4120541d2cd5ee04fdfa7d) | `` rust-analyzer-unwrapped: 2026-04-27 -> 2026-06-01 ``                            |