### PR TITLE
chore(opencode): update overlay to v1.18.15

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -27,13 +27,13 @@
 }:
 opencode.overrideAttrs (
   _finalAttrs: prevAttrs: rec {
-    version = "1.18.14";
+    version = "1.18.15";
 
     src = fetchFromGitHub {
       owner = "anomalyco";
       repo = "opencode";
       tag = "v${version}";
-      hash = "sha256-Sxbchn8AuIcQaqfOT5QESk+rju6aryl4TZsiW4r7v0w=";
+      hash = "sha256-yUPwXDv93O0Ub/giX78FJyFxZyaUzSguDoK2y/YIPBM=";
     };
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {


### PR DESCRIPTION
Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated OpenCode to version 1.18.15.
  * Refreshed the associated source verification data for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->