### PR TITLE
feat(monitoring): GitHub CI visibility on sdrhub

### DIFF
--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -158,6 +158,7 @@ jobs:
               [freminal]="darwin"
               [frext]="darwin"
               [nix-yazi-plugins]="darwin"
+              [github-ci-exporter]="skip"
               [nixpkgs-stable]="skip"
               [nixpkgs-kernel]="skip"
               [home-manager-stable]="skip"

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -164,6 +164,7 @@ jobs:
               [home-manager-stable]="server"
               [catppuccin-stable]="server"
               [sops-nix-stable]="server"
+              [github-ci-exporter]="server"
               [nix-yazi-plugins]="desktop"
               [nix-yazi-plugins-stable]="server"
               [nixos-needsreboot]="global"

--- a/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
+++ b/.opencode/skills/projects/nixos-eval-impacted-hosts/scripts/impacted-hosts.sh
@@ -223,6 +223,7 @@ declare -A INPUT_CATEGORY=(
   [home-manager-stable]="server"
   [catppuccin-stable]="server"
   [sops-nix-stable]="server"
+  [github-ci-exporter]="server"
   [sops-nix]="desktop"
   [nix-yazi-plugins]="desktop"
   [nix-yazi-plugins-stable]="server"

--- a/.opencode/skills/projects/nixos-input-category-sync/SKILL.md
+++ b/.opencode/skills/projects/nixos-input-category-sync/SKILL.md
@@ -57,6 +57,7 @@ Linux categories, as of the `nixpkgs-kernel` sync fix:
 | `solaar`                  | `desktop`         | Desktop peripheral daemon                              |
 | `freminal`                | `desktop`         | Terminal emulator, desktops only                       |
 | `frext`                   | `desktop`         | Desktop tooling                                        |
+| `github-ci-exporter`      | `server`          | Prometheus exporter; runs on sdrhub only               |
 | `walls-catppuccin`        | `desktop`         | Wallpapers                                             |
 | `walls-zhichaoh`          | `desktop`         | Wallpapers                                             |
 | `walls-cozypixels`        | `desktop`         | Wallpapers                                             |

--- a/flake.lock
+++ b/flake.lock
@@ -148,6 +148,22 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
         "lastModified": 1761588595,
         "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
@@ -161,7 +177,7 @@
         "type": "github"
       }
     },
-    "flake-compat_5": {
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -260,6 +276,24 @@
         "type": "github"
       }
     },
