### PR TITLE
fix(skills): gate concurrent plans on merge order, not prediction

### DIFF
--- a/.opencode/skills/shared/adopt-orchestration-model/SKILL.md
+++ b/.opencode/skills/shared/adopt-orchestration-model/SKILL.md
@@ -61,10 +61,19 @@ Add to the repo's `agents.md`, near the top:
 
 This repo uses the shared orchestration model. `autonomy-boundaries`
 governs when to continue versus stop: the assigned scope is the
-boundary, not a step count. `agent-orchestration-protocol` governs
-sub-agent scoping, `plan-decomposition` governs turning plans into
-subtasks, and `parallel-work-isolation` governs concurrent work.
+boundary, not a step count, and irreversible operations still need
+explicit approval. `agent-orchestration-protocol` governs sub-agent
+scoping, `plan-decomposition` governs turning plans into subtasks,
+`plan-sequencing-discipline` governs the numbered plan set (ordering,
+cross-plan dependencies, status at merge), and
+`parallel-work-isolation` governs concurrent work.
 ```
+
+Name every shared skill the repo is granting authority to. A skill left
+out of this list is still discovered and still loaded, but it does not
+outrank the repo's own `agents.md`, so a conflict silently resolves the
+old way. Drop any line that does not apply -- a repo with no numbered
+plan set does not need the `plan-sequencing-discipline` clause.
 
 Absent that declaration, the repo keeps whatever its `agents.md`
 already says.

--- a/.opencode/skills/shared/plan-sequencing-discipline/SKILL.md
+++ b/.opencode/skills/shared/plan-sequencing-discipline/SKILL.md
@@ -143,16 +143,26 @@ must pass:
   allowed; concurrent *completion* is not.
 
 That second condition is a hard barrier, not a prediction. Because merge
-is the completion trigger, letting the higher-numbered plan merge first
-makes it `complete` while a lower-numbered plan is still in progress --
-which violates the prefix invariant directly. Two independent plans race
-to finish, so roughly half the time the wrong one wins.
+is the completion trigger, letting a higher-numbered plan merge first
+makes it `complete` while a lower-numbered one is not -- which violates
+the prefix invariant directly.
 
-So the rule is: **the higher-numbered plan may be worked on in
-parallel, but must hold at `pending merge` until every lower-numbered
-plan it is racing has merged.** If the lower one turns out to need
-another week, the higher one waits at `pending merge`, or the two are
-renumbered before either starts.
+State the barrier from the invariant, not from the concurrency:
+
+> **A plan may merge only when every lower-numbered plan is already
+> `complete`.**
+
+Do not weaken this to "every lower-numbered plan it was racing".
+Whether two plans overlapped in time is irrelevant to the invariant --
+the prefix is broken by *any* incomplete lower plan, including one that
+never started and one nobody is working on. Plan 31 merging while plan 5
+sits at `stub` is the same violation as plan 31 beating plan 30 in a
+race.
+
+If a lower plan turns out to need another week, the higher one waits at
+`pending merge`. If that wait is unacceptable, renumber **before** work
+starts -- once either plan is active its number is frozen and this
+option is gone.
 
 Two plans that are adjacent, mutually independent, and forward-clean
 are eligible for concurrent execution under that barrier. Eligible is
@@ -175,8 +185,9 @@ than a long-held barrier.
 - Do NOT renumber a plan that has started.
 - Do NOT number a subtask under any plan but its own.
 - Do NOT leave a plan at `pending merge` after its PR has merged.
-- Do NOT merge a higher-numbered plan while a lower-numbered one it ran
-  concurrently with is still incomplete. Hold at `pending merge`.
+- Do NOT merge a plan while **any** lower-numbered plan is incomplete,
+  whether or not the two ran concurrently, and whether or not the lower
+  one has started. Hold at `pending merge`.
 - Do NOT update an index without updating the plan document in the same
   commit, or vice versa.
 
@@ -194,3 +205,9 @@ than a long-held barrier.
 - A repo's status vocabulary does not map onto the one-directional
   shape above (e.g. it has a `blocked` or `withdrawn` state). Ask how
   that state interacts with the prefix invariant rather than assuming.
+- A finished plan is stuck at `pending merge` behind a lower-numbered
+  plan that is stalled, abandoned, or much larger than estimated. The
+  legitimate options -- wait, split the lower plan so its blocking part
+  lands, or accept a documented exception -- are all decisions for the
+  user. Do not merge out of order to unblock yourself, and do not
+  renumber started work to dodge the barrier.

--- a/.opencode/skills/shared/plan-sequencing-discipline/SKILL.md
+++ b/.opencode/skills/shared/plan-sequencing-discipline/SKILL.md
@@ -37,6 +37,12 @@ permits concurrent work on adjacent incomplete plans, and that weakness
 is the point -- strict serial ordering would forbid the parallel
 sub-agent execution that `parallel-work-isolation` exists to enable.
 
+Read precisely what it permits, though: concurrent **work**, not
+concurrent **completion**. Since merge is the completion trigger,
+merging a higher-numbered plan while a lower one is unfinished breaks
+this invariant immediately. The merge barrier that follows from that is
+spelled out under "Deciding whether two plans may run concurrently".
+
 What it forbids is a completed plan sitting above an unstarted or
 in-progress one. When that happens the numbering no longer describes
 execution order, and it must be corrected rather than explained.
@@ -133,14 +139,32 @@ verification. This skill adds the **plan-graph-level** test, and both
 must pass:
 
 - Neither plan depends on the other (directly or transitively).
-- Running them concurrently cannot produce a `complete` plan above an
-  incomplete one -- i.e. if one finishes first, the prefix invariant
-  still holds.
+- **Merges are ordered lowest-number-first.** Concurrent *work* is
+  allowed; concurrent *completion* is not.
+
+That second condition is a hard barrier, not a prediction. Because merge
+is the completion trigger, letting the higher-numbered plan merge first
+makes it `complete` while a lower-numbered plan is still in progress --
+which violates the prefix invariant directly. Two independent plans race
+to finish, so roughly half the time the wrong one wins.
+
+So the rule is: **the higher-numbered plan may be worked on in
+parallel, but must hold at `pending merge` until every lower-numbered
+plan it is racing has merged.** If the lower one turns out to need
+another week, the higher one waits at `pending merge`, or the two are
+renumbered before either starts.
 
 Two plans that are adjacent, mutually independent, and forward-clean
-are eligible for concurrent execution. Eligible is not the same as
-advisable: apply the code-level test before actually running them in
-parallel.
+are eligible for concurrent execution under that barrier. Eligible is
+not advisable on its own: apply the code-level test from
+`parallel-work-isolation` before actually running them in parallel.
+
+Note what this costs. The barrier serialises the *merge*, not the work,
+so the parallelism is real but the payoff is smaller than it looks -- a
+finished higher plan sitting at `pending merge` is capital tied up, and
+it still needs a rebase after the lower plan lands. If the merge order
+is going to be a problem, renumbering before work starts is cheaper
+than a long-held barrier.
 
 ## Hard rules
 
@@ -151,6 +175,8 @@ parallel.
 - Do NOT renumber a plan that has started.
 - Do NOT number a subtask under any plan but its own.
 - Do NOT leave a plan at `pending merge` after its PR has merged.
+- Do NOT merge a higher-numbered plan while a lower-numbered one it ran
+  concurrently with is still incomplete. Hold at `pending merge`.
 - Do NOT update an index without updating the plan document in the same
   commit, or vice versa.
 

--- a/agents.md
+++ b/agents.md
@@ -124,7 +124,9 @@ This repo uses the shared orchestration model. `autonomy-boundaries`
 governs when to continue versus stop: the assigned scope is the
 boundary, not a step count, and irreversible operations still need
 explicit approval. `agent-orchestration-protocol` governs sub-agent
-scoping, `plan-decomposition` governs turning plans into subtasks, and
+scoping, `plan-decomposition` governs turning plans into subtasks,
+`plan-sequencing-discipline` governs the numbered plan set (ordering,
+cross-plan dependencies, status at merge), and
 `parallel-work-isolation` governs concurrent work.
 
 Note what that declaration does. opencode discovers the shared skills


### PR DESCRIPTION
Addresses both CodeRabbit findings on #2174.

## 1. The concurrency rule contradicted its own invariant (Major)

`plan-sequencing-discipline` declared adjacent, independent, forward-clean plans eligible for concurrent execution, conditioned on:

> Running them concurrently cannot produce a `complete` plan above an incomplete one -- i.e. if one finishes first, the prefix invariant still holds.

Two problems:

**It was unverifiable.** You cannot know in advance which of two concurrent plans finishes first, so the condition could never be checked. A dead rule.

**It was wrong.** Because merge is the completion trigger, the higher-numbered plan merging first makes it `complete` while a lower one is in progress — violating the contiguous-prefix invariant directly:

```text
t0  plan 30 in progress, plan 31 in progress     prefix OK
t1  plan 31's PR merges -> 31 complete
    plan 30 still in progress
    => complete(31) above incomplete(30)         VIOLATED
