### PR TITLE
feat(skills): add plan-sequencing-discipline

### DIFF
--- a/.opencode/skills/shared/plan-decomposition/SKILL.md
+++ b/.opencode/skills/shared/plan-decomposition/SKILL.md
@@ -9,6 +9,12 @@ This skill governs **planning time**: turning a goal into subtasks that
 a sub-agent can execute without judgement calls. It is the companion to
 `agent-orchestration-protocol`, which governs **execution time**.
 
+Scope boundary: this skill is about **one** plan's internals. For the
+plan **set** -- numbering as execution order, dependencies between
+plans, the contiguous-completed-prefix invariant, status transitions at
+merge time, and keeping a roadmap index in sync -- load
+`plan-sequencing-discipline`.
+
 ## Decompose just in time, against real code
 
 Plan documents should be written in two tiers:

--- a/.opencode/skills/shared/plan-sequencing-discipline/SKILL.md
+++ b/.opencode/skills/shared/plan-sequencing-discipline/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: plan-sequencing-discipline
+description: Use when maintaining a numbered set of plan/roadmap documents over time in any of fred's repos -- adding a plan, renumbering one, declaring a dependency between plans, changing a plan's status field, marking one complete when its PR merges, or deciding whether two plans may run concurrently. Codifies the number-is-the-execution-order rule, the contiguous-completed-prefix invariant, the no-forward-dependencies rule, freeze-on-start, the merge-is-the-completion-trigger rule, and the index-must-not-drift rule. Distinct from plan-decomposition, which covers turning ONE plan into subtasks.
+---
+
+# Plan sequencing discipline
+
+`plan-decomposition` covers turning **one** plan into subtasks. This
+skill covers the **set** of plans: how they are ordered, how
+dependencies between them are constrained, and how their status is kept
+honest as work lands.
+
+Both failure modes this prevents have actually happened in fred's repos
+and are recorded below. They are bookkeeping failures, not code
+failures, which is exactly why they go unnoticed until the plan is
+lying about the state of the project.
+
+## The number is the execution order
+
+A plan's number **is** its position in the sequence. There is no
+separate phase concept, no ordering document beside the numbering, and
+no second source of truth.
+
+A repo that layered a Phase A / Phase B split on top of its numbering
+produced the order `07`=A, `08`=B, `09`=A, `10`=A, `11`=B -- document
+order diverged from execution order, and the sequence became unreadable
+without opening every document. An external ordering file is the same
+mistake relocated: a second document drifts from the numbering exactly
+as phase labels did.
+
+## The completed set is a contiguous prefix
+
+A `complete` plan may never sit above a plan that is not complete.
+
+This is **deliberately weaker** than strict serial execution. It
+permits concurrent work on adjacent incomplete plans, and that weakness
+is the point -- strict serial ordering would forbid the parallel
+sub-agent execution that `parallel-work-isolation` exists to enable.
+
+What it forbids is a completed plan sitting above an unstarted or
+in-progress one. When that happens the numbering no longer describes
+execution order, and it must be corrected rather than explained.
+
+Note the interaction: this invariant breaks *silently* if someone
+forgets to flip a status at merge time. The plan file and reality
+disagree, the prefix looks intact, and nothing complains.
+
+## No forward dependencies
+
+Every dependency a plan declares must name a **strictly lower** number.
+
+A forward dependency means the sequence is not a valid topological
+order, and a graph that is not a valid topological order can deadlock.
+This is not hypothetical. One repo reached a state where plan 11 blocked
+on plan 8, plan 8 needed a working implementation that depended on plan
+12, and plan 12 was blocked on plan 8 going green. **No legal first
+move into implementation existed.** Every rule in this skill exists to
+make that mechanically impossible rather than merely discouraged.
+
+If a plan genuinely needs something from a higher-numbered plan, the
+numbering is wrong, or the work is split at the wrong boundary. Fix the
+order; do not add the edge.
+
+## A number freezes the moment work starts
+
+Once a plan goes active (branch created, first commit made), its number
+is immutable. Renumbering only ever touches plans that have **never**
+started -- by definition those carry no branch and no commit pointing at
+them.
+
+A repo that renumbered twice in one day without this rule accumulated
+77 dangling cross-references that had to be found and fixed by hand.
+
+The same applies to subtask IDs: a subtask is `<its own plan's
+number>.<n>`, never another plan's prefix and never a letter-suffixed
+variant of one. Two real bugs came from violating this -- a plan
+numbered its subtasks against a different plan's old number, and
+another numbered its subtasks against a temporary staging document. The
+result was one subtask ID naming two unrelated pieces of work in two
+different files, neither of which lived in the document actually
+carrying that number.
+
+## The merge is the completion trigger
+
+Status moves in one direction. The exact vocabulary is per-repo, but
+the shape is:
+
+```text
+stub/planned -> in progress -> pending merge -> complete
+```
+
+**The defining event for `complete` is the PR merging**, not the last
+subtask commit and not the branch going green. Advance the status in
+the same change that records the merge.
+
+This is the transition that gets forgotten, for three compounding
+reasons all observed in practice:
+
+1. **The trunk lags the work.** A long-running integration branch can
+   be dozens of commits ahead of the mainline, so "is it merged?" has
+   two answers depending on which branch is meant. Answer it about the
+   plan's own target branch.
+2. **Status is often maintained in more than one place** and only one
+   gets updated. See the next section.
+3. **The workflow updates the plan at task-completion time on the
+   branch, and has no step that fires at merge time** -- so statuses
+   freeze at whatever they were when the branch closed.
+
+If a repo's workflow has no merge-time step, that is the bug. Add one.
+
+## An index and its detail documents must not drift
+
+When a top-level index (a roadmap table, a master plan) restates facts
+that also live in the individual plan documents, both are updated **in
+the same commit**. Always.
+
+This is not theoretical either: one index drifted within an hour of
+being rewritten, because a plan gained a dependency entry and the
+index row was not updated alongside it. Another repo tracked status in
+two tables -- a summary column and a completion-date table -- and
+routinely showed a completion date next to a status of "pending merge".
+
+Prefer a mechanical check over vigilance. If the repo has a
+plan-linting command, run it before claiming any plan work is done; if
+it does not, the duplication is a standing liability and worth
+surfacing.
+
+## Deciding whether two plans may run concurrently
+
+`parallel-work-isolation` gives the code-level test: disjoint files,
+disjoint behaviour, no shared-type edits, independently valid
+verification. This skill adds the **plan-graph-level** test, and both
+must pass:
+
+- Neither plan depends on the other (directly or transitively).
+- Running them concurrently cannot produce a `complete` plan above an
+  incomplete one -- i.e. if one finishes first, the prefix invariant
+  still holds.
+
+Two plans that are adjacent, mutually independent, and forward-clean
+are eligible for concurrent execution. Eligible is not the same as
+advisable: apply the code-level test before actually running them in
+parallel.
+
+## Hard rules
+
+- Do NOT introduce a second ordering source (a phase label, an
+  ordering document, a priority field that overrides the number).
+- Do NOT add a dependency pointing at a higher number. Re-order
+  instead.
+- Do NOT renumber a plan that has started.
+- Do NOT number a subtask under any plan but its own.
+- Do NOT leave a plan at `pending merge` after its PR has merged.
+- Do NOT update an index without updating the plan document in the same
+  commit, or vice versa.
+
+## When to stop and ask
+
+- The correct fix is renumbering a plan that has already started.
+  That is prohibited above; surface the conflict rather than choosing
+  between two bad options.
+- A plan genuinely appears to need a forward dependency. Either the
+  split is at the wrong boundary or the order is wrong -- both are
+  design decisions, not bookkeeping.
+- The completed set is already not a contiguous prefix when you arrive.
+  Report it; do not silently renumber live work to repair the
+  invariant.
+- A repo's status vocabulary does not map onto the one-directional
+  shape above (e.g. it has a `blocked` or `withdrawn` state). Ask how
+  that state interacts with the prefix invariant rather than assuming.

