### PR TITLE
chore(flake/sops-nix): `f1406619` -> `d1337e05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1472,11 +1472,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1786375908,
+        "narHash": "sha256-G7qDAT98nywA4EFmJCwIRO5wKvDlBBN3BWpsOnjAto8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "d1337e05ba0a8e88a75d2c0e1595d82f3b3e2ac4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                     |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`03b17c88`](https://github.com/Mic92/sops-nix/commit/03b17c88d1d8ac4f125c87f8c9b4bb8380341fcd) | `` tests: fix age key provisioning under systemd-stage-1 `` |