### PR TITLE
feat(monitoring): alert when the fail2ban pipeline breaks

### DIFF
--- a/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
@@ -1,0 +1,197 @@
+groups:
+  # Alerts about the fail2ban ban-metrics pipeline on fredvps.
+  #
+  # WHAT THIS GROUP DOES NOT ALERT ON
+  #
+  # Bans. Not ban counts, not ban rate, not individual jails firing, not
+  # recidive, not ssh-decoy catching a scanner. All of that is the system
+  # working as designed, and on this host it happens constantly -- 161 bans in
+  # a 48-hour window before the escalation fix. Paging on success trains the
+  # channel to be ignored, which costs more than it buys. The "Bans Over Time"
+  # and "Ban Rate" panels on the security dashboard already carry the trend.
+  #
+  # Every rule here fires only when the security control itself is broken:
+  # fail2ban unreachable, the generator stalled, or the data it produces
+  # untrustworthy. Those are the cases where the dashboard looks fine and is
+  # lying, which is precisely when nobody is looking at it.
+  #
+  # SCOPE
+  #
+  # fredvps is the only host running fail2ban-ban-metrics.service, because it
+  # is the only internet-facing node in the fleet. Rules deliberately do NOT
+  # pin hostname="fredvps": if the generator is ever added to a second host,
+  # unpinned rules cover it automatically, whereas a pinned rule would silently
+  # exclude it. The one exception is the absent() rule below, which cannot work
+  # without naming the host it expects.
+  - name: fail2ban-pipeline
+    rules:
+      # The daemon is unreachable while the generator still runs.
+      #
+      # This is the case f2b_ban_metrics_fail2ban_up exists for. The generator
+      # writes a fresh timestamp unconditionally, so when the jail-list query
+      # fails the result is an empty ban table under a green "Ban Data Age"
+      # panel -- visually identical to "nobody is banned right now", which is
+      # a completely normal state. Without this rule the only signal that
+      # enforcement has stopped is a human noticing the table is emptier than
+      # usual.
+      #
+      # critical, not warning: fail2ban being down on the only internet-facing
+      # host means nothing is banning anything.
+      #
+      # 10m rather than something tighter because fail2ban is restarted by
+      # every activation that touches its config, and the generator can land
+      # in that window. Five consecutive failed runs is not a restart.
+      - alert: Fail2banDown
+        expr: f2b_ban_metrics_fail2ban_up == 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "fail2ban is unreachable on {{ $labels.hostname }}"
+          description: >-
+            fail2ban-client cannot retrieve the jail list, so no ban state is
+            being read and the security dashboard is showing an empty table
+            with a fresh timestamp. Bans may not be enforced at all. Check
+            fail2ban.service.
+
+      # Daemon reachable, individual jail queries failing.
+      #
+      # Distinct from Fail2banDown on purpose. This is the partial case: the
+      # jail list came back, but at least one `fail2ban-client get <jail> banip`
+      # failed, so that jail contributes no rows while every other health
+      # signal stays green. Before the exit status was captured this was
+      # completely invisible -- `|| true` turned the failure into an empty
+      # result.
+      #
+      # warning, not critical: enforcement is unaffected, the iptables rules
+      # are still in place. This is a visibility fault, not a security one.
+      - alert: Fail2banJailQueryFailing
+        expr: f2b_ban_metrics_jail_query_failures > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "fail2ban jail queries failing on {{ $labels.hostname }}"
+          description: >-
+            {{ $value }} jail(s) could not be queried for their ban list. Those
+            jails are missing from the dashboard while the rest of the data
+            looks healthy. Usually a socket timeout or a jail that stopped
+            between the status call and the per-jail query.
+
+      # The generator has stopped producing fresh data.
+      #
+      # Deliberately overlaps SystemdTimerStale (capacity-alerts.yaml) rather
+      # than relying on it. That rule fires at 72 hours and excludes nothing
+      # relevant here, which is the right threshold for the daily and weekly
+      # timers it was written for and uselessly coarse for a timer that runs
+      # every 2 minutes. It also only knows whether the timer *triggered*,
+      # not whether the run produced anything -- a unit that starts, fails
+      # early and exits leaves the timer looking healthy.
+      #
+      # 600s is five missed ticks. The dashboard's own staleness panel turns
+      # orange at 200s, so this is deliberately well past "one slow run".
+      - alert: Fail2banBanMetricsStale
+        expr: time() - f2b_ban_metrics_generated_timestamp_seconds > 600
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "fail2ban ban metrics are stale on {{ $labels.hostname }}"
+          description: >-
+            The ban-metrics textfile has not been regenerated in over 10
+            minutes against a 2-minute timer. The Active Bans table is showing
+            stale data, which is indistinguishable from an empty one. Check
+            fail2ban-ban-metrics.service and its timer.
+
+      # The meta-rule: everything above matches nothing if the textfile
+      # disappears entirely.
+      #
+      # Modelled directly on NixOSDeployStateMetricsMissing in
+      # system-alerts.yaml, for the same reason documented there: Prometheus
+      # reports a rule whose expression matches nothing as health=ok, so a
+      # metric that stops existing makes every rule depending on it silently
+      # inert. Five rules in this repository rotted that way before anyone
+      # noticed, which is why scripts/check-alert-metrics.sh exists. This is
+      # the runtime equivalent for this group.
+      #
+      # f2b_ban_metrics_fail2ban_up is the right series to select: it is
+      # emitted unconditionally on every run -- including the failure path,
+      # where it is written as 0 -- so its absence always means "the generator
+      # is not reporting", never "the condition is false".
+      #
+      # This is the one rule that must name the host. absent() is only true
+      # when the vector is completely empty, and an unlabelled absent() would
+      # go off the moment fail2ban is deliberately removed from the fleet's
+      # only fail2ban host. Naming fredvps makes the expectation explicit: if
+      # this alert is wrong because the host was decommissioned, the fix is to
+      # delete this rule, and that is a deliberate decision rather than a
+      # silent loss of coverage.
+      #
+      # 1h because a host reboot or a long activation should not page.
+      - alert: Fail2banBanMetricsMissing
+        expr: absent(f2b_ban_metrics_fail2ban_up{hostname="fredvps"})
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "fail2ban ban metrics are missing entirely from fredvps"
+          description: >-
+            No f2b_ban_metrics_fail2ban_up series exists, so every other rule
+            in this group is silently matching nothing and cannot fire. Either
+            the node_exporter textfile collector has lost the file or
+            fail2ban-ban-metrics.service has never run. If fail2ban was
+            intentionally removed from this host, delete this rule group.
+
+  - name: fail2ban-data-quality
+    rules:
+      # fail2ban-client output no longer parses.
+      #
+      # The generator extracts ip, bantime and expiry from
+      # `banip --with-time` with sed patterns matched against a specific
+      # layout. A package bump that changes that layout would otherwise
+      # present as an empty Active Bans table with every health signal green,
+      # since unparsable lines used to be skipped silently.
+      #
+      # 30m because a single malformed line during a restart is noise. A
+      # sustained nonzero count means the format actually moved.
+      - alert: Fail2banParseFailures
+        expr: f2b_ban_metrics_parse_failures > 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "fail2ban ban output is not parsing on {{ $labels.hostname }}"
+          description: >-
+            {{ $value }} line(s) from fail2ban-client did not match the
+            expected `<ip> <start> + <bantime> = <expiry>` layout. Likely a
+            fail2ban upgrade changed the output format; the Active Bans table
+            is incomplete or empty. Compare
+            `fail2ban-client get <jail> banip --with-time` against the parser
+            in hosts/linux/fredvps/configuration.nix.
+
+      # A jail exceeded the 200-address per-jail cap.
+      #
+      # Two possible meanings, both worth knowing about: either the host is
+      # under a distributed sweep large enough to matter, or the cap needs
+      # raising. Per-IP rows beyond the cap are dropped from the table.
+      #
+      # Safe to alert on only because f2b_banned_ip_max_bantime_seconds is
+      # computed BEFORE truncation. Until that fix, hitting the cap also
+      # silently under-reported the longest active ban, so this alert would
+      # have fired alongside a panel that was quietly wrong.
+      #
+      # Peak concurrent bans in any jail to date is 84, so this has headroom
+      # and should not fire in normal operation.
+      - alert: Fail2banBanListTruncated
+        expr: f2b_banned_ip_truncated > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "fail2ban jail {{ $labels.jail }} exceeded its ban-list cap on {{ $labels.hostname }}"
+          description: >-
+            {{ $value }} banned address(es) in jail {{ $labels.jail }} are
+            omitted from the exported metrics because the 200-per-jail cap was
+            hit. Aggregates stay correct, but the Active Bans table is
+            incomplete. Either an unusually large sweep is in progress or
+            MAX_PER_JAIL needs raising.

