### PR TITLE
fix: make fail2ban escalation work, and show who is banned

### DIFF
--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -120,6 +120,140 @@ in
     ];
   };
 
+  # Per-IP ban metrics, for the "Active Bans" panel on the security dashboard.
+  #
+  # WHY node_exporter AND NOT THE FAIL2BAN EXPORTER
+  #
+  # prometheus-fail2ban-exporter reports only per-JAIL aggregates
+  # (f2b_jail_banned_current and friends). It has no per-IP series, so "which
+  # addresses are banned and for how long" cannot be answered from it.
+  #
+  # It does ship a --collector.textfile.directory flag, and that was tried
+  # first. It is broken: the exporter gzips its own metrics and then appends
+  # the textfile content UNCOMPRESSED, so Prometheus rejects the whole scrape
+  # with "gzip: invalid header" and every fail2ban metric disappears. That was
+  # observed in production, not inferred.
+  #
+  # node_exporter's textfile collector is a separate, working implementation
+  # that is already enabled fleet-wide and already serving four .prom files on
+  # this host, so this follows an established path instead of a novel one.
+  #
+  # WHY fail2ban-client AND NOT THE SQLITE DATABASE
+  #
+  # The running daemon holds fail2ban.sqlite3 open; concurrent reads fail with
+  # "database is locked". `fail2ban-client get <jail> banip --with-time` is the
+  # supported interface and already returns everything needed:
+  #
+  #   20.199.183.210 <TAB> 2026-08-09 14:23:56 + 3600 = 2026-08-09 15:23:56
+  systemd = {
+    services.fail2ban-ban-metrics = {
+      description = "Write per-IP fail2ban ban metrics for node_exporter";
+      after = [ "fail2ban.service" ];
+      wants = [ "fail2ban.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        # Deliberately no sandboxing beyond the default. This needs to talk to
+        # the fail2ban socket as root and write into a root-owned directory
+        # shared with the other generators, matching how those units are
+        # written in modules/monitoring/agent/node_exporter.nix.
+        ExecStart = pkgs.writeShellScript "fail2ban-ban-metrics.sh" ''
+          set -uo pipefail
+
+          export PATH=${
+            lib.makeBinPath [
+              pkgs.fail2ban
+              pkgs.coreutils
+              pkgs.gnused
+            ]
+          }
+
+          TEXTFILE_DIR=/var/lib/node_exporter/textfiles
+          OUT="$TEXTFILE_DIR/fail2ban_bans.prom"
+          TMP="$OUT.$$"
+
+          mkdir -p "$TEXTFILE_DIR"
+
+          # Cap per jail. Only CURRENTLY banned addresses are emitted, so this
+          # normally sits around ten and expires down on its own -- but a
+          # distributed sweep during a 64h escalated bantime could pile up, and
+          # unbounded per-IP labels are how a metrics backend gets hurt. Anything
+          # past the cap is counted, not emitted.
+          MAX_PER_JAIL=200
+
+          {
+            echo "# HELP f2b_banned_ip_bantime_seconds Length of the current ban for this address."
+            echo "# TYPE f2b_banned_ip_bantime_seconds gauge"
+            echo "# HELP f2b_banned_ip_expiry_timestamp_seconds Unix time at which this ban expires."
+            echo "# TYPE f2b_banned_ip_expiry_timestamp_seconds gauge"
+            echo "# HELP f2b_banned_ip_truncated Banned addresses omitted because the per-jail cap was hit."
+            echo "# TYPE f2b_banned_ip_truncated gauge"
+            echo "# HELP f2b_ban_metrics_generated_timestamp_seconds Unix time this file was last written."
+            echo "# TYPE f2b_ban_metrics_generated_timestamp_seconds gauge"
+
+            # If fail2ban is down this yields nothing and the loop is skipped,
+            # leaving a file with headers and a fresh timestamp rather than
+            # failing the unit or leaving a stale file in place.
+            jails=$(fail2ban-client status 2>/dev/null \
+              | sed -n 's/.*Jail list:[[:space:]]*//p' \
+              | tr -d ' ' | tr ',' ' ') || jails=""
+
+            for jail in $jails; do
+              n=0
+              omitted=0
+
+              # Output line: <ip> \t <start> + <bantime> = <expiry>
+              while IFS= read -r line; do
+                [ -z "$line" ] && continue
+
+                ip=''${line%%[[:space:]]*}
+                bantime=$(printf '%s' "$line" | sed -n 's/.* + \([0-9][0-9]*\) = .*/\1/p')
+                expiry=$(printf '%s' "$line" | sed -n 's/.* = //p')
+
+                [ -z "$ip" ] && continue
+                [ -z "$bantime" ] && continue
+                [ -z "$expiry" ] && continue
+
+                epoch=$(date -d "$expiry" +%s 2>/dev/null) || continue
+
+                n=$((n + 1))
+                if [ "$n" -gt "$MAX_PER_JAIL" ]; then
+                  omitted=$((omitted + 1))
+                  continue
+                fi
+
+                printf 'f2b_banned_ip_bantime_seconds{jail="%s",ip="%s"} %s\n' "$jail" "$ip" "$bantime"
+                printf 'f2b_banned_ip_expiry_timestamp_seconds{jail="%s",ip="%s"} %s\n' "$jail" "$ip" "$epoch"
+              done <<< "$(fail2ban-client get "$jail" banip --with-time 2>/dev/null || true)"
+
+              printf 'f2b_banned_ip_truncated{jail="%s"} %s\n' "$jail" "$omitted"
+            done
+
+            # Freshness. If this stops advancing the panel is showing stale data,
+            # which is otherwise indistinguishable from "nobody is banned".
+            printf 'f2b_ban_metrics_generated_timestamp_seconds %s\n' "$(date +%s)"
+          } > "$TMP"
+
+          # Atomic replace: node_exporter reads this directory on every scrape
+          # and must never see a partially written file.
+          mv "$TMP" "$OUT"
+        '';
+      };
+    };
+
+    timers.fail2ban-ban-metrics = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        # Every 2 minutes. The other textfile generators run at 10, but this one
+        # backs a live countdown, and each run is two socket round-trips to the
+        # local fail2ban daemon.
+        OnBootSec = "2min";
+        OnUnitActiveSec = "2min";
+        AccuracySec = "10s";
+      };
+    };
+  };
+
   # Filter backing the nginx-probe jail above. Matches the 444 that the
   # $blocked_probe map in nginx.nix returns for credential-theft and
   # WordPress/PHP scans.

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -236,9 +236,41 @@ in
       enable = true;
       maxretry = 5;
       bantime = "1h";
