### PR TITLE
chore(flake/nixpkgs-stable): `ee48b147` -> `8b8c811c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -858,11 +858,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1786089803,
-        "narHash": "sha256-ZuvZfVW2tB5tXYEcpcfhVXB3N4OhdZLOqOviy4OD4b4=",
+        "lastModified": 1786201459,
+        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee48b147c18c7de1e6ec97dc74792be42724bed1",
+        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`0ba79fd3`](https://github.com/NixOS/nixpkgs/commit/0ba79fd3213b4d61936f1013821d443325f7273e) | `` ci/github-script: fix types for context ``                                             |
| [`5b45cdec`](https://github.com/NixOS/nixpkgs/commit/5b45cdecadfdfe33d86104fd4ed0f6648ac288c2) | `` open-webui: align colbert-ai datasets dependency ``                                    |
| [`76246edb`](https://github.com/NixOS/nixpkgs/commit/76246edb23a10e5b23dc5fe22bc297d0f3e5eaf9) | `` stirling-pdf: 2.14.2 -> 2.14.3, remove workaround, fix darwin bin name ``              |
| [`e0d08ff3`](https://github.com/NixOS/nixpkgs/commit/e0d08ff32408f6f207986ca34c15c43fcede4d28) | `` node-core-utils: 6.4.0 -> 7.0.0 ``                                                     |
| [`31323f4f`](https://github.com/NixOS/nixpkgs/commit/31323f4f283200ad0d91a5d0247ff5597c04a13a) | `` powerdns-admin: 0.4.2 -> 0.6.1 ``                                                      |
| [`4ab5639d`](https://github.com/NixOS/nixpkgs/commit/4ab5639db898d60c2b3a61a69ccda37906d4173b) | `` ungoogled-chromium: 151.0.7922.75-1 -> 151.0.7922.108-1 ``                             |
| [`ea4dec2a`](https://github.com/NixOS/nixpkgs/commit/ea4dec2aca8c543ed9794074709ccf9c3381c53e) | `` widevine-cdm: 4.10.2934.0 -> 4.10.3050.0 ``                                            |
| [`4ff85f1f`](https://github.com/NixOS/nixpkgs/commit/4ff85f1fb6c968167c5cb8a6980c502d9f44f27b) | `` matrix-synapse-unwrapped: 1.157.2 -> 1.158.0 ``                                        |
| [`f72377aa`](https://github.com/NixOS/nixpkgs/commit/f72377aa84152c00825010df731ef3661844716c) | `` grafana: 13.0.3 -> 13.0.6 ``                                                           |
| [`26cc67c7`](https://github.com/NixOS/nixpkgs/commit/26cc67c7f8938c6b684d89a3564b143850bf561f) | `` hiredis: 1.4.0 -> 1.4.1 ``                                                             |
| [`c99bc1b3`](https://github.com/NixOS/nixpkgs/commit/c99bc1b3b3e986fcc6ca770c8c01582e20d38b76) | `` btcpayserver: 2.3.4 -> 2.4.2 ``                                                        |
| [`7f52caf6`](https://github.com/NixOS/nixpkgs/commit/7f52caf66940992c46e95a7049d9facc4d0cd086) | `` nbxplorer: 2.6.0 -> 2.6.10 ``                                                          |
| [`545a6ead`](https://github.com/NixOS/nixpkgs/commit/545a6eade1714690fefe4fde9419d0e96f0cd091) | `` lockbook-desktop: 26.7.23 -> 26.8.4 ``                                                 |
| [`2dafc1e0`](https://github.com/NixOS/nixpkgs/commit/2dafc1e0c85885c3308cfe6729f64bab9117cf37) | `` andcli: 2.8.0 -> 2.8.1 ``                                                              |
| [`4d7e0532`](https://github.com/NixOS/nixpkgs/commit/4d7e0532c35f8862daaf750a05ba5b0b1fc135e9) | `` python3Packages.pydub: don't warn on calls to ffmpeg ``                                |
| [`8b8215c8`](https://github.com/NixOS/nixpkgs/commit/8b8215c878ed735807039d0452e123b56daaba08) | `` Revert "ci/github-script/get-pr-commit-details: output file list for merge commits" `` |
| [`419f71c7`](https://github.com/NixOS/nixpkgs/commit/419f71c73ee04307b70693f71595d5498c7ce19b) | `` cinny-desktop: 4.12.5 -> 4.12.6 ``                                                     |
| [`865c7e64`](https://github.com/NixOS/nixpkgs/commit/865c7e6441d81032161ba4b0b24a1a954263add8) | `` cinny-unwrapped: 4.12.3 -> 4.12.6 ``                                                   |
| [`85d4db7f`](https://github.com/NixOS/nixpkgs/commit/85d4db7f12f0ba4c2356f1eec76d493264f0bbb0) | `` xfr: 0.9.22 -> 0.9.25 ``                                                               |
| [`b3a9c19c`](https://github.com/NixOS/nixpkgs/commit/b3a9c19c81bf2b2273e19ef925fabfa81faa9c1b) | `` ghostfolio: 3.35.0 -> 3.43.0 ``                                                        |
| [`6fcfc661`](https://github.com/NixOS/nixpkgs/commit/6fcfc6614bd59e2956dab468eb0c510f8309a759) | `` pocket-id: re-enable a test, now it mocks networking ``                                |
| [`011fa9ca`](https://github.com/NixOS/nixpkgs/commit/011fa9caf62a5d88a81baec1efa3b08b30d55a33) | `` pocket-id: fix some test failing after upstream hid some test files behind tags ``     |
| [`718031ff`](https://github.com/NixOS/nixpkgs/commit/718031ff9e0260a92cb8e23bf91ba060709c4f78) | `` fastnetmon-advanced: add netali to maintainers ``                                      |
| [`391eca80`](https://github.com/NixOS/nixpkgs/commit/391eca805fa0088f867771355cda23c38904ef15) | `` fastnetmon-advanced: 2.0.380 -> 2.0.383 ``                                             |
| [`ad234eb4`](https://github.com/NixOS/nixpkgs/commit/ad234eb4db46fa189d08ed4d45c39f0e696795f2) | `` gleam: 1.18.0 -> 1.18.1 ``                                                             |
| [`19087200`](https://github.com/NixOS/nixpkgs/commit/190872008b54bf2083d2e8885c8164bec216e671) | `` chromium,chromedriver: 151.0.7922.75 -> 151.0.7922.108 ``                              |
| [`ce46d9ff`](https://github.com/NixOS/nixpkgs/commit/ce46d9ff8b3a92da4185a10afd8f5d970b897a8c) | `` mastodon: 4.6.4 -> 4.6.5 ``                                                            |
| [`def0884e`](https://github.com/NixOS/nixpkgs/commit/def0884ed5c07c551fcbed9c889ba7ea8b839e2d) | `` pnpm_11: 11.18.0 -> 11.20.0 ``                                                         |
| [`69d01232`](https://github.com/NixOS/nixpkgs/commit/69d01232c57af55983191f302d4f2053facdcea1) | `` python3Packages.typed-argparse: skip broken tests ``                                   |
| [`484bad4a`](https://github.com/NixOS/nixpkgs/commit/484bad4a8fa9c792d83e4784d516553c548f18e2) | `` knot-resolver_6: 6.4.1 -> 6.4.2 ``                                                     |
| [`41f4ff34`](https://github.com/NixOS/nixpkgs/commit/41f4ff34d64296d38d4de4ca43ce14352b322c48) | `` knot-resolver_5: 5.7.7 -> 5.7.8 ``                                                     |
| [`8ab19452`](https://github.com/NixOS/nixpkgs/commit/8ab19452fe443baf200112ea7932aa7737baa45e) | `` pocket-id: add esch to maintainers ``                                                  |
| [`7b212cd5`](https://github.com/NixOS/nixpkgs/commit/7b212cd524f4cab7390266f72f496260b73cd92b) | `` pocket-id: 2.11.0 -> 2.12.0 ``                                                         |
| [`8fa9f02c`](https://github.com/NixOS/nixpkgs/commit/8fa9f02c0c840b1ce58751b63b393e3a90b8a69a) | `` pocket-id: 2.10.0 -> 2.11.0 ``                                                         |
| [`f6808d50`](https://github.com/NixOS/nixpkgs/commit/f6808d5010955aea192ce920718312554c1355bc) | `` pocket-id: 2.9.0 -> 2.10.0 ``                                                          |
| [`235619d3`](https://github.com/NixOS/nixpkgs/commit/235619d36a51850385aeca6cdc30c7aae4a4cd3e) | `` angie: 1.11.5 -> 1.11.8 ``                                                             |
| [`04b8fc05`](https://github.com/NixOS/nixpkgs/commit/04b8fc059f37373773f7c23051d0995412f3696e) | `` modrinth-app: fix build ``                                                             |
| [`2336488f`](https://github.com/NixOS/nixpkgs/commit/2336488f6c8b1d6fd530d49f3fd6519cd1c5564c) | `` frankenphp: 1.12.5 -> 1.12.6 ``                                                        |
| [`7ba1ff4f`](https://github.com/NixOS/nixpkgs/commit/7ba1ff4f8caaac723693b5a527023e4e207bb426) | `` wayvr: 26.2.1 -> 26.7.1 ``                                                             |
| [`8f8fcdd4`](https://github.com/NixOS/nixpkgs/commit/8f8fcdd44dad31ee191d4eb24d4ffc7158349bd0) | `` prismlauncher: target final wrapper in instance shortcuts ``                           |