--- a/agents.md
+++ b/agents.md
@@ -70,8 +70,9 @@ and HFDL decoders.
 │       │                  # markdown-lint-discipline) plus the
 │       │                  # orchestration model: agent-orchestration-
 │       │                  # protocol, autonomy-boundaries, plan-
-│       │                  # decomposition, parallel-work-isolation,
-│       │                  # module-cohesion, state-representation,
+│       │                  # decomposition, plan-sequencing-discipline,
+│       │                  # parallel-work-isolation, module-cohesion,
+│       │                  # state-representation,
 │       │                  # adopt-orchestration-model. The
 │       │                  # orchestration set is OPT-IN per repo --
 │       │                  # a repo declares it in its own agents.md.
@@ -148,6 +149,7 @@ the task. The full bodies live under `.opencode/skills/`.
 | `agent-orchestration-protocol` | Before spawning sub-agents. Action classes, scope, prohibitions, stop conditions.               |
 | `autonomy-boundaries`       | Executing a multi-step plan. Scope is the boundary, not a step count.                              |
 | `plan-decomposition`        | Turning a plan or epic into implementable subtasks.                                                |
+| `plan-sequencing-discipline` | Maintaining a numbered plan set: ordering, cross-plan deps, status at merge, index drift.         |
 | `parallel-work-isolation`   | Running more than one implementation agent at once. Worktrees, foundation-first, merge-back.       |
 | `adopt-orchestration-model` | Migrating another repo onto the shared orchestration model.                                        |
 | `module-cohesion`           | Adding a type to a file that names a different concept.                                            |