+
+      # How long ban history is retained, which is what the escalation above
+      # counts against. The stock value is 1d, so an address that stays away
+      # for a day has its ban count purged and starts again at 1h -- and the
+      # scanners hitting this host reappear on roughly that cadence, which
+      # would have defeated the escalation even after fixing the multipliers.
+      #
+      # 30d means a persistent scanner keeps climbing the ladder across weeks
+      # instead of resetting daily. Cost is a slightly larger sqlite file;
+      # it was 200 KB holding 113 bans, so a month of history is negligible.
+      daemonSettings.Definition.dbpurgeage = "30d";
+      # Escalating bans for repeat offenders.
+      #
+      # `multipliers` is a SEQUENCE indexed by ban count, not a factor. It was
+      # previously "2", a one-element list, and fail2ban reuses the last
+      # element once the ban count exceeds the list length -- so every ban
+      # after the first was multiplied by exactly 2 and the duration flatlined
+      # at 2h regardless of maxtime.
+      #
+      # Observed on 34.44.183.157 before this change:
+      #
+      #   ban 1  3600s      ban 4  7200s   (should have been 28800)
+      #   ban 2  7200s      ban 5  7200s   (should have been 57600)
+      #   ban 3  7200s
+      #
+      # That mattered practically: the same addresses reappeared roughly every
+      # three hours, so a 2h ban had already expired by the time they came
+      # back and the escalation never bit. 161 bans against 100 unbans in 48
+      # hours, with single addresses banned up to five times.
+      #
+      # The explicit sequence gives 1h, 2h, 4h, 8h, 16h, 32h, 64h and then
+      # holds at 64h, with maxtime capping at a week.
       bantime-increment = {
         enable = true;
-        multipliers = "2";
+        multipliers = "1 2 4 8 16 32 64";
         maxtime = "168h";
       };
 

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -217,6 +217,10 @@ in
             echo "# TYPE f2b_ban_metrics_fail2ban_up gauge"
             echo "# HELP f2b_ban_metrics_parse_failures Lines from fail2ban-client that did not parse."
             echo "# TYPE f2b_ban_metrics_parse_failures gauge"
+            echo "# HELP f2b_ban_metrics_jail_query_failures Jails whose ban list could not be read."
+            echo "# TYPE f2b_ban_metrics_jail_query_failures gauge"
+            echo "# HELP f2b_banned_ip_max_bantime_seconds Longest ban in force in this jail, including addresses omitted by the cap."
+            echo "# TYPE f2b_banned_ip_max_bantime_seconds gauge"
 
             # Health, kept separate from freshness on purpose.
             #
@@ -236,10 +240,27 @@ in
             fi
 
             parse_failures=0
+            jail_query_failures=0
 
             for jail in $jails; do
               n=0
               omitted=0
