### PR TITLE
chore(flake/nixpkgs-stable): `04607e11` -> `445d861c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -936,11 +936,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1785858998,
-        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
+        "lastModified": 1785989512,
+        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
+        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`bf266b71`](https://github.com/NixOS/nixpkgs/commit/bf266b71a17e560fa82ec399a8fa4c67ed7a3cb7) | `` chromium,chromedriver: 151.0.7922.71 -> 151.0.7922.75 ``                         |
| [`58ad90a9`](https://github.com/NixOS/nixpkgs/commit/58ad90a9f3962d1ae8ba3f40bb1ec19c4dd41f7d) | `` python3Packages.django_6: 6.0.7 -> 6.0.8 ``                                      |
| [`19ffb12b`](https://github.com/NixOS/nixpkgs/commit/19ffb12bcc03f6f036e018341611f263e38d803e) | `` networkmanager-iodine: 1.2.0-unstable-2025-12-22 -> 1.2.0-unstable-2026-03-14 `` |
| [`b631cab3`](https://github.com/NixOS/nixpkgs/commit/b631cab33a02165b22bbce75d58578b40f1ce230) | `` google-chrome: 151.0.7922.71 -> 151.0.7922.75 ``                                 |
| [`cd586a97`](https://github.com/NixOS/nixpkgs/commit/cd586a9706ed0561e7b182d0e8f2cf28680ee6e4) | `` shogihome: 1.28.1 -> 1.29.0 ``                                                   |
| [`e83df385`](https://github.com/NixOS/nixpkgs/commit/e83df38589c06bccda84e88c23d1a8315cf3a1a9) | `` scrcpy: 4.0 -> 4.1 ``                                                            |
| [`b1507c0c`](https://github.com/NixOS/nixpkgs/commit/b1507c0c40b1940951963614a9d0c2c262de59de) | `` zipline: 4.6.4 -> 4.6.5 ``                                                       |
| [`9ea5ce97`](https://github.com/NixOS/nixpkgs/commit/9ea5ce97516e6fcbe81f5e275e75f3f2bbb910d8) | `` shaka-packager: 3.9.2 -> 3.9.3 ``                                                |
| [`ce14da51`](https://github.com/NixOS/nixpkgs/commit/ce14da5185f6632b1a8c9029855e45a7cf08c124) | `` nodejs_26: 26.6.0 -> 26.7.0 ``                                                   |
| [`0cae902f`](https://github.com/NixOS/nixpkgs/commit/0cae902f57a413d8b2cc9ba2bfe4e3d620510ea5) | `` h2o: 2.3.0-rolling-2026-07-31 → 2.3.0-rolling-2026-08-04 ``                      |
| [`ffe9ae6a`](https://github.com/NixOS/nixpkgs/commit/ffe9ae6a24d78e2ee164ab980e7414617e4c943d) | `` linphone-desktop: Fix missing ringtones ``                                       |
| [`e986382e`](https://github.com/NixOS/nixpkgs/commit/e986382e7d6534f8745873e36febe8ab5c6361b4) | `` nezha-agent: 2.3.0 -> 2.3.1 ``                                                   |
| [`911135a9`](https://github.com/NixOS/nixpkgs/commit/911135a9c2519675b40e7fe712e5905997f08297) | `` anytype: 0.56.0 -> 0.56.1 ``                                                     |
| [`d8d24707`](https://github.com/NixOS/nixpkgs/commit/d8d24707722d8e0303dc9d4835e7e8133abdbe48) | `` nginx-sso: 0.27.7 -> 0.27.8 ``                                                   |
| [`9370dd8a`](https://github.com/NixOS/nixpkgs/commit/9370dd8a5a60bab5d92fc9a61a02325abc7122a0) | `` invidious: minor cleanup ``                                                      |
| [`436b48e9`](https://github.com/NixOS/nixpkgs/commit/436b48e9ad634338bd21e94b459fab5d82426b1b) | `` invidious: set meta.platforms to linux ``                                        |
| [`155d9ff3`](https://github.com/NixOS/nixpkgs/commit/155d9ff33f25fccf1bb4528af18be4b6bbc150f8) | `` invidious: add metadata.changelog and metadata.downloadPage ``                   |
| [`2a8a0c1b`](https://github.com/NixOS/nixpkgs/commit/2a8a0c1ba179366f7674fa22ad6d695de73e870b) | `` invidious: 2.20260804.0 -> 2.20260804.1 ``                                       |
| [`43836cfc`](https://github.com/NixOS/nixpkgs/commit/43836cfc044cc3be4e92feb15c0c3f56f9fb07ac) | `` rundeck: 6.0.1 -> 6.1.0 ``                                                       |
| [`83b584d1`](https://github.com/NixOS/nixpkgs/commit/83b584d1d992030ac5de61a1de9783926cd97762) | `` glpi-agent: 1.18 -> 1.19 ``                                                      |
| [`d091a9a3`](https://github.com/NixOS/nixpkgs/commit/d091a9a309a8f23fce352b7bae126ffe90342a09) | `` osu-lazer: 2026.726.0 -> 2026.804.2 ``                                           |
| [`860b2645`](https://github.com/NixOS/nixpkgs/commit/860b26450032ef7352e45014c4b18aebac0ee8d6) | `` osu-lazer-bin: 2026.726.0 -> 2026.804.2 ``                                       |
| [`89a44f3f`](https://github.com/NixOS/nixpkgs/commit/89a44f3f0436110751db29720899559846a30039) | `` alp: 1.1.18 -> 1.2.0 ``                                                          |
| [`00cdc6da`](https://github.com/NixOS/nixpkgs/commit/00cdc6da4e82047c0f4f4d67d870362b412d401b) | `` thunderbird-latest-bin-unwrapped: 153.0 -> 153.0.1 ``                            |
| [`b35b41f3`](https://github.com/NixOS/nixpkgs/commit/b35b41f3497c3a24931128a28c5777cb676030ff) | `` invidious: 2.20260723.0 -> 2.20260804.0 ``                                       |
| [`cb112c15`](https://github.com/NixOS/nixpkgs/commit/cb112c1524c4c1714db97aec7feed642452b424c) | `` beamPackages.elixir_1_20: 1.20.2 -> 1.20.3 ``                                    |
| [`3e8c1c68`](https://github.com/NixOS/nixpkgs/commit/3e8c1c6897e9acdf31c2d53ed7a4a112994a2392) | `` python315: 3.15.0b4 -> 3.15.0rc1 ``                                              |
| [`462c478f`](https://github.com/NixOS/nixpkgs/commit/462c478fbad254676279acdf64a1185510087575) | `` simplex-chat-desktop: 6.5.6 -> 7.0.0 ``                                          |
| [`d96883a2`](https://github.com/NixOS/nixpkgs/commit/d96883a2d6add22cd74a3a101f6bbefb3b094a7c) | `` buildbox: 1.4.13 -> 1.4.15 ``                                                    |
| [`9661a1d0`](https://github.com/NixOS/nixpkgs/commit/9661a1d09f53db06a0b2cfd2e60c59db4362f275) | `` garnet: 2.1.0 -> 2.1.1 ``                                                        |
| [`cea78b87`](https://github.com/NixOS/nixpkgs/commit/cea78b871e7ca4c827f1a78529d615a5f33ac290) | `` modrinth-app-unwrapped: 0.15.11 -> 0.17.3 ``                                     |
| [`278e2dd4`](https://github.com/NixOS/nixpkgs/commit/278e2dd468774e082ac04bf65cfc4e190163305d) | `` librewolf-unwrapped: 153.0.1-1 -> 153.0.3-1 ``                                   |
| [`7b0c6bd4`](https://github.com/NixOS/nixpkgs/commit/7b0c6bd48cb7bc8ba7536f3c4e8429744129bb86) | `` wakapi: 2.17.4 -> 2.17.5 ``                                                      |
| [`8d48810a`](https://github.com/NixOS/nixpkgs/commit/8d48810ab0571a3b11ca229200233adfc212f665) | `` nix-cl: avoid empty path segments in prefixed env variables ``                   |
| [`a278e115`](https://github.com/NixOS/nixpkgs/commit/a278e1158d60baa051673aa1f4cfac6e933e0ca3) | `` wakapi: 2.17.3 -> 2.17.4 ``                                                      |
| [`05a80fdf`](https://github.com/NixOS/nixpkgs/commit/05a80fdf50554976218d1ae38769c34220e63243) | `` beam29Packages.erlang: 29.0.4 -> 29.0.5 ``                                       |
| [`e43af445`](https://github.com/NixOS/nixpkgs/commit/e43af4458d96247359a0c8df48a17be294b52bf9) | `` beam28Packages.erlang: 28.5.0.4 -> 28.5.0.5 ``                                   |
| [`88e0a8ed`](https://github.com/NixOS/nixpkgs/commit/88e0a8ed2aad086d3ef1c0c22c405b363d457e8b) | `` beam27Packages.erlang: 27.3.4.15 -> 27.3.4.16 ``                                 |
| [`034ef97c`](https://github.com/NixOS/nixpkgs/commit/034ef97c68d2b10063c24a6703c70f6343ed8101) | `` pg_exporter: init at 1.4.0 ``                                                    |
| [`68d7d0ab`](https://github.com/NixOS/nixpkgs/commit/68d7d0ab28be776b26b301c9e54577c3a21336e1) | `` pdfding: patch version manually ``                                               |
| [`1738eeef`](https://github.com/NixOS/nixpkgs/commit/1738eeeff50f1368848377f2789df2a69b3a8b80) | `` pdfding: 1.11.0 -> 1.12.0 ``                                                     |
| [`f355a035`](https://github.com/NixOS/nixpkgs/commit/f355a035fd2984f27ae0ade42c054ddd324653de) | `` pdfding: 1.10.0 -> 1.11.0 ``                                                     |
| [`c2b85f1a`](https://github.com/NixOS/nixpkgs/commit/c2b85f1a19c35e46292314759815039753e8a5f4) | `` go_1_27: 1.27rc1 -> 1.27rc2 ``                                                   |
| [`89d2ca77`](https://github.com/NixOS/nixpkgs/commit/89d2ca772b37c0388a1b0299e04bcb2faa5e1b66) | `` gitlab: 18.11.7 -> 19.0.4 ``                                                     |
| [`4f190ff4`](https://github.com/NixOS/nixpkgs/commit/4f190ff48531c51ea3500b9537fc6ebbc7897c20) | `` gitlab-container-registry: 4.39.0 -> 4.40.2 ``                                   |
| [`4345bf47`](https://github.com/NixOS/nixpkgs/commit/4345bf4773285a9354d1c041716e6402e48c0dcb) | `` nixos/gitlab: configure database metadata for GCR 4.40 compatability ``          |
| [`6bb50fe1`](https://github.com/NixOS/nixpkgs/commit/6bb50fe1a4998e9e5638f8642b98d41aaf0b8daa) | `` nixos/gitlab: move into seperate directory ``                                    |
| [`24df18d9`](https://github.com/NixOS/nixpkgs/commit/24df18d9389db14b2b6d163c8a9ee893e05d29be) | `` thunderbird-latest-unwrapped: 153.0 -> 153.0.1 ``                                |
| [`429fed22`](https://github.com/NixOS/nixpkgs/commit/429fed22e5bb75eecb54c87bcf72785892be09e3) | `` go_1_27: init at 1.27rc1 ``                                                      |
| [`8274d915`](https://github.com/NixOS/nixpkgs/commit/8274d91520ae327347d8558297d9d0b83be85671) | `` mediawiki: fix warning for tablePrefix on non-mysql databases ``                 |
| [`bc9575c3`](https://github.com/NixOS/nixpkgs/commit/bc9575c3d27e0773d28ead6336e08913d21e2135) | `` jetty: 12.1.9 -> 12.1.10 ``                                                      |