### PR TITLE
feat(monitoring): surface pull requests that need action

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         "rust-overlay": "rust-overlay_6"
       },
       "locked": {
-        "lastModified": 1786333654,
-        "narHash": "sha256-e7MrSyWUyEs07bT2OcAg4d911MUPsdKYOXJrzOjjKDU=",
+        "lastModified": 1786385498,
+        "narHash": "sha256-kQvU6Dj7iaiQODRxi5LO4/4u1PvNQ4V9oPwUC55c/io=",
         "owner": "FredSystems",
         "repo": "github-ci-exporter",
-        "rev": "1368f489fbd0a469d32aca945dd9669fd08e7321",
+        "rev": "9c2fa65878a5913ee091c08ee33dc6e5910f4bce",
         "type": "github"
       },
       "original": {

--- a/modules/monitoring/master/alert-rules/github-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/github-alerts.yaml
@@ -83,6 +83,43 @@ groups:
           summary: "Scheduled workflow {{ $labels.workflow }} has not run in {{ $labels.org }}/{{ $labels.repo }}"
           description: "Last run was {{ $value | humanizeDuration }} ago, more than three times its configured schedule interval."
 
+      # An open PR whose checks are failing. Distinct from
+      # GitHubCIFailingDefaultBranch: that rule describes what has already
+      # landed, this one describes work that cannot land.
+      #
+      # Bots are deliberately included. A renovate PR failing CI is at least as
+      # actionable as a human one, because it blocks a dependency bump and will
+      # sit there indefinitely -- that is exactly the state that went unnoticed
+      # on github-ci-exporter and freminal.
+      #
+      # Drafts are excluded by the exporter, so no filter is needed here.
+      #
+      # 1h rather than the 15m used for branch CI: a PR is usually pushed to
+      # several times in quick succession, and each push restarts its checks.
+      - alert: GitHubPullRequestChecksFailing
+        expr: github_pull_needs_attention{checks="failure"} == 1
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: "PR #{{ $labels.number }} failing checks in {{ $labels.org }}/{{ $labels.repo }}"
+          description: "Checks on pull request #{{ $labels.number }} by {{ $labels.author }} are failing, so it cannot merge."
+
+      # Green, mergeable, and no auto-merge armed: nothing will land this
+      # without a human pressing the button. Renovate PRs sit in this state on
+      # repositories where platformAutomerge is off.
+      #
+      # 6h so a PR that is merged promptly never alerts; this is a "you have
+      # forgotten about this" signal, not a notification that CI passed.
+      - alert: GitHubPullRequestAwaitingMerge
+        expr: github_pull_ready_to_merge == 1
+        for: 6h
+        labels:
+          severity: info
+        annotations:
+          summary: "PR #{{ $labels.number }} is green and waiting to merge in {{ $labels.org }}/{{ $labels.repo }}"
+          description: "Checks pass and there are no conflicts, but auto-merge is not enabled, so #{{ $labels.number }} needs a manual merge."
+
       # A human pull request left open for a month. Bot PRs are excluded
       # entirely -- renovate and dependabot routinely hold PRs open by design,
       # and including them would make this fire constantly.

--- a/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
@@ -237,6 +237,108 @@ tests:
         exp_alerts: []
 
   # ---------------------------------------------------------------------------
+  # GitHubPullRequestChecksFailing
+  # ---------------------------------------------------------------------------
+
+  - interval: 5m
+    name: GitHubPullRequestChecksFailing fires on a broken PR
+    input_series:
+      - series: 'github_pull_needs_attention{org="fredsystems", repo="github-ci-exporter", number="8", author="renovate", author_kind="bot", draft="false", checks="failure", mergeable="mergeable", auto_merge="false", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubPullRequestChecksFailing
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              org: fredsystems
+              repo: github-ci-exporter
+              number: "8"
+              author: renovate
+              author_kind: bot
+              draft: "false"
+              checks: failure
+              mergeable: mergeable
+              auto_merge: "false"
+              job: github-ci
+            exp_annotations:
+              summary: "PR #8 failing checks in fredsystems/github-ci-exporter"
+              description: "Checks on pull request #8 by renovate are failing, so it cannot merge."
+
+  # A conflicting-but-green PR also sets needs_attention. It must not be
+  # reported as a checks failure, because the fix is a rebase, not a code fix.
+  - interval: 5m
+    name: GitHubPullRequestChecksFailing ignores a conflict with passing checks
+    input_series:
+      - series: 'github_pull_needs_attention{org="fredsystems", repo="nixos", number="1615", author="fredclausen", author_kind="human", draft="false", checks="success", mergeable="conflicting", auto_merge="false", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubPullRequestChecksFailing
+        exp_alerts: []
+
+  - interval: 5m
+    name: GitHubPullRequestChecksFailing does not fire before the for clause
+    input_series:
+      - series: 'github_pull_needs_attention{org="fredsystems", repo="freminal", number="481", author="fredclausen", author_kind="human", draft="false", checks="failure", mergeable="mergeable", auto_merge="true", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: GitHubPullRequestChecksFailing
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
+  # GitHubPullRequestAwaitingMerge
+  # ---------------------------------------------------------------------------
+
+  - interval: 5m
+    name: GitHubPullRequestAwaitingMerge fires on a green PR with no automerge
+    input_series:
+      - series: 'github_pull_ready_to_merge{org="sdr-enthusiasts", repo="plane-alert-db", number="854", author="TheFilipcom4607", author_kind="human", draft="false", checks="success", mergeable="mergeable", auto_merge="false", job="github-ci"}'
+        values: "1+0x100"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: GitHubPullRequestAwaitingMerge
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              org: sdr-enthusiasts
+              repo: plane-alert-db
+              number: "854"
+              author: TheFilipcom4607
+              author_kind: human
+              draft: "false"
+              checks: success
+              mergeable: mergeable
+              auto_merge: "false"
+              job: github-ci
+            exp_annotations:
+              summary: "PR #854 is green and waiting to merge in sdr-enthusiasts/plane-alert-db"
+              description: "Checks pass and there are no conflicts, but auto-merge is not enabled, so #854 needs a manual merge."
+
+  # The exporter sets ready_to_merge to 0 when auto-merge is armed, because the
+  # PR will land unattended. Nothing to alert on.
+  - interval: 5m
+    name: GitHubPullRequestAwaitingMerge ignores a PR with automerge armed
+    input_series:
+      - series: 'github_pull_ready_to_merge{org="fredsystems", repo="freminal", number="483", author="fredclausen", author_kind="human", draft="false", checks="success", mergeable="mergeable", auto_merge="true", job="github-ci"}'
+        values: "0+0x100"
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: GitHubPullRequestAwaitingMerge
+        exp_alerts: []
+
+  - interval: 5m
+    name: GitHubPullRequestAwaitingMerge does not fire on a freshly green PR
+    input_series:
+      - series: 'github_pull_ready_to_merge{org="sdr-enthusiasts", repo="plane-alert-db", number="854", author="someone", author_kind="human", draft="false", checks="success", mergeable="mergeable", auto_merge="false", job="github-ci"}'
+        values: "1+0x100"
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: GitHubPullRequestAwaitingMerge
+        exp_alerts: []
+
+  # ---------------------------------------------------------------------------
   # GitHubHumanPullRequestStale
   # ---------------------------------------------------------------------------
 
@@ -246,7 +348,7 @@ tests:
   - interval: 5m
     name: GitHubHumanPullRequestStale fires on an old human PR
     input_series:
-      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="1615", author="fredclausen", author_kind="human", draft="false", job="github-ci"}'
+      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="1615", author="fredclausen", author_kind="human", draft="false", checks="success", mergeable="mergeable", auto_merge="false", job="github-ci"}'
         values: "-2678400+0x30"
     alert_rule_test:
       - eval_time: 2h
