### PR TITLE
chore(flake/freminal): `62221287` -> `d75c8d3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -420,11 +420,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1785851963,
-        "narHash": "sha256-M8PB/kURu61sJV9l2SkKrxyDw6CDoFcpS/7JzDRZwsY=",
+        "lastModified": 1786249459,
+        "narHash": "sha256-IJ9DP2/HWnGbPULgIKngwuzWRePfMcBn68yow7hQLFs=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "62221287ee87f60f133e3d69569f93c613661ca4",
+        "rev": "d75c8d3f08f7262042fc169278b021965ff8bfc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b54195e3`](https://github.com/fredsystems/freminal/commit/b54195e306fceffa6dab1a4a4c019f4f76005fd1) | `` chore: adopt the shared agent orchestration model `` |