--- a/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
@@ -1,0 +1,232 @@
+# promtool unit tests for the fail2ban ban-metrics pipeline rules.
+#
+# Gotcha, documented in smart-alerts-test.yaml and re-stated here because it
+# bites every new file in this directory: rules evaluate at the top-level
+# evaluation_interval, but samples are spaced at each test's own `interval`.
+# If `interval` exceeds Prometheus' 5m lookback delta the series is stale at
+# most evaluation steps and a `for:` clause never accumulates a continuous
+# pending period. Keep every interval <= 5m and make input_series long enough
+# to cover the rule's `for:` plus eval_time.
+#
+# The staleness and absent() rules need care beyond that:
+#
+#   - Fail2banBanMetricsStale compares against time(), so the timestamp values
+#     must be absolute epoch seconds consistent with the test clock, which
+#     starts at 0. A series holding 0 is therefore "generated at epoch 0" and
+#     goes stale immediately, which is what the firing case relies on.
+#   - Fail2banBanMetricsMissing uses absent(), which needs the series to be
+#     genuinely absent. Its firing case supplies an unrelated series so the
+#     test has something to evaluate against.
+rule_files:
+  - ../fail2ban-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  #########################################################################
+  # Fail2banDown
+  #########################################################################
+  - interval: 1m
+    name: Fail2banDown fires when the daemon cannot be reached
+    input_series:
+      - series: 'f2b_ban_metrics_fail2ban_up{hostname="fredvps", instance="fredvps.tailc21fc7.ts.net:9100", job="node", role="agent"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: Fail2banDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: fredvps
+              instance: fredvps.tailc21fc7.ts.net:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "fail2ban is unreachable on fredvps"
+              description: "fail2ban-client cannot retrieve the jail list, so no ban state is being read and the security dashboard is showing an empty table with a fresh timestamp. Bans may not be enforced at all. Check fail2ban.service."
+
+  - interval: 1m
+    name: Fail2banDown silent while fail2ban is up
+    input_series:
+      - series: 'f2b_ban_metrics_fail2ban_up{hostname="fredvps"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: Fail2banDown
+        exp_alerts: []
+
+  - interval: 1m
+    name: Fail2banDown does not fire on a short restart blip
+    # Down for 5 minutes then recovered -- shorter than the 10m `for:`, which
+    # is the fail2ban-restart-during-activation case the delay exists for.
+    input_series:
+      - series: 'f2b_ban_metrics_fail2ban_up{hostname="fredvps"}'
+        values: "0+0x5 1+0x25"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: Fail2banDown
+        exp_alerts: []
+
+  #########################################################################
+  # Fail2banJailQueryFailing
+  #########################################################################
+  - interval: 1m
+    name: Fail2banJailQueryFailing fires when a jail query fails
+    input_series:
+      - series: 'f2b_ban_metrics_jail_query_failures{hostname="fredvps", role="agent"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: Fail2banJailQueryFailing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: fredvps
+              role: agent
+            exp_annotations:
+              summary: "fail2ban jail queries failing on fredvps"
+              description: "1 jail(s) could not be queried for their ban list. Those jails are missing from the dashboard while the rest of the data looks healthy. Usually a socket timeout or a jail that stopped between the status call and the per-jail query."
+
+  - interval: 1m
+    name: Fail2banJailQueryFailing silent when all queries succeed
+    input_series:
+      - series: 'f2b_ban_metrics_jail_query_failures{hostname="fredvps"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: Fail2banJailQueryFailing
+        exp_alerts: []
+
+  #########################################################################
+  # Fail2banBanMetricsStale
+  #########################################################################
+  - interval: 1m
+    name: Fail2banBanMetricsStale fires when the generator stops
+    # Timestamp frozen at epoch 0 while the test clock advances, so age
+    # crosses 600s at t=10m and the 10m `for:` completes at t=20m.
+    input_series:
+      - series: 'f2b_ban_metrics_generated_timestamp_seconds{hostname="fredvps", role="agent"}'
+        values: "0+0x40"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: Fail2banBanMetricsStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: fredvps
+              role: agent
+            exp_annotations:
+              summary: "fail2ban ban metrics are stale on fredvps"
+              description: "The ban-metrics textfile has not been regenerated in over 10 minutes against a 2-minute timer. The Active Bans table is showing stale data, which is indistinguishable from an empty one. Check fail2ban-ban-metrics.service and its timer."
+
+  - interval: 1m
+    name: Fail2banBanMetricsStale silent while the timer keeps up
+    # Advances 60 per minute, so age stays at ~0 and never approaches 600s.
+    input_series:
+      - series: 'f2b_ban_metrics_generated_timestamp_seconds{hostname="fredvps"}'
+        values: "0+60x40"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: Fail2banBanMetricsStale
+        exp_alerts: []
+
+  #########################################################################
+  # Fail2banBanMetricsMissing
+  #########################################################################
+  - interval: 1m
+    name: Fail2banBanMetricsMissing fires when the series is gone entirely
+    # An unrelated series so there is something to evaluate; the rule's own
+    # selector matches nothing, which is the condition under test.
+    input_series:
+      - series: 'up{job="node", hostname="fredvps"}'
+        values: "1+0x80"
+    alert_rule_test:
+      - eval_time: 70m
+        alertname: Fail2banBanMetricsMissing
+        exp_alerts:
+          # absent() synthesises a series carrying the equality matchers from
+          # its argument, so hostname="fredvps" appears on the alert even
+          # though no such series exists. That is useful here -- the
+          # notification names the host it is talking about.
+          - exp_labels:
+              severity: warning
+              hostname: fredvps
+            exp_annotations:
+              summary: "fail2ban ban metrics are missing entirely from fredvps"
+              description: "No f2b_ban_metrics_fail2ban_up series exists, so every other rule in this group is silently matching nothing and cannot fire. Either the node_exporter textfile collector has lost the file or fail2ban-ban-metrics.service has never run. If fail2ban was intentionally removed from this host, delete this rule group."
+
+  - interval: 1m
+    name: Fail2banBanMetricsMissing silent when the metric is present
+    # Present and reporting a FAILURE (0). Absence and failure are different
+    # conditions -- this rule must stay quiet and let Fail2banDown handle it.
+    input_series:
+      - series: 'f2b_ban_metrics_fail2ban_up{hostname="fredvps"}'
+        values: "0+0x80"
+    alert_rule_test:
+      - eval_time: 70m
+        alertname: Fail2banBanMetricsMissing
+        exp_alerts: []
+
+  #########################################################################
+  # Fail2banParseFailures
+  #########################################################################
+  - interval: 1m
+    name: Fail2banParseFailures fires on sustained parse failures
+    input_series:
+      - series: 'f2b_ban_metrics_parse_failures{hostname="fredvps", role="agent"}'
+        values: "3+0x50"
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: Fail2banParseFailures
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: fredvps
+              role: agent
+            exp_annotations:
+              summary: "fail2ban ban output is not parsing on fredvps"
+              description: "3 line(s) from fail2ban-client did not match the expected `<ip> <start> + <bantime> = <expiry>` layout. Likely a fail2ban upgrade changed the output format; the Active Bans table is incomplete or empty. Compare `fail2ban-client get <jail> banip --with-time` against the parser in hosts/linux/fredvps/configuration.nix."
+
+  - interval: 1m
+    name: Fail2banParseFailures ignores a transient blip
+    # 10 minutes of failures then clean -- under the 30m `for:`.
+    input_series:
+      - series: 'f2b_ban_metrics_parse_failures{hostname="fredvps"}'
+        values: "1+0x10 0+0x40"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: Fail2banParseFailures
+        exp_alerts: []
+
+  #########################################################################
+  # Fail2banBanListTruncated
+  #########################################################################
+  - interval: 1m
+    name: Fail2banBanListTruncated fires when a jail exceeds the cap
+    input_series:
+      - series: 'f2b_banned_ip_truncated{hostname="fredvps", jail="nginx-probe", role="agent"}'
+        values: "12+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: Fail2banBanListTruncated
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: fredvps
+              jail: nginx-probe
+              role: agent
+            exp_annotations:
+              summary: "fail2ban jail nginx-probe exceeded its ban-list cap on fredvps"
+              description: "12 banned address(es) in jail nginx-probe are omitted from the exported metrics because the 200-per-jail cap was hit. Aggregates stay correct, but the Active Bans table is incomplete. Either an unusually large sweep is in progress or MAX_PER_JAIL needs raising."
+
+  - interval: 1m
+    name: Fail2banBanListTruncated silent when under the cap
+    input_series:
+      - series: 'f2b_banned_ip_truncated{hostname="fredvps", jail="nginx-probe"}'
+        values: "0+0x30"
+      - series: 'f2b_banned_ip_truncated{hostname="fredvps", jail="recidive"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: Fail2banBanListTruncated
+        exp_alerts: []

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -198,6 +198,7 @@ in
         ./alert-rules/sdr-alerts.yaml
         ./alert-rules/meta-alerts.yaml
         ./alert-rules/capacity-alerts.yaml