@@ -260,6 +362,9 @@ tests:
               author: fredclausen
               author_kind: human
               draft: "false"
+              checks: success
+              mergeable: mergeable
+              auto_merge: "false"
               job: github-ci
             exp_annotations:
               summary: "PR #1615 open 31d 2h 0m 0s in fredsystems/nixos"
@@ -270,7 +375,7 @@ tests:
   - interval: 5m
     name: GitHubHumanPullRequestStale ignores bot PRs
     input_series:
-      - series: 'github_pull_created_timestamp_seconds{org="sdr-enthusiasts", repo="docker-acarshub", number="900", author="renovate", author_kind="bot", draft="false", job="github-ci"}'
+      - series: 'github_pull_created_timestamp_seconds{org="sdr-enthusiasts", repo="docker-acarshub", number="900", author="renovate", author_kind="bot", draft="false", checks="success", mergeable="mergeable", auto_merge="false", job="github-ci"}'
         values: "-2678400+0x30"
     alert_rule_test:
       - eval_time: 2h
@@ -281,7 +386,7 @@ tests:
   - interval: 5m
     name: GitHubHumanPullRequestStale ignores drafts
     input_series:
-      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="42", author="fredclausen", author_kind="human", draft="true", job="github-ci"}'
+      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="42", author="fredclausen", author_kind="human", draft="true", checks="success", mergeable="mergeable", auto_merge="false", job="github-ci"}'
         values: "-2678400+0x30"
     alert_rule_test:
       - eval_time: 2h