```

Two independent plans race to finish, so roughly half the time the wrong one wins. The skill permitted the exact state its central invariant forbids.

**Fix:** a barrier, not a prediction. Concurrent *work* is allowed; concurrent *completion* is not. The higher-numbered plan holds at `pending merge` until every lower-numbered plan it raced has merged.

I also recorded the cost honestly rather than selling the parallelism: the barrier serialises the merge, so a finished higher plan sitting at `pending merge` is capital tied up and still needs a rebase afterwards. Renumbering before work starts is often cheaper than a long-held barrier.

## 2. Missing from the authority declaration (Major)

`plan-sequencing-discipline` was in `agents.md`'s skill table but not in the execution-model declaration. The table makes a skill *discoverable*; only the declaration gives it *precedence* over the repo's own `agents.md`. In one but not the other means it loads and then silently loses any conflict.

Added there — and to the template in `adopt-orchestration-model` that every migrating repo copies, which had the same omission and would have propagated it to freminal and fredshell. The template now also says to name every skill being granted authority, and to drop clauses that don't apply.

## Verification

- All 9 Linux hosts eval clean.
- Full pre-commit suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified execution guidance for numbered plans, including ordering, dependencies, and merge status.
  * Documented support for concurrent plan work while requiring merges to proceed in ascending numerical order.
  * Added guidance on how repository-specific instructions and non-applicable rules are handled.
  * Explained that higher-numbered plans must remain pending until all lower-numbered plans are complete.
  * Added escalation guidance for sequencing conflicts and merge-order violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->