### PR TITLE
chore(flake/home-manager): `7834e825` -> `367f7ef8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -616,11 +616,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786031233,
-        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
+        "lastModified": 1786286733,
+        "narHash": "sha256-7dN93WKkEERgutPtTjK7SY3ZarO2LAU33A1+vKu+7cc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7834e82588860aaf780cec1366524456a70898d7",
+        "rev": "367f7ef80856d18438953d54dda235d42a46ba31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`367f7ef8`](https://github.com/nix-community/home-manager/commit/367f7ef80856d18438953d54dda235d42a46ba31) | `` claude-code: shorten generated plugin name to "hm" `` |