### PR TITLE
ci: cache flake inputs + build closures, vendor apple fonts, fix attic GC, self-heal runners

### DIFF
--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -125,7 +125,7 @@
         "https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/sb/sbomnix/package.nix"
       ],
       "workaround": "overlays/default.nix -- `sbomnix` overlay overriding makeWrapperArgs to prepend nixVersions.nix_2_34 (emits schema version 4) instead of the upstream-pinned nix_2_31 (see FIXME(nixpkgs-sbomnix-nix231-pin)); flake/dev/packages.nix exposes it as `.#sbomnix`; cve-scan.yaml invokes `.#sbomnix` instead of `nixpkgs#sbomnix`.",
-      "revert_action": "sbomnix#267 is already CLOSED (the parser was fixed in 1.8.0); the residual bug is purely nixpkgs' stale wrapper pin, for which no upstream issue exists yet. `pkgs-min-version` with `min_version: null` keeps this BLOCKED (never falsely resolved) — it is a reminder to re-check manually. When a future nixpkgs sbomnix update drops the nix_2_31 PATH pin (verify pkgs/by-name/sb/sbomnix/package.nix in our pinned nixpkgs no longer references nixVersions.nix_2_31), delete the `sbomnix` overlay from overlays/default.nix and its FIXME, revert flake/dev/packages.nix to `import nixpkgs { inherit system; }` with no overlays and drop the `inherit (pkgs) sbomnix;` line, revert cve-scan.yaml to `nix shell --inputs-from . nixpkgs#sbomnix --command sbomnix`, confirm a manual `workflow_dispatch` CVE scan is green, then set `done: true`. If it becomes urgent, file a nixpkgs issue to establish a real `issue-closed`/`nixpkgs-pin-contains-commit` signal and retarget this entry."
+      "revert_action": "sbomnix#267 is already CLOSED (the parser was fixed in 1.8.0); the residual bug is purely nixpkgs' stale wrapper pin, for which no upstream issue exists yet. `pkgs-min-version` with `min_version: null` keeps this BLOCKED (never falsely resolved) \u2014 it is a reminder to re-check manually. When a future nixpkgs sbomnix update drops the nix_2_31 PATH pin (verify pkgs/by-name/sb/sbomnix/package.nix in our pinned nixpkgs no longer references nixVersions.nix_2_31), delete the `sbomnix` overlay from overlays/default.nix and its FIXME, revert flake/dev/packages.nix to `import nixpkgs { inherit system; }` with no overlays and drop the `inherit (pkgs) sbomnix;` line, revert cve-scan.yaml to `nix shell --inputs-from . nixpkgs#sbomnix --command sbomnix`, confirm a manual `workflow_dispatch` CVE scan is green, then set `done: true`. If it becomes urgent, file a nixpkgs issue to establish a real `issue-closed`/`nixpkgs-pin-contains-commit` signal and retarget this entry."
     },
     {
       "id": "nixpkgs-536365-ld64-mac-notification-sys",
@@ -188,6 +188,21 @@
       "workaround": "features/desktop/print/default.nix -- `system-config-printer-iconfix` overrides system-config-printer's .desktop `Icon=printer` to an absolute path pointing at the package's own bundled `i-network-printer.png`, bypassing icon-theme-name resolution entirely (see FIXME(vicinae-468-printer-icon)).",
       "revert_action": "No upstream PR/issue exists yet for this specific \"printer\" name bug (only the linked discussion, where multiple reporters hit the identical symptom, unresolved as of Oct 2025) so `min_version` stays null (BLOCKED) until one is filed and a fix version is known. Once vicinae ships a fix and our pinned nixpkgs' `vicinae` package version reflects it, set `min_version` accordingly (or `done: true` after manually confirming `Icon=printer` renders correctly in vicinae), then delete `system-config-printer-iconfix` and its FIXME from features/desktop/print/default.nix, reverting to a plain `programs.system-config-printer.enable = true;`.",
       "$comment": "No upstream_pr recorded yet -- if one is opened for this specific bug, add its number here so the checker nudges once merged."
+    },
+    {
+      "id": "attic-gc-sqlite-chunk-limit",
+      "done": false,
+      "summary": "attic's orphan-chunk reaper deletes at most 500 chunks per GC pass on SQLite and does not loop, so a cache producing more orphans per day than 500 x passes/day can never converge. The 500 cites SQLite's pre-3.32 999-variable limit; the SQLite compiled into the binary reports MAX_VARIABLE_NUMBER=32766.",
+      "repo": "zhaofengli/attic",
+      "check": "pkgs-min-version",
+      "package": "attic-server",
+      "eval_host": "fredhub",
+      "min_version": null,
+      "tracking": [
+        "https://github.com/zhaofengli/attic/blob/main/server/src/gc.rs"
+      ],
+      "workaround": "overlays/attic-server.nix -- postPatch substituteInPlace raising `DatabaseBackend::Sqlite => 500` to 10000 (see FIXME(attic-gc-sqlite-chunk-limit)); wired in overlays/default.nix. Paired with a 15-minute garbage-collection interval in modules/services/attic/attic_server.nix.",
+      "revert_action": "NOT YET REPORTED UPSTREAM -- file an issue/PR against zhaofengli/attic first (either raise the SQLite limit or make run_reap_orphan_chunks loop until drained), then set `upstream_pr` and add the issue URL to `tracking`. Once a fix ships and lands in our pinned nixpkgs, set `min_version` to the carrying attic-server version; when the checker confirms it, delete overlays/attic-server.nix, its entry in overlays/default.nix and the FIXME, rebuild fredhub, and set this entry `done: true`. min_version is null so this entry stays BLOCKED and can never falsely resolve."
     }
   ]
 }

--- a/.github/workflows/cache-flake-inputs.yaml
+++ b/.github/workflows/cache-flake-inputs.yaml
@@ -1,0 +1,98 @@
+---
+name: Cache Flake Inputs
+
+# Pushes every flake input's source to the Attic cache.
+#
+# Why this exists
+# ---------------
+# CI caches outputs -- host toplevels, home-manager activations, the dev
+# shell, packages. It never cached *inputs*. But evaluating any host
+# requires materialising every input source in the store first, so a cold
+# runner had to fetch ~90 sources from GitHub, releases.nixos.org and
+# (until they were vendored) Apple's CDN on every single job.
+#
+# That is not just bandwidth, it is a correctness problem. An input
+# source fetched from its origin is hash-checked against flake.lock, and
+# a mismatch is a hard *evaluation* error. On 2026-08-06 Apple silently
+# re-published SF-Pro.dmg 86 bytes larger; the pinned narHash stopped
+# matching and every desktop eval plus the fleet-manifest job failed.
+# Nothing in this repo had changed.
+#
+# Flake input paths are substitutable like any other store path, so once
+# they are in Attic, Nix takes them off the LAN and never contacts the
+# origin. That makes evaluation independent of ~90 third parties' uptime
+# and byte-stability, and it would have prevented the incident above
+# outright.
+#
+# Note this is deliberately a Linux-only job with no darwin counterpart:
+# input sources are platform-independent, so archiving them once covers
+# the darwin runners too.
+#
+# Retention caveat: these paths are not part of any deployed closure, so
+# they are roots of nothing. If the `fred` cache is ever configured to
+# reap unreferenced NARs, this guard silently erodes -- the daily
+# schedule below re-warms it, but check the cache's retention settings
+# before relying on it.
+
+on:
+  # Any lock change can introduce a new source that nothing has cached.
+  push:
+    branches: [main]
+    paths:
+      - "flake.lock"
+      - ".github/workflows/cache-flake-inputs.yaml"
+
+  # Daily, so a cache that has lost paths (retention, manual GC) refills
+  # itself without waiting for the next lock bump.
+  schedule:
+    - cron: "45 4 * * *"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  archive:
+    name: Archive flake inputs to Attic
+    runs-on: [self-hosted, Linux]
+    # Forks have no route to the LAN cache.
+    if: github.repository == 'fredsystems/nixos'
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          trust-runner-user: true
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
+            substituters = http://192.168.31.14:8080/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
+
+      - name: Archive and push flake inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Logging in to Attic..."
+          nix shell --inputs-from . nixpkgs#attic-client --command attic login fred http://192.168.31.14:8080 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIxNDgyMzMyODksIm5iZiI6MTc2OTU0MjA4OSwic3ViIjoiZnJlZCIsImh0dHBzOi8vand0LmF0dGljLnJzL3YxIjp7ImNhY2hlcyI6eyJmcmVkIjp7InIiOjEsInciOjEsImNjIjoxfX19fQ.WhR5ixdW0j-wV77Tl8VubJPEyEvgQ8nQWYbgJxI8pPiLJN6v4DVaqKPu15mcY0N0B0zKnq9-njG5EOn2Z2-4dMgfx9ttTA-lltxrvPf5nKR9zAXg6hgPYsnGQuRFBvAFzlfPCpcIU2rgEVzMajzjipQgfUnVPDuto9uPU1VG25fncVRYz5dUhOXTfvN_WWpzcgQ7HDHQufbui5IoG-nmFMFWcNkxTCw7XVNs1PYFpadMGn6zAeh9Hi6epYYllr1aTcmTCx6ut3-fbFdQaxGG_HsCyxFiIf9r6GNSQvZOeHbeLcE21RQ6qNrkKZuQiVoOAcQr7ngpQ2jjcWnajw_hCPi6rqByZxdZy8IAbPQ83nm9o5UlfKg99sr6YSV-6ZTBvsOm-ioUX9hSktWm3O7cdH74ygmbUC_QL-os6aYNhbyQjSEMgiOpS65VnFURG58gnnvVHncMvohyDKwZqcWVtiaQApNeL3_LEATtX_zdqlaWdCVXO3t3QlD0ebYVhb4rn2KEg0GOZHGpWPqJnszRSMwXgWM1fG37OF117Qz6O9280BoEMdjLvITr5Cq0kQqS0PzapLdI5maU6ZluyqvAvgqdHzwjey4hDDq3FjITA_JMUStRlH7sMwtaSGTiTTOHQPe7WT9PImqfm4G8Q3urOsHMBE_Au1dqnUz4Lq-yU4M
+
+          # Fetches every input (recursively) into the local store and
+          # prints the resulting store paths.
+          echo "Archiving flake inputs..."
+          nix flake archive --json > archive.json
+
+          # `.inputs` rather than the whole document: the root object's
+          # own `path` is this checkout, which is not worth caching.
+          nix shell --inputs-from . nixpkgs#jq --command \
+            jq -r '.inputs | .. | .path? // empty' archive.json \
+            | sort -u > input.paths
+
+          echo "Found $(wc -l < input.paths) input source path(s)."
+
+          xargs -r -a input.paths ./scripts/attic-push.sh

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -293,7 +293,7 @@ jobs:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
-            substituters = http://192.168.31.14/fred https://cache.nixos.org/
+            substituters = http://192.168.31.14:8080/fred https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0=
 
       # Magic Nix Cache is NOT used here — multiple self-hosted runners
@@ -320,7 +320,7 @@ jobs:
           fi
 
           echo "Pushing system result..."
-          nix shell --inputs-from . nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+          ./scripts/attic-push.sh result
 
           : > build.stderr
           echo "Building home-manager for: ${{ matrix.system }}"
@@ -331,7 +331,7 @@ jobs:
           fi
 
           echo "Pushing home-manager result..."
-          nix shell --inputs-from . nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+          ./scripts/attic-push.sh result
 
           if [ "$error" -ne 0 ]; then
             echo "One or more warnings were detected during the build."
@@ -443,7 +443,7 @@ jobs:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
-            substituters = http://192.168.31.14/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            substituters = http://192.168.31.14:8080/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 
       - name: Build & push dev shell + packages
@@ -476,8 +476,7 @@ jobs:
 
           echo "Pushing built dev outputs to Attic..."
           # Push the realised store paths (and their closures) directly.
-          xargs -r nix shell --inputs-from . nixpkgs#attic-client --command \
-            attic push fred --ignore-upstream-cache-filter -j 2 < devshell.paths
+          xargs -r -a devshell.paths ./scripts/attic-push.sh
 
   # =====================================================================
   # Required Check Summary

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -475,7 +475,16 @@ jobs:
 
           echo "Pushing built dev outputs to Attic..."
           # Push the realised store paths (and their closures) directly.
