### PR TITLE
chore(flake/nixpkgs-stable): `445d861c` -> `ee48b147`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -858,11 +858,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1785989512,
-        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
+        "lastModified": 1786089803,
+        "narHash": "sha256-ZuvZfVW2tB5tXYEcpcfhVXB3N4OhdZLOqOviy4OD4b4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
+        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`539169f8`](https://github.com/NixOS/nixpkgs/commit/539169f812d1e0b86f6905f7a4994cf0970fb21d) | `` linux_5_10: 5.10.263 -> 5.10.264 ``                                                |
| [`4fdd0cf8`](https://github.com/NixOS/nixpkgs/commit/4fdd0cf89d257f7b2d5a678f68aad17c34e09f4a) | `` linux_5_15: 5.15.214 -> 5.15.215 ``                                                |
| [`e011e41e`](https://github.com/NixOS/nixpkgs/commit/e011e41e54123177a23182d0cc625a2427ce1d04) | `` linux_6_1: 6.1.181 -> 6.1.182 ``                                                   |
| [`df2cfdde`](https://github.com/NixOS/nixpkgs/commit/df2cfdded297b7102da18e9e621b00ff67cf3429) | `` linux_6_6: 6.6.149 -> 6.6.150 ``                                                   |
| [`c565d309`](https://github.com/NixOS/nixpkgs/commit/c565d3091f3d511c5c47b036393980a3af02bdd2) | `` linux_6_12: 6.12.101 -> 6.12.102 ``                                                |
| [`0dbf1f71`](https://github.com/NixOS/nixpkgs/commit/0dbf1f71fdd429d4fa8c2a4645945fd81a6e7a29) | `` python3Packages.tpm2-pytss: 2.3.0 -> 3.0.0-rc1 ``                                  |
| [`8fb84250`](https://github.com/NixOS/nixpkgs/commit/8fb842502a6fc72bd2a62621c411a341e181f988) | `` google-chrome: 151.0.7922.75 -> 151.0.7922.108 ``                                  |
| [`130ee8f2`](https://github.com/NixOS/nixpkgs/commit/130ee8f2f12c10cfe87cdbbc2401d11e009e4482) | `` ungoogled-chromium: 151.0.7922.71-1 -> 151.0.7922.75-1 ``                          |
| [`9374fc07`](https://github.com/NixOS/nixpkgs/commit/9374fc07b368e04120946c87c24bf8477d5b9607) | `` linux_5_10: 5.10.262 -> 5.10.263 ``                                                |
| [`d405905f`](https://github.com/NixOS/nixpkgs/commit/d405905f9b4e8571a5dbf9a7aad9f01e60cd185c) | `` linux_5_15: 5.15.213 -> 5.15.214 ``                                                |
| [`d8a03d50`](https://github.com/NixOS/nixpkgs/commit/d8a03d507c7f9286e20875b4a4ac0c42c5a13a06) | `` linux_6_1: 6.1.180 -> 6.1.181 ``                                                   |
| [`224b9abe`](https://github.com/NixOS/nixpkgs/commit/224b9abe2e25e6d1adf94c2dc473d1f8caf88cca) | `` linux_6_6: 6.6.148 -> 6.6.149 ``                                                   |
| [`cfc0fb0c`](https://github.com/NixOS/nixpkgs/commit/cfc0fb0c66755de16c3ad38a8810e93766cf0e32) | `` linux_6_18: 6.18.42 -> 6.18.43 ``                                                  |
| [`6fece71c`](https://github.com/NixOS/nixpkgs/commit/6fece71c1dd871c8f43dfd7c122c58e77cb88e6b) | `` linux_7_1: 7.1.6 -> 7.1.7 ``                                                       |
| [`8d7fb945`](https://github.com/NixOS/nixpkgs/commit/8d7fb9450ead45837e9f0f9e832ebe164c5aba18) | `` vscode-extensions.anthropic.claude-code: 2.1.222 -> 2.1.223 ``                     |
| [`6834114c`](https://github.com/NixOS/nixpkgs/commit/6834114cf561a95a4710e6fdd5d8982f5925aa83) | `` claude-code: 2.1.222 -> 2.1.223 ``                                                 |
| [`c1cb4bbe`](https://github.com/NixOS/nixpkgs/commit/c1cb4bbe50b1871cc9431a9828fc73bde83addd4) | `` vscode-extensions.anthropic.claude-code: 2.1.221 -> 2.1.222 ``                     |
| [`8d8ee12e`](https://github.com/NixOS/nixpkgs/commit/8d8ee12e1ebe3a12e6079c788f9e9f1a671290d2) | `` claude-code: 2.1.221 -> 2.1.222 ``                                                 |
| [`1d00c039`](https://github.com/NixOS/nixpkgs/commit/1d00c03906a4d8247fffeb2fa4814268fb6464db) | `` vscode-extensions.anthropic.claude-code: 2.1.220 -> 2.1.221 ``                     |
| [`c9f90380`](https://github.com/NixOS/nixpkgs/commit/c9f903805fa199166f01b1e4fcf4d1644ac51f8b) | `` claude-code: 2.1.220 -> 2.1.221 ``                                                 |
| [`c6740b7c`](https://github.com/NixOS/nixpkgs/commit/c6740b7ce58ab8c86148e758bd8e9b8c7724fe10) | `` claude-code: 2.1.219 -> 2.1.220 ``                                                 |
| [`7a18fb16`](https://github.com/NixOS/nixpkgs/commit/7a18fb16edea9f6e887d33e7d28a24f3879541d5) | `` claude-code: allow easily overriding manifest ``                                   |
| [`21018484`](https://github.com/NixOS/nixpkgs/commit/21018484b994188d4dcc1a2188d52722a2420c5b) | `` claude-code: 2.1.218 -> 2.1.219 ``                                                 |
| [`dcbcf55a`](https://github.com/NixOS/nixpkgs/commit/dcbcf55a631abde8313143a13d5f4c1e93e7e360) | `` vscode-extensions.anthropic.claude-code: 2.1.217 -> 2.1.218 ``                     |
| [`6440094e`](https://github.com/NixOS/nixpkgs/commit/6440094ef0bd8d38a3fdda2fe31c11f3898c80d1) | `` claude-code: 2.1.217 -> 2.1.218 ``                                                 |
| [`acfd404c`](https://github.com/NixOS/nixpkgs/commit/acfd404cf437aad19fc77083335f6a3cd6cefc68) | `` vscode-extensions.anthropic.claude-code: 2.1.216 -> 2.1.217 ``                     |
| [`45be8705`](https://github.com/NixOS/nixpkgs/commit/45be8705f656ace547a089c6268897103d4227b7) | `` claude-code: 2.1.216 -> 2.1.217 ``                                                 |
| [`e5067d85`](https://github.com/NixOS/nixpkgs/commit/e5067d85624a8d78c02fab34bbfba027e23b6256) | `` vscode-extensions.anthropic.claude-code: 2.1.215 -> 2.1.216 ``                     |
| [`5113bd38`](https://github.com/NixOS/nixpkgs/commit/5113bd383858af76dae64d8e583ad14e15f0bac1) | `` claude-code: 2.1.215 -> 2.1.216 ``                                                 |
| [`11062c0c`](https://github.com/NixOS/nixpkgs/commit/11062c0cd9051371f009d8a99db648767739f076) | `` vscode-extensions.anthropic.claude-code: 2.1.214 -> 2.1.215 ``                     |
| [`c0e7727e`](https://github.com/NixOS/nixpkgs/commit/c0e7727ea5f2639414aafb80d98cc94c43346ef1) | `` claude-code: 2.1.214 -> 2.1.215 ``                                                 |
| [`e4aab21b`](https://github.com/NixOS/nixpkgs/commit/e4aab21baaed2bd4bf156aaf2c141ab25620ec3d) | `` vscode-extensions.anthropic.claude-code: 2.1.212 -> 2.1.214 ``                     |
| [`6e688ec9`](https://github.com/NixOS/nixpkgs/commit/6e688ec96f56779e03f71472e3e561a202836e3e) | `` claude-code: 2.1.212 -> 2.1.214 ``                                                 |
| [`9057e2ce`](https://github.com/NixOS/nixpkgs/commit/9057e2ce287add37c51949c9cf741c78a532e765) | `` vscode-extensions.anthropic.claude-code: 2.1.211 -> 2.1.212 ``                     |
| [`3c0fb001`](https://github.com/NixOS/nixpkgs/commit/3c0fb001ac487f79ce3a62d1e68cfffb18f30084) | `` claude-code: 2.1.211 -> 2.1.212 ``                                                 |
| [`bdc300dd`](https://github.com/NixOS/nixpkgs/commit/bdc300dded20ec80ba4dee5b51359574ed0d3f33) | `` vscode-extensions.anthropic.claude-code: 2.1.210 -> 2.1.211 ``                     |
| [`79962a6a`](https://github.com/NixOS/nixpkgs/commit/79962a6ac7090731d01c09afa1bf43b1c9d01ee6) | `` claude-code: 2.1.210 -> 2.1.211 ``                                                 |
| [`d6508a4a`](https://github.com/NixOS/nixpkgs/commit/d6508a4ae003560f0f857ece674b0c9bf22b750e) | `` vscode-extensions.anthropic.claude-code: 2.1.209 -> 2.1.210 ``                     |
| [`4ceed98e`](https://github.com/NixOS/nixpkgs/commit/4ceed98eca7854e2282568559926e5f0ad2d4133) | `` claude-code: 2.1.209 -> 2.1.210 ``                                                 |
| [`8ef619f2`](https://github.com/NixOS/nixpkgs/commit/8ef619f2ca36144e76b2fee7b474e36de0f7c0e7) | `` vscode-extensions.anthropic.claude-code: 2.1.207 -> 2.1.209 ``                     |
| [`fb4dd7df`](https://github.com/NixOS/nixpkgs/commit/fb4dd7df19403de9c43552adafb04f1994a83bcc) | `` claude-code: 2.1.207 -> 2.1.209 ``                                                 |
| [`13a5481a`](https://github.com/NixOS/nixpkgs/commit/13a5481a789ab2c31fe50cacf894cae6eaa78cbb) | `` vscode-extensions.anthropic.claude-code: 2.1.206 -> 2.1.207 ``                     |
| [`43688e5c`](https://github.com/NixOS/nixpkgs/commit/43688e5c95f79bd11dc35cbfc554c4f6a07d0016) | `` claude-code: 2.1.206 -> 2.1.207 ``                                                 |
| [`76f54425`](https://github.com/NixOS/nixpkgs/commit/76f544259f88484b5b3b42d0917b0307969d1cdf) | `` vscode-extensions.anthropic.claude-code: 2.1.205 -> 2.1.206 ``                     |
| [`2f29bcd9`](https://github.com/NixOS/nixpkgs/commit/2f29bcd9ae6b0ae7482d26b8bcdec450f323092e) | `` claude-code: 2.1.205 -> 2.1.206 ``                                                 |
| [`619e7ea2`](https://github.com/NixOS/nixpkgs/commit/619e7ea255463dd519899e0271c038eae430c4af) | `` vscode-extensions.anthropic.claude-code: 2.1.204 -> 2.1.205 ``                     |
| [`4690b139`](https://github.com/NixOS/nixpkgs/commit/4690b139c8668847f7c75135823fd2cc222bb09b) | `` claude-code: 2.1.204 -> 2.1.205 ``                                                 |
| [`0289beb4`](https://github.com/NixOS/nixpkgs/commit/0289beb40c9df398bb9986a45c8b6fd1b3aa91fc) | `` vscode-extensions.anthropic.claude-code: 2.1.202 -> 2.1.204 ``                     |
| [`b841b74d`](https://github.com/NixOS/nixpkgs/commit/b841b74d9d774de342fbff8bb8f1ce6b6dd07f45) | `` claude-code: 2.1.202 -> 2.1.204 ``                                                 |
| [`1a6227be`](https://github.com/NixOS/nixpkgs/commit/1a6227be7f858fb2d4d7b0726c28a85ddaa73629) | `` vscode-extensions.anthropic.claude-code: 2.1.201 -> 2.1.202 ``                     |
| [`26f959df`](https://github.com/NixOS/nixpkgs/commit/26f959df7c94d7389a480b2accc90d2710612767) | `` claude-code: 2.1.201 -> 2.1.202 ``                                                 |
| [`4ac38575`](https://github.com/NixOS/nixpkgs/commit/4ac38575d995b0eff6ec4945b290045d99829375) | `` vscode-extensions.anthropic.claude-code: 2.1.199 -> 2.1.201 ``                     |
| [`17c65c9b`](https://github.com/NixOS/nixpkgs/commit/17c65c9bf05739a65fc82721b89f90e0495ecafa) | `` claude-code: 2.1.199 -> 2.1.201 ``                                                 |
| [`1db87dfd`](https://github.com/NixOS/nixpkgs/commit/1db87dfd17a699bc2891f789122368152d40f6a1) | `` vscode-extensions.anthropic.claude-code: 2.1.198 -> 2.1.199 ``                     |
| [`dc334dce`](https://github.com/NixOS/nixpkgs/commit/dc334dce36908d01c170f6b1aa3f364fe8560269) | `` claude-code: 2.1.198 -> 2.1.199 ``                                                 |
| [`db2f2eb4`](https://github.com/NixOS/nixpkgs/commit/db2f2eb453ce662410c2d02bddcc2c837c5e51b1) | `` vscode-extensions.anthropic.claude-code: 2.1.197 -> 2.1.198 ``                     |
| [`b5486d99`](https://github.com/NixOS/nixpkgs/commit/b5486d99944a8fb696516ef64c6fde4731b7f4d5) | `` claude-code: 2.1.197 -> 2.1.198 ``                                                 |
| [`fda2865d`](https://github.com/NixOS/nixpkgs/commit/fda2865da58bd09a1f9e0fcf70d3c8c2643182ef) | `` vscode-extensions.anthropic.claude-code: 2.1.196 -> 2.1.197 ``                     |
| [`004198d6`](https://github.com/NixOS/nixpkgs/commit/004198d63bd89fac3ac434da789424be92d94cad) | `` claude-code: 2.1.196 -> 2.1.197 ``                                                 |
| [`cf0d47d2`](https://github.com/NixOS/nixpkgs/commit/cf0d47d2d8d3b5cb8d428088134323b2f85b93e2) | `` vscode-extensions.anthropic.claude-code: 2.1.195 -> 2.1.196 ``                     |
| [`f00a93b4`](https://github.com/NixOS/nixpkgs/commit/f00a93b44b23f194ca56e8864ccf3d03bbf1fac9) | `` claude-code: 2.1.195 -> 2.1.196 ``                                                 |
| [`7972ac0a`](https://github.com/NixOS/nixpkgs/commit/7972ac0a0883b1acb14f806d4273629c6b07399d) | `` vscode-extensions.anthropic.claude-code: 2.1.193 -> 2.1.195 ``                     |
| [`2cc76837`](https://github.com/NixOS/nixpkgs/commit/2cc76837a4cf4029e71abca6e37978df6f085fa4) | `` claude-code: 2.1.193 -> 2.1.195 ``                                                 |
| [`903740e8`](https://github.com/NixOS/nixpkgs/commit/903740e8b3e6cee8a3e40a6e6da82c353a1b85d7) | `` vscode-extensions.anthropic.claude-code: 2.1.191 -> 2.1.193 ``                     |
| [`488abf86`](https://github.com/NixOS/nixpkgs/commit/488abf86bd580fb301afd1d2f2957438500cdf84) | `` claude-code: 2.1.191 -> 2.1.193 ``                                                 |
| [`2d3ae766`](https://github.com/NixOS/nixpkgs/commit/2d3ae766cefa4505850d64a4f39a7a76459480b5) | `` vscode-extensions.anthropic.claude-code: 2.1.187 -> 2.1.191 ``                     |
| [`5a4d7252`](https://github.com/NixOS/nixpkgs/commit/5a4d7252008270ff57dbb39e934566eb3020c72c) | `` claude-code: 2.1.187 -> 2.1.191 ``                                                 |
| [`987c8648`](https://github.com/NixOS/nixpkgs/commit/987c86487c713438d6d1a16ed3642746a8a2ecac) | `` vicinae: drop whispersofthedawn as maintainer ``                                   |
| [`ee21386a`](https://github.com/NixOS/nixpkgs/commit/ee21386a81d2a9d48ac4e795e7858efcadf227b3) | `` calls: add gnome team ``                                                           |
| [`d79f1c65`](https://github.com/NixOS/nixpkgs/commit/d79f1c6519496879af758b623e2bc49289cbfdf6) | `` calls: add GNOME update script ``                                                  |
| [`b45e4ac3`](https://github.com/NixOS/nixpkgs/commit/b45e4ac3d4578b5b6a7241a6f16094cc4974e244) | `` calls: 49.1.1 -> 50.0 ``                                                           |
| [`d9649552`](https://github.com/NixOS/nixpkgs/commit/d9649552066d19b1658bd22f6e53aa4b84f25df1) | `` calls: fix wrong appstream package being used ``                                   |
| [`18eb57d3`](https://github.com/NixOS/nixpkgs/commit/18eb57d3e5a1e807cddc7e58a209da312261a957) | `` calls: add changelog ``                                                            |
| [`1b4a1ca4`](https://github.com/NixOS/nixpkgs/commit/1b4a1ca49d315125631f9054125090df430831a0) | `` cosign: 3.0.6 -> 3.1.1 ``                                                          |
| [`b1fc5cdd`](https://github.com/NixOS/nixpkgs/commit/b1fc5cdda2d3129ab033523cfff20186cb699380) | `` python3Packages.mpv: ignore some flaky or timing sensitive tests ``                |
| [`dc6faca8`](https://github.com/NixOS/nixpkgs/commit/dc6faca8bb765bd222a24501e7b3ab8e88853e0a) | `` vikunja: 2.4.0 -> 2.5.0 ``                                                         |
| [`f9ce345c`](https://github.com/NixOS/nixpkgs/commit/f9ce345cedd3887835b27b8ff7fafb1c60fb25fd) | `` uutils-coreutils: 0.9.0 -> 0.10.0 ``                                               |
| [`9c67146e`](https://github.com/NixOS/nixpkgs/commit/9c67146eef60ae8537f2ec41747c72366dd34bbd) | `` nixos/hydra: Add zstd to hydra-server's PATH ``                                    |
| [`f7d85f7b`](https://github.com/NixOS/nixpkgs/commit/f7d85f7b37fdbce3afb9b4aec3f9b4e00cd7e576) | `` python3Packages.rq: disable racy test ``                                           |
| [`bb5d5952`](https://github.com/NixOS/nixpkgs/commit/bb5d595225091cbdad989ba29d8d378f6298234d) | `` archisteamfarm: 6.3.6.1 -> 6.3.8.4 ``                                              |
| [`46f59080`](https://github.com/NixOS/nixpkgs/commit/46f590803c89388583e4b79b3f8307b86ead892b) | `` vte: 0.84.0 -> 0.84.1 ``                                                           |
| [`35636033`](https://github.com/NixOS/nixpkgs/commit/35636033d5f168f7f47468bdebf3f5c21f8e0012) | `` jenkins: 2.568.1 -> 2.568.2 ``                                                     |
| [`796d30c0`](https://github.com/NixOS/nixpkgs/commit/796d30c05e03e1a13efeb453af71c83e60fafa7d) | `` livebook: 0.19.8 -> 0.19.9 ``                                                      |
| [`97b5e2fa`](https://github.com/NixOS/nixpkgs/commit/97b5e2fa6b5ba7cda75dd74a5ce5a940b6a462ec) | `` librewolf-unwrapped: disbaled MOZ_TELEMETRY_REPORTING ``                           |
| [`074e5237`](https://github.com/NixOS/nixpkgs/commit/074e5237aa62f0679fb3da17b420ed0b65bfd964) | `` buildMozillaMach: add support for extraPreConfigure ``                             |
| [`1c3ada29`](https://github.com/NixOS/nixpkgs/commit/1c3ada29fad27645bd07abd94534a563c1ba703e) | `` gnome-contacts: add glycin-loaders to buildInputs ``                               |
| [`17b25c40`](https://github.com/NixOS/nixpkgs/commit/17b25c40afdd3fae651eb97c818db44bbac49d20) | `` radicle-node-unstable: 1.10.0-rc.2 -> 1.10.0 ``                                    |
| [`d7bc0b7a`](https://github.com/NixOS/nixpkgs/commit/d7bc0b7a68e59d4529b82decd591a47c9f6182d6) | `` radicle-node: 1.9.1 -> 1.10.0 ``                                                   |
| [`6e0146d6`](https://github.com/NixOS/nixpkgs/commit/6e0146d60a00ba82dee5a4873cd9ed712398d956) | `` radicle-node-unstable: 1.10.0-rc.1 -> 1.10.0-rc.2 ``                               |
| [`f72b152d`](https://github.com/NixOS/nixpkgs/commit/f72b152dd5614ed9070626c30536ee5ce6f7969f) | `` radicle-node-unstable: 1.9.1 -> 1.10.0-rc.1 ``                                     |
| [`9a49e60e`](https://github.com/NixOS/nixpkgs/commit/9a49e60e28ffda4673edbcba393129c2dc69deb8) | `` nixos/security.wrappers: include CAP_LAST_CAP when raising ambient capabilities `` |
| [`299fc42c`](https://github.com/NixOS/nixpkgs/commit/299fc42cf2e62a2e6015c20185a36ab54fd3b14c) | `` gssdp_1_6: 1.6.5 -> 1.6.6 ``                                                       |
| [`01d6368f`](https://github.com/NixOS/nixpkgs/commit/01d6368f098bd2240b1765fad6ef78ed14277791) | `` gssdp_1_6: 1.6.4 -> 1.6.5, gupnp_1_6: 1.6.9 -> 1.6.10 ``                           |
| [`fbda0825`](https://github.com/NixOS/nixpkgs/commit/fbda0825810563d3315f2fad0de5430a45a24682) | `` spidermonkey_140: 140.11.0 -> 140.13.0 ``                                          |
| [`1f4d99e0`](https://github.com/NixOS/nixpkgs/commit/1f4d99e06dccc0cbf0637baa252ad1d29a21d0ab) | `` wrapGAppsHook: add tests for multiple outputs ``                                   |
| [`e4ef2291`](https://github.com/NixOS/nixpkgs/commit/e4ef22915f345072f5a0347fe165057e3c4ff9cc) | `` wrapGAppsHook: only wrap $outBin by default ``                                     |
| [`57fd2993`](https://github.com/NixOS/nixpkgs/commit/57fd2993312db4b657639865424fa54b8d523d5c) | `` wrapGAppsHook: make more bash variables local ``                                   |
| [`7257f49b`](https://github.com/NixOS/nixpkgs/commit/7257f49bf5de02118bdb5729e8cce3e3bb912a19) | `` audit: 4.2 -> 4.2.1 ``                                                             |
| [`d8e4c5f9`](https://github.com/NixOS/nixpkgs/commit/d8e4c5f970764f74531d023f37159bbb85fda65f) | `` nixos/tests/utmp: init ``                                                          |
| [`01f2caa1`](https://github.com/NixOS/nixpkgs/commit/01f2caa1f3bb70d27464aadffe272237d9417529) | `` luajit: update deprecated `substituteInPlace  --replace` ``                        |
| [`994517d5`](https://github.com/NixOS/nixpkgs/commit/994517d55a6d1ebf5cd94ab79a224f31940f7dc4) | `` imagemagick: 7.1.2-28 -> 7.1.2-29 ``                                               |
| [`e1f42c2d`](https://github.com/NixOS/nixpkgs/commit/e1f42c2de8bdf71c10a8ab9320c1eab642d210fa) | `` nodejs_24: 24.18.0 -> 24.18.1 ``                                                   |
| [`0a429786`](https://github.com/NixOS/nixpkgs/commit/0a42978653d4835e34eea806f1f63f3846af0432) | `` tpm2-tss: 4.1.3 -> 4.2.0 ``                                                        |
| [`f7d9866f`](https://github.com/NixOS/nixpkgs/commit/f7d9866fbe4f46048aaab0761a20b49aa6023e6d) | `` libssh2: remove SuperSandro2000 as maintainer ``                                   |
| [`e5a4bea0`](https://github.com/NixOS/nixpkgs/commit/e5a4bea09e735d27c650553960f35ee03e803989) | `` libssh2: patch CVE-2026-58050 and CVE-2026-58051 ``                                |
| [`a50f6160`](https://github.com/NixOS/nixpkgs/commit/a50f61604ca92f5d4deb911499538ac67261239d) | `` nixos-rebuild-ng: fix too long TMPDIR detection ``                                 |
| [`4cbd4585`](https://github.com/NixOS/nixpkgs/commit/4cbd458570173ed4ad0324e4f33e9c98256799d0) | `` musl: patch known vulnerabilities ``                                               |
| [`b08921be`](https://github.com/NixOS/nixpkgs/commit/b08921be9af8d4681b24689069d14af006e6f343) | `` wrapGAppsHook: prepare for structuredAttrs ``                                      |
| [`be63548e`](https://github.com/NixOS/nixpkgs/commit/be63548ec46229e8292a20738f754227c8c5ddbc) | `` imagemagick: 7.1.2-27 -> 7.1.2-28 ``                                               |
| [`4e914270`](https://github.com/NixOS/nixpkgs/commit/4e91427026d18b0b2fb1e46c845220bb816b319c) | `` coreutils: security patches ``                                                     |
| [`a7566828`](https://github.com/NixOS/nixpkgs/commit/a75668281e963298f71e915e9213747eff4605dd) | `` s2n-tls: 1.7.2 -> 1.7.6 ``                                                         |
| [`27d05580`](https://github.com/NixOS/nixpkgs/commit/27d055804421e2ac9ed9dcdda88abcb5b8803261) | `` javaPackages.compiler.openjdk21: 21.0.12+2 -> 21.0.12+8 ``                         |
| [`a734bf82`](https://github.com/NixOS/nixpkgs/commit/a734bf826cf6cb313fb295bba05aa9e4c76a284d) | `` audit: 4.1.4 -> 4.2 ``                                                             |
| [`6dd6ac57`](https://github.com/NixOS/nixpkgs/commit/6dd6ac57d3140e62b6ac471d12449e6a7dcc6f81) | `` libffiReal: add aduh95 as maintainer ``                                            |
| [`2ddcc20b`](https://github.com/NixOS/nixpkgs/commit/2ddcc20bd057729cf028446b0a76d2412b8a62f0) | `` libffiReal: 3.7.0 -> 3.7.1 ``                                                      |
| [`a9546b34`](https://github.com/NixOS/nixpkgs/commit/a9546b34ce174fda003a9497601f94b07417b6ac) | `` unbound: 1.25.1 -> 1.25.2 ``                                                       |
| [`b44e733b`](https://github.com/NixOS/nixpkgs/commit/b44e733b951f1f20cb32e3de3b7d1527611be7ff) | `` valkey: 9.1.0 -> 9.1.1 ``                                                          |
| [`5959eaf8`](https://github.com/NixOS/nixpkgs/commit/5959eaf885a5aee48d3639846c35f34f129eb27e) | `` libssh: 0.12.0 -> 0.12.1 ``                                                        |
| [`09c0ae7a`](https://github.com/NixOS/nixpkgs/commit/09c0ae7a368663a4161d7ff906997aa2d71aedea) | `` spidermonkey_140: 140.9.0 -> 140.11.0 ``                                           |
| [`a650d552`](https://github.com/NixOS/nixpkgs/commit/a650d5526e772b954ffe90abfaa4d9adcf1d9b6a) | `` llvmPackages_22: 22.1.5 -> 22.1.8 ``                                               |