+              max_bantime=0
+
+              # Captured into a variable rather than piped directly into the
+              # loop so the exit status is observable. Previously this ended
+              # in `|| true`, which turned a failed query into an empty result:
+              # the jail silently contributed no bans while fail2ban_up stayed
+              # 1 and the timestamp stayed fresh, so every health signal read
+              # green with data missing. A per-jail failure is distinct from
+              # the daemon being unreachable, so it gets its own counter
+              # rather than clearing fail2ban_up.
+              if ! banlist=$(fail2ban-client get "$jail" banip --with-time 2>/dev/null); then
+                jail_query_failures=$((jail_query_failures + 1))
+                printf 'f2b_banned_ip_truncated{jail="%s"} 0\n' "$jail"
+                printf 'f2b_banned_ip_max_bantime_seconds{jail="%s"} 0\n' "$jail"
+                continue
+              fi
 
               # Output line: <ip> \t <start> + <bantime> = <expiry>
               while IFS= read -r line; do
@@ -262,6 +283,22 @@ in
                   continue
                 fi
 
+                # Tracked before the cap, so the aggregate stays correct even
+                # when per-IP series are dropped.
+                #
+                # `banip --with-time` returns bans sorted ascending by EXPIRY
+                # (banmanager.py getBanList -> lst.sort on end-of-ban), and
+                # expiry order is not bantime order -- a fresh 1h ban expires
+                # before an older 2h one. So the cap removes an arbitrary
+                # slice with respect to duration, and max() over the emitted
+                # series alone can under-report the longest ban in force.
+                # Which is exactly the number the "Longest Active Ban" panel
+                # exists to show, and exactly when it matters: a sweep large
+                # enough to hit the cap.
+                if [ "$bantime" -gt "$max_bantime" ]; then
+                  max_bantime=$bantime
+                fi
+
                 n=$((n + 1))
                 if [ "$n" -gt "$MAX_PER_JAIL" ]; then
                   omitted=$((omitted + 1))
@@ -277,12 +314,14 @@ in
                   "$jail" "$ip" "$jail" "$ip" "$bantime"
                 printf 'f2b_banned_ip_expiry_timestamp_seconds{jail="%s",ip="%s",ban_id="%s:%s"} %s\n' \
                   "$jail" "$ip" "$jail" "$ip" "$epoch"
-              done <<< "$(fail2ban-client get "$jail" banip --with-time 2>/dev/null || true)"
+              done <<< "$banlist"
 
               printf 'f2b_banned_ip_truncated{jail="%s"} %s\n' "$jail" "$omitted"
+              printf 'f2b_banned_ip_max_bantime_seconds{jail="%s"} %s\n' "$jail" "$max_bantime"
             done
 
             printf 'f2b_ban_metrics_parse_failures %s\n' "$parse_failures"
+            printf 'f2b_ban_metrics_jail_query_failures %s\n' "$jail_query_failures"
 
             # Freshness. If this stops advancing the panel is showing stale data,
             # which is otherwise indistinguishable from "nobody is banned".

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -115,9 +115,32 @@ in
     # the public opening served nothing but scanners. Removed together with
     # the app's own 0.0.0.0 bind below; re-add both if the app ever needs to
     # be reached without going through nginx.
-    firewall.allowedTCPPorts = [
-      2269
-    ];
+    firewall = {
+      allowedTCPPorts = [
+        2269
+      ];
+
+      # Catches anything knocking on port 22, feeding the ssh-decoy jail.
+      #
+      # sshd listens on 2269, so nothing legitimate ever addresses 22 on this
+      # host. That makes a SYN to 22 a zero-false-positive signal: it is a
+      # scanner every single time. The firewall drops those packets anyway,
+      # but silently, so the address was free to keep probing everything else.
+      # Logging them gives fail2ban something to match, which puts a port-22
+      # knock on the same escalation ladder as everything else.
+      #
+      # Appended to nixos-fw ahead of the final log-refuse jump. It only LOGs
+      # -- the packet still falls through to the normal refuse path, so this
+      # changes what is recorded, not what is allowed. Rate-limited because
+      # this host is internet-facing and an unthrottled LOG on a scanned port
+      # is a self-inflicted journal flood; the jail needs 2 hits in a day, so
+      # the limit is far above what detection requires.
+      extraCommands = ''
+        ip46tables -w -A nixos-fw -p tcp --dport 22 --syn \
+          -m limit --limit 12/m --limit-burst 6 \
+          -j LOG --log-level info --log-prefix "ssh-decoy: "
+      '';
+    };
   };
 
   # Per-IP ban metrics, for the "Active Bans" panel on the security dashboard.
@@ -190,13 +213,29 @@ in
             echo "# TYPE f2b_banned_ip_truncated gauge"
             echo "# HELP f2b_ban_metrics_generated_timestamp_seconds Unix time this file was last written."
             echo "# TYPE f2b_ban_metrics_generated_timestamp_seconds gauge"
+            echo "# HELP f2b_ban_metrics_fail2ban_up Whether the jail list could be read from fail2ban."
+            echo "# TYPE f2b_ban_metrics_fail2ban_up gauge"
+            echo "# HELP f2b_ban_metrics_parse_failures Lines from fail2ban-client that did not parse."
+            echo "# TYPE f2b_ban_metrics_parse_failures gauge"
 