-          xargs -r -a devshell.paths ./scripts/attic-push.sh
+          # Guarded rather than relying on `xargs -r`: BSD xargs on the
+          # darwin runners has historically differed on whether -r is a
+          # no-op, and running attic-push.sh with no arguments is a usage
+          # error. `-a` is avoided outright -- it is GNU-only and is what
+          # broke the darwin dev-shell job ("xargs: invalid option -- a").
+          if [ -s devshell.paths ]; then
+            xargs ./scripts/attic-push.sh < devshell.paths
+          else
+            echo "No dev outputs to push."
+          fi
 
   # =====================================================================
   # Required Check Summary

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -143,7 +143,6 @@ jobs:
               [darwin]="darwin"
               [freminal]="darwin"
               [frext]="darwin"
-              [apple-fonts]="darwin"
               [nixpkgs-stable]="skip"
               [home-manager-stable]="skip"
               [catppuccin-stable]="skip"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -654,7 +654,16 @@ jobs:
 
           echo "Pushing built dev outputs to Attic..."
           # Push the realised store paths (and their closures) directly.
-          xargs -r -a devshell.paths ./scripts/attic-push.sh
+          # Guarded rather than relying on `xargs -r`: BSD xargs on the
+          # darwin runners has historically differed on whether -r is a
+          # no-op, and running attic-push.sh with no arguments is a usage
+          # error. `-a` is avoided outright -- it is GNU-only and is what
+          # broke the darwin dev-shell job ("xargs: invalid option -- a").
+          if [ -s devshell.paths ]; then
+            xargs ./scripts/attic-push.sh < devshell.paths
+          else
+            echo "No dev outputs to push."
+          fi
 
   # =====================================================================
   # Required summary check

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -652,24 +652,6 @@ jobs:
               ".#packages.${system}.${attr}" >> devshell.paths
           done <<< "$pkg_attrs"
 
-          # Flake checks (pre-commit-check, prometheus-alert-rules).
-          #
-          # lint.yaml builds `.#checks.x86_64-linux.pre-commit-check` but runs
-          # on ubuntu-latest, which cannot reach the LAN cache, so it can
-          # neither push nor pull it. Building here means `nix flake check`
-          # on any fleet machine substitutes instead of re-running the whole
-          # hook suite. Linux only: the darwin dev shell already pulls the
-          # check's `enabledPackages` in via devShells, which is the part
-          # that actually costs time to build.
-          check_attrs=$(nix eval --raw ".#checks.${system}" \
-            --apply 'cs: builtins.concatStringsSep "\n" (builtins.attrNames cs)')
-          while read -r attr; do
-            [ -z "$attr" ] && continue
-            echo "  building checks.${system}.${attr}"
-            nix build --no-link --print-out-paths \
-              ".#checks.${system}.${attr}" >> devshell.paths
-          done <<< "$check_attrs"
-
           echo "Pushing built dev outputs to Attic..."
           # Push the realised store paths (and their closures) directly.
           xargs -r -a devshell.paths ./scripts/attic-push.sh

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -146,7 +146,6 @@ jobs:
               [frext]="desktop"
               [solaar]="desktop"
               [nix-flatpak]="desktop"
-              [apple-fonts]="desktop"
               [walls-catppuccin]="desktop"
               [walls-zhichaoh]="desktop"
               [walls-cozypixels]="desktop"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -389,7 +389,7 @@ jobs:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
-            substituters = http://192.168.31.14/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            substituters = http://192.168.31.14:8080/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 
       - name: Build server system
@@ -412,7 +412,7 @@ jobs:
           fi
 
           echo "Pushing first result..."
-          nix shell --inputs-from . nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+          ./scripts/attic-push.sh result
 
           : > build.stderr
           echo "Building home-manager for: ${{ matrix.system }}"
@@ -423,7 +423,7 @@ jobs:
           fi
 
           echo "Pushing second result..."
-          nix shell --inputs-from . nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+          ./scripts/attic-push.sh result
 
           if [ "$error" -ne 0 ]; then
             echo "One or more warnings were detected during the build."
@@ -457,7 +457,7 @@ jobs:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
-            substituters = http://192.168.31.14/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            substituters = http://192.168.31.14:8080/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 
       - name: Build desktop system
@@ -480,7 +480,7 @@ jobs:
           fi
 
           echo "Pushing first result..."
-          nix shell --inputs-from . nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+          ./scripts/attic-push.sh result
 
           : > build.stderr
           echo "Building home-manager for: ${{ matrix.system }}"
@@ -491,7 +491,7 @@ jobs:
           fi
 
           echo "Pushing second result..."
-          nix shell --inputs-from . nixpkgs#attic-client --command attic push fred result --ignore-upstream-cache-filter -j 2
+          ./scripts/attic-push.sh result
 
           if [ "$error" -ne 0 ]; then
             echo "One or more warnings were detected during the build."
@@ -622,7 +622,7 @@ jobs:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
-            substituters = http://192.168.31.14/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            substituters = http://192.168.31.14:8080/fred https://colmena.cachix.org https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= colmena.cachix.org-1:7BzpDnjjH8ki2CT3f6GdOk7QAzPOl+1t3LvTLXqYcSg= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 
       - name: Build & push dev shell + packages
@@ -653,10 +653,27 @@ jobs:
               ".#packages.${system}.${attr}" >> devshell.paths
           done <<< "$pkg_attrs"
 
+          # Flake checks (pre-commit-check, prometheus-alert-rules).
+          #
+          # lint.yaml builds `.#checks.x86_64-linux.pre-commit-check` but runs
+          # on ubuntu-latest, which cannot reach the LAN cache, so it can
+          # neither push nor pull it. Building here means `nix flake check`
+          # on any fleet machine substitutes instead of re-running the whole
+          # hook suite. Linux only: the darwin dev shell already pulls the
+          # check's `enabledPackages` in via devShells, which is the part
+          # that actually costs time to build.
+          check_attrs=$(nix eval --raw ".#checks.${system}" \
+            --apply 'cs: builtins.concatStringsSep "\n" (builtins.attrNames cs)')
+          while read -r attr; do
+            [ -z "$attr" ] && continue
+            echo "  building checks.${system}.${attr}"
+            nix build --no-link --print-out-paths \
+              ".#checks.${system}.${attr}" >> devshell.paths
+          done <<< "$check_attrs"
+
           echo "Pushing built dev outputs to Attic..."
           # Push the realised store paths (and their closures) directly.
-          xargs -r nix shell --inputs-from . nixpkgs#attic-client --command \
-            attic push fred --ignore-upstream-cache-filter -j 2 < devshell.paths
+          xargs -r -a devshell.paths ./scripts/attic-push.sh
 
   # =====================================================================
   # Required summary check

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -112,7 +112,7 @@ jobs:
           trust-runner-user: true
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
-            substituters = http://192.168.31.14/fred https://cache.nixos.org/
+            substituters = http://192.168.31.14:8080/fred https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0=
 
       # Magic Nix Cache is NOT used here — multiple self-hosted runners

--- a/.github/workflows/fleet-manifest.yaml
+++ b/.github/workflows/fleet-manifest.yaml
@@ -82,7 +82,7 @@ jobs:
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
-            substituters = http://192.168.31.14/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            substituters = http://192.168.31.14:8080/fred https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA=
 
       - name: Generate and publish manifest

