### PR TITLE
chore(flake/nixvim): `c7be4930` -> `902dd399`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -1001,11 +1001,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1784555310,
-        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "lastModified": 1786098110,
+        "narHash": "sha256-shi1tjDhCGGd0kIgVPNY03V8NBWSTzhMSFDb7IqSoec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+        "rev": "afb4584a80bbf779ce0f691509ff902d188c2b3d",
         "type": "github"
       },
       "original": {
@@ -1182,11 +1182,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1785763201,
-        "narHash": "sha256-wA373y/B9orM3HatLu9oS+Ke5lmdZyBl/bdjd2gLMq4=",
+        "lastModified": 1786376793,
+        "narHash": "sha256-57PySMBzfIOqHYfBQhDMIFy9CHMpRArhK9gWHZsp3/g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c7be49306b23a952c0151cf4bbeacd944ed82f2a",
+        "rev": "902dd3995bd830f824ca146796743e3baf587d4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`902dd399`](https://github.com/nix-community/nixvim/commit/902dd3995bd830f824ca146796743e3baf587d4c) | `` modules/lsp: update server packages ``                        |
| [`f65ba905`](https://github.com/nix-community/nixvim/commit/f65ba905f3cf7744ef40d9cd9d58502d13896d58) | `` tests/all-package-defaults: disable oxlint on darwin ``       |
| [`ce22ef31`](https://github.com/nix-community/nixvim/commit/ce22ef31fdb0d37c3efe7e31e292bb38c3b50e83) | `` tests/all-package-defaults: disable ponyc on aarch64-linux `` |
| [`9cdd9799`](https://github.com/nix-community/nixvim/commit/9cdd979953a47b7e9565a21c66764476d1c2b477) | `` misc: address new ruff requirements in python script ``       |
| [`c2e6de07`](https://github.com/nix-community/nixvim/commit/c2e6de075b289e6ba08806fdeb6f82ebff4052d3) | `` generated: Update ``                                          |
| [`2e414dee`](https://github.com/nix-community/nixvim/commit/2e414dee299c978624f29206803b58567a62b9bb) | `` flake: Update ``                                              |