@@ -291,7 +396,7 @@ tests:
   - interval: 5m
     name: GitHubHumanPullRequestStale ignores a recent PR
     input_series:
-      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="99", author="fredclausen", author_kind="human", draft="false", job="github-ci"}'
+      - series: 'github_pull_created_timestamp_seconds{org="fredsystems", repo="nixos", number="99", author="fredclausen", author_kind="human", draft="false", checks="success", mergeable="mergeable", auto_merge="false", job="github-ci"}'
         values: "-864000+0x30"
     alert_rule_test:
       - eval_time: 2h

--- a/modules/monitoring/master/dashboards/github-ci.json
+++ b/modules/monitoring/master/dashboards/github-ci.json
@@ -417,6 +417,680 @@
       ]
     },
     {
+      "id": 27,
+      "type": "row",
+      "title": "Pull Requests Needing Action",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      }
+    },
+    {
+      "id": 28,
+      "type": "stat",
+      "title": "PRs Failing Checks",
+      "description": "Open non-draft PRs whose head-commit checks failed. These are broken and need fixing.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_pull_needs_attention{checks=\"failure\"} == 1) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "type": "stat",
+      "title": "Green, Awaiting Merge",
+      "description": "Checks pass and the branch is mergeable, but auto-merge is not armed. These are waiting on a human to press the button.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_pull_ready_to_merge == 1) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "stat",
+      "title": "Conflicting",
+      "description": "Open non-draft PRs that conflict with the base branch and need a rebase.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_pull_needs_attention{mergeable=\"conflicting\"} == 1) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "type": "stat",
+      "title": "Total Needing Action",
+      "description": "Open non-draft PRs that are failing, conflicting, or ready to merge without auto-merge.",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [],
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "count(github_pull_needs_attention == 1) or vector(0)",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "table",
+      "title": "Broken Pull Requests",
+      "description": "Open non-draft PRs whose checks failed, or which conflict with the base branch. Bot-authored PRs are included: a renovate PR failing CI is exactly as actionable as a human one, and often more so because it blocks a dependency bump.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Checks"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "failure": {
+                        "color": "red",
+                        "index": 0,
+                        "text": "failure"
+                      },
+                      "success": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "passing"
+                      },
+                      "pending": {
+                        "color": "yellow",
+                        "index": 2,
+                        "text": "running"
+                      },
+                      "none": {
+                        "color": "text",
+                        "index": 3,
+                        "text": "no CI"
+                      },
+                      "unknown": {
+                        "color": "text",
+                        "index": 4,
+                        "text": "unknown"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Merge"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "conflicting": {
+                        "color": "orange",
+                        "index": 0,
+                        "text": "conflict"
+                      },
+                      "mergeable": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "clean"
+                      },
+                      "unknown": {
+                        "color": "text",
+                        "index": 2,
+                        "text": "unknown"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_pull_needs_attention{checks=\"failure\"} == 1",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_pull_needs_attention{mergeable=\"conflicting\"} == 1",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "hostname": true,
+              "role": true,
+              "draft": true
+            },
+            "renameByName": {
+              "org": "Org",
+              "repo": "Repository",
+              "number": "PR",
+              "author": "Author",
+              "author_kind": "Kind",
+              "checks": "Checks",
+              "mergeable": "Merge",
+              "auto_merge": "Automerge"
+            },
+            "indexByName": {
+              "org": 0,
+              "repo": 1,
+              "number": 2,
+              "checks": 3,
+              "mergeable": 4,
+              "auto_merge": 5,
+              "author": 6,
+              "author_kind": 7
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Checks"
+              },
+              {
+                "field": "Org"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "type": "table",
+      "title": "Green and Waiting on a Merge",
+      "description": "Checks pass, no conflicts, and auto-merge is NOT armed, so nothing will land these without a click. This is the state renovate PRs sit in on repositories where platformAutomerge is disabled.",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Checks"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "failure": {
+                        "color": "red",
+                        "index": 0,
+                        "text": "failure"
+                      },
+                      "success": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "passing"
+                      },
+                      "pending": {
+                        "color": "yellow",
+                        "index": 2,
+                        "text": "running"
+                      },
+                      "none": {
+                        "color": "text",
+                        "index": 3,
+                        "text": "no CI"
+                      },
+                      "unknown": {
+                        "color": "text",
+                        "index": 4,
+                        "text": "unknown"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Merge"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "conflicting": {
+                        "color": "orange",
+                        "index": 0,
+                        "text": "conflict"
+                      },
+                      "mergeable": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "clean"
+                      },
+                      "unknown": {
+                        "color": "text",
+                        "index": 2,
+                        "text": "unknown"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "github_pull_ready_to_merge == 1",
+          "legendFormat": "",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "hostname": true,
+              "role": true,
+              "draft": true
+            },
+            "renameByName": {
+              "org": "Org",
+              "repo": "Repository",
+              "number": "PR",
+              "author": "Author",
+              "author_kind": "Kind",
+              "checks": "Checks",
+              "mergeable": "Merge",
+              "auto_merge": "Automerge"
+            },
+            "indexByName": {
+              "org": 0,
+              "repo": 1,
+              "number": 2,
+              "checks": 3,
+              "mergeable": 4,
+              "auto_merge": 5,
+              "author": 6,
+              "author_kind": 7
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Org"
+              },
+              {
+                "field": "Repository"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
       "id": 7,
       "type": "row",
       "title": "Workflow Inventory",
@@ -425,7 +1099,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 35
       }
     },
     {
@@ -437,7 +1111,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 36
       },
       "datasource": {
         "type": "prometheus",
@@ -530,7 +1204,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 36
       },
       "datasource": {
         "type": "prometheus",
@@ -599,7 +1273,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 44
       }
     },
     {
@@ -611,7 +1285,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 25
+        "y": 45
       },
       "datasource": {
         "type": "prometheus",
@@ -669,7 +1343,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 25
+        "y": 45
       },
       "datasource": {
         "type": "prometheus",
@@ -727,7 +1401,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 25
+        "y": 45
       },
       "datasource": {
         "type": "prometheus",
@@ -785,7 +1459,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 25
+        "y": 45
       },
       "datasource": {
         "type": "prometheus",
@@ -843,7 +1517,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 49
       },
       "datasource": {
         "type": "prometheus",
@@ -936,7 +1610,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 49
       },
       "datasource": {
         "type": "prometheus",
@@ -1045,7 +1719,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 57
       }
     },
     {
@@ -1057,7 +1731,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 38
+        "y": 58
       },
       "datasource": {
         "type": "prometheus",
@@ -1119,7 +1793,7 @@
         "h": 4,
         "w": 6,
         "x": 6,
-        "y": 38
+        "y": 58
       },
       "datasource": {
         "type": "prometheus",
@@ -1185,7 +1859,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 38
+        "y": 58
       },
       "datasource": {
         "type": "prometheus",
@@ -1251,7 +1925,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 38
+        "y": 58
       },
       "datasource": {
         "type": "prometheus",
@@ -1317,7 +1991,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 62
       },
       "datasource": {
         "type": "prometheus",
@@ -1386,7 +2060,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 62
       },
       "datasource": {
         "type": "prometheus",
@@ -1463,7 +2137,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 70
       },
       "datasource": {
         "type": "prometheus",
@@ -1521,7 +2195,7 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 50
+        "y": 70
       },
       "datasource": {
         "type": "prometheus",
@@ -1583,7 +2257,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 50
+        "y": 70
       },
       "datasource": {
         "type": "prometheus",


### PR DESCRIPTION
Default-branch CI health said nothing about whether an **open PR** is stuck. Renovate PRs sitting green because automerge is off, and PRs that are flat broken, were both invisible.

## Exporter bump

Picks up `github_pull_needs_attention` and `github_pull_ready_to_merge`, plus `checks` / `mergeable` / `auto_merge` labels on the existing PR metric.

That release also stops reporting runs whose event the workflow no longer declares — which was showing months-old `push` failures for `frext` and `bike-fitter-1000` whose `ci.yml` now runs only on `pull_request`.

## Dashboard

New **"Pull Requests Needing Action"** section, placed second next to CI health since both answer *"what should I do now"*:

| Panel | Shows |
| --- | --- |
| 4 stats | failing checks, green-awaiting-merge, conflicting, total |
| Broken Pull Requests | failing or conflicting, colour-coded by check and merge state |
| Green and Waiting on a Merge | checks pass, no conflicts, **no automerge armed** |

Bots are **included** in the broken-PR view deliberately. A renovate PR failing CI is at least as actionable as a human one — it blocks a dependency bump and sits there indefinitely. Exactly the state that went unnoticed on `github-ci-exporter` and `freminal`.

## Alert rules

| Alert | `for:` | Reasoning |
| --- | --- | --- |
| `GitHubPullRequestChecksFailing` | 1h | Longer than branch CI's 15m: a PR is usually pushed to several times in quick succession, and each push restarts its checks |
| `GitHubPullRequestAwaitingMerge` | 6h | So a promptly-merged PR never alerts. This is "you forgot about this", not "CI passed" |

Both `severity: info`.

Six new promtool cases, including the two false positives worth guarding:

- A **conflicting-but-green** PR must not be reported as a checks failure — the fix is a rebase, not a code change
- A PR with **automerge armed** must not be reported as awaiting a merge

## Currently surfaced

```
freminal            #481  failure  mergeable    auto=true   <- broken
github-ci-exporter  #8    failure  mergeable    auto=false  <- broken
plane-alert-db      #854  success  mergeable    auto=false  <- awaiting merge
nixos               #1615 success  conflicting  auto=false
gitbook-adsb-guide  #176  success  conflicting  auto=false
gitbook-adsb-guide  #185  success  conflicting  auto=false
docker-vesselalert  #32   none     conflicting  auto=false
```

## Verification

- All **9 hosts** evaluate, no evaluation warnings
- **17** alert-rule test cases pass (11 rules)
- Dashboard: all 18 referenced metrics confirmed present in live exporter output; panel geometry checked for overlaps and duplicate IDs
- `decoder-units-sync` and `input-category-sync` green
- All pre-commit hooks pass