--- a/.github/workflows/update-apple-fonts.yaml
+++ b/.github/workflows/update-apple-fonts.yaml
@@ -1,0 +1,148 @@
+---
+name: update-apple-fonts
+
+# overlays/apple-fonts.nix pins Apple's font dmgs by flat sha256. Apple
+# serves them from a single mutable CDN path with no version in the URL
+# and keeps no history, so the only way to notice a new release is to
+# re-hash the file and compare.
+#
+# Unlike most update workflows, this one is NOT urgent and its PR is not
+# a fix for anything. A stale hash here breaks nothing: evaluation never
+# touches the dmg (it only needs the hash string), and the patched font
+# output already lives in Attic, so no build fetches it either. This is
+# purely a "new fonts exist, do you want them" notification.
+#
+# That is the entire reason the fonts were vendored out of the
+# apple-fonts flake input on 2026-08-06. As a `flake = false` input the
+# same event was a hard evaluation failure across every desktop and the
+# fleet-manifest job, because flake inputs are materialised during eval
+# and hash-checked against flake.lock. See overlays/apple-fonts.nix.
+#
+# Weekly rather than daily: Apple's observed cadence is roughly annual
+# (the families carried timestamps of 2025-07-10 until 2026-08-05), and
+# each run re-downloads ~383 MB to hash it. If that ever needs to be
+# cheaper, gate the download on a HEAD request comparing the CDN's ETag
+# against a committed baseline.
+#
+# No build step here on purpose. Nerd Fonts-patching SF Pro is far too
+# slow for a GitHub-hosted runner; the PR's own ci-linux desktop matrix
+# builds and caches it.
+
+on:
+  schedule:
+    - cron: "15 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-apple-fonts:
+    name: Check Apple font dmgs for updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # PAT (not GITHUB_TOKEN) so the pushed branch triggers CI on the
+          # resulting PR -- see the same note in renovate-relock.yaml.
+          token: ${{ secrets.PAT }}
+          persist-credentials: true
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: accept-flake-config = true
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github[bot]"
+
+      - name: Re-hash the dmgs
+        id: check
+        run: |
+          set -euo pipefail
+
+          base="https://devimages-cdn.apple.com/design/resources/download"
+          overlay="overlays/apple-fonts.nix"
+
+          # Attribute name -> dmg basename, mirroring `families` in the
+          # overlay. Keep in sync when adding a family.
+          declare -A files=(
+            [sf-pro]="SF-Pro.dmg"
+            [sf-compact]="SF-Compact.dmg"
+            [sf-mono]="SF-Mono.dmg"
+            [ny]="NY.dmg"
+          )
+
+          changed=""
+
+          for name in "${!files[@]}"; do
+            file="${files[$name]}"
+
+            # The committed hash inside this family's block.
+            current=$(awk -v fam="    $name = {" '
+              $0 == fam { inblock = 1 }
+              inblock && /hash = / {
+                match($0, /"[^"]+"/)
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            ' "$overlay")
+
+            if [ -z "$current" ]; then
+              echo "::error::could not read current hash for $name from $overlay"
+              exit 1
+            fi
+
+            latest=$(nix store prefetch-file --json --name "$file" "$base/$file" \
+              | nix shell --inputs-from . nixpkgs#jq --command jq -r .hash)
+
+            if [ "$current" = "$latest" ]; then
+              echo "$name: unchanged ($current)"
+              continue
+            fi
+
+            echo "$name: $current -> $latest"
+
+            # Each hash appears exactly once in the file, so a global
+            # substitution of the old value is unambiguous.
+            sed -i "s|$current|$latest|" "$overlay"
+            changed="${changed:+$changed, }$name"
+          done
+
+          if [ -z "$changed" ]; then
+            echo "No font updates."
+            echo "changed=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        if: steps.check.outputs.changed != ''
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          CHANGED: ${{ steps.check.outputs.changed }}
+        run: |
+          set -euo pipefail
+
+          branch="update-apple-fonts-$(date +%Y%m%d)"
+
+          git checkout -b "$branch"
+          git add overlays/apple-fonts.nix
+          git commit -m "chore(apple-fonts): refresh dmg hashes ($CHANGED)"
+          git push --force-with-lease origin "$branch"
+
+          gh pr create \
+            --title "chore(apple-fonts): refresh dmg hashes ($CHANGED)" \
+            --body "Apple re-published the following font families: $CHANGED.
+
+          The vendored hashes in \`overlays/apple-fonts.nix\` have been updated to
+          match. This is not a fix for a broken state -- a stale hash does not
+          break evaluation or any cached build. Merging simply picks up whatever
+          Apple changed.
+
+          Opened automatically by \`.github/workflows/update-apple-fonts.yaml\`." \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/update-apple-fonts.yaml
+++ b/.github/workflows/update-apple-fonts.yaml
@@ -134,6 +134,20 @@ jobs:
           git commit -m "chore(apple-fonts): refresh dmg hashes ($CHANGED)"
           git push --force-with-lease origin "$branch"
 
+          # The branch name is date-stamped, so a same-day re-run (a retry, or
+          # a workflow_dispatch) pushes to a branch that already has an open
+          # PR. `gh pr create` errors in that case, failing the job AFTER it
+          # has already pushed the update -- the work is done but the run is
+          # red. Force-pushing above already updated the existing PR's head,
+          # so there is nothing left to do.
+          existing="$(gh pr list --head "$branch" --state open --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open for $branch; updated it in place."
+            exit 0
+          fi
+
           gh pr create \
             --title "chore(apple-fonts): refresh dmg hashes ($CHANGED)" \
             --body "Apple re-published the following font families: $CHANGED.

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -111,7 +111,6 @@ declare -A INPUT_CATEGORY=(
   [frext]="desktop"
   [solaar]="desktop"
   [nix-flatpak]="desktop"
-  [apple-fonts]="desktop"
   [walls-catppuccin]="desktop"
   [walls-zhichaoh]="desktop"
   [walls-cozypixels]="desktop"

--- a/agent-docs/ATTIC_CREDENTIAL_ROTATION.md
+++ b/agent-docs/ATTIC_CREDENTIAL_ROTATION.md
@@ -1,0 +1,184 @@
+# Attic credential rotation
+
+Runbook for replacing the Attic tokens that are currently committed to
+this repository. Written 2026-08-06, not yet executed.
+
+This is a procedure document, not a record of work done. Delete it once
+the rotation is complete and the invariants at the end have been folded
+into `modules/services/attic/attic_server.nix`.
+
+## Why this is needed
+
+Two JWTs are committed in tracked files. Both expire 2038-01-27, so
+neither ages out on any useful timescale.
+
+| Token subject | Scope                                                                                             | Lives in                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `fred`        | cache `fred`: read, write, configure                                                              | `ci-linux.yaml` (x3), `ci-darwin.yaml` (x2), `cache-flake-inputs.yaml` |
+| `fred_root`   | cache `*`: read, write, delete, create-cache, configure-cache, configure-retention, destroy-cache | `modules/services/attic/attic_client.nix`                              |
+
+`fred_root` is the serious one, and it is the one the PR review bots did
+_not_ flag. `attic_client.nix` is imported by both `flake/lib/mk-system.nix`
+and `flake/lib/mk-darwin-system.nix`, so that token is rendered into
+`~/.config/attic/config.toml` on **every machine in the fleet**. It can
+destroy any cache on the server.
+
+Both are also transmitted over plaintext HTTP to `192.168.31.14:8080`,
+so anyone on the LAN can observe them in flight.
+
+## The constraint that shapes everything
+
+Attic has **no token revocation**. `Token::from_jwt` in `token/src/lib.rs`
+is a stateless signature-and-expiry check with no database lookup, and
+the strings `revoke`, `revocation` and `jti` appear nowhere in the
+upstream repository.
+
+The only way to invalidate a leaked token is to rotate the server's
+`ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64`, which invalidates **every**
+token at once. Both tokens must therefore be replaced in a single
+coordinated cutover. There is no incremental path.
+
+## The fact that makes it cheap
+
+The `fred` cache is public:
+
+```text
+$ curl -s -o /dev/null -w '%{http_code}' http://192.168.31.14:8080/fred/nix-cache-info
+200
+```
+
+Pulls need no credential. `substituters` in `modules/base/system.nix`
+carries only the _public_ signing key, and there is no netrc anywhere in
+the fleet.
+
+So rotating the JWT secret does not stop a single machine from building.
+It breaks exactly two things: CI pushes, and interactive `attic push`.
+
+## What does NOT need doing
+
+- **No NAR re-signing.** The cache signing keypair is separate from the
+  JWT secret. Its private half lives in atticd's database and was never
+  committed; only the public half (`fred:Jjyhv...`) appears in
+  `trusted-public-keys`, which is correct and by design. The ~46 GiB of
+  cached content stays valid.
+- **No git history rewrite.** The old tokens remain in history forever.
+  Rotation is what makes them worthless; rewriting history would not,
+  and would break every existing clone and PR.
+- **No fleet-wide outage window.** See above: pulls are anonymous.
+
+## Phase 0 - shrink the target
+
+Do this first, because it is the change that stops the problem
+recurring.
+
+Since pulls are anonymous, the fleet does not need a token at all, let
+alone a cache-destroying one. Remove the `token` line from
+`modules/services/attic/attic_client.nix`, keeping the endpoint
+definition:
+
+```nix
+file.".config/attic/config.toml".text = ''
+  default-server = "local"
+
+  [servers.local]
+  endpoint = "http://192.168.31.14:8080"
+'';
+```
+
+Anyone needing to push by hand runs `attic login` once with a token
+minted for the occasion. After this, standing credentials are exactly
+one: a push-scoped CI token in GitHub Actions secrets.
+
+## Phase 1 - prepare, no outage
+
+Nothing here is deployed, so it can be merged whenever.
+
+1. Rewrite the six workflow occurrences to read the token from a
+   secret:
+
+   ```yaml
+   - name: Log in to Attic
+     run: |
+       nix shell --inputs-from . nixpkgs#attic-client --command \
+         attic login fred http://192.168.31.14:8080 "$ATTIC_TOKEN"
+     env:
+       ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+   ```
+
+   Passing it through `env:` rather than inline keeps it out of the
+   rendered command line in logs.
+
+2. Apply the phase 0 change to `attic_client.nix`.
+
+3. Do **not** merge yet if you want a clean cutover -- merging before
+   phase 2 leaves CI unable to push (the secret does not exist yet).
+   Either merge and accept a red push step until phase 2, or hold the
+   branch.
+
+## Phase 2 - cutover
+
+Push access is down from the atticd restart until the Actions secret is
+set. Sequence it when CI is idle; it is a few minutes.
+
+1. On fredhub, generate a new RS256 secret and write it into the
+   sops-managed `atticd_env`:
+
+   ```sh
+   nix run nixpkgs#openssl -- genrsa -traditional 4096 | base64 -w0
+   ```
+
+   Put it in the `ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64` entry of the
+   sops secret consumed by `services.atticd.environmentFile`.
+
+2. Deploy fredhub and restart atticd. Both old tokens are now dead.
+
+3. Mint the replacement CI token. Note the validity: **1 year, not 12**.
+
+   ```sh
+   sudo atticd-atticadm make-token --validity "1y" --sub "ci" \
+     --push "fred" --pull "fred" --create-cache "fred"
+   ```
+
+4. Store it as the `ATTIC_TOKEN` repository secret, then merge the
+   phase 1 branch.
+
+5. Deploy the fleet so the superuser token stops being written to
+   every machine.
+
+## Phase 3 - verify
+
+```sh
+# anonymous pull still works
+curl -s -o /dev/null -w '%{http_code}\n' \
+  http://192.168.31.14:8080/fred/nix-cache-info    # expect 200
+
+# the old token is now rejected
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer <OLD_TOKEN>" \
+  http://192.168.31.14:8080/fred/nix-cache-info    # expect 401
+
+# no token left in tracked content
+grep -rn "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9" --exclude-dir=.git .
+```
+
+Then trigger any workflow with a push step and confirm it succeeds.
+
+## Rollback
+
+If the cutover goes wrong, restore the previous `atticd_env` from sops
+history and restart atticd. The old tokens work again, and everything
+returns to the current state. This is safe precisely because no content
+was re-signed and no history was rewritten.
+
+## Invariants to keep afterwards
+
+- Tokens are minted with `--validity "1y"`. The current `12y` in the
+  setup comment of `attic_server.nix` is why a leak is a crisis rather
+  than a scheduled event.
+- No token in tracked content, ever. CI reads `secrets.ATTIC_TOKEN`;
+  humans run `attic login` locally.
+- The fleet gets no token at all. If a machine needs push access,
+  that is a deliberate exception, not the default.
+- Plaintext HTTP on the LAN remains an accepted risk. If that changes,
+  the endpoint moves behind TLS or a tunnel and every `endpoint =`
+  reference updates with it.

--- a/features/desktop/environments/modules/wayle/default.nix
+++ b/features/desktop/environments/modules/wayle/default.nix
@@ -106,27 +106,44 @@ let
     '';
   };
 
-  # ── NixOS config state indicator (ports fred-bar's waybar-updates.sh) ──
-  # Reports, in priority order: a pending reboot (/run/reboot-required), a
-  # checked-out branch other than main, or how many commits the local config
-  # is behind its upstream. Emits wayle-custom-module JSON ({text,class,
-  # tooltip}); the `class` is carried for when wayle ships custom CSS, while
-  # the Nerd Font glyph conveys state today.
+  # ── NixOS deploy state indicator ──────────────────────────────────────
+  # Reports whether THIS MACHINE is running the closure main expects for it.
   #
-  # The network `git fetch` is throttled to at most once per hour via a
-  # timestamp stamp file, so the wayle display poll (every 60s) only ever
-  # reads cheap local git state and never blocks on the network.
-  nixosStateRepo = "/home/${user}/GitHub/nixos";
+  # This used to compare the local git checkout against its upstream and
+  # report "behind by N commits", which was wrong in both directions:
+  #
+  #   1. False clean. `git pull` with no deploy made the widget go quiet
+  #      while the machine carried on running the old generation. The thing
+  #      being measured was the checkout, not the system.
+  #   2. False dirty. Any commit touching only servers put every desktop
+  #      into "behind by N", so the indicator was lit most of the time and
+  #      therefore ignored.
+  #
+  # Both fall out of measuring the wrong object. The right one already
+  # exists: nixos-deploy-state-metric.service (modules/monitoring/agent/
+  # node_exporter.nix) compares `readlink -f /run/current-system` against
+  # the per-host expected closure in the fleet manifest published by
+  # .github/workflows/fleet-manifest.yaml. That is per-host, so a
+  # server-only commit is correctly invisible here, and it is keyed on what
+  # is actually activated, so pulling without deploying still reads as
+  # drifted.
+  #
+  # This widget deliberately does NOT reimplement that comparison -- it
+  # reads the .prom the service already emits (world-readable 0644,
+  # refreshed every 10 minutes). One state machine, one place to be wrong.
+  # It also means the widget does no network I/O at all, so the git fetch
+  # and its throttle stamp are gone.
+  #
+  # States, from that service: up_to_date | drifted | unmanaged | unknown.
+  nixosStateProm = "/var/lib/node_exporter/textfiles/nixos_deploy_state.prom";
   nixosStateScript = pkgs.writeShellApplication {
     name = "wayle-nixos-state";
     runtimeInputs = [
-      pkgs.git
       pkgs.coreutils
+      pkgs.gnused
     ];
     text = ''
-      repo="''${NIXOS_REPO:-${nixosStateRepo}}"
-      main_branch="''${MAIN_BRANCH:-main}"
-      fetch_max_age=3600 # seconds (1 hour)
+      prom="''${DEPLOY_STATE_PROM:-${nixosStateProm}}"
 
       # The module renders the icon via the icon slot: the JSON `alt` field
       # keys into the custom module's icon-map (reboot|update|clean), and the
@@ -137,62 +154,88 @@ let
         printf '{"text":"","alt":"%s","class":"%s","tooltip":"%s"}\n' "$1" "$2" "$3"
       }
 
+      # Pull a label out of the single nixos_deploy_info sample. The leading
+      # [,{] anchors the match to a whole label name, so `short_rev` cannot
+      # match inside `short_expected_rev`.
+      info_label() {
+        sed -n "s/^nixos_deploy_info{.*[,{]$1=\"\([^\"]*\)\".*/\1/p" "$prom" | head -1
+      }
+
+      gauge() {
+        sed -n "s/^$1{[^}]*} \([0-9][0-9]*\).*/\1/p" "$prom" | head -1
+      }
+
+      human_age() {
+        secs="$1"
+        if [ "$secs" -lt 3600 ]; then
+          printf '%dm' "$((secs / 60))"
+        elif [ "$secs" -lt 86400 ]; then
+          printf '%dh' "$((secs / 3600))"
+        else
+          printf '%dd' "$((secs / 86400))"
+        fi
+      }
+
       # 1. Reboot required (highest priority).
       if [ -f /run/reboot-required ]; then
         emit "reboot" "reboot" "Reboot required"
         exit 0
       fi
 
-      # 2. Must be a git repository to say anything further. Styled as the
-      #    neutral "clean" state (non-actionable) but with its own tooltip.
-      if [ ! -d "$repo/.git" ]; then
-        emit "clean" "clean" "NixOS config is not a git repository"
-        exit 0
-      fi
-      cd "$repo"
-
-      # 3. Non-main branch is treated as "dirty".
-      current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
-      if [ -n "$current_branch" ] && [ "$current_branch" != "$main_branch" ]; then
-        emit "update" "updates" "On non-main branch: $current_branch"
+      # 2. No metrics. Deliberately NOT styled clean: the previous widget's
+      #    worst failure mode was looking healthy while saying nothing
+      #    meaningful, and "the exporter never ran" is exactly that.
+      if [ ! -r "$prom" ]; then
+        emit "update" "updates" "Deploy state unknown: nixos-deploy-state-metric has not produced metrics"
         exit 0
       fi
 
-      # 4. Resolve upstream tracking ref.
-      upstream="$(git for-each-ref --format='%(upstream:short)' \
-        "$(git symbolic-ref -q HEAD)" 2>/dev/null || true)"
-      if [ -z "$upstream" ]; then
-        emit "update" "updates" "No upstream configured for $main_branch"
-        exit 0
-      fi
-
-      # 5. Throttled network fetch: only fetch if the stamp is older than
-      #    fetch_max_age (or missing). Failures are non-fatal.
-      stamp="''${XDG_RUNTIME_DIR:-/tmp}/wayle-nixos-state.fetch"
+      state="$(sed -n 's/^nixos_deploy_state{[^}]*state="\([^"]*\)"} 1$/\1/p' "$prom" | head -1)"
+      running_rev="$(info_label short_rev)"
+      expected_rev="$(info_label short_expected_rev)"
+      drifted_since="$(gauge nixos_drifted_since_seconds)"
+      manifest_age="$(gauge nixos_manifest_age_seconds)"
       now="$(date +%s)"
-      last=0
-      if [ -f "$stamp" ]; then
-        last="$(cat "$stamp" 2>/dev/null || echo 0)"
-      fi
-      if [ "$((now - last))" -ge "$fetch_max_age" ]; then
-        if git fetch --quiet 2>/dev/null; then
-          echo "$now" > "$stamp"
-        fi
-      fi
 
-      # 6. Count commits behind upstream (local state only, no network).
-      behind="$(git rev-list --count "HEAD..$upstream" 2>/dev/null || echo 0)"
-      if [ "$behind" -gt 0 ]; then
-        if [ "$behind" -eq 1 ]; then
-          emit "update" "updates" "Config behind upstream by 1 commit"
-        else
-          emit "update" "updates" "Config behind upstream by $behind commits"
-        fi
+      : "''${state:=}"
+      : "''${drifted_since:=0}"
+      : "''${manifest_age:=0}"
+
+      # A manifest nobody has refreshed in a day makes every verdict below
+      # suspect, "up to date" included. Surface that rather than trust it.
+      if [ "$manifest_age" -gt 86400 ]; then
+        emit "update" "updates" "Fleet manifest is $(human_age "$manifest_age") old; deploy state cannot be trusted"
         exit 0
       fi
 
-      # 7. Clean and up to date.
-      emit "clean" "clean" "System configuration up to date"
+      case "$state" in
+        drifted)
+          behind=""
+          if [ "$drifted_since" -gt 0 ] && [ "$now" -gt "$drifted_since" ]; then
+            behind=" for $(human_age "$((now - drifted_since))")"
+          fi
+          emit "update" "updates" \
+            "Deploy needed$behind: running ''${running_rev:-unknown}, main expects ''${expected_rev:-unknown}"
+          ;;
+        unmanaged)
+          # Running something main never published: a local, dirty or
+          # feature-branch build. Same remedy, different cause, so say which.
+          emit "update" "updates" \
+            "Running a closure main never published (local or branch build); deploy to return to main"
+          ;;
+        unknown)
+          # The manifest predates the running closure, i.e. this host was
+          # deployed more recently than the manifest was published. Normal
+          # for a few minutes after a deploy and not actionable.
+          emit "clean" "clean" "Deployed ahead of the published manifest; state will settle shortly"
+          ;;
+        up_to_date)
+          emit "clean" "clean" "Running the closure main expects (''${running_rev:-unknown})"
+          ;;
+        *)
+          emit "update" "updates" "Deploy state could not be read from the metrics file"
+          ;;
+      esac
     '';
   };
 

--- a/features/desktop/environments/modules/wayle/default.nix
+++ b/features/desktop/environments/modules/wayle/default.nix
@@ -225,9 +225,22 @@ let
           ;;
         unknown)
           # The manifest predates the running closure, i.e. this host was
-          # deployed more recently than the manifest was published. Normal
-          # for a few minutes after a deploy and not actionable.
-          emit "clean" "clean" "Deployed ahead of the published manifest; state will settle shortly"
+          # deployed more recently than the manifest was published.
+          #
+          # Normally that is a deploy racing the publisher and is not
+          # actionable -- but a STUCK publisher produces the same state
+          # indefinitely, so treating it as unconditionally clean would hide
+          # a broken deploy-state pipeline behind the 24h guard above.
+          #
+          # fleet-manifest.yaml publishes every 6h and on every push to main,
+          # so a manifest older than two cycles is not "catching up", it is
+          # stuck. Below that, stay quiet; above it, say so.
+          if [ "$manifest_age" -gt 43200 ]; then
+            emit "update" "updates" \
+              "Deploy state indeterminate: manifest is $(human_age "$manifest_age") old and predates the running closure"
+          else
+            emit "clean" "clean" "Deployed ahead of the published manifest; state will settle shortly"
+          fi
           ;;
         up_to_date)
           emit "clean" "clean" "Running the closure main expects (''${running_rev:-unknown})"

--- a/features/desktop/fonts/default.nix
+++ b/features/desktop/fonts/default.nix
@@ -2,7 +2,6 @@
   lib,
   pkgs,
   config,
-  inputs,
   ...
 }:
 let
@@ -20,10 +19,17 @@ in
     #   pkgs.fira-code-symbols
     # ];
 
+    # Apple's font licence permits use but not redistribution, so the
+    # vendored SF / New York packages (overlays/apple-fonts.nix) are marked
+    # unfree and have to be named here explicitly.
     nixpkgs.config.allowUnfreePredicate =
       pkg:
       builtins.elem (lib.getName pkg) [
         "joypixels"
+        "ny-nerd"
+        "sf-compact-nerd"
+        "sf-mono-nerd"
+        "sf-pro-nerd"
       ];
     nixpkgs.config.joypixels.acceptLicense = true;
 
@@ -43,8 +49,10 @@ in
         twemoji-color-font
         noto-fonts-color-emoji
         google-fonts
-        inputs.apple-fonts.packages.${pkgs.stdenv.hostPlatform.system}.sf-pro-nerd
-        inputs.apple-fonts.packages.${pkgs.stdenv.hostPlatform.system}.ny-nerd
+        apple-fonts.sf-pro-nerd
+        apple-fonts.ny-nerd
+        apple-fonts.sf-compact-nerd
+        apple-fonts.sf-mono-nerd
         # corefonts
         # cifs-utils
         # dina-font

--- a/flake.lock
+++ b/flake.lock
@@ -968,11 +968,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1785692966,
-        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -735,11 +735,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1785898735,
-        "narHash": "sha256-5CjkrKNFlfPxwhISptR+UkkJx/pTKTLUJHmXL565k4Q=",
+        "lastModified": 1786030128,
+        "narHash": "sha256-BRDMCP5tQ/3Mq4aGkS2Z0N91OLudQBfEYJNcLDaVmvM=",
         "owner": "epireyn",
         "repo": "niri-flake",
-        "rev": "8021817b5b809ae8bd8c97a65937d858452c6e32",
+        "rev": "73dd68bb231c0dec694dc5bdfebbde0e299281f3",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1785858998,
-        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
+        "lastModified": 1785989512,
+        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
+        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
         "type": "github"
       },
       "original": {
@@ -1125,11 +1125,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -691,11 +691,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785958398,
-        "narHash": "sha256-5r/JgsoNMTx+qIh83WkxpujEKBR7PF5ssnh5vYCuSAw=",
+        "lastModified": 1786031233,
+        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7c70cc290290f373f50cd820403833d250459ac",
+        "rev": "7834e82588860aaf780cec1366524456a70898d7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -936,11 +936,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1785858998,
-        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
+        "lastModified": 1785989512,
+        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
+        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,58 +1,5 @@
 {
   "nodes": {
-    "apple-fonts": {
-      "inputs": {
-        "ci": "ci",
-        "nixpkgs": "nixpkgs",
-        "ny": "ny",
-        "sf-arabic": "sf-arabic",
-        "sf-armenian": "sf-armenian",
-        "sf-compact": "sf-compact",
-        "sf-georgian": "sf-georgian",
-        "sf-hebrew": "sf-hebrew",
-        "sf-mono": "sf-mono",
-        "sf-pro": "sf-pro"
-      },
-      "locked": {
-        "lastModified": 1786018145,
-        "narHash": "sha256-4cjJFmq6JC0Gk9wWt3aZzqovtmM9mikrDWjsBL2ZWu8=",
-        "owner": "Lyndeno",
-        "repo": "apple-fonts.nix",
-        "rev": "66b5379c6a429ad4ea6ff3943cc1f651df55cc70",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Lyndeno",
-        "repo": "apple-fonts.nix",
-        "type": "github"
-      }
-    },
-    "blueprint": {
-      "inputs": {
-        "nixpkgs": [
-          "apple-fonts",
-          "ci",
-          "nixpkgs"
-        ],
-        "systems": [
-          "apple-fonts",
-          "ci"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776249299,
-        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
-        "owner": "numtide",
-        "repo": "blueprint",
-        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "blueprint",
-        "type": "github"
-      }
-    },
     "cargo-bundle-src": {
       "flake": false,
       "locked": {
@@ -71,7 +18,7 @@
     },
     "catppuccin": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1785485193,
@@ -108,34 +55,12 @@
         "type": "github"
       }
     },
-    "ci": {
-      "inputs": {
-        "blueprint": "blueprint",
-        "nixpkgs": [
-          "apple-fonts",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779849193,
-        "narHash": "sha256-Bc80n+fA3NtxqYHWcdb1XFuYLaV+yX2xnvDRnwAv4ak=",
-        "owner": "Lyndeno",
-        "repo": "ci",
-        "rev": "38cfa6f01bdaf91bc4ce44176b322bab2bb208a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Lyndeno",
-        "repo": "ci",
-        "type": "github"
-      }
-    },
     "colmena": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "stable": "stable"
       },
       "locked": {
@@ -580,7 +505,7 @@
       "inputs": {
         "flake-compat": "flake-compat_4",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1763988335,
@@ -729,7 +654,7 @@
       "inputs": {
         "niri-stable": "niri-stable",
         "niri-unstable": "niri-unstable",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-stable": "nixpkgs-stable",
         "xwayland-satellite-stable": "xwayland-satellite-stable",
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
@@ -870,7 +795,7 @@
       "inputs": {
         "flake-utils": "flake-utils_7",
         "git-hooks": "git-hooks_3",
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1785715923,
@@ -888,18 +813,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
-        "type": "github"
+        "lastModified": 1785301185,
+        "narHash": "sha256-PlAXr9kpfXhMFU0OQ7qtE8FhLQo21WXFVGqIC85UFyc=",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1043539.9bc02893134c/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-kernel": {
@@ -952,22 +874,6 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1764406085,
-        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
         "lastModified": 1785692966,
         "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
         "owner": "nixos",
@@ -982,7 +888,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
+    "nixpkgs_11": {
       "locked": {
         "lastModified": 1784555310,
         "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
@@ -998,7 +904,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1785692966,
         "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
@@ -1014,7 +920,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_13": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -1032,19 +938,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1785301185,
-        "narHash": "sha256-PlAXr9kpfXhMFU0OQ7qtE8FhLQo21WXFVGqIC85UFyc=",
-        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1043539.9bc02893134c/nixexprs.tar.xz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1783224372,
         "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
@@ -1059,7 +952,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1784796856,
         "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
@@ -1071,28 +964,28 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
         "lastModified": 1784796856,
         "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "nixos",
@@ -1107,7 +1000,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -1123,7 +1016,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1785828668,
         "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
@@ -1139,7 +1032,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1759417375,
         "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
@@ -1155,10 +1048,26 @@
         "type": "github"
       }
     },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1764406085,
+        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_12",
+        "nixpkgs": "nixpkgs_11",
         "systems": "systems_8"
       },
       "locked": {
@@ -1175,23 +1084,11 @@
         "type": "github"
       }
     },
-    "ny": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-3257NAH4qlan2YHVLpNRy7x8IJqR2pal3OzFo/ykqXs=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/NY.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/NY.dmg"
-      }
-    },
     "precommit": {
       "inputs": {
         "flake-utils": "flake-utils_3",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
@@ -1212,7 +1109,7 @@
       "inputs": {
         "flake-utils": "flake-utils_8",
         "git-hooks": "git-hooks_4",
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_12",
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
@@ -1233,7 +1130,7 @@
       "inputs": {
         "flake-utils": "flake-utils_4",
         "git-hooks": "git-hooks_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
@@ -1252,7 +1149,6 @@
     },
     "root": {
       "inputs": {
-        "apple-fonts": "apple-fonts",
         "catppuccin": "catppuccin",
         "catppuccin-stable": "catppuccin-stable",
         "colmena": "colmena",
@@ -1267,7 +1163,7 @@
         "nix-yazi-plugins": "nix-yazi-plugins",
         "nix-yazi-plugins-stable": "nix-yazi-plugins-stable",
         "nixos-needsreboot": "nixos-needsreboot",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_10",
         "nixpkgs-kernel": "nixpkgs-kernel",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixvim": "nixvim",
@@ -1282,7 +1178,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1784870759,
@@ -1321,7 +1217,7 @@
     },
     "rust-overlay_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1785476452,
@@ -1360,7 +1256,7 @@
     },
     "rust-overlay_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_14"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1785736145,
@@ -1374,90 +1270,6 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "type": "github"
-      }
-    },
-    "sf-arabic": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-/0gjRimqvZyE60xYxxPdlU+7Q2LJnnvtbmwOP0YmS9U=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Arabic.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Arabic.dmg"
-      }
-    },
-    "sf-armenian": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-rRoDkbNMYkzOHZmQm96Zv80TZvRlAeoxkv4pMHP5nUg=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Armenian.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Armenian.dmg"
-      }
-    },
-    "sf-compact": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-83JwqfF9O4+gemMQXWHLRg2GNz2jHxsej1F1IkM2dug=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Compact.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Compact.dmg"
-      }
-    },
-    "sf-georgian": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-IevVNOC28IiR45YfI3PsZzXLMRxuB5u7UiE53Zn6tRU=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Georgian.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Georgian.dmg"
-      }
-    },
-    "sf-hebrew": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-Dw84kYwMpCtKKKqm8cZcQ9TZ7GayU5MO7W0LJw0Rcwk=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Hebrew.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Hebrew.dmg"
-      }
-    },
-    "sf-mono": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-ICdHRFdNL7PM/fXJUzS7LgZxZiqcyIuCMHLze4En4vg=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Mono.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Mono.dmg"
-      }
-    },
-    "sf-pro": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-vINUEMyFmNzZRBOX2aQ4heScWur6RyA/MPmsqlMPIx4=",
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Pro.dmg"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Pro.dmg"
       }
     },
     "solaar": {

--- a/flake.nix
+++ b/flake.nix
@@ -115,11 +115,6 @@
     };
 
     # CI: desktop
-    apple-fonts = {
-      url = "github:Lyndeno/apple-fonts.nix";
-    };
-
-    # CI: desktop
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -260,7 +255,6 @@
       catppuccin,
       catppuccin-stable,
       sops-nix-stable,
-      apple-fonts,
       nixvim,
       nix-flatpak,
       niri,
@@ -383,7 +377,6 @@
           darwin
           nixvim
           niri
-          apple-fonts
           solaar
           colmena
           walls-catppuccin

--- a/flake/lib/mk-system.nix
+++ b/flake/lib/mk-system.nix
@@ -186,7 +186,6 @@ let
             ;
           inherit (inputs)
             catppuccin
-            apple-fonts
             nixvim
             niri
             ;

--- a/hosts/linux/fredhub/configuration.nix
+++ b/hosts/linux/fredhub/configuration.nix
@@ -54,6 +54,13 @@ in
     enable = true;
     repo = "FredSystems/nixos";
     defaultTokenFile = config.sops.secrets."github-token".path;
-    runnerCount = 4; # Auto-generates runner-1 through runner-4
+    # Auto-generates runner-1 through runner-8.
+    #
+    # fredhub is the only Linux runner host, and ci-linux.yaml's matrix can
+    # fan out to 9 hosts, so 4 was the throughput ceiling for a full-fleet
+    # rebuild. The box is 32 cores / 125 GiB with ~120 GiB genuinely
+    # available; an idle runner costs ~65 MiB, so the runners themselves are
+    # free. See the max-jobs note below before raising this further.
+    runnerCount = 8;
   };
 }

--- a/modules/monitoring/master/alert-rules/alert-rules.yaml
+++ b/modules/monitoring/master/alert-rules/alert-rules.yaml
@@ -53,8 +53,24 @@ groups:
 
   - name: systemd-alerts
     rules:
+      # github-runner-runner-* is excluded and handled by GitHubRunnerFailed
+      # below instead. Those units are self-healing: modules/services/
+      # github-runners.nix runs a watchdog timer every 15 minutes that
+      # restarts any runner sitting in `failed`. Paging critical at 2
+      # minutes for a condition that repairs itself within 15 is noise --
+      # which is precisely what the 2026-08-06 GitHub outage produced.
+      #
+      # Note the exclusion is `github-runner-runner-.*`, not
+      # `github-runner-.*`: github-runner-watchdog.service deliberately
+      # stays covered by this rule, because nothing else would notice the
+      # watchdog itself dying.
       - alert: SystemdUnitFailed
-        expr: node_systemd_unit_state{state="failed", name!~"docker-.*", role!="desktop"} == 1
+        expr: |
+          node_systemd_unit_state{
+            state="failed",
+            name!~"docker-.*|github-runner-runner-.*",
+            role!="desktop"
+          } == 1
         for: 2m
         labels:
           severity: critical
@@ -79,6 +95,58 @@ groups:
         annotations:
           summary: "GitHub runner {{ $labels.name }} appears to be crash-looping"
           description: "The unit {{ $labels.name }} cycled state more than 6 times in 5 minutes — this is too rapid to be normal CI job cycling."
+
+      # Fires only for a runner the watchdog could NOT rescue.
+      #
+      # The self-healing sweep in modules/services/github-runners.nix runs
+      # every 15 minutes, so 20m means "a full sweep has been and gone and
+      # this unit is still failed" -- a genuine problem needing hands,
+      # rather than the transient GitHub-API failures that used to strand
+      # runners (see the cleanupRunner comment in that module).
+      #
+      # Keep this `for:` strictly greater than the watchdog's
+      # OnUnitActiveSec, or this becomes the 2-minute noise it replaced.
+      - alert: GitHubRunnerFailed
+        expr: |
+          node_systemd_unit_state{
+            state="failed",
+            name=~"github-runner-runner-.*",
+            role!="desktop"
+          } == 1
+        for: 20m
+        labels:
+          severity: critical
+        annotations:
+          summary: "GitHub runner {{ $labels.name }} is stuck FAILED on {{ $labels.hostname }}"
+          description: >-
+            {{ $labels.name }} has been failed for over 20 minutes, so the
+            github-runner-watchdog timer has already tried and failed to
+            restart it. Check `journalctl -u {{ $labels.name }}` and
+            `journalctl -u github-runner-watchdog`.
+
+      # Every runner on a host down at once. Distinct from the per-unit rule
+      # above because this is the state where CI stops moving entirely
+      # rather than losing one slot of capacity.
+      #
+      # Summing the "active" series rather than counting matching units
+      # matters: node_systemd_unit_state emits a series per (unit, state)
+      # with a 0/1 value, so the active series still exists (as 0) for a
+      # down runner. A `count(... == 1) == 0` formulation would produce an
+      # empty result and could never fire.
+      - alert: GitHubRunnersAllDown
+        expr: |
+          sum by (hostname) (
+            node_systemd_unit_state{state="active", name=~"github-runner-runner-.*"}
+          ) == 0
+        for: 20m
+        labels:
+          severity: critical
+        annotations:
+          summary: "All GitHub runners are down on {{ $labels.hostname }}"
+          description: >-
+            No github-runner unit on {{ $labels.hostname }} has been active
+            for 20 minutes. Self-hosted CI for this platform is stalled and
+            the watchdog has not recovered it.
 
   - name: container-alerts
     rules:

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -896,3 +896,101 @@ tests:
       - eval_time: 25h
         alertname: TailscaleAuthKeyExpiringSoon
         exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # GitHub runner self-healing rules
+  #
+  # These encode the division of labour introduced with the watchdog timer in
+  # modules/services/github-runners.nix: runner units repair themselves within
+  # 15 minutes, so the generic SystemdUnitFailed rule deliberately ignores them
+  # and GitHubRunnerFailed waits 20m to page only for a failure the watchdog
+  # could not fix. Both halves of that are asserted below, because getting the
+  # exclusion right in one rule and wrong in the other reintroduces exactly the
+  # 2-minute page storm it was meant to remove.
+  # ---------------------------------------------------------------------------
+
+  - interval: 1m
+    name: SystemdUnitFailed ignores runner units but still covers the watchdog
+    input_series:
+      - series: 'node_systemd_unit_state{state="failed", name="github-runner-runner-3.service", hostname="fredhub", role="agent"}'
+        values: "1+0x200"
+      - series: 'node_systemd_unit_state{state="failed", name="github-runner-watchdog.service", hostname="fredhub", role="agent"}'
+        values: "1+0x200"
+    alert_rule_test:
+      # The runner is the watchdog's job, not this rule's.
+      # The watchdog itself has no minder, so it must still page here.
+      - eval_time: 30m
+        alertname: SystemdUnitFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              state: failed
+              name: github-runner-watchdog.service
+              hostname: fredhub
+              role: agent
+            exp_annotations:
+              summary: "Systemd unit github-runner-watchdog.service FAILED on fredhub"
+              description: "The unit github-runner-watchdog.service has been in a failed state for >2 minutes."
+
+  # A runner failure shorter than the watchdog's sweep is the transient case
+  # (GitHub API blip) and must stay silent.
+  - interval: 1m
+    name: GitHubRunnerFailed stays silent inside the watchdog's 15m window
+    input_series:
+      - series: 'node_systemd_unit_state{state="failed", name="github-runner-runner-3.service", hostname="fredhub", role="agent"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: GitHubRunnerFailed
+        exp_alerts: []
+
+  - interval: 1m
+    name: GitHubRunnerFailed fires once the watchdog has had its chance
+    input_series:
+      - series: 'node_systemd_unit_state{state="failed", name="github-runner-runner-3.service", hostname="fredhub", role="agent"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: GitHubRunnerFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              state: failed
+              name: github-runner-runner-3.service
+              hostname: fredhub
+              role: agent
+            exp_annotations:
+              summary: "GitHub runner github-runner-runner-3.service is stuck FAILED on fredhub"
+              description: "github-runner-runner-3.service has been failed for over 20 minutes, so the github-runner-watchdog timer has already tried and failed to restart it. Check `journalctl -u github-runner-runner-3.service` and `journalctl -u github-runner-watchdog`."
+
+  # One live runner is enough to keep CI moving, so the fleet-level rule must
+  # not fire just because some runners are between jobs.
+  - interval: 1m
+    name: GitHubRunnersAllDown stays silent while one runner is active
+    input_series:
+      - series: 'node_systemd_unit_state{state="active", name="github-runner-runner-1.service", hostname="fredhub", role="agent"}'
+        values: "0+0x200"
+      - series: 'node_systemd_unit_state{state="active", name="github-runner-runner-2.service", hostname="fredhub", role="agent"}'
+        values: "1+0x200"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: GitHubRunnersAllDown
+        exp_alerts: []
+
+  - interval: 1m
+    name: GitHubRunnersAllDown fires when every runner on the host is down
+    input_series:
+      - series: 'node_systemd_unit_state{state="active", name="github-runner-runner-1.service", hostname="fredhub", role="agent"}'
+        values: "0+0x200"
+      - series: 'node_systemd_unit_state{state="active", name="github-runner-runner-2.service", hostname="fredhub", role="agent"}'
+        values: "0+0x200"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: GitHubRunnersAllDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: fredhub
+            exp_annotations:
+              summary: "All GitHub runners are down on fredhub"
+              description: "No github-runner unit on fredhub has been active for 20 minutes. Self-hosted CI for this platform is stalled and the watchdog has not recovered it."

--- a/modules/services/attic/attic_server.nix
+++ b/modules/services/attic/attic_server.nix
@@ -15,8 +15,14 @@
   # copy the non root one to `.github/workflows/ci-linux.yaml`
   # attic login local http://localhost:8080 <token above>
   # attic cache create fred
-  # attic cache configure --retention-period "30 days" fred
   # attic cache configure fred --public
+  #
+  # Deliberately NOT run: `attic cache configure --retention-period ... fred`.
+  # Retention is set declaratively below via the server-wide default, so it
+  # survives the cache being destroyed and recreated. A per-cache value
+  # overrides the global default (attic coalesces cache.retention_period with
+  # the server default), so setting it by hand would silently take precedence
+  # over this file.
 
   sops.secrets = {
     "atticd_env" = { };
@@ -37,6 +43,60 @@
         min-size = 16 * 1024;
         avg-size = 64 * 1024;
         max-size = 256 * 1024;
+      };
+
+      garbage-collection = {
+        # NOT the upstream default of 12 hours, deliberately.
+        #
+        # Orphan chunk reaping is capped at 500 chunks per pass, hardcoded
+        # per database backend in attic's gc.rs (`DatabaseBackend::Sqlite
+        # => 500`, sized to SQLite's old 999-variable statement limit), and
+        # the reaper does NOT loop -- it deletes one batch and returns. So
+        # throughput is entirely a function of how often a pass runs:
+        #
+        #   capacity = 500 chunks x passes per day
+        #
+        # This cache produces roughly 16,000 orphan chunks/day (3.1M
+        # accumulated between 2026-01-27 and 2026-08-06). At the upstream
+        # 12h interval capacity is 1,000/day -- 16x short, so the backlog
+        # grows forever. That is exactly what happened: by 2026-08-06 there
+        # were 3,120,701 unreclaimed chunks holding ~82 GiB, on a 138 GiB
+        # store, and nothing had ever been reaped.
+        #
+        # 15 minutes gives 96 passes/day = 48,000 chunks/day, ~3x headroom.
+        # The per-pass cost is one full-table UPDATE over the chunk table
+        # (~1.0s at 4.9M rows, ~0.4s at 1.8M), so this is ~40s/day of write
+        # locking against the live daemon.
+        #
+        # To drain a large existing backlog, temporarily set this to "5s",
+        # deploy, watch `sudo du -sh /var/lib/atticd/storage` until it
+        # levels off, then restore. Do it while CI is quiet: the repeated
+        # write lock contends with pushes.
+        interval = "15 minutes";
+        #interval = "5s";
+
+        # Time-based expiry. Attic deletes an object only when BOTH its
+        # created_at and last_accessed_at are older than the cutoff, and
+        # last_accessed_at is bumped only when a client actually downloads
+        # the NAR (not on a bare .narinfo lookup). So this is "delete
+        # anything nothing has fetched in 30 days", not an LRU eviction:
+        # there is no size cap and nothing is freed early under disk
+        # pressure.
+        #
+        # Until this was set, default-retention-period was the upstream
+        # default of zero, which excludes every cache from time-based GC
+        # entirely.
+        #
+        # Interaction with the cache-warming jobs, worth knowing before
+        # shortening this:
+        #   - cache-flake-inputs.yaml pushes flake input sources. Cold CI
+        #     runners download every one of them on every job, so they are
+        #     bumped constantly and never expire.
+        #   - scripts/attic-push.sh pushes build closures. Those are only
+        #     downloaded when CI actually has to build something, so a
+        #     rarely used build dep can expire. That is fine: the next
+        #     build refetches it from cache.nixos.org and re-pushes it.
+        default-retention-period = "30 days";
       };
     };
   };