+        ./alert-rules/fail2ban-alerts.yaml
       ];
 
       scrapeConfigs = [

--- a/scripts/check-alert-metrics.sh
+++ b/scripts/check-alert-metrics.sh
@@ -145,6 +145,36 @@ for name in sorted(os.listdir(rules_dir)):
         cleaned = re.sub(r"'[^']*'", " ", cleaned)
         cleaned = re.sub(r"\[[^\]]*\]", " ", cleaned)
 
+        # Same reasoning, second syntax. Label names also appear as bare
+        # identifiers inside the PARENTHESISED argument of a grouping or
+        # vector-matching clause, which the brace strip above cannot see:
+        #
+        #   * on (host) group_left (running, expected, short_rev, ...)
+        #     max by (host, running, expected, short_rev, ...) (nixos_deploy_info)
+        #
+        # The keywords themselves are in RESERVED, but their argument lists
+        # were not removed, so every label named there leaked into the
+        # identifier scan. The `"_" not in ident` heuristic below then silently
+        # absorbed the ones without underscores (`running`, `expected`) while
+        # reporting the ones with them (`short_rev`, `short_expected_rev`) as
+        # MISSING metrics -- two permanent false positives that made this
+        # script exit 1 on a clean tree.
+        #
+        # That matters more than the two names suggest: a checker that always
+        # fails is one people learn to ignore, which is exactly how the five
+        # rotted rules in the header comment accumulated in the first place.
+        #
+        # Safe against the empty-parens form (`on () group_left () min(...)`,
+        # used in system-alerts, capacity-alerts and smart-alerts): the
+        # [^()]* body matches the empty string, so only the clause itself is
+        # consumed and the following expression is left intact. Verified
+        # against all four grouping clauses currently in this directory.
+        cleaned = re.sub(
+            r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^()]*\)",
+            " ",
+            cleaned,
+        )
+
         for ident in re.findall(r"\b[a-zA-Z_][a-zA-Z0-9_:]*\b", cleaned):
             if ident in RESERVED:
                 continue


