### PR TITLE
chore(flake/home-manager): `a7c70cc2` -> `7834e825`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -691,11 +691,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785958398,
-        "narHash": "sha256-5r/JgsoNMTx+qIh83WkxpujEKBR7PF5ssnh5vYCuSAw=",
+        "lastModified": 1786031233,
+        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7c70cc290290f373f50cd820403833d250459ac",
+        "rev": "7834e82588860aaf780cec1366524456a70898d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`7834e825`](https://github.com/nix-community/home-manager/commit/7834e82588860aaf780cec1366524456a70898d7) | `` wlr-which-key: add `programs.wlr-which-key` `` |
| [`18c17cab`](https://github.com/nix-community/home-manager/commit/18c17cab653e4f34dfb62588147ff86c3a670fd7) | `` wiremix: add module ``                         |
| [`c1b62f9b`](https://github.com/nix-community/home-manager/commit/c1b62f9b55b4ed3c7647f796b27981d802e6a94b) | `` maintainers: update rachitvrma ``              |