--- a/modules/services/github-runners.nix
+++ b/modules/services/github-runners.nix
@@ -48,11 +48,17 @@ let
       exit 0
     fi
 
+    # per_page=100 because the endpoint defaults to 30. fredhub alone now
+    # registers 8 and the Mac Studio 4, and stale entries accumulate on top
+    # of that, so a stale runner could land on page 2 and never be deleted --
+    # after which re-registration fails on the duplicate name. 100 covers the
+    # fleet with room to spare; full pagination would be ceremony for a
+    # 12-runner estate.
     if ! RUNNER_LIST="$(
       ${pkgs.curl}/bin/curl -sf --max-time 30 \
         -H "Authorization: token $TOKEN" \
         -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/$REPO/actions/runners"
+        "https://api.github.com/repos/$REPO/actions/runners?per_page=100"
     )"; then
       echo "WARNING: could not list runners (GitHub API unreachable or erroring);" \
            "skipping cleanup for $RUNNER_NAME" >&2

--- a/modules/services/github-runners.nix
+++ b/modules/services/github-runners.nix
@@ -13,35 +13,150 @@ let
   hostname = config.networking.hostName;
   isLinux = !isDarwin;
 
-  # Cleanup helper: delete runner by name before (re)registering
+  # Cleanup helper: delete runner by name before (re)registering.
+  #
+  # This runs as ExecStartPre, so ANY non-zero exit here fails the unit --
+  # and upstream's restart policy does not cover that. nixpkgs sets
+  # `Restart = if ephemeral then "on-success" else "no"` plus
+  # `RestartForceExitStatus = [ 2 ]`, i.e. it restarts on a clean exit
+  # (job finished, runner deregistered) and on the runner binary's own
+  # retryable exit code 2. An ExecStartPre failure is neither, so the unit
+  # lands in `failed` and stays there until someone intervenes.
+  #
+  # That is exactly what happened during the 2026-08-06 GitHub outage:
+  #
+  #   github-runner-cleanup: Deleting stale GitHub runner: ...-runner-3
+  #   systemd: Control process exited, code=exited, status=22/n/a
+  #   systemd: Failed with result 'exit-code'
+  #
+  # status 22 is curl's "HTTP error returned" from `-f`. The GitHub API
+  # returned 5xx, `set -e` aborted, and the runner was dead for hours.
+  #
+  # Deleting a stale registration is best-effort housekeeping: if it fails,
+  # the worst case is that registration later rejects a duplicate name and
+  # the runner exits 2, which upstream DOES restart. So every API failure
+  # here is a warning, never fatal. The script always exits 0.
   cleanupRunner = pkgs.writeShellScriptBin "github-runner-cleanup" ''