### PR DESCRIPTION
Closes the shared-skill gap found by the freminal and fredshell migration audits. This is the prerequisite for both repo migrations — deleting their local plan skills without this would lose rules.

## Why

The two audits independently surfaced two halves of the same missing skill:

| Repo | Rules it holds | Where |
| --- | --- | --- |
| fredshell | number-is-execution-order, contiguous-completed-prefix, no-forward-dependencies, freeze-on-start, index-drift | `fredshell-plan-discipline` + ADR 0007 |
| freminal | two-tables-must-agree, merge is the completion trigger | `freminal-plan-status-lifecycle` |

Nothing shared covered either. `plan-decomposition` is about **one** plan's internals; neither it nor any other shared skill said anything about maintaining the plan **set**.

## The incident that justifies it

fredshell's ADR 0007 records a real deadlock: plan 11 blocked on plan 8, plan 8 needed a working implementation that depended on plan 12, and plan 12 was blocked on plan 8 going green. **No legal first move into implementation existed.** The no-forward-dependencies rule exists to make that mechanically impossible.

Also recorded rather than paraphrased away: the 77 dangling cross-references from renumbering already-started plans, and the subtask ID that named two unrelated pieces of work in two different files because it was numbered against another plan's prefix.

## The parallelism half

The contiguous-prefix rule is **deliberately weaker** than strict serial execution, specifically so concurrent sub-agent work on adjacent incomplete plans stays possible — that reasoning currently lives only in ADR 0007's rejected-alternatives section. The skill adds it as a plan-graph-level independence test that complements the code-level test in `parallel-work-isolation`; both must pass.

## Also

`plan-decomposition` gains an explicit scope boundary pointing here, since the two are easy to confuse.

## Verification

- All 9 Linux hosts eval clean.
- Frontmatter validated across every skill (name matches directory, H1 present).
- Full pre-commit suite passes.

## Follow-up

freminal and fredshell migrations are next, in that order, now that the gap is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for sequencing numbered plans, managing dependencies, tracking completion, and maintaining consistent status updates.
  * Added checks for concurrency eligibility and escalation when sequencing rules cannot be satisfied.

* **Documentation**
  * Clarified that plan-internal guidance is separate from plan-set sequencing responsibilities.
  * Updated the skills documentation to include the new plan-sequencing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->