### PR DESCRIPTION
Follow-up to #2181. That PR added health instrumentation to the fail2ban
ban-metrics generator and **nothing read any of it** -- `fail2ban_up`,
`parse_failures`, `jail_query_failures` and `truncated` existed only on a
Grafana panel. The one case they were built for, a silent failure at 3am, is
exactly the case where nobody is looking at Grafana.

Six rules in two groups, plus 13 promtool unit tests.

## Pipeline health

| Alert | Severity | `for:` | Fires when |
| ----------------------------- | -------- | ---- | ------------------------------------------ |
| `Fail2banDown`                | critical | 10m  | Daemon unreachable, generator still running |
| `Fail2banJailQueryFailing`    | warning  | 15m  | Daemon up, one jail's query failing         |
| `Fail2banBanMetricsStale`     | warning  | 10m  | Generator stopped producing                 |
| `Fail2banBanMetricsMissing`   | warning  | 1h   | The textfile is gone entirely               |

`Fail2banDown` is the important one. The generator writes its freshness
timestamp unconditionally, so a failed jail-list query presents as an empty
ban table under a *green* age panel -- visually identical to "nobody is
banned", which is a perfectly normal state.

`Fail2banBanMetricsMissing` is the meta-rule that keeps the others honest. If
the textfile disappears, every rule above it matches nothing and Prometheus
reports them all `health=ok`. That is the failure mode
`scripts/check-alert-metrics.sh` was written for after five rules rotted that
way, and it is modelled directly on `NixOSDeployStateMetricsMissing`.