-    set -euo pipefail
+    set -uo pipefail
 
     RUNNER_NAME="$1"
     TOKEN_FILE="$2"
     REPO="$3"
 
-    TOKEN="$(cat "$TOKEN_FILE")"
+    if ! TOKEN="$(cat "$TOKEN_FILE")"; then
+      echo "WARNING: cannot read $TOKEN_FILE; skipping stale-runner cleanup" >&2
+      exit 0
+    fi
 
-    RUNNER_ID="$(
-      ${pkgs.curl}/bin/curl -sf \
+    if ! RUNNER_LIST="$(
+      ${pkgs.curl}/bin/curl -sf --max-time 30 \
         -H "Authorization: token $TOKEN" \
         -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/$REPO/actions/runners" \
+        "https://api.github.com/repos/$REPO/actions/runners"
+    )"; then
+      echo "WARNING: could not list runners (GitHub API unreachable or erroring);" \
+           "skipping cleanup for $RUNNER_NAME" >&2
+      exit 0
+    fi
+
+    RUNNER_ID="$(
+      printf '%s' "$RUNNER_LIST" \
       | ${pkgs.jq}/bin/jq -r --arg NAME "$RUNNER_NAME" '
           .runners[] | select(.name == $NAME) | .id
         '
-    )"
+    )" || RUNNER_ID=""
 
