### PR TITLE
feat: shared agent orchestration model (opt-in per repo)

### DIFF
--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -104,6 +104,20 @@ jobs:
                 flake_lock_changed=true ;;
               modules/*|profiles/*|home-profiles/*|dotfiles/*|overlays/*)
                 global=true ;;
+              .opencode/skills/*)
+                # Currently a no-op for darwin: Freds-MacBook-Pro sets
+                # `ai.opencode.enable = false` (NixOS/nix#15638 workaround)
+                # and Freds-Mac-Studio does not import the feature at all,
+                # so the skills tree reaches no darwin closure. Verified by
+                # diffing the toplevel drvPath with and without a skills
+                # change -- identical.
+                #
+                # Kept as an explicit case rather than left to fall through,
+                # because the moment opencode is re-enabled on darwin the
+                # tree lands in that host's home-manager closure and this
+                # must become `global=true`. An explicit case with this note
+                # is a breadcrumb; silence in the catch-all is a trap.
+                ;;
               features/*)
                 global=true ;;
               .github/renovate.json5)

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -106,6 +106,14 @@ jobs:
                 flake_lock_changed=true ;;
               modules/*|profiles/*|home-profiles/*|dotfiles/*|overlays/*)
                 global=true ;;
+              .opencode/skills/*)
+                # features/ai/opencode bakes this tree into every host's
+                # home-manager closure via `skillsSource`, so a skill edit
+                # changes activationPackage on all of them. Verified by
+                # diffing the activation drvPath with and without a skill
+                # change. Without this case it fell through to the
+                # catch-all and shipped with no host verification at all.
+                global=true ;;
               features/desktop/*)
                 desktop_global=true ;;
               features/*)

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -175,6 +175,12 @@ while IFS= read -r path; do
     modules/*|profiles/*|home-profiles/*|dotfiles/*|overlays/*)
       GLOBAL=1
       ;;
+    .opencode/skills/*)
+      # features/ai/opencode bakes this tree into every host's
+      # home-manager closure via `skillsSource`, so a skill edit changes
+      # activationPackage on all of them.
+      GLOBAL=1
+      ;;
     features/desktop/*)
       DESKTOP_GLOBAL=1
       ;;

--- a/.opencode/skills/shared/adopt-orchestration-model/SKILL.md
+++ b/.opencode/skills/shared/adopt-orchestration-model/SKILL.md
@@ -5,17 +5,38 @@ description: Use when migrating one of fred's repos onto the shared orchestratio
 
 # Adopting the shared orchestration model
 
-The shared skills in the nixos config repo
-(`agent-orchestration-protocol`, `autonomy-boundaries`,
-`plan-decomposition`, `parallel-work-isolation`, `module-cohesion`,
-`state-representation`) are installed on every machine and available in
-every repo. But they only take effect where a repo's `agents.md` does
-not contradict them.
+The shared skills (`agent-orchestration-protocol`,
+`autonomy-boundaries`, `plan-decomposition`,
+`parallel-work-isolation`, `module-cohesion`, `state-representation`)
+are installed at `~/.config/opencode/skills/` on every machine.
 
-**This migration is opt-in and per-repo.** Most repos should not do it.
-It is worth the effort only where multi-step plan-driven work actually
-happens. A small repo with occasional one-off changes gains nothing and
-should be left exactly as it is.
+## What is and is not opt-in
+
+Be precise about the mechanism, because it is easy to overstate:
+
+- **Discovery is global and cannot be opted out of.** opencode scans
+  the global skills directory and loads any skill whose description
+  matches the task. There is no per-repo switch that hides them.
+- **What is opt-in is authority.** `agents.md` is always-on core
+  context; skills are loaded on demand. So when a repo's `agents.md`
+  says "stop and confirm after every step" and `autonomy-boundaries`
+  says "run the whole scope", **the repo's `agents.md` wins**. The
+  shared skill is loaded but overridden.
+
+The declaration below is what resolves that conflict. Adding it is the
+act of adoption; without it, a repo that still carries a
+confirm-every-step rule keeps that behaviour even though the skill is
+present.
+
+**The agent-side rule, stated once:** if a repo's `agents.md` declares
+the shared orchestration model, `autonomy-boundaries` governs
+continue-versus-stop. If it does not, follow that repo's `agents.md` as
+written and do not apply scope-bounded autonomy on your own initiative.
+
+**Migration is per-repo and most repos should not do it.** It is worth
+the effort only where multi-step plan-driven work actually happens. A
+small repo with occasional one-off changes gains nothing and should be
+left exactly as it is.
 
 ## Is this repo a candidate?
 
@@ -86,8 +107,17 @@ gotchas, domain rules, plan-status conventions tied to this repo's
 documents.
 
 Delete as generic: orchestration protocol, subtask contracts, commit
-format, testing mandate, markdown lint rules, module cohesion,
-state representation, panic-free policy.
+format, testing mandate, markdown lint rules, module cohesion, state
+representation.
+
+One qualification on language policy. The panic-free rule
+(`unwrap`/`expect` forbidden outside tests) lives in
+`rust-best-practices`, which is a **language** skill, not a shared one.
+Delete a local copy only if the repo is Rust and the rule genuinely
+matches; a non-Rust repo's equivalent rule (unchecked assertions,
+swallowed exceptions) has no shared skill covering it yet, so keep it
+locally or raise the gap first. Do not delete a language-specific rule
+on the assumption that a shared skill covers it -- check.
 
 A local skill that is 80% generic and 20% specific gets **rewritten
 down to the 20%**, with a line pointing at the shared skill for the
@@ -110,20 +140,27 @@ Hand this to a sub-agent, one repo at a time. Fill in the bracket.
 
 ```text
 ACTION CLASS: READ-ONLY. Do NOT edit, write, or create any files.
-Do NOT commit.
+Do NOT commit. Do NOT run any command that mutates state (no git
+checkout/stash/add/commit, no package installs, no formatters). Do NOT
+proceed to the next subtask or begin the migration itself.
 
 Audit the repository at [PATH] for migration onto the shared agent
 orchestration model. The shared skills are installed at
 ~/.config/opencode/skills/shared/ -- read agent-orchestration-protocol,
 autonomy-boundaries, plan-decomposition, parallel-work-isolation,
-module-cohesion, and state-representation first so you know what is
-already covered generically.
+module-cohesion, state-representation, and adopt-orchestration-model
+itself first, so you know both what is already covered generically and
+what the migration criteria are.
 
 Then report, with file:line citations for every finding:
 
-1. CANDIDACY. Does this repo meet the migration criteria in
-   adopt-orchestration-model? Quote the evidence. If it does not,
-   say so and stop -- do not produce the rest of the report.
+1. CANDIDACY. A repo is a candidate only if MOST of these hold:
+   work is driven by plan/roadmap documents with numbered tasks;
+   sessions routinely span many steps; sub-agents are used for
+   decomposition; local skills duplicate generic policy; agents.md
+   forces confirmation after every step. Quote the evidence for each.
+   If the repo is not a candidate, say so and stop -- do not produce
+   the rest of the report.
 
 2. AUTONOMY BLOCKERS. Every rule in agents.md / AGENTS.md (and in any
    plan documents) that forces confirmation after each step, forbids
@@ -131,8 +168,11 @@ Then report, with file:line citations for every finding:
    each one exactly.
 
 3. GENUINE STOP TRIGGERS. Every rule that should be KEPT because it
-   guards scope, invariants, or unresolved decisions. These must
-   survive migration.
+   guards scope, invariants, unresolved decisions, or irreversible
+   operations. These must survive migration. The distinction: a rule
+   that stops correct in-scope work is a blocker (section 2); a rule
+   that stops work outside scope or on a broken assumption is a
+   keeper.
 
 4. LOCAL SKILL TRIAGE. For each skill in .opencode/skills/, classify
    as DELETE (fully covered by a shared skill -- name which),

--- a/.opencode/skills/shared/adopt-orchestration-model/SKILL.md
+++ b/.opencode/skills/shared/adopt-orchestration-model/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: adopt-orchestration-model
+description: Use when migrating one of fred's repos onto the shared orchestration model -- adopting scope-bounded autonomy, the shared orchestration/decomposition/parallel-isolation skills, and deleting per-repo duplicates of generic skills. Also use when auditing a repo's agents.md for rules that block unattended execution. Covers the opt-in declaration, the delete-vs-keep test for existing local skills, and the exact prompt to hand a migration sub-agent.
+---
+
+# Adopting the shared orchestration model
+
+The shared skills in the nixos config repo
+(`agent-orchestration-protocol`, `autonomy-boundaries`,
+`plan-decomposition`, `parallel-work-isolation`, `module-cohesion`,
+`state-representation`) are installed on every machine and available in
+every repo. But they only take effect where a repo's `agents.md` does
+not contradict them.
+
+**This migration is opt-in and per-repo.** Most repos should not do it.
+It is worth the effort only where multi-step plan-driven work actually
+happens. A small repo with occasional one-off changes gains nothing and
+should be left exactly as it is.
+
+## Is this repo a candidate?
+
+Migrate only if **most** of these hold:
+
+- Work is driven by plan or roadmap documents with numbered tasks.
+- Sessions routinely span many steps.
+- Sub-agents are used for decomposition.
+- The repo has local skills that duplicate generic policy.
+- `agents.md` contains a rule forcing confirmation after every step.
+
+If a repo is just "make this change" work, stop here. Leave it alone.
+
+## What migration changes
+
+### 1. Declare the opt-in
+
+Add to the repo's `agents.md`, near the top:
+
+```markdown
+## Execution model
+
+This repo uses the shared orchestration model. `autonomy-boundaries`
+governs when to continue versus stop: the assigned scope is the
+boundary, not a step count. `agent-orchestration-protocol` governs
+sub-agent scoping, `plan-decomposition` governs turning plans into
+subtasks, and `parallel-work-isolation` governs concurrent work.
+```
+
+Absent that declaration, the repo keeps whatever its `agents.md`
+already says.
+
+### 2. Remove the rules that block autonomy
+
+The specific patterns to find and replace -- these are what make
+unattended execution impossible:
+
+| Pattern to remove                                     | Why                                                        |
+| ----------------------------------------------------- | ------------------------------------------------------------ |
+| "Stop and post a summary -- wait for confirmation"    | Makes the user a manual scheduler for already-approved work |
+| "Do NOT execute multiple steps in one session"        | Directly forbids finishing an approved plan                 |
+| "You feel unsure but think you can guess"             | Unfalsifiable; an agent can always claim it                 |
+| Per-step confirmation gates inside plan documents     | Same problem, moved into the plan                           |
+
+Replace with a pointer to `autonomy-boundaries`. **Keep** every
+genuine stop trigger: ambiguous requirements, weakened invariants,
+scope expansion, unresolved design decisions, `TENTATIVE` markers.
+
+The distinction: remove rules that stop **correct in-scope work**.
+Keep rules that stop **work outside scope or on a broken assumption**.
+
+### 3. Apply the delete-vs-keep test to local skills
+
+For each local skill, ask: **would this rule be wrong in another
+repo?**
+
+- **No, it is generic** -- delete it and rely on the shared skill.
+  Check the shared skill actually covers it first; if it is missing a
+  case, add the case to the shared skill rather than keeping the local
+  copy.
+- **Yes, it is repo-specific** -- keep it. Trim any generic preamble
+  that now duplicates a shared skill, and reference the shared skill
+  instead.
+
+Keep repo-specific: architecture invariants, which benchmark covers
+what, wiring checklists for this repo's config system, per-file
+gotchas, domain rules, plan-status conventions tied to this repo's
+documents.
+
+Delete as generic: orchestration protocol, subtask contracts, commit
+format, testing mandate, markdown lint rules, module cohesion,
+state representation, panic-free policy.
+
+A local skill that is 80% generic and 20% specific gets **rewritten
+down to the 20%**, with a line pointing at the shared skill for the
+rest. Do not leave the duplicated 80% in place "for convenience" -- two
+copies of a rule drift, and the local copy silently wins.
+
+### 4. Record the execution model in plan documents
+
+If the repo's plans describe parallelism ad hoc, replace that prose
+with a reference to `parallel-work-isolation` plus the repo-specific
+facts: the branch topology, which tasks are genuinely disjoint, and
+which shared types need a foundation-first step.
+
+Reasoning about parallelism that lives only in one plan document is
+lost the moment that version ships. It belongs in the skill.
+
+## Migration prompt
+
+Hand this to a sub-agent, one repo at a time. Fill in the bracket.
+
+```text
+ACTION CLASS: READ-ONLY. Do NOT edit, write, or create any files.
+Do NOT commit.
+
+Audit the repository at [PATH] for migration onto the shared agent
+orchestration model. The shared skills are installed at
+~/.config/opencode/skills/shared/ -- read agent-orchestration-protocol,
+autonomy-boundaries, plan-decomposition, parallel-work-isolation,
+module-cohesion, and state-representation first so you know what is
+already covered generically.
+
+Then report, with file:line citations for every finding:
+
+1. CANDIDACY. Does this repo meet the migration criteria in
+   adopt-orchestration-model? Quote the evidence. If it does not,
+   say so and stop -- do not produce the rest of the report.
+
+2. AUTONOMY BLOCKERS. Every rule in agents.md / AGENTS.md (and in any
+   plan documents) that forces confirmation after each step, forbids
+   multi-step execution, or is an unfalsifiable stop condition. Quote
+   each one exactly.
+
+3. GENUINE STOP TRIGGERS. Every rule that should be KEPT because it
+   guards scope, invariants, or unresolved decisions. These must
+   survive migration.
+
+4. LOCAL SKILL TRIAGE. For each skill in .opencode/skills/, classify
+   as DELETE (fully covered by a shared skill -- name which),
+   TRIM (mostly generic; state which parts are the repo-specific
+   remainder), or KEEP (genuinely repo-specific). Give a one-line
+   reason each.
+
+5. SHARED SKILL GAPS. Anything in a local skill that is generic but
+   NOT yet covered by a shared skill. These need adding upstream
+   before the local copy can be deleted -- this is the most important
+   section, because deleting an uncovered rule loses it.
+
+6. PARALLELISM. Any reasoning about parallel execution, branch
+   topology, or worktrees currently living in plan documents rather
+   than in a skill. Quote it.
+
+Do NOT make any changes. Report only. Stop after reporting.
+```
+
+Then review the report yourself before authorising an IMPLEMENTATION
+pass. Section 5 in particular is where knowledge gets lost: if the
+audit found a generic rule the shared skills do not cover, add it
+upstream **first**, then delete the local copy.
+
+## Order of operations
+
+1. Run the audit prompt. Read the report.
+2. Fix any shared-skill gaps found in section 5, in the nixos repo.
+   Deploy so the updated skills are installed.
+3. Only then, in the target repo: update `agents.md`, delete/trim local
+   skills, update plan documents.
+4. Verify the repo's own suite still passes and that a plan-driven
+   session behaves as expected.
+
+Migrating the target repo before closing the upstream gaps loses rules.
+
+## When to stop and ask
+
+- The audit finds a rule that looks generic but the user may have added
+  deliberately for that repo. Ask; do not delete a rule whose history
+  you cannot see.
+- Two repos disagree about a rule that should be shared. That
+  disagreement needs resolving before either is migrated -- surface
+  both versions.
+- A repo's plan documents encode a parallelism model that contradicts
+  `parallel-work-isolation`. The repo may know something the shared
+  skill does not; surface it rather than overwriting.

--- a/.opencode/skills/shared/agent-orchestration-protocol/SKILL.md
+++ b/.opencode/skills/shared/agent-orchestration-protocol/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: agent-orchestration-protocol
+description: Use whenever about to spawn sub-agents to decompose a task in any of fred's repos. Codifies the mandatory action-class scoping protocol for sub-agent prompts -- READ-ONLY, CODE-REVIEW, IMPLEMENTATION, COMMIT -- with explicit scope, deliverable, prohibitions, and stop condition in every spawned prompt. Also covers the pre-existing-bug cleanup-entry convention and orchestrator-level stop conditions. Ignore this and sub-agents go off-script.
+---
+
+# Sub-agent orchestrator protocol
+
+When acting as an orchestrator -- decomposing a task into sub-agent
+work -- this protocol is **mandatory**. It exists because sub-agents
+told to "understand the code" have repeatedly decided on their own to
+start writing code, committing, and moving to the next task.
+
+A sub-agent inherits none of your context and all of your authority.
+Whatever you do not explicitly forbid, it may do.
+
+## Every sub-agent prompt MUST contain all five
+
+1. **Action class** -- one of the four below, stated in caps at the top.
+2. **Exact scope** -- which files/modules it may read or modify. Be
+   specific. Glob if you must, but prefer file lists.
+3. **Deliverable** -- what it must return.
+4. **Explicit prohibitions** -- what it must NOT do. Always include at
+   minimum:
+   - "Do NOT edit any files." (READ-ONLY / CODE-REVIEW)
+   - "Do NOT commit." (IMPLEMENTATION)
+   - "Do NOT proceed to the next subtask." (always)
+5. **Stop condition** -- when to stop. "Stop after reporting findings."
+   or "Stop after the verification suite passes."
+
+If any is missing, the orchestrator has failed. Do not spawn.
+
+## Action classes
+
+| Action class       | MAY                                               | MUST NOT                                                        |
+| ------------------ | ------------------------------------------------- | ----------------------------------------------------------------- |
+| **READ-ONLY**      | Read, search, analyze, report findings            | Edit or write files, run state-mutating commands                  |
+| **CODE-REVIEW**    | Read files, analyze diffs, report issues          | Edit or write files, commit, run tests                            |
+| **IMPLEMENTATION** | Read + edit + write files within the stated scope | Touch files outside scope, commit, push, move to the next subtask |
+| **COMMIT**         | Stage and commit specified changes                | Edit code, start new work                                         |
+
+## Templates
+
+### READ-ONLY exploration
+
+```text
+ACTION CLASS: READ-ONLY. Do NOT edit, write, or create any files.
+Do NOT run any command that mutates state.
+
+Read the following and report back:
+- <exact file list, with line ranges if known>
+
+Return: <the specific facts the orchestrator needs>
+
+Stop after reporting. Do NOT write code. Do NOT proceed to
+implementation.
+```
+
+### Scoped IMPLEMENTATION
+
+```text
+ACTION CLASS: IMPLEMENTATION. You may edit the files listed below.
+Do NOT commit. Do NOT proceed to the next subtask. Do NOT touch files
+outside this list.
+
+Scope: <exact file list>
+
+Task: <the one change, with concrete type/function names already
+chosen by the orchestrator -- not "design a way to ...">
+
+Verification: <the repo's exact commands>
+
+Stop condition: report files modified, a summary of changes, and
+verification results. Do NOT commit. Do NOT update plan documents.
+Do NOT start the next subtask.
+```
+
+The orchestrator supplies the repo's real verification commands; see
+`testing-mandate` for what they are per repo.
+
+## Scope is the boundary
+
+A sub-agent operates under `autonomy-boundaries`: it runs front to back
+within its stated scope and stops the moment it would exceed it.
+
+If a sub-agent discovers it needs to modify files outside its assigned
+scope, it **must stop and report**. The orchestrator resolves the
+cross-scope dependency by re-scoping or re-sequencing -- **never** by
+telling the sub-agent to expand its own scope mid-task. An agent that
+can widen its own boundary does not have one.
+
+## Pre-existing bugs surfaced during a subtask
+
+When a sub-agent finds a bug outside the current subtask's scope:
+
+1. The sub-agent **stops and reports**. It does NOT fix the bug as part
+   of the current subtask, even if the fix is one line.
+2. The orchestrator records it as a **numbered cleanup entry** in the
+   host task's plan document, in the same numbering space as the task.
+3. The cleanup entry includes: surface point (commit + subtask), impact,
+   scope of fix, suggested approach, verification criteria, and
+   scheduling constraints.
+4. The original subtask's completion notes **link to the cleanup entry
+   by number** rather than carrying the full description.
+5. Informal "known issues" sections are not used. Every surfaced bug is
+   either resolved or has a numbered entry.
+
+The point is that a bug found mid-task must survive the session. A
+TODO comment or a chat message does not.
+
+## Parallelism
+
+Sub-agents may run concurrently only under the isolation and
+decomposition rules in `parallel-work-isolation`. The short version:
+
+- Concurrent **READ-ONLY** agents on one checkout are always safe --
+  they write nothing.
+- Concurrent **IMPLEMENTATION** agents on one checkout are never safe.
+  They share a build directory; one agent's half-finished edit breaks
+  another's test run, and the second agent then tries to "fix" damage
+  that is not its own.
+- Concurrent implementation requires isolated worktrees, and even then
+  requires that the tasks be semantically disjoint -- not merely
+  touching different files.
+
+Load `parallel-work-isolation` before running any implementation work
+in parallel.
+
+## Orchestrator-level stop conditions
+
+- A sub-agent's report contradicts what you expected. Do not spawn the
+  next one; surface the discrepancy first.
+- A sub-agent reports "I could not do this without expanding scope".
+  Re-scope or re-sequence before continuing.
+- The plan calls for more than about five parallel sub-agents in one
+  file area. That is over-decomposition; rethink.
+- Two sub-agent reports describe the same code differently. One of them
+  is wrong and you do not yet know which.
+
+## When to stop and ask
+
+- Decomposition would require a design decision the plan did not make.
+  That decision is the orchestrator's, and if the orchestrator cannot
+  make it, it is the user's.
+- A subtask cannot be scoped to an explicit file list. That means the
+  work is not understood well enough to delegate.

--- a/.opencode/skills/shared/autonomy-boundaries/SKILL.md
+++ b/.opencode/skills/shared/autonomy-boundaries/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: autonomy-boundaries
+description: Use whenever executing a multi-step plan, task document, or numbered subtask list in any of fred's repos, and whenever deciding whether to continue to the next step or stop and ask. Codifies the scope-bounded autonomy rule -- the assigned scope is the boundary, not a step count -- that replaces the older "stop and confirm after every single step" protocol. Defines the four continue conditions, the hard stop triggers, and the scope-expansion prohibition that keeps an agent from doing work the user did not ask for.
+---
+
+# Autonomy boundaries: scope is the boundary
+
+An agent executing a plan should run **front to back within the scope
+it was given**, and stop the moment it would exceed that scope or hits
+something the plan did not foresee.
+
+This replaces the older rule -- "execute one step, stop, post a
+summary, wait for confirmation, repeat" -- which made the user a
+manual scheduler for work they had already approved. Approving a plan
+_is_ the confirmation. Re-asking after each step does not add safety;
+it adds latency and trains the user to rubber-stamp.
+
+But the old rule existed for a real reason: sub-agents told to
+"understand the code" repeatedly decided on their own to start writing
+code, committing, and moving on to the next task. **The fix for that is
+a hard scope boundary, not a short leash.** A leash slows down correct
+work exactly as much as incorrect work. A boundary only stops the
+incorrect kind.
+
+## The rule
+
+> **"Do plan X" means all of plan X, front to back, and nothing else.**
+
+Continue to the next step **without asking** while all four hold:
+
+1. **Verification is green.** The repo's mandatory suite passes (see
+   `testing-mandate`). A red suite is a full stop, never a "fix it
+   while I'm here".
+2. **No scope expansion.** Every file you touched is inside the
+   assigned scope. Needing a file outside it is a stop.
+3. **No unresolved design decision.** The plan already decided every
+   type name, signature, and approach. If you would have to _choose_
+   rather than _implement_, that is a stop.
+4. **Nothing unforeseen.** No pre-existing bug, no wrong assumption in
+   the plan, no upstream surprise. The plan describes reality.
+
+If all four hold, keep going. Do not post a summary and wait. Do not
+ask "shall I continue?". Finish the scope.
+
+The moment any one fails: **stop, and report.** Not "stop, work around
+it, and mention it later".
+
+## Hard stop triggers
+
+Stop immediately and surface to the user when:
+
+- The verification suite fails in a way the plan did not predict.
+- The work requires editing a file outside the assigned scope.
+- A design decision was left open (or the plan's decision turns out to
+  be unimplementable as written).
+- A pre-existing bug is found. Report it; do not fix it inline. See
+  `agent-orchestration-protocol` for the cleanup-entry convention.
+- The plan contradicts the code -- the plan was written against a state
+  that no longer exists.
+- A step marked `TENTATIVE`, `needs approval`, or equivalent is
+  reached. Those markers exist precisely to force a stop.
+- A change would weaken a stated invariant, even if tests still pass.
+- You are about to do something the user did not ask for because it
+  seems obviously beneficial. That is scope creep with good intentions.
+  Surface it as a suggestion instead.
+
+## What "and nothing else" forbids
+
+The scope boundary is symmetric: it stops you doing _less_ than asked,
+and it stops you doing _more_.
+
+- No opportunistic refactors of code you happened to read.
+- No "while I was in there" fixes.
+- No tidying unrelated lint warnings.
+- No new files -- especially markdown -- outside the plan. See
+  `no-summary-documents`.
+- No proceeding into the _next_ plan/version because the current one
+  finished cleanly.
+- No expanding a sub-agent's scope to avoid a round trip.
+
+If something outside scope genuinely needs doing, it is reported as a
+finding, and the user (or the orchestrator) decides. The work item is
+recorded; it is not silently absorbed.
+
+## Reverting to step-by-step confirmation
+
+Scope-bounded autonomy is the default, but it is not mandatory. The
+user can request the older behaviour per session, and it overrides
+this skill:
+
+```text
+Step-by-step mode: execute one subtask, then stop and report. Wait
+for my confirmation before each subsequent subtask.
+```
+
+Honour that for the rest of the session. Useful when the plan is
+speculative, the blast radius is large, or the user is actively
+watching and wants to steer.
+
+The inverse also holds -- if the user says "just do the whole thing,
+don't check in with me", that does **not** remove the hard stop
+triggers above. Those are safety, not ceremony. An unforeseen problem
+still stops the run.
+
+## Reporting when you do stop
+
+A stop is not a failure; it is the protocol working. Report:
+
+1. What was completed (with verification status for each step).
+2. Exactly where you stopped and which trigger fired.
+3. What you found -- the specific bug, ambiguity, or conflict.
+4. Options, if there are several, with a recommendation.
+
+Do not bury the trigger under a summary of the work. Lead with why you
+stopped.
+
+## Relationship to the other skills
+
+- `agent-orchestration-protocol` -- how to scope sub-agents so they
+  inherit a correct boundary in the first place.
+- `plan-decomposition` -- how to write subtasks whose scope is
+  unambiguous, so condition 2 is checkable.
+- `testing-mandate` -- what "verification is green" means per repo.
+- `commit-discipline` -- each step still leaves the tree green and
+  committable.
+
+## When to stop and ask
+
+- The assigned scope is itself ambiguous ("clean up the parser"). Get
+  it pinned down before starting; an unclear boundary cannot be
+  respected.
+- The plan's remaining steps depend on a decision the user deferred.
+- You have stopped three times on the same plan for related reasons.
+  The plan is probably wrong; say so rather than continuing to
+  chip at it.

--- a/.opencode/skills/shared/autonomy-boundaries/SKILL.md
+++ b/.opencode/skills/shared/autonomy-boundaries/SKILL.md
@@ -26,7 +26,7 @@ incorrect kind.
 
 > **"Do plan X" means all of plan X, front to back, and nothing else.**
 
-Continue to the next step **without asking** while all four hold:
+Continue to the next step **without asking** while all five hold:
 
 1. **Verification is green.** The repo's mandatory suite passes (see
    `testing-mandate`). A red suite is a full stop, never a "fix it
@@ -38,9 +38,35 @@ Continue to the next step **without asking** while all four hold:
    rather than _implement_, that is a stop.
 4. **Nothing unforeseen.** No pre-existing bug, no wrong assumption in
    the plan, no upstream surprise. The plan describes reality.
+5. **The step is reversible.** See below -- irreversible operations
+   need explicit approval even when they are squarely in scope.
 
-If all four hold, keep going. Do not post a summary and wait. Do not
+If all five hold, keep going. Do not post a summary and wait. Do not
 ask "shall I continue?". Finish the scope.
+
+### Irreversible operations always need approval
+
+Being in scope is not sufficient authority to do something that cannot
+be undone. A plan can legitimately contain a destructive step, and the
+other four conditions can all pass for it.
+
+Stop and get explicit approval before:
+
+- Deleting data, dropping a database, or removing a volume.
+- Rewriting published history (`push --force`, `rebase` of pushed
+  commits, `filter-branch`).
+- Deploying, restarting a production service, or applying
+  infrastructure changes to live hosts.
+- Changing access control: keys, tokens, permissions, firewall rules,
+  user accounts.
+- Transmitting repository contents anywhere external.
+- Any `rm -rf` outside a build/scratch directory.
+
+Reversible-by-design work -- editing tracked files, committing to a
+feature branch, opening a PR -- is not in this list and proceeds
+normally. The test is whether an error is recoverable with a local
+`git` operation. If undoing it needs a backup, a provider console, or
+an apology, it needs approval first.
 
 The moment any one fails: **stop, and report.** Not "stop, work around
 it, and mention it later".

--- a/.opencode/skills/shared/module-cohesion/SKILL.md
+++ b/.opencode/skills/shared/module-cohesion/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: module-cohesion
+description: Use when about to add a type, struct, enum, or trait to an existing file whose name describes a different concept, add a second unrelated test module to a file, or add code to a file you had to scroll to the end of to find the insertion point. Applies in every one of fred's repos regardless of language. Codifies one CONCEPT per module (not one type per file), the path-names-the-concept rule, and the prohibition on splits that widen visibility.
+---
+
+# Module cohesion: one concept per module
+
+A module holds **one concept**. Not one type -- one concept. A concept
+may need several types to express it, and those belong together.
+
+The inverse is what this skill prevents: a file that accumulated a
+second, unrelated concept because it was the file already open.
+
+Repos may add their own exemplars and high-risk files on top of this;
+the rules below are the common core.
+
+## The trigger
+
+Load this skill when any of these is true:
+
+- You are adding a type to a file whose **name describes a different
+  concept** than the type you are adding.
+- You are adding a **second unrelated test module** to a file.
+- You had to **scroll to the end of the file** to find where to put the
+  new code. That scroll is the signal: you no longer hold the file's
+  shape in your head, and neither will the next reader.
+- You are adding to a file that already carries a length suppression.
+
+## Rules
+
+1. **The path names the concept.** A reader should predict a file's
+   contents from its path alone. If the path says `parser` and the file
+   also holds a colour table, one of them is in the wrong place.
+
+2. **A concept may be several types.** Do not split a struct from its
+   builder, its error type, and its iterator just to make files
+   smaller. Cohesion beats file count. "One type per file" is not the
+   rule and produces a directory of fragments that must all be opened
+   together.
+
+3. **Unrelated means unrelated to the module's concept**, not
+   "unrelated to the type next to it". Two types that jointly express
+   one idea belong together even if they share no fields.
+
+4. **Test modules follow their subject.** Tests for a concept live with
+   that concept. A second test module covering something else is the
+   same smell as a second production concept.
+
+5. **Length is a symptom, not the rule.** A long file about one
+   coherent concept is fine. A short file about two concepts is not.
+   Do not split by line count; split by concept.
+
+6. **A new concept gets a new module.** Rather than making the
+   already-large file larger, create the module the concept deserves --
+   and say that you are doing so, rather than doing it silently.
+
+## What this does not license
+
+- **Do not split a module to dodge a length lint.** Moving half a
+  concept into `foo_extra` to get under a threshold makes the code
+  worse and the lint quieter. Fix the concept boundary or leave it.
+
+- **Do not widen visibility to enable a split.** If extracting a type
+  into its own module forces internals from private to public, the
+  split is wrong. A split that damages encapsulation costs more than
+  the large file it fixed. This is the most common failure mode:
+  the mechanical move succeeds, and the module's invariants are now
+  enforceable by nobody.
+
+- **Do not create a `utils` / `helpers` / `misc` module.** Those names
+  describe no concept, so nothing can ever be predicted from the path,
+  and they accumulate without limit. If a helper has no home, it is
+  usually a hint that its concept has not been named yet.
+
+- **Do not reorganise unrelated code while you are in there.** Improving
+  cohesion is worthwhile, but it is its own task with its own review.
+  See `autonomy-boundaries` -- an opportunistic reorganisation is scope
+  creep even when it is an improvement.
+
+## When to stop and ask
+
+- The correct split is obvious but large, touching many call sites.
+  Surface it as a proposal; do not fold a wide mechanical refactor into
+  an unrelated change.
+- You cannot name the concept a module would hold. That means the
+  boundary is not understood yet -- naming it is the actual work.
+- Splitting would require making internals public. Stop; surface the
+  tension rather than choosing encapsulation loss silently.

--- a/.opencode/skills/shared/parallel-work-isolation/SKILL.md
+++ b/.opencode/skills/shared/parallel-work-isolation/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: parallel-work-isolation
+description: Use whenever planning or executing work that runs more than one implementation agent at the same time in any of fred's repos -- deciding whether tasks can be parallelised, setting up git worktrees, choosing a branch topology, or merging parallel workstreams back. Codifies the file-conflict vs logic-conflict distinction, the foundation-first pattern for shared types, the one-active-editor-per-region rule, per-worktree build directories, and the integration-branch merge model. Load this before spawning concurrent IMPLEMENTATION sub-agents.
+---
+
+# Parallel work isolation
+
+Running several implementation agents at once is only safe when both
+halves are handled:
+
+1. **Mechanical isolation** -- they must not corrupt each other's
+   files or build artifacts.
+2. **Semantic isolation** -- they must not independently change the
+   same behaviour.
+
+Most parallel-agent failures come from solving (1) and assuming it
+covered (2). It does not.
+
+## The distinction that matters most
+
+> Worktrees stop file conflicts. They do not stop logic conflicts.
+> Two agents, two folders, zero merge conflicts, and both quietly
+> change how the same function behaves. Git sees no overlap. The tests
+> pass in each worktree alone. They break when both land.
+
+Git detects **textual** conflict only. It has no concept of two agents
+independently changing what a function _does_. A clean merge whose
+combined behaviour is wrong is the characteristic failure of parallel
+agent work, and no isolation technology prevents it. Only decomposition
+does.
+
+So the first question is never "how do I isolate these agents" but
+**"are these tasks actually independent?"**
+
+## Deciding whether tasks can run in parallel
+
+Tasks are parallel-safe only when all hold:
+
+- **Disjoint files.** No two tasks edit the same file.
+- **Disjoint behaviour.** No two tasks change the same observable
+  behaviour, invariant, or data flow, even through different files.
+- **No shared-type edits.** Neither adds a field, variant, or
+  signature change to a type the other consumes. This is the most
+  commonly missed one -- see foundation-first below.
+- **Independent verification.** Each task's tests pass on its own
+  branch _and_ would still pass with the other task's changes applied.
+
+If any fails, the tasks are sequential, or need a foundation step
+first. "They touch different files" is necessary, not sufficient.
+
+## Foundation-first for shared types
+
+When several tasks each need to add to a shared type -- a common enum,
+a config struct, a bottom-of-the-dependency-graph crate -- do **not**
+let them race that edit in parallel branches. Instead:
+
+1. Land **one** foundation change on the integration branch that adds
+   every shared shell the parallel tasks need: the new variants, the
+   new fields, the new config keys, the new signatures.
+2. Fork the feature branches from the foundation-carrying integration
+   branch.
+3. Each feature branch then fills in behaviour behind an interface
+   that already exists and that nobody else is editing.
+
+This converts the worst class of conflict (structural edits to a shared
+type, which merge badly and break every downstream crate) into no
+conflict at all. It costs one extra sequenced step and saves a merge
+disaster.
+
+## One active editor per shared region
+
+Where tasks genuinely must touch the same file or region, branches
+prevent corruption but do not remove the merge-conflict and
+review-serialization tax. Keep **at most one actively-editing agent per
+shared-file region at a time**, and rebase the other branches after
+each merge.
+
+"Parallel" here means parallel _branches and workstreams_, not several
+agents editing the same file at the same instant.
+
+## Mechanical isolation: git worktrees
+
+A worktree gives each agent its own working directory, `HEAD`, and
+index against one shared object store.
+
+**Verified isolated per worktree:** working files, `HEAD`, index,
+`ORIG_HEAD`, per-worktree refs.
+
+**Verified shared across all worktrees -- these bite:**
+
+| Shared            | Consequence                                                           |
+| ----------------- | ----------------------------------------------------------------------- |
+| `.git/config`     | A config change in one worktree is immediately visible in all others   |
+| `.git/hooks`      | One hook set for every worktree                                        |
+| `refs/stash`      | `git stash` is effectively one global variable across all worktrees    |
+| Object store      | Safe for concurrent commits, but see `gc` below                        |
+
+Rules that follow:
+
+- **Never `git stash` in an agent worktree.** A stash pushed in one
+  tree is visible in every other, and a `stash pop` in the wrong tree
+  applies someone else's changes. Commit to a scratch branch instead.
+- **Each agent gets its own branch.** Git refuses to check out the same
+  branch in two worktrees; this is a feature, not an obstacle.
+- **Do not run `git gc --prune=now` while agents are working.** Git's
+  own documentation states concurrent `gc` carries a real (if low)
+  corruption risk. Let `gc.auto` be, and run manual gc when idle.
+
+### Setup
+
+```sh
+git worktree add ../<repo>-<task> -b <task-branch> <integration-branch>
+```
+
+Each worktree gets its own build directory automatically, because
+build tools default to a path relative to the tree root.
+
+### Teardown
+
+```sh
+git worktree remove ../<repo>-<task>
+git worktree prune
+```
+
+Remove worktrees when the task merges. Stale worktrees hold branch
+locks and confuse the next run.
+
+## Build isolation
+
+**Give every worktree its own build directory.** Do not point several
+worktrees at one shared build output.
+
+For Rust specifically: do **not** share `CARGO_TARGET_DIR` across
+worktrees. Cargo's lock is per-target-directory and is not aware that
+two trees hold different source. Across divergent trees you get either
+full serialization (losing the parallelism you set this up for) or
+corrupted artifacts. Cargo's own maintainers scope the "safe to share"
+claim to a single source tree building different packages -- not to
+different worktrees on different branches.
+
+The cost is a full dependency build per worktree. Recover it with a
+shared compiler cache (`sccache` via `RUSTC_WRAPPER`), which is the
+documented way to share compilation across checkouts without sharing
+the build directory. Note that a shared cache helps most with
+dependency compilation and least with incremental rebuilds of the crate
+under active edit.
+
+Expect occasional brief contention on the global package-cache lock
+(`~/.cargo/.package-cache`) even with separate build directories. That
+is a real lock working correctly, not a hang -- but it does mean
+concurrent dependency-fetching agents will sometimes wait on each
+other.
+
+## Containers are usually the wrong tool here
+
+Containers isolate processes and OS state. The parallel-agent problem
+is semantic disagreement between agents, which containerization does
+not touch. For a single-language project with no external services they
+add real cost -- language-server wiring, display plumbing for GUI
+tests, copy-on-write penalties on build directories unless you mount
+them out -- for isolation that worktrees already provide.
+
+Reach for containers only when you need genuine service isolation (a
+per-agent database) or OS-level sandboxing.
+
+**If a repo is Nix-flake-managed, do not introduce a container whose
+toolchain is defined separately from the flake.** That reintroduces the
+toolchain-drift problem the flake exists to eliminate. Build the image
+from the flake so the lock file stays the single source of truth.
+
+## Branch topology and merging back
+
+For a version or epic executed as several parallel tasks:
+
+```text
+main
+ └── <version>-integration          the eventual single PR
+      ├── task-a/<slug>
+      ├── task-b/<slug>
+      └── task-c/<slug>
+```
+
+- Feature branches fork from the **integration branch**, not `main`.
+- The foundation change lands on the integration branch first.
+- Each task merges back into the integration branch when green.
+- After each merge, the other live branches **rebase** on the
+  integration branch to pick up shared changes before continuing.
+- When all tasks are in, **one PR**: integration branch to `main`.
+
+Merging back is orchestrator work. Do it **sequentially, one branch at
+a time**, running the full verification suite after each merge -- not
+just the merged branch's tests. The whole point is to catch the
+semantic collision that each branch's own tests cannot see. Never
+octopus-merge parallel agent branches: that pattern is for trivial
+non-conflicting merges, not for reconciling independently written code.
+
+If verification fails only after two branches are combined, that is a
+logic conflict. Stop and surface it; do not patch over it in the
+integration branch without understanding which task's assumption was
+wrong.
+
+## When to stop and ask
+
+- Task decomposition cannot produce semantically disjoint tasks. Say so
+  and run sequentially; forced parallelism produces the clean-merge,
+  broken-behaviour failure.
+- Two parallel branches both need to change the same shared type and a
+  foundation step cannot cover it.
+- Combined verification fails after a merge that each branch passed
+  alone.
+- The number of parallel worktrees is growing to keep agents busy
+  rather than because the work is genuinely independent.

--- a/.opencode/skills/shared/parallel-work-isolation/SKILL.md
+++ b/.opencode/skills/shared/parallel-work-isolation/SKILL.md
@@ -112,8 +112,24 @@ Rules that follow:
 git worktree add ../<repo>-<task> -b <task-branch> <integration-branch>
 ```
 
-Each worktree gets its own build directory automatically, because
-build tools default to a path relative to the tree root.
+A worktree does **not** guarantee a separate build directory. Build
+tools default to a tree-relative output path, but an environment
+variable or tool configuration overrides that default -- and an
+exported `CARGO_TARGET_DIR`, a dev-shell that sets one, or a global
+config file applies to every worktree at once, silently collapsing
+them onto one output directory.
+
+Before running anything concurrently, verify each build tool's actual
+output path per worktree:
+
+```sh
+# Rust: must be empty, or a DIFFERENT path per worktree
+echo "${CARGO_TARGET_DIR:-<unset: tree-relative, good>}"
+```
+
+Check the dev shell too, not just the interactive environment -- a
+`mkShell` that exports a build-output variable is invisible until you
+enter it.
 
 ### Teardown
 

--- a/.opencode/skills/shared/plan-decomposition/SKILL.md
+++ b/.opencode/skills/shared/plan-decomposition/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: plan-decomposition
+description: Use when turning a plan, roadmap version, epic, or feature request into implementable subtasks in any of fred's repos -- especially when activating a stub plan or fleshing out a task list for sub-agent execution. Codifies just-in-time planning (do not decompose far-future work), the orchestrator-decomposes / implementer-executes / orchestrator-reviews division of labour, the five-part subtask contract, and the decomposition heuristics that make subtasks parallel-safe.
+---
+
+# Plan decomposition
+
+This skill governs **planning time**: turning a goal into subtasks that
+a sub-agent can execute without judgement calls. It is the companion to
+`agent-orchestration-protocol`, which governs **execution time**.
+
+## Decompose just in time, against real code
+
+Plan documents should be written in two tiers:
+
+- **Imminently-activated work** carries a full per-subtask breakdown,
+  written against the _current_ codebase.
+- **Far-term work** stays an **enriched stub**: goal, task summary,
+  every durable design decision already made, open questions tagged
+  "decide at activation" -- but **no subtask decomposition**.
+
+The reasons are economic and correctness-driven:
+
+1. A breakdown written far in advance is a guess about a codebase that
+   will have changed underneath it. It rots.
+2. Decomposition is the expensive orchestration work. Doing it early
+   means paying for it, watching it go stale, and paying again to
+   re-validate at activation.
+3. A plan should crystallise a stable understanding, not lead it.
+
+**Durable decisions are recorded; perishable breakdowns are deferred.**
+When a real design decision gets made in discussion -- an invariant, a
+dependency cut, a chosen library -- write it into the stub now. Do not
+invent subtask lists for work that is not next.
+
+## Activation: one dedicated session
+
+When work moves from stub to active:
+
+1. **Read first.** The plan, its dependencies, and -- critically -- the
+   _current code_ it will touch. Map the real seams, not remembered
+   ones.
+2. **Resolve open questions** with the user. The stub's "decide at
+   activation" list is the agenda. Do not silently pick answers.
+3. **Decompose** into subtasks (shape below) against the seams found in
+   step 1.
+4. **Write the breakdown into the plan document**, replacing the stub
+   body.
+5. **Then** begin execution under `agent-orchestration-protocol`.
+
+Activation planning is orchestration, not implementation. Do not begin
+implementing in the same breath as decomposing.
+
+## Division of labour
+
+- **Orchestrator** (the expensive model): reads code, decomposes,
+  writes subtasks, sequences them, reviews output, makes every
+  architectural call.
+- **Implementer** (the cheap model): executes one tightly-scoped
+  subtask per invocation, with **no architectural latitude**.
+- **Orchestrator reviews**: every implementation subtask gets a
+  CODE-REVIEW pass before acceptance.
+
+The implementer fills in the body. It never chooses the shape.
+
+## When a subtask is correctly scoped
+
+All five must hold:
+
+1. **Single concern.** One logical change. If the description needs
+   "and also", split it.
+2. **Explicit file scope.** The exact files it may touch are named. No
+   "and related files".
+3. **No open design decisions.** Every type name, variant, signature,
+   and approach is already decided and written into the subtask. If the
+   implementer would have to _choose_, decomposition is incomplete.
+4. **Self-contained verification.** The subtask names the exact
+   commands that prove it correct, and leaves the repo's suite green --
+   the `commit-discipline` invariant.
+5. **Bounded.** Roughly one focused implementation pass. If it spans
+   many files across module boundaries or needs judgement mid-stream,
+   it belongs to the orchestrator or needs splitting.
+
+## Subtask template
+
+```text
+#### NN.M -- <single-concern title>
+
+Scope: <exact file list>
+
+What: <the one change, with concrete type/function names already
+chosen -- not "design a way to ...">
+
+Deliverable: <the code + the tests that prove it>
+
+Verification: <the repo's exact commands, plus any subtask-specific test>
+
+Prohibitions: do NOT touch files outside scope; do NOT decide
+<the thing already decided above>; do NOT proceed to NN.(M+1).
+
+Stop: report files changed + verification results; await review.
+```
+
+The plan-doc subtask and the spawned sub-agent prompt are two views of
+the same contract. Keep them identical in substance.
+
+## Decomposition heuristics
+
+- **Audit before implement.** When current behaviour is ambiguous, the
+  first subtask is a READ-ONLY audit that resolves the ambiguity and
+  feeds the implementation subtasks. Do not fold the audit into the
+  first implementation subtask.
+- **Foundation before features.** If several subtasks each need to add
+  to a shared type, land all those shells in one foundation subtask
+  first. See `parallel-work-isolation` -- this is what makes the rest
+  parallel-safe.
+- **Types before behaviour before presentation.** Add the typed state,
+  then the logic that maintains it, then the transport, then the
+  rendering. Each is its own subtask, in that order.
+- **Cross-cutting checklists get their own subtask.** Wiring that has a
+  known silent-failure mode (a config option that must be registered in
+  several places) is never bolted onto a feature subtask.
+- **Documentation updates that are mandatory get a subtask**, not a
+  hopeful mention in another subtask's deliverable.
+- **Benchmarks**: if the work touches a benchmarked hot path, a
+  before/after capture subtask is mandatory. See
+  `performance-benchmarks`.
+
+## Decompose for parallelism deliberately
+
+When the work will run as parallel workstreams, decomposition is what
+makes that safe. Before declaring subtasks parallel, check them against
+the independence tests in `parallel-work-isolation`: disjoint files,
+disjoint behaviour, no shared-type edits, independently valid
+verification.
+
+Write the execution model into the plan document itself -- which
+subtasks may run concurrently, which are strictly sequenced, and the
+branch topology. An execution model that lives only in the
+orchestrator's head is lost at the end of the session and re-derived
+(differently) next time.
+
+## Hard rules
+
+- Do NOT decompose work that is not being activated now.
+- Do NOT begin implementation in the same breath as decomposition.
+  Decompose, get sign-off, then execute.
+- Do NOT let a subtask carry an unresolved design decision into the
+  implementer. That choice belongs to the orchestrator.
+- Do NOT write subtasks against remembered code. Re-read the seams; the
+  codebase moved.
+- Do NOT renumber subtasks when one is withdrawn or deferred. Keep the
+  number and mark it, so the decision is not re-litigated by the next
+  reader.
+
+## When to stop and ask
+
+- An open question has no obvious answer and the user has not weighed
+  in. That is the activation conversation.
+- The external spec being targeted is unstable. Do not decompose
+  against a moving target.
+- Decomposition reveals the work is far larger than its estimate. Stop
+  and re-scope before writing twenty subtasks.
+- You are tempted to flesh out the _next_ chunk of work while you are
+  here. Don't. One activation per session.

--- a/.opencode/skills/shared/state-representation/SKILL.md
+++ b/.opencode/skills/shared/state-representation/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: state-representation
+description: Use when about to add a bool field or bool parameter, pass a bare true/false at a call site, add a second bool that cannot legally be true at the same time as an existing one, transport a bool across a crate/thread/process/API boundary, or reach for an excessive-bools lint suppression. Applies in every one of fred's repos regardless of language. Codifies the named-domain-enum rule, the three cases where a bool MUST become an enum, and the three cases where a bool is correct.
+---
+
+# State representation: name the state
+
+A `bool` says a value has two cases. It does not say **what the cases
+mean**. `true` at a call site is unreadable, unsearchable, and silently
+swappable with the argument next to it.
+
+The rule: **state is a named domain enum, not a bare `bool`.**
+
+Repos may add their own high-risk sites and exemplars on top of this;
+the rules below are the common core.
+
+## Name the enum for its domain, never generically
+
+The enum's name says what the state _is_. Its variants say what the
+cases _are_ in that domain's language.
+
+```text
+Bad:   Enabled / Disabled          (shared, meaningless, collides)
+Bad:   Flag, State, Mode, Status   (says nothing)
+Good:  BlinkState::{Enabled, Disabled}
+Good:  CursorVisibility::{Visible, Hidden}
+Good:  WrapMode::{Wrap, NoWrap}
+```
+
+A single shared generic `Enabled`/`Disabled` type used for a dozen
+unrelated concepts is barely better than a `bool`: it type-checks when
+you pass cursor visibility to a blink parameter.
+
+## When a bool MUST become a named enum
+
+### 1. Bool parameters -- always, no exceptions
+
+A `bool` in a parameter list is illegible at the call site:
+
+```text
+render(surface, true, false, true)
+```
+
+Nobody can read that, and the arguments can be transposed silently.
+Every boolean parameter becomes a named enum -- or, when there are
+several, a small options struct with named fields.
+
+This applies even to private functions. "It's only called twice" is how
+it becomes called nine times.
+
+### 2. Two or more bools that cannot legally both be true
+
+Two bools encode four states. If only three are legal, the type permits
+an unrepresentable one, and every reader must reconstruct that rule
+from context:
+
+```text
+Bad:   is_loading: bool, is_error: bool     (what does true/true mean?)
+Good:  LoadState::{Idle, Loading, Error}
+```
+
+Make the illegal state unrepresentable rather than documenting that it
+must not happen.
+
+### 3. Bools crossing a boundary
+
+A bool that crosses a crate, module, thread, process, serialization, or
+public-API boundary loses whatever local context made it readable. At
+the far side it is just `true`.
+
+If the value is transported -- through a snapshot, a channel, a
+message, a public signature, a stored record -- create the enum. Locality
+of the definition does not survive the boundary.
+
+## Where bools stay -- do NOT convert these
+
+Three cases where a `bool` is the correct type:
+
+### Independent simultaneous signals
+
+Several conditions that are genuinely independent and may all hold at
+once are not one state machine. A struct of named bool fields is
+correct; forcing them into one enum would misrepresent them.
+
+The test: can any combination legally occur? If yes, they are
+independent signals, not an enum.
+
+### Modifier and flag sets
+
+Sets like keyboard modifiers (`shift`, `ctrl`, `alt`) are independent
+by nature, are usually consumed as a set, and often map to an external
+protocol's bit layout. Leave them as bools or a bitflags type.
+
+### Config toggles deserialised from an external format
+
+A `true`/`false` in TOML, JSON, or YAML that maps directly to a config
+field stays a bool at the deserialisation boundary. The external format
+has no enum. Convert to a domain enum _after_ parsing if the value then
+drives internal state.
+
+## Existing suppressions are evidence, not permission
+
+A lint suppression (`excessive_bools`, `fn_params_excessive_bools`, or
+equivalent) already in the tree is a record that someone hit this rule
+and deferred it. It is **not** precedent for adding another.
+
+When you touch code carrying such a suppression, the default is to fix
+the underlying representation and delete the suppression. Adding a new
+one requires a real justification that fits one of the three
+"bools stay" cases above -- and should be stated in a comment.
+
+## The cost is not the argument
+
+The runtime cost of a fieldless enum versus a bool is zero in every
+language fred's repos use. Performance is never the reason to keep a
+bool. If someone reaches for that argument, the real reason is that the
+change is tedious -- which is a scheduling question, not a design one.
+
+## When to stop and ask
+
+- The conversion would ripple through a large public API surface. That
+  is a real cost; surface it and let the user schedule it rather than
+  doing it inline as a drive-by.
+- You cannot find a good domain name for the enum. That usually means
+  the state is not actually one concept and the code needs a different
+  split.
+- An external protocol or wire format dictates a boolean layout that a
+  domain enum would fight.

--- a/.opencode/skills/shared/state-representation/SKILL.md
+++ b/.opencode/skills/shared/state-representation/SKILL.md
@@ -111,10 +111,23 @@ one requires a real justification that fits one of the three
 
 ## The cost is not the argument
 
-The runtime cost of a fieldless enum versus a bool is zero in every
-language fred's repos use. Performance is never the reason to keep a
-bool. If someone reaches for that argument, the real reason is that the
-change is tedious -- which is a scheduling question, not a design one.
+In Rust, a fieldless enum with two variants is one byte, the same as a
+`bool`, and the conversion is a measured zero-cost change. TypeScript
+string-literal union types and Python enums are not automatically free:
+a string union is wider than a boolean in a serialized payload, and a
+Python `enum.Enum` member is an object rather than an interned
+singleton.
+
+So "it costs nothing" is a Rust claim, not a universal one. What _is_
+universal: the cost is small, bounded, and paid at a boundary you
+control, and it is almost never the real objection. If someone reaches
+for performance here, ask for the measurement. Usually the actual reason
+is that the change is tedious -- a scheduling question, not a design
+one.
+
+Where the representation genuinely is on a hot path or in a
+size-constrained wire format, measure it and record the number, per
+`performance-benchmarks`.
 
 ## When to stop and ask
 

--- a/agents.md
+++ b/agents.md
@@ -67,7 +67,14 @@ and HFDL decoders.
 │       ├── shared/        # Cross-repo policies (precommit, commits,
 │       │                  # testing, no-summary-documents, flaky tests,
 │       │                  # performance benchmarks, flake dev-shell,
-│       │                  # markdown-lint-discipline)
+│       │                  # markdown-lint-discipline) plus the
+│       │                  # orchestration model: agent-orchestration-
+│       │                  # protocol, autonomy-boundaries, plan-
+│       │                  # decomposition, parallel-work-isolation,
+│       │                  # module-cohesion, state-representation,
+│       │                  # adopt-orchestration-model. The
+│       │                  # orchestration set is OPT-IN per repo --
+│       │                  # a repo declares it in its own agents.md.
 │       ├── languages/     # Per-language rules (rust, typescript)
 │       └── projects/      # nixos-specific procedures only
 └── .github/
@@ -121,6 +128,13 @@ the task. The full bodies live under `.opencode/skills/`.
 | `nixos-input-category-sync` | When editing flake inputs / `flake.lock` / `ci-linux.yaml` / the impacted-hosts script.            |
 | `nixos-add-host`            | When adding a new host (server or desktop).                                                        |
 | `nixos-add-flake-input`     | When adding (or removing) a flake input.                                                           |
+| `agent-orchestration-protocol` | Before spawning sub-agents. Action classes, scope, prohibitions, stop conditions.               |
+| `autonomy-boundaries`       | Executing a multi-step plan. Scope is the boundary, not a step count.                              |
+| `plan-decomposition`        | Turning a plan or epic into implementable subtasks.                                                |
+| `parallel-work-isolation`   | Running more than one implementation agent at once. Worktrees, foundation-first, merge-back.       |
+| `adopt-orchestration-model` | Migrating another repo onto the shared orchestration model.                                        |
+| `module-cohesion`           | Adding a type to a file that names a different concept.                                            |
+| `state-representation`      | Adding a `bool` field or parameter, or crossing a boundary with one.                               |
 | `precommit-fix-loop`        | When a commit is rejected by pre-commit hooks.                                                     |
 | `commit-discipline`         | Before any commit / PR.                                                                            |
 | `testing-mandate`           | Before declaring any task done.                                                                    |

--- a/agents.md
+++ b/agents.md
@@ -117,6 +117,23 @@ unstable `nixpkgs`. CI treats changes to the `nixpkgs` input as
 
 ---
 
+## Execution model
+
+This repo uses the shared orchestration model. `autonomy-boundaries`
+governs when to continue versus stop: the assigned scope is the
+boundary, not a step count, and irreversible operations still need
+explicit approval. `agent-orchestration-protocol` governs sub-agent
+scoping, `plan-decomposition` governs turning plans into subtasks, and
+`parallel-work-isolation` governs concurrent work.
+
+Note what that declaration does. opencode discovers the shared skills
+globally and loads them by description match, so their presence is not
+opt-in. What this section opts into is **authority**: `agents.md` is
+always-on core context and therefore outranks an on-demand skill, so
+without this declaration a repo's own `agents.md` would win any
+conflict. Repos that have not declared the model are followed as
+written. See `adopt-orchestration-model`.
+
 ## Skills you will need in this repo
 
 These are loaded on demand by opencode when their description matches

--- a/hosts/linux/hfdlhub1/configuration.nix
+++ b/hosts/linux/hfdlhub1/configuration.nix
@@ -43,7 +43,7 @@
       ###############################################################
       {
         name = "dumphfdl-1";
-        image = "ghcr.io/sdr-enthusiasts/docker-dumphfdl:latest-build-200@sha256:df87d1e74639ec5bfd634e0ef64c21cce1f44fe00b878736e14b3199dff470b9";
+        image = "ghcr.io/sdr-enthusiasts/docker-dumphfdl:latest-build-201@sha256:3de816c1cfc7f89b40574faaa8e175dd76b8f4c31e88744c68a8de5f21d5219a";
 
         tty = true;
         restart = "always";
@@ -75,7 +75,7 @@
       ###############################################################
       {
         name = "dumphfdl-2";
-        image = "ghcr.io/sdr-enthusiasts/docker-dumphfdl:latest-build-200@sha256:df87d1e74639ec5bfd634e0ef64c21cce1f44fe00b878736e14b3199dff470b9";
+        image = "ghcr.io/sdr-enthusiasts/docker-dumphfdl:latest-build-201@sha256:3de816c1cfc7f89b40574faaa8e175dd76b8f4c31e88744c68a8de5f21d5219a";
 
         tty = true;
         restart = "always";
@@ -112,7 +112,7 @@
       ###############################################################
       {
         name = "dumphfdl-3";
-        image = "ghcr.io/sdr-enthusiasts/docker-dumphfdl:latest-build-200@sha256:df87d1e74639ec5bfd634e0ef64c21cce1f44fe00b878736e14b3199dff470b9";
+        image = "ghcr.io/sdr-enthusiasts/docker-dumphfdl:latest-build-201@sha256:3de816c1cfc7f89b40574faaa8e175dd76b8f4c31e88744c68a8de5f21d5219a";
 
         tty = true;
         restart = "always";

--- a/modules/monitoring/master/loki-ruler.nix
+++ b/modules/monitoring/master/loki-ruler.nix
@@ -213,13 +213,29 @@ let
             # program that dies. The only signal that is consistent across
             # the whole container family, and it covers dumphfdl and
             # hfdlobserver, neither of which ships a HEALTHCHECK.
+            #
+            # `sdrplay` is excluded from the prefix match. The SDRplay vendor
+            # daemon (sdrplay_apiService) segfaults during its own teardown
+            # whenever it is stopped while a decoder still holds a device
+            # handle, so every container restart produced a CAUTION line and
+            # a critical page. That is a shutdown artefact, not a decoder
+            # crash: the decoder in question came back and resumed
+            # normally. The real bug is fixed in docker-dumphfdl (the
+            # decoder now execs so s6 supervises it directly, instead of
+            # reporting "successfully stopped" while it is still running),
+            # but the vendor daemon will segfault again for anyone else who
+            # kills it with a client attached, so the exclusion stays.
+            #
+            # A decoder death still pages, because those lines carry the
+            # decoder's own prefix (`[dumphfdl]`, `[hfdlobserver]`, ...).
+            # This narrows the match; it does not disable the alert.
             alert = "SDRDecoderCrashed";
-            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `[s6wrap] !!! CAUTION !!!` [15m])) > 0'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `[s6wrap] !!! CAUTION !!!` != `[sdrplay] [s6wrap]` [15m])) > 0'';
             for = "0m";
             labels.severity = "critical";
             annotations = {
               summary = "Decoder process crashed in {{ $labels.unit }} on {{ $labels.host }}";
-              description = "s6wrap reported a supervised program terminating on a signal in the last 15 minutes.";
+              description = "s6wrap reported a supervised program terminating on a signal in the last 15 minutes. The SDRplay API daemon is excluded -- it segfaults on teardown by design flaw, see the rule comment.";
             };
           }
 
@@ -269,13 +285,30 @@ let
           }
 
           {
+            # `ReleaseDevice` is excluded deliberately. The API daemon being
+            # gone while a decoder releases its device is the *shutdown*
+            # path: s6-rc stops the sdrplay service, the vendor daemon
+            # segfaults on teardown, and the decoder's ReleaseDevice() then
+            # finds nothing listening and throws. Every container restart
+            # therefore produced a critical page for a decoder that was
+            # about to come back healthy.
+            #
+            # What remains is the case the alert is actually named for: a
+            # decoder that cannot *acquire* its radio because the daemon is
+            # not answering. That is genuinely unrecoverable without
+            # intervention, which is why it stays critical.
+            #
+            # Note the annotation used to claim "cannot acquire its radio"
+            # while matching the release path -- it described the opposite
+            # of what had happened, which is worse than not alerting during
+            # triage.
             alert = "SDRPlayApiUnresponsive";
-            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `sdrplay_api_ServiceNotResponding` [30m])) > 0'';
+            expr = ''sum by (host, hostname, unit) (count_over_time({unit=~"docker-.*"} |= `sdrplay_api_ServiceNotResponding` != `ReleaseDevice` [30m])) > 0'';
             for = "0m";
             labels.severity = "critical";
             annotations = {
               summary = "SDRplay API unresponsive on {{ $labels.host }}";
-              description = "sdrplay_apiService is not answering. The decoder in {{ $labels.unit }} cannot acquire its radio until the service is restarted.";
+              description = "sdrplay_apiService is not answering a device-acquire call. The decoder in {{ $labels.unit }} cannot start until the service is restarted. Release-path failures during container shutdown are excluded -- see the rule comment.";
             };
           }
 


### PR DESCRIPTION
Promotes the orchestration knowledge that was trapped in freminal into shared skills every repo can use, and fixes a CI blind spot found while verifying it.

## 1. `fix(ci)`: skill edits were invisible to the host filter

`features/ai/opencode` bakes `.opencode/skills/` into every host's home-manager closure via `skillsSource`, so editing a skill changes `home.activationPackage` on all nine Linux hosts. Neither the CI path filter nor the impacted-hosts script had a case for it, so those edits fell through the catch-all and were treated as no-impact.

Verified by diffing the activation `drvPath` across a skills-only change:

```text
with:    liiv6slng89j846rplg2x2nprrqnp4xy-home-manager-generation.drv
without: 5ryz45z6abn2i93hqghi94pi52pkxz88-home-manager-generation.drv
```

Every skills change to date shipped with zero host verification, including the previous PR. Without this fix, this PR would have too.

## 2. `feat(skills)`: seven shared skills

The problem: `freminal-orchestrator-protocol` is generic in everything but its example paths, yet `fredshell` has 8 local skills and no orchestration guidance, and `frext` has none. Separately, `module-cohesion` and `state-representation` each exist as two independently-maintained near-copies (126/107 and 199/141 lines).

| Skill | Core rule |
| --- | --- |
| `autonomy-boundaries` | "Do plan X" means all of X, front to back, and nothing else |
| `agent-orchestration-protocol` | Action classes, five mandatory prompt elements, cleanup entries |
| `plan-decomposition` | JIT planning, orchestrator/implementer split, subtask contract |
| `parallel-work-isolation` | Logic vs file conflicts, worktrees, foundation-first, merge-back |
| `module-cohesion` | Generic core of the duplicated pair |
| `state-representation` | Generic core of the duplicated pair |
| `adopt-orchestration-model` | Migration criteria + READ-ONLY audit prompt |

**`autonomy-boundaries` is the load-bearing one.** It replaces "stop and confirm after every step" — which made the user a manual scheduler for already-approved work — with four continue conditions: verification green, no scope expansion, no unresolved design decision, nothing unforeseen. Any failure is an immediate stop.

No step cap, deliberately: a cap halts correct work at an arbitrary point, which is the problem being solved. The scope does the work. The "and nothing else" half is explicit, and step-by-step mode remains available per session.

**`parallel-work-isolation`** promotes reasoning currently stranded in `PLAN_VERSION_110.md`/`111.md` — worktrees stop file conflicts but not logic conflicts, foundation-first for shared types, one active editor per shared region. Also records the verified worktree footguns (shared config/hooks/stash, concurrent `gc`) and why containers are usually wrong here, in particular that a container toolchain defined outside the flake reintroduces the drift the flake exists to prevent.

**Opt-in.** A repo declares the model in its own `agents.md`; repos where this ceremony isn't worth it are unaffected.

## Verification

- All 9 Linux hosts eval clean; Daytona + fredhub home-manager activation eval clean.
- Both commits eval green independently (bisect-safe).
- Frontmatter validated across all skills: name matches directory, H1 present, description non-thin.
- Full pre-commit suite passes.

## Follow-up (separate PRs)

freminal and fredshell still hold local duplicates. Migration is one PR per repo, gated on running the audit prompt first — section 5 of that audit (generic rules not yet covered upstream) exists specifically to prevent losing a rule by deleting a local skill too early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared guidance for orchestration, autonomy boundaries, parallel work, plan decomposition, module cohesion, and state representation.
  - Added adoption guidance for migrating workflows to shared orchestration practices.

- **Documentation**
  - Updated skills documentation and execution-model guidance.

- **CI Improvements**
  - Shared skill changes now trigger validation across all Linux systems.
  - Darwin validation distinguishes shared skill changes that do not affect current builds.

- **Bug Fixes**
  - Refined monitoring alerts to ignore expected shutdown and teardown messages while retaining genuine failure detection.

- **Maintenance**
  - Updated `dumphfdl` containers to build 201.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->