### PR TITLE
fix(monitoring): track xng replacing acarsdec-3 on acarshub

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -71,6 +71,16 @@ jobs:
         # build with the specific test case that covers it.
         run: nix build --no-link --print-build-logs .#checks.x86_64-linux.pre-commit-check
 
+      - name: Check decoder heartbeat coverage
+        # Not a pre-commit hook: this one needs a full nixosConfigurations
+        # evaluation to read each host's services.adsb.containers, which is
+        # far too slow to run on every commit. It compares that against the
+        # decoderUnits list in loki-ruler.nix, catching both a heartbeat rule
+        # for a container that no longer exists (fires forever) and a decoder
+        # container with no rule at all (silently unmonitored). Both halves
+        # occurred when acarsdec-3 was replaced by xng on acarshub.
+        run: nix build --no-link --print-build-logs .#checks.x86_64-linux.decoder-units-sync
+
   # =====================================================================
   # Required Check Summary
   # =====================================================================

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -15,6 +15,7 @@
     system:
     let
       pkgs = import inputs.nixpkgs { inherit system; };
+      inherit (pkgs) lib;
 
       excludes = [
         "secrets.yaml"
@@ -160,6 +161,97 @@
       # Standalone check so `nix flake check` and CI catch category drift
       # even when the pre-commit hook is bypassed or the change arrives by
       # a route that never ran hooks (bot PRs, web edits).
+
+      # Enforces that the decoder heartbeat list in loki-ruler.nix matches the
+      # containers actually declared on each host.
+      #
+      # This drifted in production: acarsdec-3 was replaced by xng on
+      # acarshub, the host config was updated, and the heartbeat list was not.
+      # DecoderHeartbeatMissing then fired continuously for a container that
+      # no longer existed, while the container that replaced it went entirely
+      # unmonitored. The file carried a comment saying the list "must track
+      # the services.adsb.containers definitions"; a comment is not an
+      # enforcement mechanism.
+      #
+      # Only decoder containers are required to be covered. Sidecars like
+      # dozzle-agent have no heartbeat and are not expected in the list, so
+      # the check is one-directional plus a stale-entry test: every unit named
+      # in decoderUnits must exist on its host, and any container matching a
+      # known decoder-image prefix must be covered.
+      decoder-units-sync =
+        let
+          decoderPrefixes = [
+            "acarsdec"
+            "dumpvdl2"
+            "dumphfdl"
+            "hfdlobserver"
+            "dump978"
+            "xng"
+          ];
+
+          hostsWithDecoders = lib.filterAttrs (
+            _: cfg: (cfg.config.services.adsb.containers or [ ]) != [ ]
+          ) self.nixosConfigurations;
+
+          # unit name as it appears in the ruler, per host
+          actualUnits = lib.mapAttrs (
+            _: cfg: map (c: "docker-${c.name}.service") cfg.config.services.adsb.containers
+          ) hostsWithDecoders;
+
+          # containers whose name starts with a known decoder prefix
+          expectedUnits = lib.mapAttrs (
+            _: cfg:
+            map (c: "docker-${c.name}.service") (
+              lib.filter (
+                c: lib.any (prefix: lib.hasPrefix prefix c.name) decoderPrefixes
+              ) cfg.config.services.adsb.containers
+            )
+          ) hostsWithDecoders;
+
+          covered = self.nixosConfigurations.sdrhub.config.monitoring.decoderUnits;
+          coveredByHost = lib.mapAttrs (_: units: map (d: d.unit) units) (lib.groupBy (d: d.host) covered);
+
+          # 1. every covered unit must exist on its host
+          stale = lib.flatten (
+            map (
+              d:
+              let
+                onHost = actualUnits.${d.host} or [ ];
+              in
+              lib.optional (
+                !lib.elem d.unit onHost
+              ) "  stale: ${d.host} has no ${d.unit} (heartbeat rule fires forever)"
+            ) covered
+          );
+
+          # 2. every decoder container must be covered
+          uncovered = lib.flatten (
+            lib.mapAttrsToList (
+              host: units:
+              map (u: "  uncovered: ${host} runs ${u} with no heartbeat rule") (
+                lib.subtractLists (coveredByHost.${host} or [ ]) units
+              )
+            ) expectedUnits
+          );
+
+          problems = stale ++ uncovered;
+        in
+        pkgs.runCommand "decoder-units-sync-check" { } (
+          if problems == [ ] then
+            ''
+              echo "decoder heartbeat coverage OK (${toString (builtins.length covered)} units)"
+              touch "$out"
+            ''
+          else
+            ''
+              echo "decoder heartbeat list is out of sync with the host configs:" >&2
+              ${lib.concatMapStringsSep "\n" (p: "echo ${lib.escapeShellArg p} >&2") problems}
+              echo "" >&2
+              echo "Update decoderUnits in modules/monitoring/master/loki-ruler.nix." >&2
+              exit 1
+            ''
+        );
+
       input-category-sync =
         pkgs.runCommand "input-category-sync-check"
           {

--- a/hosts/linux/acarshub/configuration.nix
+++ b/hosts/linux/acarshub/configuration.nix
@@ -28,7 +28,7 @@ in
     "docker/acarshub.env" = mkContainerSecrets [
       "acarsdec-1"
       "acarsdec-2"
-      "acarsdec-3"
+      "xng"
       "dozzle-agent"
     ];
   };

--- a/modules/monitoring/master/loki-ruler.nix
+++ b/modules/monitoring/master/loki-ruler.nix
@@ -31,6 +31,7 @@
 # instances collapse into a single group with an empty hostname. Alloy sets
 # `host` and `hostname` identically, so aggregations here carry both.
 {
+  lib,
   pkgs,
   ...
 }:
@@ -67,9 +68,21 @@ let
       pattern = "\\[STATS\\] Total in the last";
     }
     {
+      # xng replaced acarsdec-3 on this receiver. It emits no periodic stats
+      # line at all -- 6h of logs contained zero STATS-style output -- so the
+      # only available liveness signal is "logging anything", as with
+      # hfdlobserver.
+      #
+      # That makes this rule traffic-dependent, unlike every other entry here.
+      # It is acceptable because xng covers 16 ACARS channels including busy
+      # ones: over a 48h sample the quietest hour still produced 117 lines,
+      # roughly two per minute. The 45m window is well beyond any plausible
+      # lull while still catching a wedged container within an hour.
       host = "acarshub";
-      unit = "docker-acarsdec-3.service";
-      pattern = "\\[STATS\\] Total in the last";
+      unit = "docker-xng.service";
+      pattern = null;
+      window = "45m";
+      trafficDependent = true;
     }
     {
       host = "vdlmhub";
@@ -154,7 +167,14 @@ let
       };
       annotations = {
         summary = "Decoder ${d.unit} on ${d.host} has stopped logging";
-        description = "No heartbeat line for ${window}. The container is running but wedged, or its journal has stopped reaching Loki. This is independent of how much traffic the receiver should be decoding, so it is not a quiet-band false positive.";
+        description =
+          "No heartbeat line for ${window}. The container is running but wedged, or its journal has stopped reaching Loki. "
+          + (
+            if d.trafficDependent or false then
+              "This decoder emits no periodic heartbeat, so the signal is any log line at all: an exceptionally quiet band could in principle produce this alert without the container being broken."
+            else
+              "This is independent of how much traffic the receiver should be decoding, so it is not a quiet-band false positive."
+          );
       };
     }
   ) decoderUnits;