-            # If fail2ban is down this yields nothing and the loop is skipped,
-            # leaving a file with headers and a fresh timestamp rather than
-            # failing the unit or leaving a stale file in place.
-            jails=$(fail2ban-client status 2>/dev/null \
+            # Health, kept separate from freshness on purpose.
+            #
+            # The timestamp below is written unconditionally, so a failed query
+            # still produces a fresh file rather than a stale one. That alone
+            # would make "fail2ban is down" look identical to "nobody is
+            # banned" -- both render as an empty table with a green age panel,
+            # and the down case is the one worth paging on. This flag is what
+            # separates them.
+            if jails=$(fail2ban-client status 2>/dev/null \
               | sed -n 's/.*Jail list:[[:space:]]*//p' \
-              | tr -d ' ' | tr ',' ' ') || jails=""
+              | tr -d ' ' | tr ',' ' '); then
+              echo "f2b_ban_metrics_fail2ban_up 1"
+            else
+              jails=""
+              echo "f2b_ban_metrics_fail2ban_up 0"
+            fi
+
+            parse_failures=0
 
             for jail in $jails; do
               n=0
@@ -210,11 +249,18 @@ in
                 bantime=$(printf '%s' "$line" | sed -n 's/.* + \([0-9][0-9]*\) = .*/\1/p')
                 expiry=$(printf '%s' "$line" | sed -n 's/.* = //p')
 
-                [ -z "$ip" ] && continue
-                [ -z "$bantime" ] && continue
-                [ -z "$expiry" ] && continue
+                # A non-empty line that does not parse means the output format
+                # drifted. Counted rather than skipped silently, since the
+                # symptom would otherwise be an empty table that looks healthy.
+                if [ -z "$ip" ] || [ -z "$bantime" ] || [ -z "$expiry" ]; then
+                  parse_failures=$((parse_failures + 1))
+                  continue
+                fi
 
-                epoch=$(date -d "$expiry" +%s 2>/dev/null) || continue
+                if ! epoch=$(date -d "$expiry" +%s 2>/dev/null); then
+                  parse_failures=$((parse_failures + 1))
+                  continue
+                fi
 
                 n=$((n + 1))
                 if [ "$n" -gt "$MAX_PER_JAIL" ]; then
@@ -222,12 +268,21 @@ in
                   continue
                 fi
 
-                printf 'f2b_banned_ip_bantime_seconds{jail="%s",ip="%s"} %s\n' "$jail" "$ip" "$bantime"
-                printf 'f2b_banned_ip_expiry_timestamp_seconds{jail="%s",ip="%s"} %s\n' "$jail" "$ip" "$epoch"
+                # ban_id exists so the dashboard can join the two series on a
+                # key that is actually unique. An address in two jails at once
+                # is routine here -- the three nginx jails read the same log --
+                # and joining on ip alone pairs the wrong ban length with the
+                # wrong jail, producing a plausible-looking wrong row.
+                printf 'f2b_banned_ip_bantime_seconds{jail="%s",ip="%s",ban_id="%s:%s"} %s\n' \
+                  "$jail" "$ip" "$jail" "$ip" "$bantime"
+                printf 'f2b_banned_ip_expiry_timestamp_seconds{jail="%s",ip="%s",ban_id="%s:%s"} %s\n' \
+                  "$jail" "$ip" "$jail" "$ip" "$epoch"
               done <<< "$(fail2ban-client get "$jail" banip --with-time 2>/dev/null || true)"
 
               printf 'f2b_banned_ip_truncated{jail="%s"} %s\n' "$jail" "$omitted"
             done
+
+            printf 'f2b_ban_metrics_parse_failures %s\n' "$parse_failures"
 
             # Freshness. If this stops advancing the panel is showing stale data,
             # which is otherwise indistinguishable from "nobody is banned".
@@ -263,23 +318,74 @@ in
   # access log, written by our own rule. That makes it an unambiguous marker
   # for "this request was a probe", unlike 404 or 403 which legitimate traffic
   # also produces here in volume.