-    if [ -n "$RUNNER_ID" ]; then
-      echo "Deleting stale GitHub runner: $RUNNER_NAME (id=$RUNNER_ID)"
-      ${pkgs.curl}/bin/curl -sf -X DELETE \
-        -H "Authorization: token $TOKEN" \
-        -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/$REPO/actions/runners/$RUNNER_ID"
-    else
+    if [ -z "$RUNNER_ID" ]; then
       echo "No stale runner named $RUNNER_NAME"
+      exit 0
     fi
+
+    echo "Deleting stale GitHub runner: $RUNNER_NAME (id=$RUNNER_ID)"
+
+    if ! ${pkgs.curl}/bin/curl -sf --max-time 30 -X DELETE \
+      -H "Authorization: token $TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/$REPO/actions/runners/$RUNNER_ID"; then
+      echo "WARNING: failed to delete stale runner $RUNNER_NAME (id=$RUNNER_ID);" \
+           "continuing -- registration will surface a genuine conflict as exit 2" >&2
+    fi
+
+    exit 0
+  '';
+
+  # Watchdog: restart github-runner units that are sitting in `failed`.
+  #
+  # Linux only, and deliberately a belt-and-braces measure rather than the
+  # primary fix -- the primary fix is cleanupRunner above no longer failing
+  # the unit on a GitHub API hiccup. This catches everything else that can
+  # strand a runner outside upstream's restart policy (`on-success` plus
+  # `RestartForceExitStatus = [ 2 ]`), including a tripped start-rate limit
+  # (StartLimitBurst=5 within 10s), which leaves a unit failed permanently.
+  #
+  # Darwin needs no equivalent: launchd.daemons use `KeepAlive = true`,
+  # which respawns unconditionally regardless of exit status, throttled to
+  # one attempt per ThrottleInterval (30s).
+  #
+  # Restarts ONLY units in the failed state. An inactive-but-not-failed
+  # runner is mid-cycle (ephemeral runners exit and are restarted between
+  # jobs) and must not be touched.
+  runnerWatchdog = pkgs.writeShellScriptBin "github-runner-watchdog" ''
+    set -uo pipefail
+
+    SELF="github-runner-watchdog.service"
+    TEXTFILE_DIR=/var/lib/node_exporter/textfiles
+    failed=0
+    recovered=0
+
+    units="$(
+      ${pkgs.systemd}/bin/systemctl list-units --all --plain --no-legend \
+        --type=service 'github-runner-*.service' 2>/dev/null \
+      | ${pkgs.gawk}/bin/awk '{print $1}'
+    )" || units=""
+
+    for unit in $units; do
+      # Never act on ourselves; that is how you write a restart loop.
+      [ "$unit" = "$SELF" ] && continue
+
+      ${pkgs.systemd}/bin/systemctl is-failed --quiet "$unit" || continue
+
+      failed=$((failed + 1))
+      echo "watchdog: $unit is in failed state; resetting and restarting"
+
+      ${pkgs.systemd}/bin/systemctl reset-failed "$unit" || true
+
+      if ${pkgs.systemd}/bin/systemctl start "$unit"; then
+        recovered=$((recovered + 1))
+        echo "watchdog: $unit restarted"
+      else
+        echo "watchdog: $unit FAILED to restart" >&2
+      fi
+    done
+
+    if [ "$failed" -eq 0 ]; then
+      echo "watchdog: no failed runner units"
+    fi
+
+    # Surface to prometheus. The alert rules key off the systemd collector's
+    # node_systemd_unit_state rather than these, but "how often did the
+    # watchdog have to intervene" is the signal that something is wrong
+    # underneath, as opposed to a one-off blip.
+    if [ -w "$TEXTFILE_DIR" ]; then
+      tmp="$TEXTFILE_DIR/.github_runner_watchdog.prom.$$"
+      {
+        echo "# HELP github_runner_watchdog_failed_units Runner units found in failed state on the last watchdog sweep."
+        echo "# TYPE github_runner_watchdog_failed_units gauge"
+        echo "github_runner_watchdog_failed_units $failed"
+        echo "# HELP github_runner_watchdog_recovered_units Runner units successfully restarted on the last watchdog sweep."
+        echo "# TYPE github_runner_watchdog_recovered_units gauge"
+        echo "github_runner_watchdog_recovered_units $recovered"
+        echo "# HELP github_runner_watchdog_last_run_timestamp_seconds Unix time of the last watchdog sweep."
+        echo "# TYPE github_runner_watchdog_last_run_timestamp_seconds gauge"
+        echo "github_runner_watchdog_last_run_timestamp_seconds $(${pkgs.coreutils}/bin/date +%s)"
+      } > "$tmp" && mv -f "$tmp" "$TEXTFILE_DIR/github_runner_watchdog.prom"
+    fi
+
+    exit 0
   '';
 
   # Darwin: wrapper script that does cleanup → configure → run for one runner.
