### PR TITLE
chore(flake/nixpkgs): `64380905` -> `b7c2ada9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1785692966,
-        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
| [`59330881`](https://github.com/NixOS/nixpkgs/commit/593308817efb5932bd5f07f0626beba2bda0edf7) | `` ctranslate2: rocm support ``                                                                                           |
| [`72b602bf`](https://github.com/NixOS/nixpkgs/commit/72b602bfe253bfdb2e5222810be4a35b78c0f556) | `` sketchybar-app-font: 2.0.62 -> 2.0.71 ``                                                                               |
| [`8c27e919`](https://github.com/NixOS/nixpkgs/commit/8c27e9199977f49eab8f7a21be4365182edba280) | `` python3Packages.patchright: mark broken ``                                                                             |
| [`d0dededc`](https://github.com/NixOS/nixpkgs/commit/d0dededc08d468d52d5e71402917954931aeb86a) | `` opencode: install model-schema.json and substitute links to https://model.dev/model-schema.json with installed file `` |
| [`39c2c84f`](https://github.com/NixOS/nixpkgs/commit/39c2c84f2ececcc07385bd2062dec15d76c1eacb) | `` shogihome: 1.28.1 -> 1.29.0 ``                                                                                         |
| [`602b4a68`](https://github.com/NixOS/nixpkgs/commit/602b4a689e6a6c2c2da3ead52f95495f548a85cc) | `` livebook: 0.19.8 -> 0.19.9 ``                                                                                          |
| [`ee919a0f`](https://github.com/NixOS/nixpkgs/commit/ee919a0f95688424fe43f78ee6ccba21a81f1d47) | `` zed-editor: 1.13.2 -> 1.14.2 ``                                                                                        |
| [`12f59599`](https://github.com/NixOS/nixpkgs/commit/12f59599633080197fa5b1e901e1c3bcf154b585) | `` nixos/pipewire: fix nix formatting ``                                                                                  |
| [`97279ff8`](https://github.com/NixOS/nixpkgs/commit/97279ff8328c79054f219ab182e2dcbd917e92a6) | `` google-chrome: 151.0.7922.71 -> 151.0.7922.75 ``                                                                       |
| [`8443bbfa`](https://github.com/NixOS/nixpkgs/commit/8443bbfa04f16e933d924b4b125ced29dd8f2eea) | `` subfinder: 2.14.0 -> 2.15.0 ``                                                                                         |
| [`e0c22449`](https://github.com/NixOS/nixpkgs/commit/e0c22449df92f8ea66b56ebeadb8515b55170449) | `` zipline: 4.6.4 -> 4.6.5 ``                                                                                             |
| [`98434fa1`](https://github.com/NixOS/nixpkgs/commit/98434fa164b9e36ac791d7893b816b374d366726) | `` datadog-pup: 1.10.0 -> 1.10.4 ``                                                                                       |
| [`8de25656`](https://github.com/NixOS/nixpkgs/commit/8de25656988391724189802ec4ed03e397543cc2) | `` radicle-node-unstable: 1.10.0-rc.2 -> 1.10.0 ``                                                                        |
| [`9e904287`](https://github.com/NixOS/nixpkgs/commit/9e904287492dcaf325829c1d030c2be2979a842c) | `` radicle-node: 1.9.1 -> 1.10.0 ``                                                                                       |
| [`26e60bc5`](https://github.com/NixOS/nixpkgs/commit/26e60bc52776907f7cf1223b1f744396acb8544c) | `` python3Packages.aioghost: 0.4.21 -> 0.4.22 ``                                                                          |
| [`52409750`](https://github.com/NixOS/nixpkgs/commit/5240975076124958a1512dc3384e207c87f7e1a6) | `` motoc: 0.3.6 -> 0.4.0 ``                                                                                               |
| [`bc04243f`](https://github.com/NixOS/nixpkgs/commit/bc04243f5dc323126b4b10f75c4087a157f31b7c) | `` nodejs_26: 26.6.0 -> 26.7.0 ``                                                                                         |
| [`9ab0b612`](https://github.com/NixOS/nixpkgs/commit/9ab0b612a65bff2ef5395955fba7ed5df8552b09) | `` libretro.mame2003-plus: 0-unstable-2026-07-19 -> 0-unstable-2026-07-28 ``                                              |
| [`4417f57d`](https://github.com/NixOS/nixpkgs/commit/4417f57d94eacee9553d29b383b4a9d02a27e89e) | `` plezy: 2.11.0 -> 2.12.1 ``                                                                                             |
| [`ce8f7edc`](https://github.com/NixOS/nixpkgs/commit/ce8f7edcb3b6260f08c9cf631d7123905b68023a) | `` pangolin-cli: 0.15.0 -> 0.15.1 ``                                                                                      |
| [`0d8d8b14`](https://github.com/NixOS/nixpkgs/commit/0d8d8b148f1296f4fbae942596705e95ccb22597) | `` terraform-providers.hashicorp_awscc: 1.94.0 -> 1.95.0 ``                                                               |
| [`01cbee65`](https://github.com/NixOS/nixpkgs/commit/01cbee65c29584af772a42d3a12dd0a5aa4a79ea) | `` chromium,chromedriver: 151.0.7922.71 -> 151.0.7922.75 ``                                                               |
| [`abf28b7b`](https://github.com/NixOS/nixpkgs/commit/abf28b7bae25edf31ada32f4e377f74172f47da9) | `` python3Packages.hoptorch: remove unused inputs ``                                                                      |
| [`723681f9`](https://github.com/NixOS/nixpkgs/commit/723681f976063f75894e6ef37a21a3c2f5876866) | `` python3Packages.torchrl: 0.13.1 -> 0.13.3 ``                                                                           |
| [`a8d1dd7f`](https://github.com/NixOS/nixpkgs/commit/a8d1dd7ff659805464bc7964c63e7d3945e2f383) | `` vscode-extensions.vue.volar: 3.3.8 -> 3.3.9 ``                                                                         |
| [`4f767964`](https://github.com/NixOS/nixpkgs/commit/4f767964867f7d8e5c8646b3802ff0987f343291) | `` matrix-alertmanager-receiver: 2026.7.22 -> 2026.8.5 ``                                                                 |
| [`8d77cd2d`](https://github.com/NixOS/nixpkgs/commit/8d77cd2dab7366c27c5b09d26ff5f01f7a260542) | `` talosctl: 1.13.7 -> 1.13.8 ``                                                                                          |
| [`fb635d6b`](https://github.com/NixOS/nixpkgs/commit/fb635d6b050711b6223881298024d49ceee5d8e1) | `` zennotes-desktop: 2.22.0 -> 2.22.1 ``                                                                                  |
| [`f2154edc`](https://github.com/NixOS/nixpkgs/commit/f2154edcc6bedad158da01133795b2cfafb3fa6a) | `` air: 1.67.3 -> 1.67.4 ``                                                                                               |
| [`4c65bff7`](https://github.com/NixOS/nixpkgs/commit/4c65bff7b96a5cc50cb09d13aad0c0ccd903d5cb) | `` terraform-providers.mongodb_mongodbatlas: 2.14.0 -> 2.15.0 ``                                                          |
| [`3aff0ff3`](https://github.com/NixOS/nixpkgs/commit/3aff0ff3d0b9a2de47c2fad9a3abca2b16426332) | `` home-assistant-custom-components.plant: 2026.6.0 -> 2026.7.2 ``                                                        |
| [`1e42553c`](https://github.com/NixOS/nixpkgs/commit/1e42553cb8105ecd43a90cbc3dc87a53e0019489) | `` vimPlugins.jupynium-nvim: init at 0.2.7 ``                                                                             |
| [`e1bc76ce`](https://github.com/NixOS/nixpkgs/commit/e1bc76ceb35e5e70934dabe749a633caecd17bb7) | `` netassert: 2.1.5 -> 2.1.6 ``                                                                                           |
| [`73bd9ae7`](https://github.com/NixOS/nixpkgs/commit/73bd9ae7ffd93689df23dcd1b9e888fa9d16e152) | `` pixi: 0.72.1 -> 0.76.1 ``                                                                                              |
| [`b9600383`](https://github.com/NixOS/nixpkgs/commit/b96003833b476cc227ee2a55886f20470053444e) | `` luaPackages.luaposix: remove std.normalize override ``                                                                 |
| [`a15ce2f6`](https://github.com/NixOS/nixpkgs/commit/a15ce2f67c4c2323357df28122d44ff7d23b7b89) | `` python3Packages.tensordict: skip failing test ``                                                                       |
| [`08ff4967`](https://github.com/NixOS/nixpkgs/commit/08ff49677ce1085d8e81fcd76f7359f3f87d316d) | `` python3Packages.kserve: skip failing test ``                                                                           |
| [`68079282`](https://github.com/NixOS/nixpkgs/commit/680792826d9aca9e3c2da54ab56619e40302a7ea) | `` python3Packages.kserve: relax pandas ``                                                                                |
| [`762df216`](https://github.com/NixOS/nixpkgs/commit/762df216d267cc6c9bedeed006f9634c104f313d) | `` python3Packages.tilelang: 0.1.11 -> 0.1.13 ``                                                                          |
| [`85025b02`](https://github.com/NixOS/nixpkgs/commit/85025b0257fd9bfe9e1d2c9e16514d1766502132) | `` vimPlugins.R-nvim: init at 1.0.0 ``                                                                                    |
| [`e111f888`](https://github.com/NixOS/nixpkgs/commit/e111f8885b705b81e9f8d8efb8b48678c31273d3) | `` python314Packages.cliff: 4.13.2 -> 4.15.0 ``                                                                           |
| [`bd76b39d`](https://github.com/NixOS/nixpkgs/commit/bd76b39d949686c7e9c43ec2d3795e958dc2774e) | `` pinact: 4.1.0 -> 4.1.1 ``                                                                                              |
| [`fb80da60`](https://github.com/NixOS/nixpkgs/commit/fb80da6087e1a9ab20676941874597732c82409f) | `` pantheon.elementary-calendar: 8.0.1 -> 8.0.2 ``                                                                        |
| [`d5870313`](https://github.com/NixOS/nixpkgs/commit/d587031303dee13903d003a92bc8f72fda536b38) | `` pantheon.elementary-code: 8.3.1 -> 8.3.2 ``                                                                            |
| [`e1da9396`](https://github.com/NixOS/nixpkgs/commit/e1da93961430640a0973c6c8fc4cdfcfa580196e) | `` python3Packages.ocrmypdf: 17.8.1 -> 17.10.0 ``                                                                         |
| [`4530d1ee`](https://github.com/NixOS/nixpkgs/commit/4530d1ee63c854dfe35454e1ed9be1c49dcf869e) | `` proton-pass-cli: 2.2.4 -> 2.2.5 ``                                                                                     |
| [`d644eade`](https://github.com/NixOS/nixpkgs/commit/d644eade0a7d9f802e17ef178a1b53edee351fdf) | `` python314Packages.os-client-config: replace deprecated assertItemsEqual ``                                             |
| [`306e9820`](https://github.com/NixOS/nixpkgs/commit/306e98202057c477ed0335d7cc8b694df5eaa6e6) | `` models-dev: generate JSON schema of model ids and expose as passthru ``                                                |
| [`ee67c850`](https://github.com/NixOS/nixpkgs/commit/ee67c8504dafc87ba63e862d76558384d10e1e8c) | `` neowall: 0.5.3 -> 0.6.0 ``                                                                                             |
| [`9723c2c5`](https://github.com/NixOS/nixpkgs/commit/9723c2c5ae3281b41cbf648cd951df93d5cb2ebd) | `` sea-orm-cli: 2.0.0 -> 2.0.1 ``                                                                                         |
| [`a9e75189`](https://github.com/NixOS/nixpkgs/commit/a9e7518937e4537281194e0cbac275932a53da8d) | `` linuxPackages.hid-ite8291r3: 0-unstable-2025-06-27 -> 0-unstable-2026-07-31 ``                                         |
| [`9d8397da`](https://github.com/NixOS/nixpkgs/commit/9d8397da3e1e881cfb30a945053e983b1d5e7b15) | `` python3Packages.togrill-bluetooth: 0.8.1 -> 0.9.0 ``                                                                   |
| [`d07339e1`](https://github.com/NixOS/nixpkgs/commit/d07339e1b1461135f5c8d2d238151cf018d2db29) | `` opencode: drop bundled Windows executables from node_modules ``                                                        |
| [`5ac5ff63`](https://github.com/NixOS/nixpkgs/commit/5ac5ff63bd4628da099e5d9ca4ded947e4ceaf91) | `` nix-eval-jobs: 2.34.3 -> 2.35.0 ``                                                                                     |
| [`4607700a`](https://github.com/NixOS/nixpkgs/commit/4607700ae7d046ac9b8612dd25526c99d9ade8fc) | `` python3Packages.torch-c-dlpack-ext: fix version ``                                                                     |
| [`bd6602ca`](https://github.com/NixOS/nixpkgs/commit/bd6602ca107ad82e59ddf4f387506a54d50f6d82) | `` amneziawg-go: 3.0.2 -> 3.0.3 ``                                                                                        |
| [`21740b60`](https://github.com/NixOS/nixpkgs/commit/21740b604437ff33814c10b3f585bd77e9c531a8) | `` nezha-agent: 2.3.0 -> 2.3.1 ``                                                                                         |
| [`dda1d127`](https://github.com/NixOS/nixpkgs/commit/dda1d127c027cea0dac032ddc4dc12ee8270d449) | `` luaPackages.nlua: keep the full shebang ``                                                                             |
| [`bca4583d`](https://github.com/NixOS/nixpkgs/commit/bca4583d6907e77aab0211b6f063aa6fb19b27d2) | `` zennotes-desktop: 2.20.2 ->2.22.0 ``                                                                                   |
| [`b5d8c699`](https://github.com/NixOS/nixpkgs/commit/b5d8c6995b2435689677a527a74c93b4935e6e00) | `` libretro.vice-x128: 0-unstable-2026-07-25 -> 0-unstable-2026-08-01 ``                                                  |
| [`46b41fa9`](https://github.com/NixOS/nixpkgs/commit/46b41fa9b675c6e1aefba390488521ff7978be6a) | `` openmeters: 1.11.0-2 -> 1.12.0 ``                                                                                      |
| [`3d07987b`](https://github.com/NixOS/nixpkgs/commit/3d07987bb24f6711d524cf6a3e4e404b0500993a) | `` pulumi-bin: 3.255.0 -> 3.256.0 ``                                                                                      |
| [`9a2987a6`](https://github.com/NixOS/nixpkgs/commit/9a2987a6f6963dc28dbb04cadbe97425b845cf4a) | `` python3Packages.torch-c-dlpack-ext: enable __structuredAttrs ``                                                        |
| [`c3f448ab`](https://github.com/NixOS/nixpkgs/commit/c3f448ab824b9f02327e45705394a8a38f6e8427) | `` python3Packages.apache-tvm-ffi: 0.1.12 -> 0.1.13-post2 ``                                                              |
| [`673acddd`](https://github.com/NixOS/nixpkgs/commit/673acddd245acc6aa1f5f5793a331011c54ba9d7) | `` ipget: 0.13.1 -> 0.13.2 ``                                                                                             |
| [`8c959a09`](https://github.com/NixOS/nixpkgs/commit/8c959a094409778e16da9c431f57dcffa0d05784) | `` knot-resolver_5: 5.7.7 -> 5.7.8 ``                                                                                     |
| [`f1c3eafd`](https://github.com/NixOS/nixpkgs/commit/f1c3eafd046fcb93c5e2e40d0ff78b8cadd792ef) | `` knot-resolver_6: 6.4.1 -> 6.4.2 ``                                                                                     |
| [`6f41b2cd`](https://github.com/NixOS/nixpkgs/commit/6f41b2cd7d028e593112453930a4771737340aa4) | `` python3Packages.os-service-types: 1.8.2 -> 1.9.0 ``                                                                    |
| [`6c619e9e`](https://github.com/NixOS/nixpkgs/commit/6c619e9e6488af7096dd41d16094019eb4d820d9) | `` ffmpeg_9: init at 9.0 ``                                                                                               |
| [`5f6fb8c8`](https://github.com/NixOS/nixpkgs/commit/5f6fb8c82664e42f69a986b01dedf2c264b43ce1) | `` volanta: 1.18.0 -> 1.18.1 ``                                                                                           |
| [`82c311f8`](https://github.com/NixOS/nixpkgs/commit/82c311f8041c960653a6762817129dff29c5c88b) | `` speakeasy-cli: 1.791.0 -> 1.791.3 ``                                                                                   |
| [`bdd83025`](https://github.com/NixOS/nixpkgs/commit/bdd83025bb90c669adc5b7e247e37da5c35a6556) | `` xdg-desktop-portal-generic: init at 0.5.0 ``                                                                           |
| [`e2db1a7c`](https://github.com/NixOS/nixpkgs/commit/e2db1a7ce0cfdd073ad1e49bd8246eee4e68547f) | `` rundeck: 6.0.1 -> 6.1.0 ``                                                                                             |
| [`f9629b43`](https://github.com/NixOS/nixpkgs/commit/f9629b43dd439f03c8d685f317a5d3b92ed6e6f3) | `` pipx: 1.16.5 -> 1.16.6 ``                                                                                              |
| [`618b5c1f`](https://github.com/NixOS/nixpkgs/commit/618b5c1fc2f1f2f44f1aa57fc1cc875e61e255a6) | `` anytype: 0.56.0 -> 0.56.1 ``                                                                                           |
| [`5c772dac`](https://github.com/NixOS/nixpkgs/commit/5c772dacd8e872a2f70afd094650ea2623cf55c1) | `` terraform-providers.linode_linode: 4.1.0 -> 4.2.0 ``                                                                   |
| [`23693bb8`](https://github.com/NixOS/nixpkgs/commit/23693bb89fb538d036f524aa6b52694dccfb3ed6) | `` owocr: enable __structuredAttrs, add meta attributes ``                                                                |
| [`5969811b`](https://github.com/NixOS/nixpkgs/commit/5969811ba16adeddacf4be4c1f5f367739939283) | `` python3Packages.azure-ai-vision-imageanalysis: switch to correct version, fix build ``                                 |
| [`356dfc24`](https://github.com/NixOS/nixpkgs/commit/356dfc240e2a0de12068fab8842e3034b65968db) | `` semantic-release: 25.0.8 -> 25.0.9 ``                                                                                  |
| [`492c3577`](https://github.com/NixOS/nixpkgs/commit/492c357760a67436d0dff62ddb10549219fe746c) | `` jsonschema-cli: 0.49.1 -> 0.49.5 ``                                                                                    |
| [`3e976227`](https://github.com/NixOS/nixpkgs/commit/3e9762275ca1038c00f70f0bdda698891ef010d0) | `` jaq: generate manpage ``                                                                                               |
| [`4da6049f`](https://github.com/NixOS/nixpkgs/commit/4da6049f28c24cd94b1982780ee874110f790e02) | `` turso: 0.7.1 -> 0.7.2 ``                                                                                               |
| [`4297ba42`](https://github.com/NixOS/nixpkgs/commit/4297ba42da541409cc22ae17e911d4a79ad6109c) | `` python3Packages.docling-serve: 1.10.0 -> 1.29.0 ``                                                                     |
| [`3c7a4ccc`](https://github.com/NixOS/nixpkgs/commit/3c7a4ccc4001199804b71cb369dafc6c2230ef84) | `` python3Packages.iamdata: 0.1.202608041 -> 0.1.202608051 ``                                                             |
| [`e7750174`](https://github.com/NixOS/nixpkgs/commit/e7750174dc6f527581ac2d498c202bf40196cc36) | `` jaq: 3.1.0 -> 3.1.1 ``                                                                                                 |
| [`d5f7a38a`](https://github.com/NixOS/nixpkgs/commit/d5f7a38a715f7fe61eebf877affa00a9b2f60c03) | `` shaka-packager: 3.9.2 -> 3.9.3 ``                                                                                      |
| [`21020ff8`](https://github.com/NixOS/nixpkgs/commit/21020ff8377e7d0edc6909600d4aea45f4918811) | `` rPackages: strip dynamic libraries ``                                                                                  |
| [`e50f4796`](https://github.com/NixOS/nixpkgs/commit/e50f4796c9a43f48ea7fae0b74f629f5e862f52a) | `` python3Packages.nicegui: 3.12.1 -> 3.15.0 ``                                                                           |
| [`1fd47b23`](https://github.com/NixOS/nixpkgs/commit/1fd47b239646cc249c3fc15f224cf7682a5c8f30) | `` python3Packages.ngff-zarr: 0.39.0 -> 0.41.0 ``                                                                         |
| [`2e940187`](https://github.com/NixOS/nixpkgs/commit/2e9401879a1395e5233fbde362a8a0c5c428afe4) | `` python3Packages.docling-jobkit: 1.8.1 -> 3.2.0 ``                                                                      |
| [`d6763a9a`](https://github.com/NixOS/nixpkgs/commit/d6763a9ae5ef17b832bf6a8a73b47763148b7496) | `` tack: 1.0.0 -> 1.0.1 ``                                                                                                |
| [`3e796f8e`](https://github.com/NixOS/nixpkgs/commit/3e796f8ef4051ec3f31399f7272f25dd838a07ae) | `` python3Packages.rapidocr: 3.8.1 -> 3.9.2 ``                                                                            |
| [`7f72ac1a`](https://github.com/NixOS/nixpkgs/commit/7f72ac1a8dd119f2a9b2ce68d0af4b17fb55fc16) | `` python3Packages.docling-ibm-models: 3.13.2 -> 3.13.3 ``                                                                |
| [`c3fc5b56`](https://github.com/NixOS/nixpkgs/commit/c3fc5b56ba88e44cb02f635785ccc5571a5d188a) | `` python3Packages.docling-parse: 5.0.0 -> 7.8.1 ``                                                                       |
| [`8a38365f`](https://github.com/NixOS/nixpkgs/commit/8a38365f9291d7d5bd4a36f37bc7f43ede071f2d) | `` python3Packages.docling: 2.69.1 -> 2.118.0 ``                                                                          |
| [`2a92f3d8`](https://github.com/NixOS/nixpkgs/commit/2a92f3d888ee5a7e5f66831f59947b48be373440) | `` python3Packages.docling-slim: init at 2.118.0 ``                                                                       |
| [`665368b7`](https://github.com/NixOS/nixpkgs/commit/665368b7bb71d85515cfde7ee1fa29d5b6ae2311) | `` python3Packages.deepsearch-toolkit: cleanup, disable tests ``                                                          |
| [`146b8a04`](https://github.com/NixOS/nixpkgs/commit/146b8a04f6c5e77a0009d321dd684add82b1cecc) | `` python3Packages.docling-core: 2.73.0 -> 2.90.0 ``                                                                      |
| [`2e9ac84a`](https://github.com/NixOS/nixpkgs/commit/2e9ac84aeab6271ee6bb6592f9af68186c87c999) | `` python3Packages.doclang: init at 0.7.3 ``                                                                              |
| [`bbbe35e8`](https://github.com/NixOS/nixpkgs/commit/bbbe35e879038519b9db6b497016460257ea678f) | `` invidious: minor cleanup ``                                                                                            |
| [`fc8d6135`](https://github.com/NixOS/nixpkgs/commit/fc8d61352ef8dd9a6becff6b15bd62f16d4bb7d6) | `` phpstan: 2.2.6 -> 2.2.8 ``                                                                                             |
| [`c140a3cd`](https://github.com/NixOS/nixpkgs/commit/c140a3cdbc52d79f66f2c54cab7c6ea067821017) | `` python3Packages.xknx: 3.17.0 -> 3.18.0 ``                                                                              |
| [`fdf79652`](https://github.com/NixOS/nixpkgs/commit/fdf79652dbd8a90c07c1c2e0f5c810de18ff3d30) | `` python3Packages.pyais: 3.1.0 -> 3.2.0 ``                                                                               |
| [`a350c65e`](https://github.com/NixOS/nixpkgs/commit/a350c65e6cde2bdee3352386c160b9d5a2098a32) | `` python3Packages.pydaikin: 2.18.3 -> 2.18.4 ``                                                                          |
| [`7cbb0438`](https://github.com/NixOS/nixpkgs/commit/7cbb0438bb63937e56159462ff06c1652802298a) | `` python3Packages.pyexploitdb: 0.3.37 -> 0.3.38 ``                                                                       |
| [`0f355dbb`](https://github.com/NixOS/nixpkgs/commit/0f355dbbcbc78ab85fd1020e44f895d932649240) | `` python3Packages.alibabacloud-ecs20140526: 7.9.3 -> 7.9.4 ``                                                            |
| [`564c339d`](https://github.com/NixOS/nixpkgs/commit/564c339d4c275d8c394bf7dbf019eb2ea8c40e57) | `` python3Packages.alibabacloud-vpc20160428: 7.1.4 -> 7.1.5 ``                                                            |
| [`9d47ba47`](https://github.com/NixOS/nixpkgs/commit/9d47ba47cbb15bea232723a1d71631551c65288a) | `` python3Packages.boschshcpy: 0.6.4 -> 0.6.6 ``                                                                          |
| [`8b5a79cd`](https://github.com/NixOS/nixpkgs/commit/8b5a79cdd54828be80fc2ac39f6bc939e046dd15) | `` invidious: set meta.platforms to linux ``                                                                              |
| [`be585541`](https://github.com/NixOS/nixpkgs/commit/be5855418a058e280742a83ad8c54e179b96ad96) | `` python3Packages.tencentcloud-sdk-python: 3.1.148 -> 3.1.150 ``                                                         |
| [`b585887d`](https://github.com/NixOS/nixpkgs/commit/b585887dabbc66e36cdaccc836fe1983ffc320de) | `` invidious: add metadata.changelog and metadata.downloadPage ``                                                         |
| [`b4cb9f38`](https://github.com/NixOS/nixpkgs/commit/b4cb9f383a5057e573fd304ac0dacac86641a088) | `` home-assistant-custom-lovelace-modules.hourly-weather: 6.8.0 -> 6.9.0 ``                                               |
| [`56199975`](https://github.com/NixOS/nixpkgs/commit/56199975b5ef0c94121ac2cfd5ffad945d34ad16) | `` invidious: 2.20260804.0 -> 2.20260804.1 ``                                                                             |
| [`e7adbf0f`](https://github.com/NixOS/nixpkgs/commit/e7adbf0f53aa66743e2146334e37d7341f389eb9) | `` glpi-agent: 1.18 -> 1.19 ``                                                                                            |
| [`3925358f`](https://github.com/NixOS/nixpkgs/commit/3925358f1f8c733a436ba8e62c6de8480fc2cda7) | `` python3Packages.django-anymail: migrate to finalAttrs ``                                                               |
| [`ee5f11ad`](https://github.com/NixOS/nixpkgs/commit/ee5f11ad659e638ba33f1d3babf0e4df9aa8ec93) | `` go-arch-lint: 1.16.0 -> 1.17.0 ``                                                                                      |
| [`be32b490`](https://github.com/NixOS/nixpkgs/commit/be32b4906a66c14b35b557d43569993632b7127e) | `` antigravity-cli: 1.1.8 -> 1.1.11 ``                                                                                    |
| [`1c7455a9`](https://github.com/NixOS/nixpkgs/commit/1c7455a9eeb7fa49f3dff20e5f4463bccce72355) | `` kiro-cli: 2.14.2 -> 2.16.1 ``                                                                                          |
| [`7248a15a`](https://github.com/NixOS/nixpkgs/commit/7248a15a2b1e0540a2cad23a76b7ebbcc9d9fa81) | `` python3Packages.streamlit-notify: migrate to finalAttrs ``                                                             |
| [`e3983c85`](https://github.com/NixOS/nixpkgs/commit/e3983c8599adc15197632d3a605dfbcf80efa0a4) | `` python3Packages.streamlit-notify: disable failing tests ``                                                             |
| [`3ca05e1a`](https://github.com/NixOS/nixpkgs/commit/3ca05e1a6561c40d9ccdc52bcf64e8f56f822363) | `` grype: 0.115.0 -> 0.116.1 ``                                                                                           |
| [`18650b02`](https://github.com/NixOS/nixpkgs/commit/18650b02be93f6b42ecb2ee80678ed522549813b) | `` badger: 4.9.5 -> 4.9.6 ``                                                                                              |
| [`865f19af`](https://github.com/NixOS/nixpkgs/commit/865f19af2f18d184d4d00d2def9421b89c478855) | `` pantheon.switchboard-plug-display: 8.0.2 -> 8.0.3 ``                                                                   |
| [`bb4bc1e8`](https://github.com/NixOS/nixpkgs/commit/bb4bc1e85c20e5a2c5548d978bafffd37aad9d82) | `` schedctl: 1.2.1 -> 1.3.0 ``                                                                                            |
| [`5044cca8`](https://github.com/NixOS/nixpkgs/commit/5044cca874a296a23477d652c1d896b5a29d4d44) | `` algia: 0.0.132 -> 0.0.135 ``                                                                                           |
| [`0a667e40`](https://github.com/NixOS/nixpkgs/commit/0a667e40736c67d33da37c76b62bd7c3aa6b9843) | `` vscode-extensions.anthropic.claude-code: 2.1.221 -> 2.1.222 ``                                                         |
| [`7ebb8a67`](https://github.com/NixOS/nixpkgs/commit/7ebb8a67337656c834324ab8f3dd97d12b2d4925) | `` claude-code: 2.1.221 -> 2.1.222 ``                                                                                     |
| [`5b16f4d9`](https://github.com/NixOS/nixpkgs/commit/5b16f4d9911c4cb674bdc94819d15a224dd8069f) | `` lib25519: fix meta.* ``                                                                                                |
| [`ed8b78e9`](https://github.com/NixOS/nixpkgs/commit/ed8b78e9bdc8b186ed04b2916aa90733b979610b) | `` h2o: 2.3.0-rolling-2026-07-31 → 2.3.0-rolling-2026-08-04 ``                                                            |
| [`e0328f1f`](https://github.com/NixOS/nixpkgs/commit/e0328f1fbc619e10ada3a8273a829d9dee181047) | `` searxng: 0-unstable-2026-07-26 -> 0-unstable-2026-08-04 ``                                                             |
| [`2dcb263d`](https://github.com/NixOS/nixpkgs/commit/2dcb263dba824cb355ce99cb7e5a5ba6f02e3a1b) | `` maintainers: update novaviper ``                                                                                       |
| [`8d62ab57`](https://github.com/NixOS/nixpkgs/commit/8d62ab57e94d059641af9a1591ad8f75d0beb671) | `` python3Packages.django-anymail: 15.0 -> 15.1 ``                                                                        |
| [`ad45f864`](https://github.com/NixOS/nixpkgs/commit/ad45f86426e5fce42721bcb1804252ea7afb4d99) | `` linux-wallpaperengine: 0-unstable-2026-06-09 -> 0.0.1-unstable-2026-06-09 ``                                           |
| [`d0618f54`](https://github.com/NixOS/nixpkgs/commit/d0618f54f4526d73715672c3f207e8e2494fda17) | `` qobuz-player: Enable strictDeps and __structuredAttrs ``                                                               |
| [`9f4dfad8`](https://github.com/NixOS/nixpkgs/commit/9f4dfad875b0aba8da95af3631684282a4cb3197) | `` tailscale: 1.102.1 -> 1.102.2 ``                                                                                       |
| [`6d9e28f5`](https://github.com/NixOS/nixpkgs/commit/6d9e28f5764db4aa46b2a49e5bdf7f49b0982188) | `` acpica-tools: Enable strictDeps and __structuredAttrs ``                                                               |
| [`780d07c3`](https://github.com/NixOS/nixpkgs/commit/780d07c3b31b39b64700723b79e0350d7f9de425) | `` redmine: Enable strictDeps and __structuredAttrs ``                                                                    |
| [`e51e37af`](https://github.com/NixOS/nixpkgs/commit/e51e37af09512f4f762138174e5441a9d0fe4a65) | `` converged-security-suite: Enable strictDeps and __structuredAttrs ``                                                   |
| [`061d8ce1`](https://github.com/NixOS/nixpkgs/commit/061d8ce1dc7a2c979fa53aa79eeac4378c18679f) | `` libjaylink: Enable strictDeps and __structuredAttrs ``                                                                 |
| [`e32b1578`](https://github.com/NixOS/nixpkgs/commit/e32b157801a79e6b6c6a2b13db82b08c0cd1512d) | `` freifunk-meshviewer: Enable strictDeps and __structuredAttrs ``                                                        |
| [`ece07a3c`](https://github.com/NixOS/nixpkgs/commit/ece07a3c250632d549a978ace473a6fac4cd487e) | `` em100: Enable strictDeps and __structuredAttrs ``                                                                      |
| [`44cd0f1f`](https://github.com/NixOS/nixpkgs/commit/44cd0f1fec89fefcb6e39ea306f6deefb4d658cd) | `` xfel: Enable strictDeps and __structuredAttrs ``                                                                       |
| [`74d3606b`](https://github.com/NixOS/nixpkgs/commit/74d3606bb465f0289b29de6e48f852a63278813d) | `` dediprog-sf100: Enable strictDeps and __structuredAttrs ``                                                             |
| [`66b1c22b`](https://github.com/NixOS/nixpkgs/commit/66b1c22b1ddfbce09b4960e96d1fc9e4e67419a3) | `` jenkins: Enable strictDeps and __structuredAttrs ``                                                                    |
| [`e4b20e06`](https://github.com/NixOS/nixpkgs/commit/e4b20e066ad6e54559912c38d6a0d09ff1c7bc40) | `` fastd-exporter: Enable strictDeps and __structuredAttrs ``                                                             |
| [`28cea1b4`](https://github.com/NixOS/nixpkgs/commit/28cea1b44867dd8020874a7fbfb652385b898848) | `` uptime-kuma: Enable strictDeps and __structuredAttrs ``                                                                |
| [`05c172cb`](https://github.com/NixOS/nixpkgs/commit/05c172cbd4c2787f9dba57ef719abfd5294b6b40) | `` tbtools: Enable strictDeps and __structuredAttrs ``                                                                    |
| [`ec2fe82d`](https://github.com/NixOS/nixpkgs/commit/ec2fe82d85d93bd5e5146e77ba1ad398b08277b1) | `` iotools: Enable strictDeps ``                                                                                          |
| [`da86a19b`](https://github.com/NixOS/nixpkgs/commit/da86a19b9565988da049c10a3fc9df810f8cc2e9) | `` flashprog: Enable strictDeps and __structuredAttrs ``                                                                  |
| [`ba494d5a`](https://github.com/NixOS/nixpkgs/commit/ba494d5a9c5adfb4007500be6b6ce546c921c737) | `` pbkdf2-password-hash: Enable strictDeps ``                                                                             |
| [`752c71cf`](https://github.com/NixOS/nixpkgs/commit/752c71cfb7bde18a000372ec6379db2692405079) | `` microcode-intel: Enable strictDeps and __structuredAttrs ``                                                            |
| [`e2b06240`](https://github.com/NixOS/nixpkgs/commit/e2b06240cd4369079f5bbb4a20840394575392af) | `` python3Packages.pyintelliclima: 0.3.1 -> 0.4.1 ``                                                                      |
| [`19f5427c`](https://github.com/NixOS/nixpkgs/commit/19f5427cc910a239b94911a47cda73c1270ddfaf) | `` temporal_capi: 0.2.4 -> 0.2.5 ``                                                                                       |
| [`3a2b1139`](https://github.com/NixOS/nixpkgs/commit/3a2b113905c10236975ce8f50914c233282d018a) | `` dua: 2.38.1 -> 2.41.1 ``                                                                                               |
| [`27b42660`](https://github.com/NixOS/nixpkgs/commit/27b4266029c90b718368f482eb60646145ed26e6) | `` nginx-sso: 0.27.7 -> 0.27.8 ``                                                                                         |
| [`1f04b24e`](https://github.com/NixOS/nixpkgs/commit/1f04b24e0bc0638f1c0b4c49dbcbce20c312b46c) | `` streamlit: 1.60.0 -> 1.61.0 ``                                                                                         |
| [`af9a5485`](https://github.com/NixOS/nixpkgs/commit/af9a5485353c1ea701d07ec4c9f674db8b992849) | `` rocm-modules: regenerate release-attrPaths.json ``                                                                     |
| [`7b686ba8`](https://github.com/NixOS/nixpkgs/commit/7b686ba8b5afcbc1cc93e60aaf0aea38a4e96205) | `` python3Packages.django_6: respect NIX_BUILD_CORES during test ``                                                       |
| [`81606d75`](https://github.com/NixOS/nixpkgs/commit/81606d750f6f6454480c6cc3dcf8d7cd28580cec) | `` python3Packages.yoyo-migrations: 8.2.0 -> 9.0.0 ``                                                                     |
| [`8b7a3232`](https://github.com/NixOS/nixpkgs/commit/8b7a3232059c2226c4f606636d152407aa1cf8fd) | `` binaryen: add updateScript ``                                                                                          |
| [`d4a18662`](https://github.com/NixOS/nixpkgs/commit/d4a18662f9043e81ebe627a928f384d5912cc757) | `` xdg-terminal-exec: 0.14.2 -> 0.14.3 ``                                                                                 |
| [`9eca3d87`](https://github.com/NixOS/nixpkgs/commit/9eca3d878e463be3ffcb2d5513a1b04e521a9128) | `` metadata-cleaner: 4.0.0 -> 4.0.1 ``                                                                                    |
| [`55514d59`](https://github.com/NixOS/nixpkgs/commit/55514d59c10aa6e52238c32502d636499d807f39) | `` alp: 1.1.18 -> 1.2.0 ``                                                                                                |
| [`2bf0e25a`](https://github.com/NixOS/nixpkgs/commit/2bf0e25ac62426473c58ab049e7bde5ce20e17d2) | `` py-spy: add GaetanLepage to maintainers ``                                                                             |
| [`3d9872bd`](https://github.com/NixOS/nixpkgs/commit/3d9872bd09909a4b958d60f33ada2f39a44c59a8) | `` py-spy: add updateScript ``                                                                                            |
| [`a722c751`](https://github.com/NixOS/nixpkgs/commit/a722c751a90c6ef6adf5c74e367aedf277c40fb9) | `` py-spy: add versionCheckHook ``                                                                                        |
| [`209390ed`](https://github.com/NixOS/nixpkgs/commit/209390eda65619e43f7ad7ef7eccd2a2cd470adb) | `` py-spy: cleanup, fix build ``                                                                                          |
| [`8c148712`](https://github.com/NixOS/nixpkgs/commit/8c148712a82f5d0f1213629e43688426cf9ef821) | `` nushellPlugins.polars: fix build ``                                                                                    |
| [`c3f5e3f2`](https://github.com/NixOS/nixpkgs/commit/c3f5e3f2a43b58770de1c11cd63eddf261e40f9d) | `` comfyui: 0.29.0 -> 0.30.1 ``                                                                                           |
| [`cb27fb50`](https://github.com/NixOS/nixpkgs/commit/cb27fb509653d55ee8abbd9bd79ea1a0fa7f83cd) | `` python3Packages.comfyui-workflow-templates-media-assets-01: 0.1.12 -> 0.1.17 ``                                        |
| [`918cc70a`](https://github.com/NixOS/nixpkgs/commit/918cc70ac04a69d3f979091160842572434f2e49) | `` python3Packages.comfyui-workflow-templates-json: 0.1.18 -> 0.1.27 ``                                                   |
| [`18265dd3`](https://github.com/NixOS/nixpkgs/commit/18265dd3ec8ffad23a98658a9c1d7f136efa1afd) | `` python3Packages.comfyui-workflow-templates-core: 0.3.284 -> 0.3.292 ``                                                 |
| [`5e9754b4`](https://github.com/NixOS/nixpkgs/commit/5e9754b4b34b213152962b3b4ac56626e8761319) | `` python3Packages.comfyui-workflow-templates: 0.11.19 -> 0.11.27 ``                                                      |
| [`660693de`](https://github.com/NixOS/nixpkgs/commit/660693deb8b1fe75c85038f5c567860bd65b2527) | `` python3Packages.comfyui-frontend-package: 1.47.10 -> 1.47.12 ``                                                        |
| [`6def545f`](https://github.com/NixOS/nixpkgs/commit/6def545f2c4ff99b25e98900c83f832bd5662637) | `` python3Packages.comfy-kitchen: 0.2.22 -> 0.2.26 ``                                                                     |
| [`e1a2aa65`](https://github.com/NixOS/nixpkgs/commit/e1a2aa65af281d470cdf70a44dfdb0ad254ad2be) | `` python3Packages.comfy-aimdo: 0.4.10 -> 0.4.11 ``                                                                       |
| [`5c83b41a`](https://github.com/NixOS/nixpkgs/commit/5c83b41ad9ad27327efb650acf2de29f0ffba385) | `` osu-lazer: 2026.726.0 -> 2026.804.2 ``                                                                                 |
| [`34996e13`](https://github.com/NixOS/nixpkgs/commit/34996e1398d80618eb5e4a1062eb3205afa6f4e0) | `` beamPackages.elixir_1_20: 1.20.2 -> 1.20.3 ``                                                                          |
| [`b396f892`](https://github.com/NixOS/nixpkgs/commit/b396f8924b27dacb302593e17d0f4eb2bfa69ab1) | `` vimPlugins.dataform-nvim: init at 0-unstable-2025-06-16 ``                                                             |
| [`d3029c2f`](https://github.com/NixOS/nixpkgs/commit/d3029c2f6a00d774c88632112d022cccf9cee033) | `` invidious: 2.20260723.0 -> 2.20260804.0 ``                                                                             |
| [`84bc1d15`](https://github.com/NixOS/nixpkgs/commit/84bc1d156edb14143f1f8999049090a940ee86db) | `` python3Packages.petl: cleanup ``                                                                                       |
| [`d5a9c182`](https://github.com/NixOS/nixpkgs/commit/d5a9c18291ad03d55ac09c5908453214e5deab29) | `` python3Packages.petl: enable __structuredAttrs ``                                                                      |
| [`63f36551`](https://github.com/NixOS/nixpkgs/commit/63f36551ee12f65827025e77c4af8a58d34c978e) | `` python3Packages.copier: migrate to finalAttrs ``                                                                       |
| [`bec1ce33`](https://github.com/NixOS/nixpkgs/commit/bec1ce33af9a73d3a14661c18b507735c572c7a3) | `` llama-cpp: 10133 -> 10273 ``                                                                                           |
| [`d2557dac`](https://github.com/NixOS/nixpkgs/commit/d2557dac9948578f6e6e15f666a8c7c5f663446a) | `` liteparse: minor cleanup ``                                                                                            |
| [`30bcb67d`](https://github.com/NixOS/nixpkgs/commit/30bcb67df3ef1c20f0b71e1b2e21cb9fe686bb7a) | `` python3Packages.nad-receiver: migrate to finalAttrs ``                                                                 |
| [`73948d32`](https://github.com/NixOS/nixpkgs/commit/73948d323b2a21b4742cc3ef8ed24a2dbeb39df3) | `` python3Packages.nad-receiver: 0.3.0 -> 0.4.0 ``                                                                        |
| [`10f870e3`](https://github.com/NixOS/nixpkgs/commit/10f870e36f03aeec8b49ba253dc431906f238cb0) | `` python3Packages.disposable-email-domains: 0.0.231 -> 0.0.237 ``                                                        |
| [`fb329d14`](https://github.com/NixOS/nixpkgs/commit/fb329d149bd50e1a1d112518399c47ab741ac7ab) | `` ocinferno: init at 0.6.2-unstable-2026-08-03 ``                                                                        |
| [`1b755680`](https://github.com/NixOS/nixpkgs/commit/1b7556802f42f6fa24b57a6020956c1d67de16af) | `` python3Packages.oci-lexer-parser: init at 0.1.2-unstable-2026-08-03 ``                                                 |
| [`9202af3a`](https://github.com/NixOS/nixpkgs/commit/9202af3aff90e3cef18a8dfdbdb6b27e050d14d8) | `` python3Packages.stookalert: drop ``                                                                                    |
| [`5fc1dcb8`](https://github.com/NixOS/nixpkgs/commit/5fc1dcb88b3aa8ed4809d313d89871cd7e1ea4f7) | `` python3Packages.confluent-kafka: sort inputs ``                                                                        |
| [`d14937d8`](https://github.com/NixOS/nixpkgs/commit/d14937d833a23de976a0181d72d20cb4e8db54bb) | `` adscan: 10.1.0 -> 11.0.0 ``                                                                                            |
| [`cd7ba491`](https://github.com/NixOS/nixpkgs/commit/cd7ba4914a7549ff8df3aa32a735eac6e8ac635a) | `` python3Packages.confluent-kafka: enable __structuredAttrs ``                                                           |
| [`289769d3`](https://github.com/NixOS/nixpkgs/commit/289769d31a7aa49a23b495cd65113cdc3a33b9af) | `` xwinmosaic: drop ``                                                                                                    |
| [`1fc9822f`](https://github.com/NixOS/nixpkgs/commit/1fc9822f7b434031161eadc972e87beb33e41e9c) | `` hk: 1.53.0 -> 1.54.0 ``                                                                                                |
| [`aa088bd8`](https://github.com/NixOS/nixpkgs/commit/aa088bd8b19e483484ec92931ebe5df9f85ce7cc) | `` syncplay: 1.7.5 -> 1.7.6 ``                                                                                            |
| [`be5fab7f`](https://github.com/NixOS/nixpkgs/commit/be5fab7fd396a9efa95ededb1c86b00ef270f29e) | `` liteparse: 1.5.3 -> 2.8.0 ``                                                                                           |
| [`38464ddc`](https://github.com/NixOS/nixpkgs/commit/38464ddcc20ed5c2e395870d1ac04aa16701e6be) | `` python315: 3.15.0b4 -> 3.15.0rc1 ``                                                                                    |
| [`8d43d7f8`](https://github.com/NixOS/nixpkgs/commit/8d43d7f8d17371d1fb68f9145bb60858db481275) | `` whisper-cpp: 1.8.7 -> 1.9.2 ``                                                                                         |
| [`81fce9d2`](https://github.com/NixOS/nixpkgs/commit/81fce9d2aafbe72d0ec984f5485c0944c2eaaaac) | `` nixos/comfyui: init ``                                                                                                 |
| [`c7058321`](https://github.com/NixOS/nixpkgs/commit/c7058321aa70d3ec035e8513461eab4d503fddd2) | `` comfyui: init at 0.29.0 ``                                                                                             |
| [`d7cb9ec9`](https://github.com/NixOS/nixpkgs/commit/d7cb9ec9f17062686c2cba29546015d2f7f91c89) | `` python3Packages.comfyui-manager: init at 4.2.2 ``                                                                      |
| [`85fcef18`](https://github.com/NixOS/nixpkgs/commit/85fcef180047121f12bcde90b75d00086a17682f) | `` python3Packages.comfyui-workflow-templates: init at 0.11.19 ``                                                         |
| [`2dbac424`](https://github.com/NixOS/nixpkgs/commit/2dbac4242beff4db79afd531316756a439bbf3f4) | `` python3Packages.comfyui-workflow-templates-media-video: init at 0.3.101 ``                                             |
| [`889d729c`](https://github.com/NixOS/nixpkgs/commit/889d729c67edcad2f7e94754f6f415902bb7ffa1) | `` python3Packages.comfyui-workflow-templates-media-other: init at 0.3.229 ``                                             |
| [`1a0e2e8e`](https://github.com/NixOS/nixpkgs/commit/1a0e2e8e992e7bf1cee3d4c70c757957e4d69544) | `` python3Packages.comfyui-workflow-templates-media-image: init at 0.3.160 ``                                             |
| [`c0935b54`](https://github.com/NixOS/nixpkgs/commit/c0935b54e9eb671b1fd21736cf2e1ac70f9a1f9f) | `` python3Packages.comfyui-workflow-templates-media-assets-01: init at 0.1.12 ``                                          |
| [`75051827`](https://github.com/NixOS/nixpkgs/commit/75051827797690994ad88668cca14518555d64a0) | `` python3Packages.comfyui-workflow-templates-media-api: init at 0.3.84 ``                                                |
| [`b9a722ed`](https://github.com/NixOS/nixpkgs/commit/b9a722ed03d1e152f39e8b1c9bcc46448bc8d301) | `` python3Packages.comfyui-workflow-templates-json: init at 0.1.18 ``                                                     |
| [`0dd5be15`](https://github.com/NixOS/nixpkgs/commit/0dd5be15bc2d9a80ae0a10a50bbf8a40d1ab1813) | `` python3Packages.comfyui-workflow-templates-core: init at 0.3.284 ``                                                    |
| [`e3f76927`](https://github.com/NixOS/nixpkgs/commit/e3f7692799e8250664adb8621d1ec957ef885f5c) | `` python3Packages.comfyui-frontend-package: init at 1.47.10 ``                                                           |
| [`83ce2622`](https://github.com/NixOS/nixpkgs/commit/83ce262299c74df119013a2c877a80a4045ca0da) | `` python3Packages.comfyui-embedded-docs: init at 0.5.9 ``                                                                |
| [`60501c24`](https://github.com/NixOS/nixpkgs/commit/60501c2470b546cfaa96e1f83fcd73d699b4008e) | `` python3Packages.comfy-kitchen: init at 0.2.22 ``                                                                       |
| [`8c4c3999`](https://github.com/NixOS/nixpkgs/commit/8c4c39996d3de952d7f0c822d83923bd9766f981) | `` python3Packages.comfy-angle: init at 0.1.0 ``                                                                          |
| [`a749274a`](https://github.com/NixOS/nixpkgs/commit/a749274af00e5ce07df6490ea745a2683fe01857) | `` python3Packages.comfy-aimdo: init at 0.4.10 ``                                                                         |
| [`549d3537`](https://github.com/NixOS/nixpkgs/commit/549d35379fe228163cdbbd7aca4923c6812a4c8b) | `` terraform-providers.scaleway_scaleway: 2.79.0 -> 2.80.0 ``                                                             |
| [`334813be`](https://github.com/NixOS/nixpkgs/commit/334813be5aee78e4c05d57b0db98d81eef27086a) | `` nginxModules: move aliases file out of modules directory ``                                                            |
| [`96256cec`](https://github.com/NixOS/nixpkgs/commit/96256cec14a5877bdb4dbdede5ce6ca1d254ac96) | `` libretro.mame2003: 0-unstable-2026-06-15 -> 0-unstable-2026-07-28 ``                                                   |
| [`98227f77`](https://github.com/NixOS/nixpkgs/commit/98227f77adb1449d65231c61a8bf721b04b10dba) | `` glib,gtk*,gnome*,related-misc: remove myself as maintainer ``                                                          |
| [`1a4b5202`](https://github.com/NixOS/nixpkgs/commit/1a4b52021f619aaf31c5f8cdfa1c9cee10fcfafa) | `` zerofs: 2.1.1 -> 2.2.1 ``                                                                                              |
| [`18a424f5`](https://github.com/NixOS/nixpkgs/commit/18a424f549ca1cbd02fc5273219a99d8ec4cd390) | `` daktari: 0.0.344 -> 0.0.347 ``                                                                                         |
| [`69749a48`](https://github.com/NixOS/nixpkgs/commit/69749a48216c60ec366616baa7c78d75b1b88038) | `` osu-lazer-bin: 2026.726.0 -> 2026.804.2 ``                                                                             |
| [`140db3ae`](https://github.com/NixOS/nixpkgs/commit/140db3ae2c818657b6df487babe2c10338b40659) | `` nxv: 0.7.0 -> 0.7.1 ``                                                                                                 |
| [`a057770d`](https://github.com/NixOS/nixpkgs/commit/a057770de161b621cc4cb558504f193baaf7346b) | `` nixos/hydra: Add zstd to hydra-server's PATH ``                                                                        |
| [`01f06f3e`](https://github.com/NixOS/nixpkgs/commit/01f06f3e48dbe79f1cc4ed2cb5a473486771675b) | `` rio: 0.5.9 -> 0.5.10 ``                                                                                                |
| [`602d08ac`](https://github.com/NixOS/nixpkgs/commit/602d08ac02153edbe68e59b11c2f0eda442ab440) | `` factorio-experimental: 2.1.11 -> 2.1.12 ``                                                                             |
| [`08705e57`](https://github.com/NixOS/nixpkgs/commit/08705e57136f1f345bd4d15dc4bebb4a0aacb083) | `` rustfmt: update homepage ``                                                                                            |
| [`f638c15b`](https://github.com/NixOS/nixpkgs/commit/f638c15b892d97180efc523a85917aaed4e67892) | `` python3Packages.bloodhound: rename from bloodhound-py ``                                                               |
| [`b1681459`](https://github.com/NixOS/nixpkgs/commit/b16814590b0e915f9800f0b0f8ded2a55771ae8d) | `` python3Packages.iamdata: 0.1.202608031 -> 0.1.202608041 ``                                                             |
| [`ed50c12b`](https://github.com/NixOS/nixpkgs/commit/ed50c12bcedca8ed2fd57c3d6b047f5a842139bb) | `` onionshare: 2.6.4 -> 2.6.5 ``                                                                                          |
| [`1afbff6c`](https://github.com/NixOS/nixpkgs/commit/1afbff6cf5694217a47e9bb9ed71033c5d35f223) | `` xk6: 1.4.7 -> 1.4.9 ``                                                                                                 |
| [`04e06ccb`](https://github.com/NixOS/nixpkgs/commit/04e06ccb8441b18c98b53b99221564f5bcf1dbaf) | `` buildbox: 1.4.13 -> 1.4.15 ``                                                                                          |
| [`5cfac418`](https://github.com/NixOS/nixpkgs/commit/5cfac418f19a1550bd8b4c933f27a15779c9e5ac) | `` postgresqlPackages.pg_squeeze: 1.9.3 -> 1.9.4 ``                                                                       |
| [`442508b6`](https://github.com/NixOS/nixpkgs/commit/442508b6be2e38c304777b334df430ed8c8cceb8) | `` libretro.beetle-saturn: 0-unstable-2026-07-07 -> 0-unstable-2026-07-30 ``                                              |
| [`e0832b87`](https://github.com/NixOS/nixpkgs/commit/e0832b878323bd1236a6d2be42359f5741e0398b) | `` hyprland: fix build by relaxing glaze dependency ``                                                                    |
| [`932ae346`](https://github.com/NixOS/nixpkgs/commit/932ae346a87fb4c5397867592f3231a17294da2a) | `` python3Packages.pysail: 0.6.6 -> 0.7.0 ``                                                                              |
| [`5c0a359b`](https://github.com/NixOS/nixpkgs/commit/5c0a359b3b57fe9959cffc0068e5a912304f7661) | `` mcaselector: add desktop entry and icon ``                                                                             |
| [`d2b33089`](https://github.com/NixOS/nixpkgs/commit/d2b33089bb5ccdeb46773b76995d74226c02ae31) | `` sail: 0.6.6 -> 0.7.0 ``                                                                                                |
| [`1191021a`](https://github.com/NixOS/nixpkgs/commit/1191021a7a48a1d1e7feb32263129c1e70e525e0) | `` nixos/portmaster: init ``                                                                                              |
| [`e3cf3631`](https://github.com/NixOS/nixpkgs/commit/e3cf36311cd933df9379021ffcb646c39a525ef0) | `` source-meta-json-schema: 16.3.0 -> 16.5.0 ``                                                                           |
| [`b199eb36`](https://github.com/NixOS/nixpkgs/commit/b199eb3681be5d413a6f9bbb1adefe8e2d63f141) | `` trivial-builders/linkFarm: use listToAttrs instead of folding ``                                                       |
| [`09b25f30`](https://github.com/NixOS/nixpkgs/commit/09b25f30c9cf0cc05f43389155ba22bf0548f9fe) | `` garnet: 2.1.0 -> 2.1.1 ``                                                                                              |
| [`ea08daa3`](https://github.com/NixOS/nixpkgs/commit/ea08daa3f3d7b4e727308278f7bc489a6cd888a5) | `` opencode{,-desktop}: 1.18.11 -> 1.18.13 ``                                                                             |
| [`ebd16f67`](https://github.com/NixOS/nixpkgs/commit/ebd16f67dbb2f4c4ad58518da484903c959b9232) | `` shader-slang: 2026.14 -> 2026.14.1 ``                                                                                  |
| [`a0f7b596`](https://github.com/NixOS/nixpkgs/commit/a0f7b596cf86bf5e8d287b20b29d44f8d72818c5) | `` python3Packages.tyro: fix build ``                                                                                     |
| [`f67a94a8`](https://github.com/NixOS/nixpkgs/commit/f67a94a8d3c425a44de8d87a7b1531b6bd40e99f) | `` just-lsp: 0.5.1 -> 0.6.1 ``                                                                                            |
| [`3272f77b`](https://github.com/NixOS/nixpkgs/commit/3272f77b85f31bb1ce835b998efad598f6c27391) | `` c2patool: 0.27.3 -> 0.27.4 ``                                                                                          |
| [`44bb1c67`](https://github.com/NixOS/nixpkgs/commit/44bb1c678bc65fe12e8defdc2b8aa426a61335f0) | `` fastly: 15.4.0 -> 15.5.0 ``                                                                                            |
| [`e89588c3`](https://github.com/NixOS/nixpkgs/commit/e89588c38323fbd926b9cd607c7dc5586a41fd0f) | `` biome: expose json schema over `passthru.jsonschema` ``                                                                |
| [`e830e60b`](https://github.com/NixOS/nixpkgs/commit/e830e60ba903c2ca02a1a4a7835086a7d442ce50) | `` unihan-database: update license ``                                                                                     |
| [`5fe29dba`](https://github.com/NixOS/nixpkgs/commit/5fe29dba2d9510d006fb70fc47471dab61f67e60) | `` librewolf-unwrapped: 153.0.1-1 -> 153.0.3-1 ``                                                                         |
| [`2863d1ca`](https://github.com/NixOS/nixpkgs/commit/2863d1cafa2ade4ac3683ee60848e38a90345bd6) | `` python3Packages.kagglesdk: 0.1.35 -> 0.1.36 ``                                                                         |
| [`c66e0639`](https://github.com/NixOS/nixpkgs/commit/c66e06395968153f878fb9131ece5f098faace38) | `` kid3: add tallesCoelho as maintainer ``                                                                                |
| [`d5c41895`](https://github.com/NixOS/nixpkgs/commit/d5c41895b068720ba5b2764756d315c4fc08d232) | `` function-runner: 9.2.1 -> 9.2.2 ``                                                                                     |
| [`7beed92d`](https://github.com/NixOS/nixpkgs/commit/7beed92dfd29e220854d7d03ef19ff45d00c43ab) | `` python3Packages.pyathena: 3.30.1 -> 3.35.4 ``                                                                          |
| [`c4ecf0e5`](https://github.com/NixOS/nixpkgs/commit/c4ecf0e51d942dcaef6ce0a5dcd8aa7054ba49f0) | `` shotcut: deduplicate opencv ``                                                                                         |
| [`3eff938e`](https://github.com/NixOS/nixpkgs/commit/3eff938e3cd79b32b0082acce34d97fabc62cb0e) | `` mlt: deduplicate opencv to fix darwin crash ``                                                                         |
| [`15d6c341`](https://github.com/NixOS/nixpkgs/commit/15d6c3415985615aeb7cc71dc567d5b4d6a3c827) | `` terraform-providers.selectel_selectel: 8.2.3 -> 8.2.4 ``                                                               |
| [`8e62be31`](https://github.com/NixOS/nixpkgs/commit/8e62be3129f45848ba3c03532dc4ab045bc129ef) | `` qownnotes: 26.7.9 -> 26.8.0 ``                                                                                         |
| [`2c0d4d65`](https://github.com/NixOS/nixpkgs/commit/2c0d4d6535409464439da2452eb2e47bce1ef3db) | `` python3Packages.xknxproject: 3.9.0 -> 3.10.0 ``                                                                        |
| [`d3151ff5`](https://github.com/NixOS/nixpkgs/commit/d3151ff5f90e55a1266d5a91fcdf06b2c06712f7) | `` orchis-theme: re-add without murrine ``                                                                                |
| [`e8e3116b`](https://github.com/NixOS/nixpkgs/commit/e8e3116b6c0ae9f727c80165d9fe84f6eee7fbb1) | `` kopuz: 0.13.0 -> 0.14.0 ``                                                                                             |
| [`7745ae83`](https://github.com/NixOS/nixpkgs/commit/7745ae83813406589133d5038603505dd3b5810b) | `` vectorcode: relax chroma-hnswlib ``                                                                                    |
| [`14e8b3d4`](https://github.com/NixOS/nixpkgs/commit/14e8b3d4485113ff1310e45969c010e27a8b7708) | `` linuxPackages.nvidiaPackages.new_feature: 610.43.03 -> 610.57.04 ``                                                    |
| [`dd4a53fa`](https://github.com/NixOS/nixpkgs/commit/dd4a53fadff47b42dce75f4d1cfedbac8a15a678) | `` apidog: 2.8.40 -> 2.8.41 ``                                                                                            |
| [`9f378628`](https://github.com/NixOS/nixpkgs/commit/9f3786284c5c028e7f8b3f2ea74d9b2ea343fd9c) | `` python3Packages.django_6: 6.0.7 -> 6.0.8 ``                                                                            |
| [`bd95553c`](https://github.com/NixOS/nixpkgs/commit/bd95553cbdb0a85ce42ee4f241f437c92265997a) | `` portmaster: init at 2.2.1 ``                                                                                           |
| [`07cc6078`](https://github.com/NixOS/nixpkgs/commit/07cc6078249b04c1ed95ccac3964992d523e3409) | `` maintainers: add WitteShadovv ``                                                                                       |
| [`4045be4f`](https://github.com/NixOS/nixpkgs/commit/4045be4fe61dd0ce8f2ca9efd776429a1792aed0) | `` rtk: 0.44.0 -> 0.44.2 ``                                                                                               |
| [`8081c68b`](https://github.com/NixOS/nixpkgs/commit/8081c68b873498c41476be1ca7b4e31af20543f9) | `` androidStudioPackages.canary: 2026.1.4.2 -> 2026.1.4.3 ``                                                              |
| [`a9d657cc`](https://github.com/NixOS/nixpkgs/commit/a9d657ccf9118f8765cd1fa350afb6620ba466b0) | `` terraform-mcp-server: 1.1.0 -> 1.2.0 ``                                                                                |
| [`f94bb419`](https://github.com/NixOS/nixpkgs/commit/f94bb419be881efb5b00c47d1e5573b5d8694a63) | `` python3Packages.requests-random-user-agent: patch version ``                                                           |
| [`61f000a4`](https://github.com/NixOS/nixpkgs/commit/61f000a49a73fcc44cbbc31c43c707357096fe9b) | `` python3Packages.ai-edge-litert: 2.1.5 -> 2.1.6 ``                                                                      |
| [`293b0b20`](https://github.com/NixOS/nixpkgs/commit/293b0b205eea70eaee8c988fd6b8ff72a593b91c) | `` vllm: pin to python 3.13 ``                                                                                            |
| [`6dbbac53`](https://github.com/NixOS/nixpkgs/commit/6dbbac53efe3570b96806493b1dc7a7c57d0e3cf) | `` aiter: fix composable kernel link ``                                                                                   |
| [`ba13b6bc`](https://github.com/NixOS/nixpkgs/commit/ba13b6bcd0dca6ad11e6ce82ca7bbabbded35024) | `` kpx: init at 1.13.0 ``                                                                                                 |
| [`9025269d`](https://github.com/NixOS/nixpkgs/commit/9025269d755ebef7ef2649b51a313491e11183fc) | `` positron-bin: 2026.06.1-6 -> 2026.07.1-5 ``                                                                            |
| [`e8334543`](https://github.com/NixOS/nixpkgs/commit/e83345430b3639905398cf68f47c7670c26f7c76) | `` openvino-genai: 2026.2.1.0 -> 2026.3.0.0 ``                                                                            |
| [`82a94a2e`](https://github.com/NixOS/nixpkgs/commit/82a94a2e64ea39f16ba3f493ec57cbfdd798a961) | `` openvino-tokenizers: 2026.2.1.0 -> 2026.3.0.0 ``                                                                       |
| [`f6e6e5c3`](https://github.com/NixOS/nixpkgs/commit/f6e6e5c3e2f69ee5e58d1ad7d4e019fbf61897a2) | `` openvino: 2026.2.1 -> 2026.3.0 ``                                                                                      |
| [`2091b0b7`](https://github.com/NixOS/nixpkgs/commit/2091b0b75c3d760181651af042e38bbceb0e994b) | `` python3Packages.petl: migrate to finalAttrs ``                                                                         |
| [`b0230e3e`](https://github.com/NixOS/nixpkgs/commit/b0230e3e1f4564289eeea295176930ccf57b0a7c) | `` mistral-vibe: 2.23.1 -> 2.23.3 ``                                                                                      |
| [`77fc08b6`](https://github.com/NixOS/nixpkgs/commit/77fc08b68c56e38a941fba66ab74d84018632a65) | `` python313Packages.pandera: 0.30.1 -> 0.32.1 ``                                                                         |
| [`429ed441`](https://github.com/NixOS/nixpkgs/commit/429ed4411e8ca7f47a65919f406a03eda0e4eb29) | `` python3Packages.standardwebhooks: 1.0.1 -> 1.1.0 ``                                                                    |
| [`dfca7caf`](https://github.com/NixOS/nixpkgs/commit/dfca7cafbbe14c4d6ccf142eb80d55e2f7cccc5c) | `` nixos/nix-daemon: Set HOME for unprivileged daemon ``                                                                  |
| [`566595f4`](https://github.com/NixOS/nixpkgs/commit/566595f4ece8631560fed958a045ca95997c85bb) | `` simplex-chat-desktop: 6.5.6 -> 7.0.0 ``                                                                                |
| [`bf2e43f4`](https://github.com/NixOS/nixpkgs/commit/bf2e43f43ef37f81be360d54ffceed10ed198004) | `` pkgsite: 0.3.0-unstable-2026-07-24 -> 0.3.0-unstable-2026-08-04 ``                                                     |
| [`71d0d578`](https://github.com/NixOS/nixpkgs/commit/71d0d578a9de61bc8776d3190c9f8da48e023cbd) | `` zammad: 7.1.1 -> 7.1.2 ``                                                                                              |
| [`d78d3f76`](https://github.com/NixOS/nixpkgs/commit/d78d3f76f3cf7d74a3bce0f27e392548554a2310) | `` grpc-health-probe: 0.4.53 -> 0.4.54 ``                                                                                 |
| [`c93b1d67`](https://github.com/NixOS/nixpkgs/commit/c93b1d67f5fa7b4a2ede2a14d8a8d08da4cf6fd4) | `` python3Packages.python-fontconfig: 0.6.2 -> 0.6.3 ``                                                                   |

*... and 683 more commits (truncated)*