### PR TITLE
fix: bound journal retention explicitly and stop uvicorn access-log duplication

### DIFF
--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -134,7 +134,16 @@
         user = "nik";
         # scipy==1.10.1 (pinned in requirements.txt) has no cp312+ wheel.
         python = pkgs.python311;
-        execStart = "$VENV/bin/uvicorn app.main:app --host 0.0.0.0 --port 8078 --workers 2";
+        # --no-access-log: uvicorn's per-request log was 248780 of this unit's
+        # 373819 journal lines over two days (67%), making it the single
+        # largest log producer on the host by a wide margin. It is also pure
+        # duplication -- nginx already records every one of these requests in
+        # /var/log/nginx/access.log (1.3M entries in the current file), and
+        # `ss` confirms nothing reaches :8078 except via the flipaholics.pro
+        # proxy_pass, so dropping it loses no coverage. Revisit if :8078 is
+        # ever exposed directly, since then nginx would no longer see
+        # everything.
+        execStart = "$VENV/bin/uvicorn app.main:app --host 0.0.0.0 --port 8078 --workers 2 --no-access-log";
       };
 
       discord-bot = {

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -97,6 +97,42 @@ in
     access-tokens = github.com=${config.sops.placeholder.github_pat}
   '';
 
+  # Explicit journal retention. Previously unset everywhere, which meant every
+  # host silently inherited journald's defaults -- and those defaults are the
+  # reason all seven servers sat at the same ~4G: SystemMaxUse defaults to 10%
+  # of the filesystem but is hard-capped at 4G, so a 74G root resolved to
+  # 7.4G -> clamped to 4G. Nothing was leaking; the cap was simply doing its
+  # job invisibly, and the only way to find that out was to go read journald's
+  # source-level defaults. Stating the policy here makes it reviewable and
+  # per-host overridable via lib.mkForce.
+  #
+  # Compression is NOT configured because it is already active -- journal
+  # headers report COMPRESSED-ZSTD, so there is no win available there.
+  services.journald.extraConfig = ''
+    # Total on-disk journal budget. 1G is ~20 days at fredvps's (post
+    # --no-access-log) rate and far more on the quieter decoder hubs, while
+    # returning ~3G per host versus the implicit 4G default.
+    SystemMaxUse=1G
+
+    # Cap per-file size so vacuuming is fine-grained. Files were landing at
+    # 50-67M, meaning journald could only ever reclaim space in chunks that
+    # coarse; 64M keeps rotation predictable rather than lumpy.
+    SystemMaxFileSize=64M
+
+    # Time ceiling, which was previously unbounded -- fredvps was holding 82
+    # days purely because 4G happened to span that long. Retention should be a
+    # decision, not a side effect of volume: a quiet host keeping a year and a
+    # noisy one keeping a week is exactly the inconsistency that makes
+    # cross-host incident correlation unreliable. Loki (sdrhub) is the
+    # long-term store at retention_period=30d, so the local journal only needs
+    # to cover the window where you would log into the box directly.
+    MaxRetentionSec=30day
+
+    # Force rotation by age so a low-traffic host still produces file
+    # boundaries, keeping MaxRetentionSec able to expire whole files.
+    MaxFileSec=1day
+  '';
+
   # The goModules fixed-output derivation in nixpkgs includes "GOPROXY" in
   # impureEnvVars, meaning it inherits GOPROXY from the Nix daemon's environment.
   # proxy.golang.org redirects Go module downloads to a GCS bucket


### PR DESCRIPTION
## Context

`/var/log/journal` on fredvps was 3.9G. Investigating that turned up two
independent things, one of which was not the problem it looked like.

## What was actually happening

**The 4G was not runaway growth.** Every server sat at the same ceiling:

| Host      | Journal |
| --------- | ------- |
| fredhub   | 2.3G    |
| sdrhub    | 4.0G    |
| acarshub  | 3.9G    |
| vdlmhub   | 3.9G    |
| hfdlhub1  | 3.4G    |
| hfdlhub2  | 3.9G    |
| fredvps   | 3.9G    |

No host set any journald options, so all of them ran on upstream
defaults. `SystemMaxUse` defaults to 10% of the filesystem but is
hard-capped at 4G; a 74G root resolves to 7.4G, which clamps to the cap.
Rotation was working correctly the whole time -- but establishing that
required reading journald's compiled-in defaults, because the
configuration said nothing.

Compression was already active (`COMPRESSED-ZSTD` in the journal
headers), so there was no win available there.

**The noise was real, though.** Over two days on fredvps:

| Unit              | Lines   | Bytes |
| ----------------- | ------- | ----- |
| pyapp-test-site   | 373,706 | 32.5M |
| docker (all)      | 60,788  | 4.7M  |
| tailscaled        | 12,746  | 0.7M  |
| pyapp-discord-bot | 4,985   | 0.4M  |

`pyapp-test-site` was 72% of all journal entries, and 248,780 of its
373,819 lines (67%) were uvicorn's per-request access log.

## Changes

**Explicit journald retention, fleet-wide** (`modules/base/system.nix`):
`SystemMaxUse=1G`, `SystemMaxFileSize=64M`, `MaxRetentionSec=30day`,
`MaxFileSec=1day`. Returns ~3G per host and makes retention a stated
decision rather than a side effect of log volume. `MaxRetentionSec`
matches Loki's `retention_period` on sdrhub, which is the real long-term
store; the local journal only needs to cover the window where you would
ssh into the box. Overridable per host with `lib.mkForce`.

**`--no-access-log` on pyapp-test-site** (`hosts/linux/fredvps/`): the
access log is pure duplication -- nginx already records every one of
these requests, and `ss` confirms nothing reaches `:8078` except via the
`flipaholics.pro` `proxy_pass`. Caveat noted in-comment: `:8078` is open
in the firewall, so that equivalence is a property of current traffic,
not of the config.

## Deliberately not done

`LogFilterPatterns` was evaluated and works (verified live -- note
`systemctl show` does not expose the property, which makes it look
unsupported). It was rejected because after `--no-access-log`, 82% of
what remains on that unit is a single bug's traceback: 1,466 crashes in
two days from an unhandled `FileNotFoundError` in the catch-all
`@app.get("/{page_name}")` route, which turns every 404 into a 500.
Filtering that would hide a live defect. Being fixed in the app repo
instead.

## Verification

`nix eval` of `system.build.toplevel.drvPath` for all 9 hosts, clean, no
evaluation warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced routine web server request logging to minimize unnecessary log output.

* **System Administration**
  * Added journal management settings, including a 1 GB storage limit, 64 MB per-file limit, 30-day retention, and daily rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->