@@ -297,7 +412,34 @@ in
         mkMerge [
           autoRunnerServices
           customRunnerServices
+          {
+            github-runner-watchdog = {
+              description = "Restart GitHub Actions runners stuck in the failed state";
+              serviceConfig = {
+                Type = "oneshot";
+                ExecStart = "${runnerWatchdog}/bin/github-runner-watchdog";
+              };
+            };
+          }
         ];
+
+      # Sweep every 15 minutes. The window matters for the alert rules: the
+      # GitHubRunnerUnitFailed alert waits 20m precisely so it only fires
+      # for a runner the watchdog has already had a chance to fix and
+      # could not, rather than for every transient failure.
+      systemd.timers.github-runner-watchdog = {
+        description = "Periodic sweep for failed GitHub Actions runners";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          # Give the runners a chance to register before the first sweep.
+          OnBootSec = "5m";
+          OnUnitActiveSec = "15m";
+          # Catch up after the host has been off, rather than waiting a
+          # full interval.
+          Persistent = true;
+          RandomizedDelaySec = "30s";
+        };
+      };
     }
 
     # ── Darwin (launchd) ─────────────────────────────────────────────

--- a/overlays/apple-fonts.nix
+++ b/overlays/apple-fonts.nix
@@ -1,0 +1,157 @@
+# Apple's San Francisco / New York font families, packaged from Apple's
+# developer-download dmgs.
+#
+# Why this is vendored instead of using github:Lyndeno/apple-fonts.nix
+# (dropped as a flake input on 2026-08-06):
+#
+# Upstream models each dmg as a `flake = false` flake *input*. Apple
+# serves those dmgs from a single mutable CDN path -- no version in the
+# URL, no history kept -- so any re-publish silently invalidates the
+# narHash pinned in flake.lock. Flake inputs are materialised during
+# *evaluation*, which makes that mismatch a hard eval error rather than
+# a build error: on 2026-08-06 Apple re-uploaded SF-Pro.dmg 86 bytes
+# larger and every desktop eval, plus the fleet-manifest job, failed
+# until the input was bumped.
+#
+# `fetchurl` is a fixed-output derivation instead. Evaluation needs only
+# the hash *string* and never the bytes; the bytes are fetched at build
+# time and only on a cache miss, which does not happen because the
+# patched font output lives in Attic. Apple can re-publish whenever it
+# likes and nothing breaks -- we bump the hash when we choose. A stale
+# hash here is not an outage.
+#
+# .github/workflows/update-apple-fonts.yaml watches the CDN ETags and
+# opens the bump PR when a family actually changes.
+#
+# Bumping a hash by hand:
+#   nix store prefetch-file --json --name SF-Pro.dmg \
+#     https://devimages-cdn.apple.com/design/resources/download/SF-Pro.dmg
+#
+# Each family yields two attributes: the plain fonts (`sf-pro`) and the
+# Nerd Fonts-patched variant (`sf-pro-nerd`). Both are lazy, so a family
+# that nothing references is never fetched or built.
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  p7zip,
+  parallel,
+  nerd-font-patcher,
+}:
+let
+  baseUrl = "https://devimages-cdn.apple.com/design/resources/download";
+
+  # `file`    -- basename on Apple's CDN.
+  # `pkgName` -- the installer payload inside the dmg.
+  # `hash`    -- flat sha256 of the dmg (see prefetch command above).
+  families = {
+    sf-pro = {
+      file = "SF-Pro.dmg";
+      pkgName = "SF Pro Fonts.pkg";
+      hash = "sha256-qQlPDem3idc1RO5Q/FKgiE1Kn3/PYt5Sl04yBPOnSmI=";
+      description = "Apple SF Pro, the San Francisco system typeface";
+    };
+
+    sf-compact = {
+      file = "SF-Compact.dmg";
+      pkgName = "SF Compact Fonts.pkg";
+      hash = "sha256-LIkAOWe+WaaGeqXeEgZjUtmmtEt4XPK5/4jvDXf/KPw=";
+      description = "Apple SF Compact, the narrow San Francisco variant";
+    };
+
+    sf-mono = {
+      file = "SF-Mono.dmg";
+      pkgName = "SF Mono Fonts.pkg";
+      hash = "sha256-bUoLeOOqzQb5E/ZCzq0cfbSvNO1IhW1xcaLgtV2aeUU=";
+      description = "Apple SF Mono, the monospaced San Francisco variant";
+    };
+
+    ny = {
+      file = "NY.dmg";
+      pkgName = "NY Fonts.pkg";
+      hash = "sha256-HC7ttFJswPMm+Lfql49aQzdWR2osjFYHJTdgjtuI+PQ=";
+      description = "Apple New York, the serif companion to San Francisco";
+    };
+  };
+
+  mkFont =
+    name: nerd:
+    let
+      family = families.${name};
+    in
+    stdenvNoCC.mkDerivation {
+      name = if nerd then "${name}-nerd" else name;
+
+      src = fetchurl {
+        url = "${baseUrl}/${family.file}";
+        inherit (family) hash;
+      };
+
+      nativeBuildInputs = [
+        p7zip
+      ]
+      ++ lib.optionals nerd [
+        parallel
+        nerd-font-patcher
+      ];
+
+      # The dmg contains an installer .pkg, which in turn contains a cpio
+      # archive named `Payload~`. Three unpacks to reach the font files.
+      unpackPhase = ''
+        runHook preUnpack
+        7z x "$src"
+        7z x './*/${family.pkgName}'
+        7z x 'Payload~'
+        runHook postUnpack
+      '';
+
+      setSourceRoot = "sourceRoot=$(pwd)";
+
+      # nerd-font-patcher writes each patched face into the working
+      # directory, leaving the originals in the unpacked subtree. That is
+      # what lets installPhase below select patched faces with -maxdepth 1.
+      buildPhase = lib.optionalString nerd ''
+        runHook preBuild
+        find \( -name \*.ttf -o -name \*.otf \) -print0 \
+          | parallel --will-cite -j "$NIX_BUILD_CORES" -0 \
+              nerd-font-patcher --no-progressbars -c {}
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out/share/fonts/opentype" "$out/share/fonts/truetype"
+      ''
+      + (
+        if nerd then
+          ''
+            find -maxdepth 1 -name \*.otf -exec mv {} "$out/share/fonts/opentype/" \;
+            find -maxdepth 1 -name \*.ttf -exec mv {} "$out/share/fonts/truetype/" \;
+          ''
+        else
+          ''
+            find -name \*.otf -exec mv {} "$out/share/fonts/opentype/" \;
+            find -name \*.ttf -exec mv {} "$out/share/fonts/truetype/" \;
+          ''
+      )
+      + ''
+        runHook postInstall
+      '';
+
+      meta = {
+        inherit (family) description;
+        homepage = "https://developer.apple.com/fonts/";
+        # Apple's font licence permits use but not redistribution, so
+        # these are unfree. features/desktop/fonts lists the names it
+        # installs in nixpkgs.config.allowUnfreePredicate.
+        license = lib.licenses.unfree;
+        platforms = lib.platforms.all;
+      };
+    };
+in
+lib.listToAttrs (
+  lib.concatMap (name: [
+    (lib.nameValuePair name (mkFont name false))
+    (lib.nameValuePair "${name}-nerd" (mkFont name true))
+  ]) (lib.attrNames families)
+)

--- a/overlays/attic-server.nix
+++ b/overlays/attic-server.nix
@@ -1,0 +1,57 @@
+# FIXME(attic-gc-sqlite-chunk-limit): WORKAROUND, not a fix.
+#
+# attic's orphan-chunk reaper deletes at most `orphan_chunk_limit` chunks
+# per garbage-collection pass and then RETURNS -- there is no drain loop
+# (server/src/gc.rs, `run_reap_orphan_chunks`). For SQLite that limit is
+# hardcoded to 500:
+#
+#   sea_orm::DatabaseBackend::Sqlite => 500,
+#   // Default statement limit imposed by sqlite:
+#   // https://www.sqlite.org/limits.html#max_variable_number
+#
+# The limit exists because the subsequent `DELETE FROM chunk WHERE id IN
+# (?, ?, ...)` binds one variable per chunk. But the cited ceiling is
+# SQLite's PRE-3.32 default of 999, obsolete since 2020. The SQLite
+# actually compiled into this binary reports:
+#
+#   sqlite version       3.46.0
+#   MAX_VARIABLE_NUMBER  32766
+#
+# so upstream is leaving ~65x on the table.
+#
+# Why this matters here rather than being cosmetic: throughput is
+# `limit x passes/day`, and each pass first runs a full-table UPDATE over
+# the chunk table (~1s at 4.9M rows) to mark new orphans. At 500/pass
+# that fixed cost is paid per 500 chunks. This cache accumulated
+# 3,120,701 unreclaimed chunks holding ~82 GiB of a 138 GiB store, and at
+# the upstream default 12h interval it would have needed ~8.5 years to
+# drain. See the interval rationale in
+# modules/services/attic/attic_server.nix.
+#
+# 10,000 keeps 3x headroom under 32,766 while amortising the per-pass
+# table scan over 20x more work.
+#
+# Revert: once upstream raises the SQLite limit or (better) makes the
+# reaper loop until drained, delete this overlay, its entry in
+# overlays/default.nix, and this FIXME. Confirm with
+# `nix build .#nixosConfigurations.fredhub.config.system.build.toplevel`
+# and check a GC pass still reports sane `Deleted N orphan chunks`.
+# See .github/workflows/track-upstream-fixes.yaml.
+#
+# Usage in overlays/default.nix:
+#   attic-server = final.callPackage ./attic-server.nix {
+#     inherit (prev) attic-server;
+#   };
+{
+  attic-server,
+}:
+attic-server.overrideAttrs (
+  _finalAttrs: prevAttrs: {
+    postPatch = (prevAttrs.postPatch or "") + ''
+      substituteInPlace server/src/gc.rs \
+        --replace-fail \
+          'sea_orm::DatabaseBackend::Sqlite => 500,' \
+          'sea_orm::DatabaseBackend::Sqlite => 10000,'
+    '';
+  }
+)

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -15,6 +15,12 @@
 #   derivation ...
 
 final: prev: {
+  # Apple's SF / New York families, vendored rather than pulled from the
+  # apple-fonts flake input. See overlays/apple-fonts.nix for why (short
+  # version: Apple mutates the dmg URLs in place, which breaks *evaluation*
+  # when they are flake inputs but is harmless for a fetchurl FOD).
+  apple-fonts = final.callPackage ./apple-fonts.nix { };
+
   cider3 = final.callPackage ./cider.nix { };
 
   # Pin opencode to the latest upstream release rather than nixpkgs'

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -21,6 +21,13 @@ final: prev: {
   # when they are flake inputs but is harmless for a fetchurl FOD).
   apple-fonts = final.callPackage ./apple-fonts.nix { };
 
+  # Raise attic's hardcoded 500-chunk-per-GC-pass SQLite limit. See
+  # overlays/attic-server.nix for the full rationale and the revert
+  # condition (FIXME id: attic-gc-sqlite-chunk-limit).
+  attic-server = final.callPackage ./attic-server.nix {
+    inherit (prev) attic-server;
+  };
+
   cider3 = final.callPackage ./cider.nix { };
 
   # Pin opencode to the latest upstream release rather than nixpkgs'

--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -38,7 +38,7 @@ opencode.overrideAttrs (
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {
       inherit version src;
-      outputHash = "sha256-3BrsXBSchRXPoqJif7GXSLD8NW2VuSIL0kgOj8IUmq8=";
+      outputHash = "sha256-GBLs3nXtfSeXb4jXxSNM8ElMa/e/EB4sZn3c2inHnco=";
     });
   }
 )