## Data quality

| Alert | Severity | `for:` | Fires when |
| --------------------------- | ------- | ---- | ------------------------------------- |
| `Fail2banParseFailures`     | warning | 30m  | `fail2ban-client` output stopped parsing |
| `Fail2banBanListTruncated`  | warning | 15m  | A jail exceeded the 200-address cap   |

`Fail2banBanListTruncated` is only safe to alert on because
`f2b_banned_ip_max_bantime_seconds` is now computed *before* truncation. Prior
to that fix, hitting the cap also silently under-reported the longest active
ban, so this would have fired alongside a panel that was quietly wrong.

## What this deliberately does not alert on

Bans. Not ban counts, not ban rate, not individual jails firing, not recidive,
not `ssh-decoy` catching a scanner. All of that is the system working as
designed, and on this host it happens constantly -- 161 bans in a 48-hour
window before the escalation fix, and 8 recidive bans in a single second
during its initial catch-up. Paging on success trains the channel to be
ignored, which costs more than it buys. Every rule here fires only when the
security control **itself** is broken.

## Notes on scoping

Rules are deliberately **not** pinned to `hostname="fredvps"`, so if the
generator is ever added to a second host it is covered automatically rather
than silently excluded. The sole exception is `Fail2banBanMetricsMissing`,
where `absent()` cannot work without naming the host it expects -- an
unpinned `absent()` would fire the moment fail2ban is intentionally removed
from the only host running it.