@@ -388,6 +408,12 @@ let
         # this series exists -- see agent-docs/MONITORING.md, Phase 6.
         name = "decoder-throughput-recording";
         interval = "1m";
+        # NOTE: xng on acarshub is deliberately absent from these rules. It
+        # emits no periodic stats line, so there is no count to unwrap; the
+        # only way to derive throughput would be to count individual decoded
+        # message lines, which is a different and much more expensive query
+        # shape than `last_over_time` on a pre-aggregated total. Its liveness
+        # is covered by the decoder-liveness group instead.
         rules = [
           {
             record = "decoder:messages:last5m";
@@ -413,41 +439,57 @@ let
   '';
 in
 {
-  # The ruler needs a writable scratch directory for rule evaluation state.
-  systemd.tmpfiles.rules = [
-    "d /var/lib/loki/rules-temp 0750 loki loki -"
-  ];
+  # Exposed so `checks.decoder-units-sync` can compare this list against the
+  # actual `services.adsb.containers` on each host. The list drifted once
+  # already: acarsdec-3 was replaced by xng on acarshub and the stale entry
+  # kept firing DecoderHeartbeatMissing for a container that no longer
+  # existed. A comment saying "this list must track the host configs" is not
+  # an enforcement mechanism.
+  options.monitoring.decoderUnits = lib.mkOption {
+    type = lib.types.listOf lib.types.attrs;
+    internal = true;
+    readOnly = true;
+    default = decoderUnits;
+    description = "Decoder units covered by heartbeat rules, read by the decoder-units-sync flake check.";
+  };
 
-  services.loki.configuration.ruler = {
-    storage = {
-      type = "local";
-      local.directory = "${rulesDir}";
-    };
+  config = {
+    # The ruler needs a writable scratch directory for rule evaluation state.
+    systemd.tmpfiles.rules = [
+      "d /var/lib/loki/rules-temp 0750 loki loki -"
+    ];
 
-    rule_path = "/var/lib/loki/rules-temp";
+    services.loki.configuration.ruler = {
+      storage = {
+        type = "local";
+        local.directory = "${rulesDir}";
+      };
 
-    alertmanager_url = "http://127.0.0.1:9093";
-    enable_alertmanager_v2 = true;
+      rule_path = "/var/lib/loki/rules-temp";
 
-    # Single-binary deployment; no ring coordination needed.
-    ring.kvstore.store = "inmemory";
+      alertmanager_url = "http://127.0.0.1:9093";
+      enable_alertmanager_v2 = true;
 
-    # Recording rule output is pushed into Prometheus, which already runs with
-    # --web.enable-remote-write-receiver (see prometheus.nix extraFlags).
-    remote_write = {
-      enabled = true;
-      clients.prometheus = {
-        url = "http://127.0.0.1:9090/api/v1/write";
-        remote_timeout = "30s";
-        queue_config = {
-          capacity = 2500;
-          max_shards = 10;
-          min_shards = 1;
+      # Single-binary deployment; no ring coordination needed.
+      ring.kvstore.store = "inmemory";
+
+      # Recording rule output is pushed into Prometheus, which already runs with
+      # --web.enable-remote-write-receiver (see prometheus.nix extraFlags).
+      remote_write = {
+        enabled = true;
+        clients.prometheus = {
+          url = "http://127.0.0.1:9090/api/v1/write";
+          remote_timeout = "30s";
+          queue_config = {
+            capacity = 2500;
+            max_shards = 10;
+            min_shards = 1;
+          };
         };
       };
     };
-  };
 
-  # Keep the generated rule file inspectable on the host for debugging.
-  environment.etc."loki/rules/decoder-logs.yaml".source = ruleFile;
+    # Keep the generated rule file inspectable on the host for debugging.
+    environment.etc."loki/rules/decoder-logs.yaml".source = ruleFile;
+  };
 }


### PR DESCRIPTION
Resolves the firing `DecoderHeartbeatMissing` alert.

## Root cause

`acarsdec-3` was replaced by `xng` on acarshub, but three places still referenced the old container:

| Location | Consequence |
| --- | --- |
| `loki-ruler.nix` `decoderUnits` | **The firing alert.** `absent_over_time` correctly reported no logs from a unit that no longer exists — while `xng` went entirely unmonitored. |
| `acarshub/configuration.nix` `mkContainerSecrets` | `restartUnits` pointed at a dead unit |
| `loki-ruler.nix` throughput recording rule | regex covers `acarsdec\|dumpvdl2`, so `xng` contributes nothing |

Verified on the host: `docker-acarsdec-1`, `docker-acarsdec-2`, `docker-xng` running; no `acarsdec-3`.

## xng needs a different heartbeat

It emits **no periodic stats line** — six hours of logs contained zero STATS-style output. It only logs decoded messages. So its signal is `pattern = null` ("any log line"), the same approach used for `hfdlobserver`.

That makes this the one traffic-dependent entry in the list, so the annotation is now conditional rather than claiming quiet-band immunity it doesn't have.

The 45m window is justified by measurement: across the available sample the **quietest hour still produced 117 lines** (~2/min), because xng covers 16 ACARS channels including busy ones.

It's deliberately excluded from the throughput recording rules — there's no pre-aggregated total to `unwrap`, and counting individual message lines is a much more expensive query shape.

## Preventing recurrence

The file already said the list *"must track the `services.adsb.containers` definitions"*. A comment is not an enforcement mechanism, and it drifted.

New `decoder-units-sync` flake check compares `decoderUnits` against each host's actual containers and fails on **both halves** of what happened here. Verified by reintroducing the exact bug:

```
stale: acarshub has no docker-acarsdec-3.service (heartbeat rule fires forever)
uncovered: acarshub runs docker-xng.service with no heartbeat rule
```

Runs in `lint.yaml` rather than as a pre-commit hook because it needs a full `nixosConfigurations` evaluation — too slow for every commit.

## Verification

- All **9 hosts** evaluate
- `decoder-units-sync` green, and proven to fail on the reintroduced bug
- `prometheus-alert-rules` green
- All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring support for the XNG decoder container.
  - XNG now uses traffic-based liveness monitoring with a 45-minute window.
  - XNG is excluded from throughput metrics where those measurements are not applicable.
  - Updated decoder heartbeat alerts to clearly distinguish traffic-dependent and traffic-independent services.

- **Bug Fixes**
  - Added automated validation to detect mismatches between configured decoder heartbeats and deployed decoder containers.
  - Included XNG in the ACARS Hub container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->