--- a/profiles/darwin.nix
+++ b/profiles/darwin.nix
@@ -93,7 +93,23 @@
         rrdtool
       ];
 
-      programs.firefox.enable = true;
+      # No programs.firefox here on purpose.
+      #
+      # It was a bare `enable = true` with no settings, extensions or
+      # policies -- purely "install a browser" -- and nixpkgs' firefox on
+      # darwin is a full Gecko source build. That is only substitutable
+      # when Hydra's aarch64-darwin builders have caught up with the
+      # nixpkgs pin, which they routinely have not: as of 2026-08-06 the
+      # newest firefox-unwrapped built for aarch64-darwin was 153.0.1
+      # while x86_64-linux was already on 153.0.3, so a freshly bumped
+      # pin meant compiling Firefox from source on the Mac.
+      #
+      # Paying hours of build time for a browser nobody here uses, with
+      # zero declarative configuration to show for it, is a bad trade.
+      # If it is ever wanted back, `homebrew.casks` in
+      # modules/services/homebrew.nix is the native answer on macOS --
+      # the linux desktops keep the real, configured firefox via
+      # features/desktop/firefox, which is unaffected by this.
     };
 
   fonts = {

--- a/scripts/attic-push.sh
+++ b/scripts/attic-push.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Push built results to the Attic binary cache, including the build-time
+# closure -- not just the runtime closure.
+#
+# Why the build closure matters
+# -----------------------------
+# `attic push fred result` pushes the *runtime* closure: exactly what a
+# host needs to activate a generation. It does not push the paths that
+# were needed to *produce* it (stdenv, compilers, unpacked sources).
+#
+# The self-hosted runners start each job with a cold store, so every CI
+# build re-fetches those build inputs from cache.nixos.org over the
+# internet, when they could come off the LAN. Measured on maranello:
+#
+#   runtime closure        4,279 paths   43.2 GiB
+#   build closure outputs  6,761 paths   58.6 GiB
+#   build-only delta       2,482 paths   15.4 GiB
+#
+# +36% of disk to stop paying internet latency on every build. The first
+# push is the expensive one; afterwards Attic already holds the paths and
+# `attic push` skips them.
+#
+# .drv files are deliberately excluded. They are store paths, so they
+# *can* be pushed, but they are useless in a binary cache: any machine
+# that evaluates the flake regenerates them byte-identically. That skips
+# ~28,700 paths per host for ~0.1 GiB of no benefit.
+#
+# Paths that are not valid locally are filtered out too. CI usually
+# substitutes most of a closure rather than building it, so
+# `--include-outputs` happily names outputs this machine never realised;
+# handing those to `attic push` would fail the job.
+#
+# Usage (from the repository root, so `nix shell --inputs-from .` works):
+#   scripts/attic-push.sh result
+#   scripts/attic-push.sh result-a result-b
+#
+# Environment:
+#   ATTIC_CACHE        cache name (default: fred)
+#   ATTIC_JOBS         parallel upload jobs (default: 2)
+#   ATTIC_PUSH_DRY_RUN if set to 1, print what would be pushed instead
+
+set -euo pipefail
+
+CACHE="${ATTIC_CACHE:-fred}"
+JOBS="${ATTIC_JOBS:-2}"
+DRY_RUN="${ATTIC_PUSH_DRY_RUN:-0}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <result> [result...]" >&2
+  exit 1
+fi
+
+# Wrapper so the attic-client invocation lives in exactly one place.
+attic_push() {
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "  [dry-run] would push $# path(s)"
+    return 0
+  fi
+
+  nix shell --inputs-from . nixpkgs#attic-client --command \
+    attic push "$CACHE" --ignore-upstream-cache-filter -j "$JOBS" "$@"
+}
+
+# Push a newline-separated file of store paths, batching via xargs so a
+# 30k-path argument list cannot blow the command-line limit.
+attic_push_file() {
+  local file="$1"
+
+  if [ ! -s "$file" ]; then
+    echo "  nothing new to push"
+    return 0
+  fi
+
+  echo "  pushing $(wc -l <"$file") path(s)"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    return 0
+  fi
+
+  xargs -r -a "$file" nix shell --inputs-from . nixpkgs#attic-client --command \
+    attic push "$CACHE" --ignore-upstream-cache-filter -j "$JOBS"
+}
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+# Runtime closures first, in a single attic invocation. Callers can pass
+# a lot of paths (the flake-input archive job passes ~90), and each
+# `nix shell ... --command attic` costs a couple of seconds to start.
+echo "==> pushing runtime closure of $# path(s)"
+attic_push "$@"
+
+: >"$workdir/all"
+
+for result in "$@"; do
+  deriver="$(nix-store --query --deriver "$result" 2>/dev/null || true)"
+
+  # Flake input sources and other non-derivation paths have no deriver.
+  # Their runtime push above is all there is to do.
+  if [ -z "$deriver" ] || [ ! -e "$deriver" ]; then
+    continue
+  fi
+
+  # Every output reachable from the derivation graph, minus the .drv
+  # files themselves.
+  nix-store --query --requisites --include-outputs "$deriver" \
+    | grep -v '\.drv$' >>"$workdir/all"
+done
+
+sort -u -o "$workdir/all" "$workdir/all"
+
+if [ -s "$workdir/all" ]; then
+  echo "==> pushing build closure"
+
+  # Outputs this machine never realised (substituted parents, unbuilt
+  # branches). attic cannot push what does not exist.
+  xargs -r -a "$workdir/all" nix-store --check-validity --print-invalid \
+    2>/dev/null | sort -u >"$workdir/invalid" || true
+
+  comm -23 "$workdir/all" "$workdir/invalid" >"$workdir/push"
+
+  attic_push_file "$workdir/push"
+fi

--- a/scripts/attic-push.sh
+++ b/scripts/attic-push.sh
@@ -78,8 +78,15 @@ attic_push_file() {
     return 0
   fi
 
-  xargs -r -a "$file" nix shell --inputs-from . nixpkgs#attic-client --command \
-    attic push "$CACHE" --ignore-upstream-cache-filter -j "$JOBS"
+  # Feed the list on stdin rather than with `xargs -a`. `-a` is a GNU
+  # extension and this script runs on the darwin runners too, where BSD
+  # xargs rejects it outright:
+  #
+  #   xargs: invalid option -- a
+  #
+  # `-r` is fine on both.
+  xargs -r nix shell --inputs-from . nixpkgs#attic-client --command \
+    attic push "$CACHE" --ignore-upstream-cache-filter -j "$JOBS" <"$file"
 }
 
 workdir="$(mktemp -d)"
@@ -115,7 +122,7 @@ if [ -s "$workdir/all" ]; then
 
   # Outputs this machine never realised (substituted parents, unbuilt
   # branches). attic cannot push what does not exist.
-  xargs -r -a "$workdir/all" nix-store --check-validity --print-invalid \
+  xargs -r nix-store --check-validity --print-invalid <"$workdir/all" \
     2>/dev/null | sort -u >"$workdir/invalid" || true
 
   comm -23 "$workdir/all" "$workdir/invalid" >"$workdir/push"


### PR DESCRIPTION
Batched because GitHub Actions was unavailable for most of the day, so these
landed as one branch rather than five. Each commit is atomic and evals green
on its own. Also merges the four pending flake-update PRs (#2157, #2158,
#2159, #2155) — their revs are pinned exactly as reviewed, verified below.

## What's here

**`feat(ci): cache flake inputs and build closures in attic`**

CI cached outputs only. Two gaps: flake input sources were never cached (56
paths / 4.3 GiB, none in Attic — so a cold runner refetched ~90 sources per
job), and build-time closures were never cached (+2,482 paths / 15.4 GiB on
top of a 43.2 GiB runtime closure). The first is a correctness issue, not
just bandwidth: an input fetched from origin is hash-checked against
flake.lock, and a mismatch is a hard **evaluation** error — which is exactly
how Apple re-publishing SF-Pro.dmg 86 bytes larger took down every desktop
eval and the fleet-manifest job with nothing in this repo having changed.

Also fixes `http://192.168.31.14/fred` → `:8080` in five workflows. fredhub
has only ever opened 8080 (since b9f136a2) and nothing listens on 80, so that
substituter was dead everywhere. It was inert rather than harmful — the
runners are NixOS fleet hosts whose own nix.conf already has :8080 — but it
would start mattering the moment a runner isn't NixOS.

**`refactor(fonts): vendor apple fonts instead of the flake input`**

Moves Apple's dmgs from `flake = false` inputs (fetched at eval, hash-checked,
fatal on mismatch) to `fetchurl` FODs (hash string only at eval, bytes only on
a cache miss). Lock goes 99 → 87 nodes with **zero remaining mutable-URL
inputs**. Adds sf-compact-nerd and sf-mono-nerd since we now own the list.

**`fix(attic): set a GC interval that can keep up`** and
**`fix(attic): raise the sqlite orphan-chunk reap limit 500 → 10000`**

`default-retention-period` was never set, so it took upstream's default of
zero — which excludes the cache from time-based GC entirely. Nothing had been
reaped since 2026-01-27. Worse, orphan-chunk reaping is capped at 500/pass
with no drain loop, so throughput is `500 × passes/day`: 1,000/day at the 12h
default against ~16,000/day of orphan production. The backlog had reached
3,120,701 chunks / ~82 GiB of a 138 GiB store, needing ~8.5 years to drain.

Result: **138 GiB → 50 GiB, 88 GiB reclaimed (64%)**, leaving 46.1 GiB of
live content. The overlay measured 83 → 1,833 chunks/s (22x).

**`feat(ci): self-heal github runners stranded by a failed ExecStartPre`**

Runners died in the outage and stayed dead — not a retry limit, *zero*
retries. Upstream restarts on clean exit and on the runner's own exit code 2;
an `ExecStartPre` failure is neither, and the cleanup helper this repo injects
is not something upstream knows about. `curl -sf` got a 5xx, `set -e` aborted,
unit dead. Cleanup is now non-fatal; a 15-minute watchdog restarts only
`failed` units as belt-and-braces. Darwin needs none — launchd already uses
`KeepAlive = true`. Alerting reshaped (not added): `SystemdUnitFailed` already
paged critical at 2 minutes for a condition that now self-heals in 15.
fredhub 4 → 8 runners.

**`fix(wayle): derive deploy state from the fleet manifest, not git`**

The widget compared the git checkout to upstream, wrong in both directions:
pulling without deploying went quiet, and any server-only commit lit up every
desktop. Now reads the `.prom` that `nixos-deploy-state-metric` already
produces from `/run/current-system` vs the per-host expected closure.

## Verification

- All 9 NixOS hosts + both darwin hosts eval with **zero** `evaluation warning:`
- home-manager activation evals for both desktops (home-manager input bumped)
- `checks.pre-commit-check` and `checks.prometheus-alert-rules` both pass
- New alert rules have promtool tests with firing **and** non-firing cases
- `scripts/attic-push.sh` shellcheck-clean; watchdog script built and executed
- Merged input revs verified identical to the PRs: nixpkgs `b7c2ada9`,
  nixpkgs-stable `445d861c`, home-manager `7834e825`, niri `73dd68bb`

## Follow-up

The attic overlay is registered in `tracked-upstream-fixes.json` but is
**BLOCKED with `min_version: null`** because it has not been reported upstream
yet — so the entry can never falsely resolve. Filing that issue (raise the
limit, or make the reaper loop) is the outstanding task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Apple SF Pro, SF Compact, SF Mono, and New York fonts, including Nerd Font variants.
  - Added automatic Apple font update checks.
  - Added automated caching of flake inputs and improved build artifact publishing.
  - Expanded build capacity and added automatic recovery for failed build runners.

- **Bug Fixes**
  - Improved deployment status reporting for drift, stale data, and unmanaged states.
  - Improved cache publishing reliability, retention, and cleanup.
  - Removed Firefox from the Darwin configuration.

- **Monitoring**
  - Added alerts when runners fail or all runners become unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->