-  environment.etc."fail2ban/filter.d/nginx-probe.conf".text = ''
-    [Definition]
-    # `.*` between the host and the request rather than an explicit
-    # `\S+ \S+ \[timestamp\]`: fail2ban extracts the timestamp with
-    # datepattern and hands the failregex a line with that section already
-    # substituted, so a regex that tries to match the literal
-    # "- - [09/Aug/2026:01:34:08 -0600]" never fires. That was verified the
-    # hard way -- the stricter pattern matched 0 of 94 real 444 lines.
+  environment.etc = {
+    "fail2ban/filter.d/nginx-probe.conf".text = ''
+      [Definition]
+      # `.*` between the host and the request rather than an explicit
+      # `\S+ \S+ \[timestamp\]`: fail2ban extracts the timestamp with
+      # datepattern and hands the failregex a line with that section already
+      # substituted, so a regex that tries to match the literal
+      # "- - [09/Aug/2026:01:34:08 -0600]" never fires. That was verified the
+      # hard way -- the stricter pattern matched 0 of 94 real 444 lines.
+      #
+      # The trailing \s keeps this anchored to the status field so it cannot
+      # match a 444 appearing anywhere else in the line, e.g. in a URL or a
+      # user agent.
+      failregex = ^<HOST> .* "[A-Z]+ [^"]*" 444\s
+      ignoreregex =
+      datepattern = ^[^\[]*\[({DATE})
+                    {^LN-BEG}
+    '';
+
+    # Host-wide, silent bans.
     #
-    # The trailing \s keeps this anchored to the status field so it cannot
-    # match a 444 appearing anywhere else in the line, e.g. in a URL or a
-    # user agent.
-    failregex = ^<HOST> .* "[A-Z]+ [^"]*" 444\s
-    ignoreregex =
-    datepattern = ^[^\[]*\[({DATE})
-                  {^LN-BEG}
-  '';
+    # Two deviations from the stock `iptables-multiport` + REJECT default,
+    # both deliberate.
+    #
+    # ALLPORTS, NOT MULTIPORT. The stock action installs the jump into INPUT
+    # as `-p tcp -m multiport --dports http,https -j f2b-nginx-probe`, so a
+    # prober banned by an nginx jail was still free to hit sshd on 2269. Note
+    # that this is NOT visible in `iptables -L f2b-nginx-probe`: the per-
+    # address rules in that chain always read `all -- <ip> 0.0.0.0/0`, because
+    # the port match lives on the INPUT jump rule, not on the ban rules. The
+    # chain listing looks host-wide under both actions; `iptables -L INPUT -n`
+    # is where the difference actually shows. `type = allports` drops the port
+    # match from the jump, which makes the "all" in the chain listing mean
+    # what it appears to.
+    #
+    # DROP, NOT REJECT. The default answers with ICMP port-unreachable, which
+    # tells a scanner immediately that it is blocked and frees it to move on.
+    # DROP makes it wait for its own TCP timeout on every connection, and
+    # since our bans are host-wide that cost applies to every port it tries.
+    #
+    # blocktype is set for both families -- iptables.conf overrides it under
+    # [Init?family=inet6] for the ICMPv6 variant, so setting only the v4 value
+    # would leave IPv6 offenders on REJECT.
+    "fail2ban/action.d/iptables-allports-drop.conf".text = ''
+      [INCLUDES]
+      before = iptables.conf
+
+      [Definition]
+      type = allports
+
+      [Init]
+      blocktype = DROP
+
+      [Init?family=inet6]
+      blocktype = DROP
+    '';
+
+    # Filter for the port-22 decoy rule (networking.firewall.extraCommands).
+    #
+    # Anchored on both the log prefix and DPT=22 so it cannot match any other
+    # kernel LOG line -- notably `logRefusedConnections`, if that is ever
+    # turned on, which uses the same field layout with a different prefix.
+    "fail2ban/filter.d/ssh-decoy.conf".text = ''
+      [Definition]
+      failregex = ^.*\bssh-decoy:\s.*\bSRC=<HOST>\b.*\bDPT=22\b
+      ignoreregex =
+    '';
+  };
 
   # Backstop for the Docker/nixos-fw gap described at the top of this file.
   # Every container port is now published on an explicit bind address, so in
@@ -371,6 +477,12 @@ in
       maxretry = 5;
       bantime = "1h";
 
+      # Host-wide silent bans for every jail. See the action definition above
+      # for why allports and why DROP. Both are set because banaction-allports
+      # is what the recidive jail below uses.
+      banaction = "iptables-allports-drop";
+      banaction-allports = "iptables-allports-drop";
+
       # How long ban history is retained, which is what the escalation above
       # counts against. The stock value is 1d, so an address that stays away
       # for a day has its ban count purged and starts again at 1h -- and the
@@ -400,11 +512,22 @@ in
       # back and the escalation never bit. 161 bans against 100 unbans in 48
       # hours, with single addresses banned up to five times.
       #
-      # The explicit sequence gives 1h, 2h, 4h, 8h, 16h, 32h, 64h and then
-      # holds at 64h, with maxtime capping at a week.
+      # Ladder: 1h, 2h, 4h, 8h, 16h, 32h, 64h, 128h, then 168h from the ninth
+      # offence on, where maxtime clamps 256h down to the week.
+      #
+      # The two trailing entries are what make maxtime load-bearing. Ending
+      # the sequence at 64 topped the ladder out at 64h, so `min(ban, maxtime)`
+      # never bound and `maxtime = 168h` was decorative -- it described a
+      # ceiling the ladder could not reach. 128 is still under the cap; 256 is
+      # the first step that exceeds it and therefore the first one maxtime
+      # actually clamps.
+      #
+      # The leading 1 is never evaluated (fail2ban skips the formula entirely
+      # on the first ban) but is load-bearing as index padding: the lookup is
+      # multipliers[banCount], so removing it shifts every later step down one.
       bantime-increment = {
         enable = true;
-        multipliers = "1 2 4 8 16 32 64";
+        multipliers = "1 2 4 8 16 32 64 128 256";
         maxtime = "168h";
       };
 
@@ -429,6 +552,7 @@ in
         "::1"
         "100.64.0.0/10"
         "73.26.160.99"
+        "209.40.70.5"
       ];
 
       jails = {
@@ -437,6 +561,51 @@ in
           port = "2269";
           filter = "sshd";
           maxretry = 3;
+        };
+
+        # Anything that SYNs port 22.
+        #
+        # sshd is on 2269, so there is no legitimate traffic to 22 on this
+        # host and no false-positive surface at all -- one knock is already
+        # proof of a scan. maxretry = 2 rather than 1 only because a single
+        # retransmitted SYN can log twice.
+        #
+        # findtime is deliberately long. Slow scanners spread a sweep over
+        # hours specifically to stay under short windows, and since the signal
+        # here is unambiguous there is no reason to give them that.
+        #
+        # backend/logpath are inherited from DEFAULT (systemd), which is
+        # correct: these lines come from the kernel via the journal.
+        ssh-decoy.settings = {
+          enabled = true;
+          filter = "ssh-decoy";
+          maxretry = 2;
+          findtime = "1d";
+        };
+
+        # Escalation across jails, which is the part per-jail bans cannot do.
+        #
+        # Ban counts are tracked per jail, so an address that trips
+        # nginx-probe once, nginx-bad-request once and ssh-decoy once is on
+        # step 1 of three separate ladders and never escalates, despite being
+        # obviously hostile. This jail reads fail2ban's own Ban lines and
+        # treats "banned anywhere, 3 times in a week" as its own offence.
+        #
+        # It cannot feed itself: the stock filter's failregex carries a
+        # `(?!recidive\])` guard, so recidive's own Ban lines are skipped.
+        # Verified with fail2ban-regex, not assumed.
+        #
+        # No logpath. Upstream's jail.conf points this at
+        # /var/log/fail2ban.log, which does not exist here -- NixOS sets
+        # `logtarget = SYSLOG`, so the daemon's own log only reaches the
+        # journal. Inheriting the systemd backend from DEFAULT is what makes
+        # this work, and setting a logpath would break it.
+        recidive.settings = {
+          enabled = true;
+          filter = "recidive";
+          maxretry = 3;
+          findtime = "1w";
+          bantime = "1w";
         };
 
         # Exploit probes, keyed on the 444s produced by the nginx map.

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -397,6 +397,7 @@
         "defaults": {
           "unit": "s",
           "mappings": [],
+          "noValue": "0",
           "color": {
             "mode": "thresholds"
           },
@@ -463,6 +464,7 @@
         "defaults": {
           "unit": "s",
           "mappings": [],
+          "noValue": "0",
           "color": {
             "mode": "thresholds"
           },
@@ -492,7 +494,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "time() - f2b_ban_metrics_generated_timestamp_seconds",
+          "expr": "max(time() - f2b_ban_metrics_generated_timestamp_seconds)",
           "legendFormat": "",
           "instant": true
         }
@@ -502,7 +504,7 @@
       "id": 31,
       "type": "table",
       "title": "Currently Banned Addresses",
-      "description": "Every address banned right now, across all jails, with how long the ban runs and how much is left. Ban Length grows with repeat offences: 1h, 2h, 4h, 8h, 16h, 32h, 64h. Sourced from a node_exporter textfile, since the fail2ban exporter publishes only per-jail totals.",
+      "description": "Every address banned right now, across all jails, with how long the ban runs and how much is left. Ban Length grows with repeat offences: 1h, 2h, 4h, 8h, 16h, 32h, 64h, 128h, then 168h. Bans are host-wide and silent (DROP on all ports), so a listed address cannot reach any service. Sourced from a node_exporter textfile, since the fail2ban exporter publishes only per-jail totals.",
       "gridPos": {
         "h": 11,
         "w": 14,
@@ -607,7 +609,7 @@
               },
               {
                 "id": "max",
-                "value": 57600
+                "value": 604800
               },
               {
                 "id": "min",
@@ -621,7 +623,7 @@
         {
           "id": "joinByField",
           "options": {
-            "byField": "ip",
+            "byField": "ban_id",
             "mode": "outer"
           }
         },
@@ -650,16 +652,21 @@
               "role": true,
               "role 1": true,
               "role 2": true,
-              "jail 2": true
+              "jail 2": true,
+              "ban_id": true,
+              "ban_id 1": true,
+              "ban_id 2": true,
+              "ip 2": true
             },
             "indexByName": {
-              "ip": 0,
+              "ip 1": 0,
               "jail 1": 1,
               "Value #B": 2,
               "Value #A": 3
             },
             "renameByName": {
               "ip": "IP",
+              "ip 1": "IP",
               "jail": "Jail",
               "jail 1": "Jail",
               "Value #A": "Time Left",

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -370,7 +370,7 @@
       "id": 32,
       "type": "stat",
       "title": "Longest Active Ban",
-      "description": "Highest ban length currently in force. Climbs as the escalation ladder engages.",
+      "description": "Highest ban length currently in force. Climbs as the escalation ladder engages. Computed across every active ban, including any the table below omits when a jail exceeds its 200-address cap, so this stays correct during a large sweep.",
       "gridPos": {
         "h": 5,
         "w": 5,
@@ -427,7 +427,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(f2b_banned_ip_bantime_seconds)",
+          "expr": "max(f2b_banned_ip_max_bantime_seconds)",
           "legendFormat": "",
           "instant": true
         }

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -354,6 +354,344 @@
       ]
     },
     {
+      "id": 30,
+      "type": "row",
+      "title": "Active Bans",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "panels": []
+    },
+    {
+      "id": 32,
+      "type": "stat",
+      "title": "Longest Active Ban",
+      "description": "Highest ban length currently in force. Climbs as the escalation ladder engages.",
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 7200
+              },
+              {
+                "color": "orange",
+                "value": 14400
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "max(f2b_banned_ip_bantime_seconds)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "type": "stat",
+      "title": "Ban Data Age",
+      "description": "Seconds since the ban table was regenerated. The timer runs every 2 minutes, so a value climbing past ~3 minutes means the generator has stopped and the table below is stale rather than empty.",
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "time() - f2b_ban_metrics_generated_timestamp_seconds",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "type": "table",
+      "title": "Currently Banned Addresses",
+      "description": "Every address banned right now, across all jails, with how long the ban runs and how much is left. Ban Length grows with repeat offences: 1h, 2h, 4h, 8h, 16h, 32h, 64h. Sourced from a node_exporter textfile, since the fail2ban exporter publishes only per-jail totals.",
+      "gridPos": {
+        "h": 11,
+        "w": 14,
+        "x": 10,
+        "y": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Ban Length",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": true,
+          "reducer": ["count"],
+          "fields": ["IP"]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Ban Length"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 7200
+                    },
+                    {
+                      "color": "orange",
+                      "value": 14400
+                    },
+                    {
+                      "color": "red",
+                      "value": 57600
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time Left"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "max",
+                "value": 57600
+              },
+              {
+                "id": "min",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "ip",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "hostname": true,
+              "hostname 1": true,
+              "hostname 2": true,
+              "exporter": true,
+              "exporter 1": true,
+              "exporter 2": true,
+              "role": true,
+              "role 1": true,
+              "role 2": true,
+              "jail 2": true
+            },
+            "indexByName": {
+              "ip": 0,
+              "jail 1": 1,
+              "Value #B": 2,
+              "Value #A": 3
+            },
+            "renameByName": {
+              "ip": "IP",
+              "jail": "Jail",
+              "jail 1": "Jail",
+              "Value #A": "Time Left",
+              "Value #B": "Ban Length"
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A",
+          "format": "table",
+          "instant": true,
+          "expr": "f2b_banned_ip_expiry_timestamp_seconds - time()"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "B",
+          "format": "table",
+          "instant": true,
+          "expr": "f2b_banned_ip_bantime_seconds"
+        }
+      ]
+    },
+    {
       "id": 7,
       "type": "row",
       "title": "Per Jail",
@@ -362,7 +700,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 18
       },
       "panels": []
     },