+    "flake-utils_10": {
+      "inputs": {
+        "systems": "systems_11"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_2"
@@ -316,6 +350,24 @@
     },
     "flake-utils_5": {
       "inputs": {
+        "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "inputs": {
         "systems": [
           "nix-yazi-plugins",
           "systems"
@@ -335,7 +387,7 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_7": {
       "inputs": {
         "systems": [
           "nix-yazi-plugins-stable",
@@ -356,27 +408,9 @@
         "type": "github"
       }
     },
-    "flake-utils_7": {
-      "inputs": {
-        "systems": "systems_7"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_8": {
       "inputs": {
-        "systems": "systems_9"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -397,11 +431,11 @@
         "systems": "systems_10"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -504,8 +538,31 @@
     "git-hooks_3": {
       "inputs": {
         "flake-compat": "flake-compat_4",
+        "nixpkgs": [
+          "github-ci-exporter",
+          "precommit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_4": {
+      "inputs": {
+        "flake-compat": "flake-compat_5",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "lastModified": 1763988335,
@@ -521,9 +578,9 @@
         "type": "github"
       }
     },
-    "git-hooks_4": {
+    "git-hooks_5": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
+        "flake-compat": "flake-compat_6",
         "nixpkgs": [
           "precommit-base",
           "nixpkgs"
@@ -540,6 +597,28 @@
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "github-ci-exporter": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "precommit": "precommit_3",
+        "rust-overlay": "rust-overlay_6"
+      },
+      "locked": {
+        "lastModified": 1786333654,
+        "narHash": "sha256-e7MrSyWUyEs07bT2OcAg4d911MUPsdKYOXJrzOjjKDU=",
+        "owner": "FredSystems",
+        "repo": "github-ci-exporter",
+        "rev": "1368f489fbd0a469d32aca945dd9669fd08e7321",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FredSystems",
+        "repo": "github-ci-exporter",
         "type": "github"
       }
     },
@@ -654,7 +733,7 @@
       "inputs": {
         "niri-stable": "niri-stable",
         "niri-unstable": "niri-unstable",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable",
         "xwayland-satellite-stable": "xwayland-satellite-stable",
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
@@ -745,35 +824,11 @@
     },
     "nix-yazi-plugins": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "flake-utils-plus": "flake-utils-plus",
         "haumea": "haumea",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1785876574,
-        "narHash": "sha256-+ylxRlYTnPfSYxa4QtjAP85CkUz0w5tYG3zP8BoR/5g=",
-        "owner": "lordkekz",
-        "repo": "nix-yazi-plugins",
-        "rev": "8877028ee13b0653c1b370ad2281e1ad04160662",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lordkekz",
-        "repo": "nix-yazi-plugins",
-        "type": "github"
-      }
-    },
-    "nix-yazi-plugins-stable": {
-      "inputs": {
-        "flake-utils": "flake-utils_6",
-        "flake-utils-plus": "flake-utils-plus_2",
-        "haumea": "haumea_2",
-        "nixpkgs": [
-          "nixpkgs-stable"
         ],
         "systems": "systems_6"
       },
@@ -791,11 +846,35 @@
         "type": "github"
       }
     },
-    "nixos-needsreboot": {
+    "nix-yazi-plugins-stable": {
       "inputs": {
         "flake-utils": "flake-utils_7",
-        "git-hooks": "git-hooks_3",
-        "nixpkgs": "nixpkgs_9"
+        "flake-utils-plus": "flake-utils-plus_2",
+        "haumea": "haumea_2",
+        "nixpkgs": [
+          "nixpkgs-stable"
+        ],
+        "systems": "systems_7"
+      },
+      "locked": {
+        "lastModified": 1785876574,
+        "narHash": "sha256-+ylxRlYTnPfSYxa4QtjAP85CkUz0w5tYG3zP8BoR/5g=",
+        "owner": "lordkekz",
+        "repo": "nix-yazi-plugins",
+        "rev": "8877028ee13b0653c1b370ad2281e1ad04160662",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lordkekz",
+        "repo": "nix-yazi-plugins",
+        "type": "github"
+      }
+    },
+    "nixos-needsreboot": {
+      "inputs": {
+        "flake-utils": "flake-utils_8",
+        "git-hooks": "git-hooks_4",
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1785715923,
@@ -874,6 +953,38 @@
     },
     "nixpkgs_10": {
       "locked": {
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1764406085,
+        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
         "lastModified": 1786106723,
         "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "nixos",
@@ -888,7 +999,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_13": {
       "locked": {
         "lastModified": 1784555310,
         "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
@@ -904,7 +1015,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
+    "nixpkgs_14": {
       "locked": {
         "lastModified": 1785967620,
         "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
@@ -920,7 +1031,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -1018,6 +1129,38 @@
     },
     "nixpkgs_7": {
       "locked": {
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
         "lastModified": 1786106723,
         "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "NixOS",
@@ -1032,43 +1175,11 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1759417375,
-        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1764406085,
-        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_11",
-        "systems": "systems_8"
+        "nixpkgs": "nixpkgs_13",
+        "systems": "systems_9"
       },
       "locked": {
         "lastModified": 1785763201,
@@ -1107,10 +1218,10 @@
     },
     "precommit-base": {
       "inputs": {
-        "flake-utils": "flake-utils_8",
-        "git-hooks": "git-hooks_4",
-        "nixpkgs": "nixpkgs_12",
-        "rust-overlay": "rust-overlay_5"
+        "flake-utils": "flake-utils_9",
+        "git-hooks": "git-hooks_5",
+        "nixpkgs": "nixpkgs_14",
+        "rust-overlay": "rust-overlay_7"
       },
       "locked": {
         "lastModified": 1786105217,
@@ -1147,6 +1258,27 @@
         "type": "github"
       }
     },
+    "precommit_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "git-hooks": "git-hooks_3",
+        "nixpkgs": "nixpkgs_7",
+        "rust-overlay": "rust-overlay_5"
+      },
+      "locked": {
+        "lastModified": 1786105217,
+        "narHash": "sha256-ySp0dc1E9ZorICTvG1467QKzZYCp0fcBECEeycz3Dtw=",
+        "owner": "FredSystems",
+        "repo": "pre-commit-checks",
+        "rev": "a994d570247f1d80cbbcd8a33c4b4f866e16af87",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FredSystems",
+        "repo": "pre-commit-checks",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "catppuccin": "catppuccin",
@@ -1156,6 +1288,7 @@
         "flake-utils": "flake-utils_2",
         "freminal": "freminal",
         "frext": "frext",
+        "github-ci-exporter": "github-ci-exporter",
         "home-manager": "home-manager",
         "home-manager-stable": "home-manager-stable",
         "niri": "niri",
@@ -1163,7 +1296,7 @@
         "nix-yazi-plugins": "nix-yazi-plugins",
         "nix-yazi-plugins-stable": "nix-yazi-plugins-stable",
         "nixos-needsreboot": "nixos-needsreboot",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_12",
         "nixpkgs-kernel": "nixpkgs-kernel",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixvim": "nixvim",
@@ -1256,7 +1389,46 @@
     },
     "rust-overlay_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_13"
+        "nixpkgs": "nixpkgs_8"
+      },
+      "locked": {
+        "lastModified": 1786076960,
+        "narHash": "sha256-jfR6OhwurCKn1tREyfOcK/Omxf1Q/DzDDFbnEr1mBLs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "57a23bfaf4f7017267294b161175db1e32eb1c85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_6": {
+      "inputs": {
+        "nixpkgs": [
+          "github-ci-exporter",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786247265,
+        "narHash": "sha256-cVTcTqAhzSNMOVddtBhFpuv+Vx6/SgrhgZWJiI61H24=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6df7076ea0f5697e3242719a4c71211f00411cf5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_7": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_15"
       },
       "locked": {
         "lastModified": 1786076960,
@@ -1379,6 +1551,21 @@
         "type": "github"
       }
     },
+    "systems_11": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "systems_2": {
       "locked": {
         "lastModified": 1681028828,
@@ -1471,6 +1658,21 @@
     },
     "systems_8": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_9": {
+      "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
@@ -1485,24 +1687,9 @@
         "type": "github"
       }
     },
-    "systems_9": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "utils": {
       "inputs": {
-        "flake-utils": "flake-utils_9"
+        "flake-utils": "flake-utils_10"
       },
       "locked": {
         "lastModified": 1779563444,

--- a/flake.nix
+++ b/flake.nix
@@ -206,6 +206,16 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # CI: server
+    # Only sdrhub runs this (monitoring master), and sdrhub is a server, so a
+    # bump rebuilds the server set rather than the desktops.
+    github-ci-exporter = {
+      url = "github:FredSystems/github-ci-exporter";
+      #path on disk
+      #url = "git+file:/home/fred/GitHub/github-ci-exporter";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # wallpapers
 
     # CI: desktop

--- a/modules/monitoring/master/alert-rules/github-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/github-alerts.yaml
@@ -1,0 +1,165 @@
+groups:
+  # Alerts on the state of CI across the sdr-enthusiasts and fredsystems
+  # organisations, sourced from github-ci-exporter on sdrhub.
+  #
+  # SCOPE
+  #
+  # These rules describe the health of the *default branch*. The exporter
+  # already excludes pull-request runs, runs of deleted workflows, and runs
+  # older than 90 days, so anything reaching these expressions is meant to
+  # describe current code. See the exporter's README for why each of those
+  # filters exists -- naively taking the newest run per workflow produced 38
+  # "failures" of which fewer than half were real.
+  #
+  # BOT vs HUMAN
+  #
+  # The exporter labels issues and pull requests with author_kind, derived
+  # from GraphQL's __typename rather than a login denylist. Rules that would
+  # otherwise be dominated by renovate and dependabot select
+  # author_kind="human". Bot activity stays on the dashboard for visibility.
+  - name: github-ci
+    rules:
+      # The core signal. A workflow whose most recent branch-state run
+      # failed.
+      #
+      # conclusion="failure" covers only genuine breakage: the exporter maps
+      # cancelled and skipped to their own conclusions, because both are
+      # routine (superseded pushes, path filters) and paging on them trains
+      # the operator to ignore the alert. timed_out and action_required are
+      # separate conclusions and are matched explicitly below.
+      #
+      # The 15m `for:` absorbs the retrigger window -- a push that fails and
+      # is immediately fixed should not page.
+      - alert: GitHubCIFailingDefaultBranch
+        expr: |
+          max by (org, repo, workflow) (
+            github_workflow_run_status{conclusion=~"failure|timed_out|action_required"}
+          ) == 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "CI failing on {{ $labels.org }}/{{ $labels.repo }}"
+          description: "Workflow {{ $labels.workflow }} last failed on the default branch of {{ $labels.org }}/{{ $labels.repo }}."
+
+      # GitHub disables scheduled workflows in a repository with no activity
+      # for 60 days, silently. The workflow simply stops running; nothing is
+      # reported anywhere. This was live in the fleet on fredsystems/fred-cal,
+      # where a weekly update-flakes had been dead long enough to be invisible.
+      #
+      # state="disabled_inactivity" only. A manual disable is deliberate and
+      # must not page.
+      - alert: GitHubWorkflowAutoDisabled
+        expr: github_workflow_enabled{state="disabled_inactivity"} == 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "GitHub auto-disabled {{ $labels.workflow }} in {{ $labels.org }}/{{ $labels.repo }}"
+          description: "GitHub disabled this workflow after 60 days of repository inactivity. It is no longer running. Re-enable it in the Actions tab, or push to the repository."
+
+      # A scheduled workflow that has missed its cadence. expected_interval is
+      # derived from the workflow's own cron expression, so the threshold
+      # adapts to weekly vs daily schedules rather than being a fixed guess.
+      #
+      # 3x rather than 2x: GitHub's scheduled runs are best-effort and are
+      # routinely delayed under load, so 2x produces false positives on hourly
+      # crons. The `unless` guard suppresses this for workflows already known
+      # to be disabled, which GitHubWorkflowAutoDisabled reports with a more
+      # accurate description.
+      - alert: GitHubScheduledWorkflowStale
+        expr: |
+          (
+            time() - github_workflow_run_timestamp_seconds
+              > 3 * github_workflow_expected_interval_seconds
+          )
+          unless on (org, repo, workflow) (
+            github_workflow_enabled == 0
+          )
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Scheduled workflow {{ $labels.workflow }} has not run in {{ $labels.org }}/{{ $labels.repo }}"
+          description: "Last run was {{ $value | humanizeDuration }} ago, more than three times its configured schedule interval."
+
+      # A human pull request left open for a month. Bot PRs are excluded
+      # entirely -- renovate and dependabot routinely hold PRs open by design,
+      # and including them would make this fire constantly.
+      #
+      # Drafts are excluded: an open draft is work in progress, not a stalled
+      # review.
+      - alert: GitHubHumanPullRequestStale
+        expr: |
+          (time() - github_pull_created_timestamp_seconds{author_kind="human", draft="false"})
+            > 30 * 24 * 3600
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: "PR #{{ $labels.number }} open {{ $value | humanizeDuration }} in {{ $labels.org }}/{{ $labels.repo }}"
+          description: "Pull request #{{ $labels.number }} by {{ $labels.author }} has been open for over 30 days."
+
+  # Health of the exporter itself. Without these, an exporter that has died or
+  # exhausted its API budget is indistinguishable from a fleet whose CI is
+  # entirely green -- the same silent-failure trap meta-alerts.yaml exists to
+  # close for the monitoring stack.
+  - name: github-ci-exporter
+    rules:
+      - alert: GitHubExporterDown
+        expr: up{job="github-ci"} == 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "github-ci-exporter is not responding"
+          description: "Prometheus cannot scrape the GitHub CI exporter on sdrhub. All CI visibility is blind."
+
+      # The exporter serves metrics even when collection fails, so `up` alone
+      # is not sufficient: a broken token or a GitHub outage leaves the
+      # process healthy and the data frozen.
+      - alert: GitHubExporterCollectionFailing
+        expr: github_exporter_scrape_success == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "github-ci-exporter cannot collect from GitHub"
+          description: "Collection cycles have been failing for 30 minutes. Displayed CI state is stale. Check the token and GitHub's status."
+
+      # Backstop for a failure mode neither of the above catches: the process
+      # is up and the last cycle reported success, but the timer has stopped
+      # or every cycle is being skipped. Three intervals of slack on a 5m
+      # cycle.
+      - alert: GitHubExporterStale
+        expr: time() - github_exporter_last_success_timestamp_seconds > 3600
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "github-ci-exporter data is stale"
+          description: "No successful collection cycle for {{ $value | humanizeDuration }}, despite the exporter being reachable."
+
+      # The exporter withholds a reserve and skips a cycle it cannot afford,
+      # so budget pressure degrades into staleness rather than errors. That
+      # makes it quiet, which is exactly why it needs its own alert.
+      - alert: GitHubExporterBudgetExhausted
+        expr: github_exporter_budget_exhausted == 1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "github-ci-exporter skipped a cycle to protect the API budget"
+          description: "The remaining GitHub API budget could not cover a full sweep, so collection was skipped. CI state is not being refreshed."
+
+      # Early warning, before the pre-flight check starts skipping cycles.
+      # 500 of 5000 is comfortably above the 250 reserve, so this fires while
+      # there is still room to act.
+      - alert: GitHubExporterRateLimitLow
+        expr: github_exporter_rate_limit_remaining < 500
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GitHub API budget low for {{ $labels.resource }}"
+          description: "Only {{ $value }} requests remain in the {{ $labels.resource }} pool. The exporter will start skipping cycles as it approaches its reserve."

--- a/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
@@ -1,0 +1,425 @@
+# promtool unit tests for the GitHub CI alerting rules.
+#
+# Run with:
+#   nix build .#checks.x86_64-linux.prometheus-alert-rules
+#
+# Same rationale as the other test files here: a rule can be syntactically
+# valid, report health=ok, and still be incapable of ever firing, because an
+# empty query result is not an error. Every alert has a firing case and a
+# non-firing case, and the non-firing cases are chosen to be the specific
+# false-positive traps each rule's guards exist to prevent -- most of which
+# were observed in real data before the exporter's filters were added.
+#
+# Keep every `interval:` at 5m or below: samples spaced beyond Prometheus'
+# 5m lookback delta go stale between evaluations, so a rule with a `for:`
+# clause never accumulates a continuous pending period and silently fails to
+# fire regardless of whether its expression is correct.
+rule_files:
+  - ../github-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # ---------------------------------------------------------------------------
+  # GitHubCIFailingDefaultBranch
+  # ---------------------------------------------------------------------------
+
+  - interval: 5m
+    name: GitHubCIFailingDefaultBranch fires on a failed default-branch run
+    input_series:
+      - series: 'github_workflow_run_status{org="fredsystems", repo="frext", workflow="CI", event="push", conclusion="failure", job="github-ci", hostname="sdrhub", role="master"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubCIFailingDefaultBranch
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              org: fredsystems
+              repo: frext
+              workflow: CI
+            exp_annotations:
+              summary: "CI failing on fredsystems/frext"
+              description: "Workflow CI last failed on the default branch of fredsystems/frext."
+
+  - interval: 5m
+    name: GitHubCIFailingDefaultBranch fires on timed_out
+    input_series:
+      - series: 'github_workflow_run_status{org="fredsystems", repo="zabbid", workflow="CI", event="push", conclusion="timed_out", job="github-ci"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubCIFailingDefaultBranch
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              org: fredsystems
+              repo: zabbid
+              workflow: CI
+            exp_annotations:
+              summary: "CI failing on fredsystems/zabbid"
+              description: "Workflow CI last failed on the default branch of fredsystems/zabbid."
+
+  # A green build must not alert. Trivial, but it is the guard that catches a
+  # regex accidentally matching every conclusion.
+  - interval: 5m
+    name: GitHubCIFailingDefaultBranch stays silent on success
+    input_series:
+      - series: 'github_workflow_run_status{org="sdr-enthusiasts", repo="docker-tar1090", workflow="Deploy", event="push", conclusion="success", job="github-ci"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubCIFailingDefaultBranch
+        exp_alerts: []
+
+  # Cancelled and skipped are routine: a superseded push cancels the in-flight
+  # run, and path filters skip workflows constantly. Paging on either would
+  # train the operator to ignore this alert.
+  - interval: 5m
+    name: GitHubCIFailingDefaultBranch ignores cancelled and skipped
+    input_series:
+      - series: 'github_workflow_run_status{org="fredsystems", repo="nixos", workflow="CI", event="push", conclusion="cancelled", job="github-ci"}'
+        values: "1+0x20"
+      - series: 'github_workflow_run_status{org="fredsystems", repo="nixos", workflow="Lint", event="push", conclusion="skipped", job="github-ci"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubCIFailingDefaultBranch
+        exp_alerts: []
+
+  # An in-flight run must not clear a failure, nor raise one of its own.
+  - interval: 5m
+    name: GitHubCIFailingDefaultBranch ignores a running build
+    input_series:
+      - series: 'github_workflow_run_status{org="fredsystems", repo="nixos", workflow="CI", event="push", conclusion="running", job="github-ci"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubCIFailingDefaultBranch
+        exp_alerts: []
+
+  # A run older than the exporter's 90-day horizon is reported as `stale`
+  # rather than by its original conclusion, because an eight-month-old result
+  # says nothing about current code and produces an alert nobody can clear
+  # without an artificial push.
+  - interval: 5m
+    name: GitHubCIFailingDefaultBranch ignores aged-out runs
+    input_series:
+      - series: 'github_workflow_run_status{org="fredsystems", repo="pre-commit-checks", workflow="Lint", event="push", conclusion="stale", job="github-ci"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubCIFailingDefaultBranch
+        exp_alerts: []
+
+  # The 15m `for:` exists so a failure that is fixed on the next push does not
+  # page.
+  - interval: 5m
+    name: GitHubCIFailingDefaultBranch does not fire before the for clause
+    input_series:
+      - series: 'github_workflow_run_status{org="fredsystems", repo="frext", workflow="CI", event="push", conclusion="failure", job="github-ci"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: GitHubCIFailingDefaultBranch
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # GitHubWorkflowAutoDisabled
+  # ---------------------------------------------------------------------------
+
+  - interval: 5m
+    name: GitHubWorkflowAutoDisabled fires on an inactivity auto-disable
+    input_series:
+      - series: 'github_workflow_enabled{org="fredsystems", repo="fred-cal", workflow="update-flakes", state="disabled_inactivity", job="github-ci"}'
+        values: "0+0x40"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubWorkflowAutoDisabled
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              org: fredsystems
+              repo: fred-cal
+              workflow: update-flakes
+              state: disabled_inactivity
+              job: github-ci
+            exp_annotations:
+              summary: "GitHub auto-disabled update-flakes in fredsystems/fred-cal"
+              description: "GitHub disabled this workflow after 60 days of repository inactivity. It is no longer running. Re-enable it in the Actions tab, or push to the repository."
+
+  # A manual disable is a deliberate choice and must never page. This is the
+  # whole reason the exporter distinguishes the two disabled states rather
+  # than exposing a single boolean.
+  - interval: 5m
+    name: GitHubWorkflowAutoDisabled ignores a manual disable
+    input_series:
+      - series: 'github_workflow_enabled{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Check container software versions", state="disabled_manually", job="github-ci"}'
+        values: "0+0x40"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubWorkflowAutoDisabled
+        exp_alerts: []
+
+  - interval: 5m
+    name: GitHubWorkflowAutoDisabled ignores an active workflow
+    input_series:
+      - series: 'github_workflow_enabled{org="fredsystems", repo="nixos", workflow="CI", state="active", job="github-ci"}'
+        values: "1+0x40"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubWorkflowAutoDisabled
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # GitHubScheduledWorkflowStale
+  # ---------------------------------------------------------------------------
+
+  # Daily cron: 3x the interval is 72h. Rather than advancing eval_time for
+  # four days (which at a 5m sample spacing would need ~1150 samples), the
+  # last-run timestamp is set four days in the past, so a short evaluation
+  # window still exercises the threshold.
+  - interval: 5m
+    name: GitHubScheduledWorkflowStale fires past three intervals
+    input_series:
+      - series: 'github_workflow_run_timestamp_seconds{org="sdr-enthusiasts", repo="docker-xng", workflow="update-flakes", job="github-ci"}'
+        values: "-345600+0x30"
+      - series: 'github_workflow_expected_interval_seconds{org="sdr-enthusiasts", repo="docker-xng", workflow="update-flakes", job="github-ci"}'
+        values: "86400+0x30"
+      - series: 'github_workflow_enabled{org="sdr-enthusiasts", repo="docker-xng", workflow="update-flakes", state="active", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: GitHubScheduledWorkflowStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              org: sdr-enthusiasts
+              repo: docker-xng
+              workflow: update-flakes
+              job: github-ci
+            exp_annotations:
+              summary: "Scheduled workflow update-flakes has not run in sdr-enthusiasts/docker-xng"
+              description: "Last run was 4d 1h 0m 0s ago, more than three times its configured schedule interval."
+
+  # The same four-day-old run against a weekly cron must NOT fire: 3x a week
+  # is 21 days. Guards against a fixed threshold silently replacing the
+  # cron-derived one.
+  - interval: 5m
+    name: GitHubScheduledWorkflowStale respects a weekly interval
+    input_series:
+      - series: 'github_workflow_run_timestamp_seconds{org="fredsystems", repo="freminal", workflow="update-flakes", job="github-ci"}'
+        values: "-345600+0x30"
+      - series: 'github_workflow_expected_interval_seconds{org="fredsystems", repo="freminal", workflow="update-flakes", job="github-ci"}'
+        values: "604800+0x30"
+      - series: 'github_workflow_enabled{org="fredsystems", repo="freminal", workflow="update-flakes", state="active", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: GitHubScheduledWorkflowStale
+        exp_alerts: []
+
+  # A disabled workflow is not "late", it is off. GitHubWorkflowAutoDisabled
+  # reports that with an accurate description; this rule must stay quiet so
+  # one condition does not produce two pages.
+  - interval: 5m
+    name: GitHubScheduledWorkflowStale is suppressed for a disabled workflow
+    input_series:
+      - series: 'github_workflow_run_timestamp_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
+        values: "-345600+0x30"
+      - series: 'github_workflow_expected_interval_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
+        values: "86400+0x30"
+      - series: 'github_workflow_enabled{org="fredsystems", repo="fred-cal", workflow="update-flakes", state="disabled_inactivity", job="github-ci"}'
+        values: "0+0x30"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: GitHubScheduledWorkflowStale
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # GitHubHumanPullRequestStale
+  # ---------------------------------------------------------------------------
+
+  # Created 31 days in the past. Encoding the age in the series value rather
+  # than advancing eval_time keeps the sample count small; a 31-day
+  # evaluation at 5m spacing would need ~8900 samples.
+  - interval: 5m
+    name: GitHubHumanPullRequestStale fires on an old human PR
+    input_series:
+      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="1615", author="fredclausen", author_kind="human", draft="false", job="github-ci"}'
+        values: "-2678400+0x30"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubHumanPullRequestStale
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              org: fredsystems
+              repo: nixos
+              number: "1615"
+              author: fredclausen
+              author_kind: human
+              draft: "false"
+              job: github-ci
+            exp_annotations:
+              summary: "PR #1615 open 31d 2h 0m 0s in fredsystems/nixos"
+              description: "Pull request #1615 by fredclausen has been open for over 30 days."
+
+  # Bot PRs are excluded by design. renovate holds PRs open indefinitely;
+  # including them would make this rule fire on dozens of PRs permanently.
+  - interval: 5m
+    name: GitHubHumanPullRequestStale ignores bot PRs
+    input_series:
+      - series: 'github_pull_created_timestamp_seconds{org="sdr-enthusiasts", repo="docker-acarshub", number="900", author="renovate", author_kind="bot", draft="false", job="github-ci"}'
+        values: "-2678400+0x30"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubHumanPullRequestStale
+        exp_alerts: []
+
+  # An open draft is work in progress, not a stalled review.
+  - interval: 5m
+    name: GitHubHumanPullRequestStale ignores drafts
+    input_series:
+      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="42", author="fredclausen", author_kind="human", draft="true", job="github-ci"}'
+        values: "-2678400+0x30"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubHumanPullRequestStale
+        exp_alerts: []
+
+  - interval: 5m
+    name: GitHubHumanPullRequestStale ignores a recent PR
+    input_series:
+      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="99", author="fredclausen", author_kind="human", draft="false", job="github-ci"}'
+        values: "-864000+0x30"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubHumanPullRequestStale
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # Exporter health
+  # ---------------------------------------------------------------------------
+
+  - interval: 5m
+    name: GitHubExporterDown fires when the scrape fails
+    input_series:
+      - series: 'up{job="github-ci", instance="127.0.0.1:9418", hostname="sdrhub", role="master"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: GitHubExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: github-ci
+              instance: 127.0.0.1:9418
+              hostname: sdrhub
+              role: master
+            exp_annotations:
+              summary: "github-ci-exporter is not responding"
+              description: "Prometheus cannot scrape the GitHub CI exporter on sdrhub. All CI visibility is blind."
+
+  # The exporter serves metrics even while collection fails, so `up` stays 1
+  # and only scrape_success reveals the problem.
+  - interval: 5m
+    name: GitHubExporterCollectionFailing fires while the process stays up
+    input_series:
+      - series: 'up{job="github-ci", instance="127.0.0.1:9418"}'
+        values: "1+0x20"
+      - series: 'github_exporter_scrape_success{job="github-ci", instance="127.0.0.1:9418"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: GitHubExporterDown
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: GitHubExporterCollectionFailing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: github-ci
+              instance: 127.0.0.1:9418
+            exp_annotations:
+              summary: "github-ci-exporter cannot collect from GitHub"
+              description: "Collection cycles have been failing for 30 minutes. Displayed CI state is stale. Check the token and GitHub's status."
+
+  - interval: 5m
+    name: GitHubExporterCollectionFailing stays silent when healthy
+    input_series:
+      - series: 'github_exporter_scrape_success{job="github-ci", instance="127.0.0.1:9418"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: GitHubExporterCollectionFailing
+        exp_alerts: []
+
+  - interval: 5m
+    name: GitHubExporterBudgetExhausted fires when a cycle is skipped
+    input_series:
+      - series: 'github_exporter_budget_exhausted{job="github-ci", instance="127.0.0.1:9418"}'
+        values: "1+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubExporterBudgetExhausted
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: github-ci
+              instance: 127.0.0.1:9418
+            exp_annotations:
+              summary: "github-ci-exporter skipped a cycle to protect the API budget"
+              description: "The remaining GitHub API budget could not cover a full sweep, so collection was skipped. CI state is not being refreshed."
+
+  - interval: 5m
+    name: GitHubExporterRateLimitLow fires per exhausted pool
+    input_series:
+      - series: 'github_exporter_rate_limit_remaining{resource="core", job="github-ci", instance="127.0.0.1:9418"}'
+        values: "300+0x20"
+      - series: 'github_exporter_rate_limit_remaining{resource="graphql", job="github-ci", instance="127.0.0.1:9418"}'
+        values: "4900+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubExporterRateLimitLow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              resource: core
+              job: github-ci
+              instance: 127.0.0.1:9418
+            exp_annotations:
+              summary: "GitHub API budget low for core"
+              description: "Only 300 requests remain in the core pool. The exporter will start skipping cycles as it approaches its reserve."
+
+  # core and graphql are independent 5000/hour pools. A healthy graphql budget
+  # must not mask an exhausted core one, which is why the exporter tracks them
+  # separately rather than reporting a single figure.
+  - interval: 5m
+    name: GitHubExporterRateLimitLow stays silent when both pools are healthy
+    input_series:
+      - series: 'github_exporter_rate_limit_remaining{resource="core", job="github-ci"}'
+        values: "4700+0x20"
+      - series: 'github_exporter_rate_limit_remaining{resource="graphql", job="github-ci"}'
+        values: "4900+0x20"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubExporterRateLimitLow
+        exp_alerts: []
+
+  - interval: 5m
+    name: GitHubExporterStale fires when no cycle has succeeded for an hour
+    input_series:
+      - series: 'github_exporter_last_success_timestamp_seconds{job="github-ci", instance="127.0.0.1:9418"}'
+        values: "-7200+0x30"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubExporterStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: github-ci
+              instance: 127.0.0.1:9418
+            exp_annotations:
+              summary: "github-ci-exporter data is stale"
+              description: "No successful collection cycle for 2h 30m 0s, despite the exporter being reachable."

--- a/modules/monitoring/master/dashboards/github-ci.json
+++ b/modules/monitoring/master/dashboards/github-ci.json
@@ -1,0 +1,1640 @@
+{
+  "id": null,
+  "uid": "github-ci-overview",
+  "title": "GitHub CI Overview",
+  "description": "CI health, issues, and pull requests across the sdr-enthusiasts and fredsystems organisations. Sourced from github-ci-exporter on sdrhub.",
+  "tags": ["github", "ci"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "5m",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "CI Health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Failing Workflows",
+      "description": "Workflows whose latest default-branch run failed. Excludes cancelled, skipped, and runs aged out past 90 days.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_workflow_run_status{conclusion=~\"failure|timed_out|action_required\"} == 1) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Passing Workflows",
+      "description": "Workflows whose latest default-branch run succeeded.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_workflow_run_status{conclusion=\"success\"} == 1) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Repos Monitored",
+      "description": "Non-archived repositories with at least one workflow file.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_repo_monitored == 1) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Auto-Disabled",
+      "description": "Workflows GitHub disabled after 60 days of repository inactivity. These have stopped running silently.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_workflow_enabled{state=\"disabled_inactivity\"} == 0) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Failing Workflows (default branch)",
+      "description": "Latest branch-state run per workflow that failed. Pull-request runs are excluded: the API's branch filter matches a PR's head branch, so a merged PR's pre-merge failure would otherwise appear here forever.",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Result"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "failure": {
+                        "color": "red",
+                        "index": 0,
+                        "text": "failure"
+                      },
+                      "timed_out": {
+                        "color": "orange",
+                        "index": 1,
+                        "text": "timed out"
+                      },
+                      "action_required": {
+                        "color": "yellow",
+                        "index": 2,
+                        "text": "action required"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_workflow_run_status{conclusion=~\"failure|timed_out|action_required\"} == 1",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "hostname": true,
+              "role": true
+            },
+            "renameByName": {
+              "org": "Org",
+              "repo": "Repository",
+              "workflow": "Workflow",
+              "event": "Trigger",
+              "conclusion": "Result"
+            },
+            "indexByName": {
+              "org": 0,
+              "repo": 1,
+              "workflow": 2,
+              "conclusion": 3,
+              "event": 4
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Org"
+              },
+              {
+                "field": "Repository"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Workflow Inventory",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      }
+    },
+    {
+      "id": 8,
+      "type": "table",
+      "title": "Auto-Disabled and Stale Workflows",
+      "description": "Workflows GitHub switched off after 60 days of repository inactivity, plus workflows whose newest branch-state run is older than 90 days. Neither is failing; both mean CI is no longer telling you anything.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_workflow_enabled{state=\"disabled_inactivity\"} == 0",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_workflow_run_stale == 1",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "hostname": true,
+              "role": true,
+              "state": false
+            },
+            "renameByName": {
+              "org": "Org",
+              "repo": "Repository",
+              "workflow": "Workflow",
+              "state": "State"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Failing Workflows Over Time",
+      "description": "Trend in failing workflows. A step change usually means one shared action broke across many repositories rather than several independent regressions.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_workflow_run_status{conclusion=~\"failure|timed_out|action_required\"} == 1) or vector(0)",
+          "legendFormat": "failing"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_workflow_run_status{conclusion=\"success\"} == 1) or vector(0)",
+          "legendFormat": "passing"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Issues and Pull Requests",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      }
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Open Issues (human)",
+      "description": "Issues opened by people. Bot-filed issues are counted separately.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 25
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(github_repo_issues_open{author_kind=\"human\"}) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Open Issues (bot)",
+      "description": "Issues filed by renovate, dependabot, and other GitHub Apps. Classified via GraphQL __typename rather than a login list.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 25
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(github_repo_issues_open{author_kind=\"bot\"}) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "Open PRs (human)",
+      "description": "Pull requests opened by people, drafts included.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 25
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(github_repo_pulls_open{author_kind=\"human\"}) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Open PRs (bot)",
+      "description": "Automated dependency and flake-update pull requests.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 25
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(github_repo_pulls_open{author_kind=\"bot\"}) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "table",
+      "title": "Open Human Issues by Repository",
+      "description": "Repositories with issues opened by people, excluding bot-filed noise.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_repo_issues_open{author_kind=\"human\"} > 0",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "hostname": true,
+              "role": true,
+              "author_kind": true
+            },
+            "renameByName": {
+              "org": "Org",
+              "repo": "Repository",
+              "Value": "Open Issues"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Open Issues",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "table",
+      "title": "Oldest Open Human Pull Requests",
+      "description": "Non-draft pull requests by people, oldest first. Bot PRs are excluded: renovate holds PRs open by design.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Age"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "(time() - github_pull_created_timestamp_seconds{author_kind=\"human\", draft=\"false\"})",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "hostname": true,
+              "role": true,
+              "author_kind": true,
+              "draft": true
+            },
+            "renameByName": {
+              "org": "Org",
+              "repo": "Repository",
+              "number": "PR",
+              "author": "Author",
+              "Value": "Age"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Age",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "row",
+      "title": "Exporter Health",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      }
+    },
+    {
+      "id": 18,
+      "type": "stat",
+      "title": "Exporter Up",
+      "description": "Whether Prometheus can reach the exporter. If this is down, every panel above is stale.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "up{job=\"github-ci\"}",
+          "legendFormat": "up",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "stat",
+      "title": "Last Collection",
+      "description": "Time since the last successful collection cycle.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 900
+              },
+              {
+                "color": "red",
+                "value": 3600
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "time() - github_exporter_last_success_timestamp_seconds",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "stat",
+      "title": "Core Budget",
+      "description": "Remaining REST API requests. Independent of the GraphQL pool.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "green",
+                "value": 1500
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_rate_limit_remaining{resource=\"core\"}",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "stat",
+      "title": "GraphQL Budget",
+      "description": "Remaining GraphQL points. Separate 5000/hour allowance from core.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "green",
+                "value": 1500
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_rate_limit_remaining{resource=\"graphql\"}",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "API Rate-Limit Budget",
+      "description": "Remaining budget per pool. core and graphql are independent 5000/hour allowances, so a healthy graphql figure does not imply a healthy core one.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_rate_limit_remaining",
+          "legendFormat": "{{resource}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_rate_limit_reserve",
+          "legendFormat": "reserve (withheld)"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Requests vs Cache Hits",
+      "description": "Conditional requests answered 304 Not Modified are not charged against the rate limit. In steady state almost every request should be a cache hit; a persistent gap means the ETag cache is not working.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_api_requests",
+          "legendFormat": "requests issued"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_api_not_modified",
+          "legendFormat": "304 (free)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_api_requests_skipped",
+          "legendFormat": "skipped (budget)"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "type": "stat",
+      "title": "Repos Skipped",
+      "description": "Repositories excluded from monitoring, by reason. Explains an unexpectedly small dashboard without reading exporter logs.",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 50
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(github_repos_skipped)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "type": "stat",
+      "title": "Collection Duration",
+      "description": "Time taken by the last collection cycle.",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 50
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 180
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_scrape_duration_seconds",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "type": "stat",
+      "title": "Cycles Bypassed",
+      "description": "Cycles skipped entirely because the remaining API budget could not cover a full sweep.",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 50
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_exporter_cycles_bypassed_total or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    }
+  ]
+}

--- a/modules/monitoring/master/default.nix
+++ b/modules/monitoring/master/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./blackbox.nix
+    ./github-ci-exporter.nix
     ./grafana.nix
     ./karma.nix
     ./loki.nix

--- a/modules/monitoring/master/github-ci-exporter.nix
+++ b/modules/monitoring/master/github-ci-exporter.nix
@@ -1,0 +1,76 @@
+# modules/monitoring/master/github-ci-exporter.nix
+#
+# GitHub CI visibility: open issues, open pull requests, and Actions state
+# for every repository in the sdr-enthusiasts and fredsystems organisations.
+#
+# WHY
+#
+# The fleet's own CI was the one system with no monitoring. Scheduled
+# workflows in particular fail silently: nothing runs on a cadence to notice
+# that a weekly `update-flakes` has been broken for two months, and GitHub
+# auto-disables cron triggers in a repository with no activity for 60 days,
+# which stops CI without any notification at all. Both conditions were present
+# in the fleet when this was first run.
+#
+# EXPOSURE
+#
+# Bound to 127.0.0.1. The exporter holds a GitHub token, so it is not
+# reachable off-host; Prometheus scrapes it over loopback. No `openFirewall`,
+# and deliberately no nginx vhost -- unlike Karma there is nothing here a
+# human needs to click.
+#
+# TOKEN
+#
+# `github_pat_public_ro` is a classic PAT scoped to `public_repo` only. That
+# is the narrowest classic scope covering issues, pull requests, and Actions
+# across both organisations with one credential. It is separate from
+# `github_pat` (used for nix.conf access-tokens on every host) so that
+# rotating one does not disturb the other.
+#
+# `public_repo` does grant write on public repositories -- classic scopes have
+# no read-only variant. Only a per-organisation fine-grained token would be
+# truly read-only, and that would require one token per org. The exporter
+# itself issues no writes.
+#
+# The secret is delivered via systemd `LoadCredential` rather than a sops
+# owner/mode, because the unit runs `DynamicUser = true` and so has no stable
+# uid to chown to. Same reasoning as the Alertmanager credentials in
+# prometheus.nix.
+{
+  config,
+  inputs,
+  pkgs,
+  ...
+}:
+{
+  imports = [ inputs.github-ci-exporter.nixosModules.default ];
+
+  sops.secrets.github_pat_public_ro = {
+    restartUnits = [ "github-ci-exporter.service" ];
+  };
+
+  services.github-ci-exporter = {
+    enable = true;
+    package = inputs.github-ci-exporter.packages.${pkgs.stdenv.hostPlatform.system}.github-ci-exporter;
+
+    orgs = [
+      "sdr-enthusiasts"
+      "fredsystems"
+    ];
+
+    listen = "127.0.0.1:9418";
+
+    # A full sweep costs ~5 of the 5000/hour core budget once the ETag cache
+    # is warm, so the interval is set by how quickly a broken build should
+    # appear rather than by rate limits. Five minutes is well inside the 15m
+    # `for:` clause on GitHubCIFailingDefaultBranch.
+    interval = "5m";
+
+    # Archived repositories and repositories with no workflow files are
+    # dropped automatically; the denylist is only for anything that survives
+    # those filters and still is not worth watching.
+    denylist = [ ];
+
+    tokenFile = config.sops.secrets.github_pat_public_ro.path;
+  };
+}

--- a/modules/monitoring/master/github-ci-exporter.nix
+++ b/modules/monitoring/master/github-ci-exporter.nix
@@ -36,6 +36,13 @@
 # owner/mode, because the unit runs `DynamicUser = true` and so has no stable
 # uid to chown to. Same reasoning as the Alertmanager credentials in
 # prometheus.nix.
+#
+# The `LoadCredential` wiring itself lives in the exporter's own NixOS module
+# (imported below), not here: this file only supplies `tokenFile`, which that
+# module turns into `LoadCredential=token:<path>` and a `GHCI_TOKEN_FILE`
+# pointing at `/run/credentials/github-ci-exporter.service/token`. Nothing
+# needs to be added here, and the root-owned sops path is read by systemd
+# before the service drops privileges.
 {
   config,
   inputs,

--- a/modules/monitoring/master/grafana.nix
+++ b/modules/monitoring/master/grafana.nix
@@ -59,6 +59,13 @@
       group = "grafana";
       mode = "0444";
     };
+
+    "grafana/provisioning/dashboards/github/github-ci.json" = {
+      source = ./dashboards/github-ci.json;
+      user = "grafana";
+      group = "grafana";
+      mode = "0444";
+    };
   };
 
   services = {
@@ -176,6 +183,19 @@
 
                 options = {
                   path = "/etc/grafana/provisioning/dashboards/security";
+                };
+              }
+
+              {
+                name = "github";
+                orgId = 1;
+                folder = "GitHub";
+                type = "file";
+                disableDeletion = true;
+                updateIntervalSeconds = 60;
+
+                options = {
+                  path = "/etc/grafana/provisioning/dashboards/github";
                 };
               }
             ];

--- a/modules/monitoring/master/prometheus.nix
+++ b/modules/monitoring/master/prometheus.nix
@@ -199,6 +199,7 @@ in
         ./alert-rules/meta-alerts.yaml
         ./alert-rules/capacity-alerts.yaml
         ./alert-rules/fail2ban-alerts.yaml
+        ./alert-rules/github-alerts.yaml
       ];
 
       scrapeConfigs = [
@@ -397,6 +398,25 @@ in
           static_configs = [
             {
               targets = [ "127.0.0.1:3333" ];
+              labels = {
+                hostname = "sdrhub";
+                role = "master";
+              };
+            }
+          ];
+        }
+
+        {
+          # GitHub CI visibility. Loopback-only: the exporter holds a token.
+          #
+          # A collection cycle sweeps ~60 repositories and can take a couple of
+          # minutes, but it runs on its own timer and only publishes results
+          # when complete, so the scrape itself is cheap. The default 10s
+          # timeout is fine.
+          job_name = "github-ci";
+          static_configs = [
+            {
+              targets = [ "127.0.0.1:9418" ];
               labels = {
                 hostname = "sdrhub";
                 role = "master";

--- a/modules/secrets/secrets.yaml
+++ b/modules/secrets/secrets.yaml
@@ -79,6 +79,7 @@ pushover:
     api_token: ENC[AES256_GCM,data:Pai4ACYrKi2WDvNeRnnHS/6T9Y5P6rsa4Mmy3UXG,iv:zr0KHmoMqsrQL53owemYXHjj9XXaJJFU3xtgBxaVq3E=,tag:U2pSsyEOkOWapXhbXO9MaA==,type:str]
 healthchecks.io:
     endpoint: ENC[AES256_GCM,data:yf8ugwvFee5uC9f355gWRDd1jh1VW5tSnrAqGmSzmo6ApKddaUaTri22HCYoaDeLxYfgCs7q7v4=,iv:/KVbQNvsoMH22TvYlvJMBjKz/eYC7efdXRYZKtFUOUs=,tag:VFsA7rIxHjBjiSAzqzYeqg==,type:str]
+github_pat_public_ro: ENC[AES256_GCM,data:DEJLkYTY0fXACc1fBG0IUeOEWOdLjGkZQlzSML7HpAokBF2h+OmPGA==,iv:JW5RP56NI5RWCZnK4zTofradrfxwMDErYsLPdK494AI=,tag:vSLNkquer+xO+LZXheQ3DA==,type:str]
 sops:
     age:
         - enc: |
@@ -180,7 +181,7 @@ sops:
             Pepv3abaOr4G73rviYi6YiaYmqxM40q7LGC7qsDZiMOVYF595aTcVA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1gpd67sr93x3h885cl0pd3rm5ykvxadmyfjmf8u2j0me76mfl3s7scvlp9p
-    lastmodified: "2026-08-09T08:34:54Z"
-    mac: ENC[AES256_GCM,data:WYcAkW1AkNvEZj5J6J3iZQVMeifFgFXdzOoZXpot4wGNBNS1K+McrlB0/VHDGEETcDq15wEy7v/WAnn/QRDstnHTRh5zq8s/+wtSWZLaitceedDTtpHGOt8LC/9d6Ow1lZYwAxGay6+JH9XadGbx2RBCMR52jITvImpOnkYTNhI=,iv:O6SC6toihTqgTR2Fd4WIi+syK1iegh3lkrXOwBP5xNQ=,tag:b8Hef1OurtVEFYNLGfZtdQ==,type:str]
+    lastmodified: "2026-08-10T02:30:38Z"
+    mac: ENC[AES256_GCM,data:HuzvKeIud1OSwcS2JA9MO3vbu+88SgklPk+l2Oq4Sdg3GRZkegajgrALJ4ECFGgZJEyqg8ktgyzoYZTf8Vh1YWafLLu4onIqGp6mSZ+pUjum8rvE5W7OPuUvjZL2veTbABvl/sIbg5xyfBtMFQ9bjoqy3W/sV7L/h4xoZcozUFo=,iv:gF05NWjlSdHalq6E0TWw2QSqfuEvUgBUkMFdCc7XHJw=,tag:U9lA+z2GG+L5aOnI2SjYtw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Adds [`github-ci-exporter`](https://github.com/fredsystems/github-ci-exporter) to the monitoring master, exporting open issues, open pull requests, and Actions state for every repository in `sdr-enthusiasts` and `fredsystems`.

## Why

The fleet's own CI was the one system with no monitoring. Scheduled workflows fail silently in particular — nothing was watching to notice a weekly `update-flakes` broken for two months, and GitHub auto-disables cron triggers in a repository idle for 60 days with no notification at all. **Both conditions were live when this first ran.**

## What landed

| Piece | Notes |
| --- | --- |
| flake input | Categorised `server` — only sdrhub runs it. All four sync locations updated; checker green. |
| `github-ci-exporter.nix` | Binds `127.0.0.1`. No firewall hole, no nginx vhost: it holds a token and there is nothing to click. |
| Token | `github_pat_public_ro`, classic PAT scoped `public_repo`. Kept separate from `github_pat` so rotating one does not disturb `nix.conf` on every host. Delivered via `LoadCredential` because the unit is `DynamicUser` — same reasoning as Alertmanager in `prometheus.nix`. |
| Scrape job | `github-ci`, loopback. |
| 9 alert rules | CI failure on default branch, inactivity auto-disable, missed cron, stale human PR, plus 5 exporter-health rules. |
| 22 promtool tests | All green. |
| Grafana dashboard | New `GitHub` folder. |

## On the alert rules

Five of the nine cover the exporter itself. Without them a dead exporter is indistinguishable from a fleet whose CI is entirely green — the same silent-failure trap `meta-alerts.yaml` closes for the monitoring stack.

The non-firing test cases encode false positives observed in **real data**, not hypotheticals: cancelled/skipped runs, in-flight runs, runs aged out past 90 days, bot-authored PRs, drafts, manual workflow disables, and a weekly cron that must not be judged against a daily threshold.

`GitHubScheduledWorkflowStale` uses `unless on (org, repo, workflow) github_workflow_enabled == 0` so a disabled workflow produces one page (`GitHubWorkflowAutoDisabled`, with an accurate description) rather than two.

## Verification

- All **9 hosts** evaluate; no `evaluation warning:` output
- `nix build .#checks.x86_64-linux.prometheus-alert-rules` green (22 tests)
- `check-input-category-sync.py`: 26 inputs, 4 locations agree
- All pre-commit hooks pass
- Every metric referenced by the dashboard (16) and rules (9) verified present in live exporter output

## Expected first-scrape state

16 real failures, clustering to ~3 root causes — 9 are `update-flakes` hitting one bug in `flake-update-action` (`Input 'token' not supplied`), which is self-referential since that action's own `update-flakes` is broken by it. Plus 7 workflows aged out as stale and 1 auto-disabled.