`Fail2banBanMetricsStale` overlaps `SystemdTimerStale` on purpose. That rule
fires at 72 hours, which is correct for the daily and weekly timers it was
written for and uselessly coarse for one running every 2 minutes. It also only
knows whether the timer *triggered*, not whether the run produced anything.

## Verification

| Check | Result |
| ------------------------------------- | ----------------------------- |
| `promtool check rules`                | 6 rules, SUCCESS              |
| `promtool test rules` (new file)      | 13 cases, SUCCESS             |
| Full existing rule suite              | still SUCCESS                 |
| `check-alert-metrics.sh`              | all 5 `f2b_*` families resolve against live Prometheus |
| `nix eval` toplevel                   | clean on all 9 hosts          |
| pre-commit                            | all hooks pass                |

Every rule was written against **live series** confirmed present in Prometheus
after your deploy, not against assumed metric names.

Each alert has both a firing and a silent test case; `Fail2banDown` also has a
short-blip case proving the 10m delay absorbs an activation restart, and
`Fail2banBanMetricsMissing` has a case proving it stays quiet when the metric
is *present but reporting failure* (that is `Fail2banDown`'s job).

One pre-existing issue surfaced but **not** fixed here, to keep this PR
focused: `check-alert-metrics.sh` reports `short_rev` and
`short_expected_rev` as MISSING. Both are `group_left` label names in
`system-alerts.yaml`, not metrics -- a false positive in the checker's
extraction, present on `main` before this branch. Happy to fix separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added monitoring alerts for fail2ban availability, jail query failures, stale or missing metrics, parser failures, and truncated ban lists.
  - Alerts include warning and critical severity levels with host-specific detection.

- **Bug Fixes**
  - Improved metric validation to correctly handle labels and vector-matching clauses.

- **Tests**
  - Added automated coverage for alert firing, healthy states, transient failures, stale data, missing metrics, and threshold conditions.

- **Monitoring**
  - Enabled the new fail2ban alert rules in Prometheus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->