@@ -375,7 +713,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 19
       },
       "datasource": {
         "type": "prometheus",
@@ -457,10 +795,44 @@
               "Time 1": true,
               "Time 2": true,
               "Time 3": true,
-              "Time 4": true
+              "Time 4": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "instance": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "hostname": true,
+              "hostname 1": true,
+              "hostname 2": true,
+              "hostname 3": true,
+              "hostname 4": true,
+              "exporter": true,
+              "exporter 1": true,
+              "exporter 2": true,
+              "exporter 3": true,
+              "exporter 4": true,
+              "role": true,
+              "role 1": true,
+              "role 2": true,
+              "role 3": true,
+              "role 4": true,
+              "jail 2": true,
+              "jail 3": true,
+              "jail 4": true
             },
             "renameByName": {
               "jail": "Jail",
+              "jail 1": "Jail",
               "Value #A": "Banned Now",
               "Value #B": "Banned Total",
               "Value #C": "Failed Now",
@@ -521,7 +893,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 19
       },
       "datasource": {
         "type": "prometheus",
@@ -578,7 +950,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 27
       },
       "datasource": {
         "type": "prometheus",
@@ -635,7 +1007,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 15
+        "y": 27
       },
       "datasource": {
         "type": "prometheus",
@@ -692,7 +1064,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 35
       },
       "panels": []
     },
@@ -705,7 +1077,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 36
       },
       "datasource": {
         "type": "loki",
@@ -737,7 +1109,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 36
       },
       "datasource": {
         "type": "loki",
@@ -794,7 +1166,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 46
       },
       "datasource": {
         "type": "loki",


### PR DESCRIPTION
Started from an observation by fred -- the same IPs kept cycling through
bans -- which turned out to be a real config bug. Fixing it exposed that
there was no way to see per-address ban state, so this adds that too.

**Deployed to fredvps and sdrhub, verified live.**

## The bug: escalation was inert

`bantime-increment` was enabled with `maxtime = 168h`, but ban durations
flatlined at 2h forever. Measured on the worst repeat offender before
changing anything:

```text
ban 1  3600s     ban 4  7200s   (should have been 28800)
ban 2  7200s     ban 5  7200s   (should have been 57600)
ban 3  7200s
```

`multipliers` is a **sequence indexed by ban count**, not a factor. It was
set to `"2"` -- a one-element list -- and fail2ban reuses the last element
once the count exceeds the list length. So every ban after the first was
multiplied by exactly 2.

This had a practical consequence rather than just being untidy: the same
addresses reappeared roughly every three hours, so a 2h ban had already
expired by the time they returned. **161 bans against 100 unbans in 48
hours**, with single addresses banned up to five times.

Two changes:

- `multipliers = "1 2 4 8 16 32 64"` → 1h, 2h, 4h, 8h, 16h, 32h, 64h,
  capped by `maxtime` at a week.
- `dbpurgeage` 1d → 30d. Ban history is what escalation counts against,
  and these scanners return on roughly a daily cadence, so the stock 1d
  purge would have defeated the fix on its own.

Already working in production -- one address is at 4h, several at 2h:

```text
Increase Ban 136.118.220.158 (2 # 2h -> 2026-08-09 17:34:37)
```

## Also verified: bans survive restart

Part of the same question. Stopping and starting fail2ban restored 13
bans from sqlite and recreated all 13 iptables rules. The `Total banned`
counter resetting is a per-session statistic, not lost state.

Worth knowing for log reading: a restart emits an `Unban` line per active
ban during teardown, then silently re-adds them. A burst of unbans
sharing one timestamp is a restart, not expiries. That accounted for all
11 apparently-premature unbans in the log -- excluding those, **52 real
unbans, 0 premature**.

## Per-IP visibility

The fail2ban exporter publishes only per-jail aggregates, so "which
addresses, for how long" was unanswerable. Now emitted as node_exporter
textfile metrics, with three dashboard panels: a sortable table of active
bans with a time-remaining gauge, the longest ban in force, and the age
of the data.

**Its own textfile collector is unusable.** That was tried first and
reverted: the exporter gzips its metrics then appends textfile content
*uncompressed*, so Prometheus rejects the whole scrape with
`gzip: invalid header` and every fail2ban metric vanishes. That was a
live outage. node_exporter's collector is a separate, working
implementation already serving four `.prom` files on this host — and this
time the scrape was verified **with `Accept-Encoding: gzip`**, which is
precisely the check whose absence caused the earlier breakage.

`fail2ban-client` is used rather than sqlite because the daemon holds the
database open and concurrent reads fail with `database is locked`.

Bounded: only currently-banned addresses are emitted (10 now, against
55294 existing series), with a hard cap of 200/jail and the remainder
counted in `f2b_banned_ip_truncated`.

## Layout fixes

A screenshot from fred showed the dashboard rendering interleaved. Two
defects:

- The new stats landed inside the "Per Jail" row and a row header
  collided with the table above. The grid is now explicit and checked
  programmatically -- zero overlapping cells.
- **Pre-existing:** "Jail Status" leaked `__name__`, `exporter` and
  `hostname` as visible columns. Its organize transformation excluded
  only Time fields, never the labels Prometheus attaches to every series.

## Verification

| Check | Result |
| ----------------------------- | ------------------------ |
| Escalation live | 4h ban observed, ladder climbing |
| Ban persistence | 13/13 restored across restart |
| gzip scrape | valid, all series present |
| `node_textfile_scrape_error` | 0 |
| Pre-existing `.prom` files | all still parse |
| Prometheus targets | 67/67 up |
| Dashboard queries | all return data |
| Panel overlaps | 0 |
| `nix eval` | clean on all 9 hosts |

## Note

One ban displays as `3601s` rather than `3600s`. The database holds a
clean 3600; `fail2ban-client --with-time` computes
`ceil(expiry) - floor(start)` on a ban that began mid-second. Cosmetic,
and deliberately not rounded away -- keeping the metric byte-identical to
what fail2ban reports is worth more than a tidy column, and rounding
would mask a real discrepancy if one ever appeared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for active Fail2ban bans, including duration, expiry, remaining time, data freshness, and health metrics.
  * Added a security dashboard for longest active bans and currently banned addresses.
  * Added detection for port scans, nginx probes, SSH decoys, and repeated cross-jail offenders.

* **Improvements**
  * Restricted inbound access to SSH on port 2269 and strengthened firewall protections.
  * Increased ban history retention to 30 days.
  * Added progressive ban durations up to 256 hours, capped at 168 hours.
  * Improved handling of unavailable or malformed ban data and limited exported addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->