### PR TITLE
chore(flake/nixpkgs-stable): `8b8c811c` -> `fcb8fcd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -937,11 +937,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1786201459,
-        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
+        "lastModified": 1786313170,
+        "narHash": "sha256-9BG7OgUWdu0ONDO5X2q6+K4bsuBITkX/3W4nNJu1Ito=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
+        "rev": "fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`3a31dd9e`](https://github.com/NixOS/nixpkgs/commit/3a31dd9ea23c23630bdd30bec4626c46047bbcf6) | `` mutter: 50.3 -> 50.4 ``                                                                |
| [`df616f9f`](https://github.com/NixOS/nixpkgs/commit/df616f9ff9455b87a47a41d61b8407995c9f1ee2) | `` libshumate: 1.6.2 -> 1.6.3 ``                                                          |
| [`f3c28997`](https://github.com/NixOS/nixpkgs/commit/f3c2899745902f0515742a9abbfe6963f643fb81) | `` gvfs: 1.60.1 -> 1.60.2 ``                                                              |
| [`ac8b2ce9`](https://github.com/NixOS/nixpkgs/commit/ac8b2ce9766049cb36dc756dcebac8e6a9df161c) | `` gnome-user-docs: 50.2 -> 50.4 ``                                                       |
| [`9152a598`](https://github.com/NixOS/nixpkgs/commit/9152a598f2b096d3db7879e6455a98edf1b52bed) | `` gnome-shell: 50.3 -> 50.4 ``                                                           |
| [`5838863b`](https://github.com/NixOS/nixpkgs/commit/5838863b01127f71d92e444e49af84e7da67c8cf) | `` gnome-maps: 50.2 -> 50.3 ``                                                            |
| [`b1c14145`](https://github.com/NixOS/nixpkgs/commit/b1c1414564158c92f4d3573c77b3368d143e248a) | `` gnome-initial-setup: 50.0 -> 50.1 ``                                                   |
| [`b2062cd7`](https://github.com/NixOS/nixpkgs/commit/b2062cd75278c1bbfda6b2ada891fba8927573f7) | `` gnome-control-center: 50.3 -> 50.4 ``                                                  |
| [`2f396e43`](https://github.com/NixOS/nixpkgs/commit/2f396e43ee42a52206a2e055d4df558a5cb6379d) | `` gexiv2_0_16: 0.16.1 -> 0.16.2 ``                                                       |
| [`33f260ee`](https://github.com/NixOS/nixpkgs/commit/33f260ee26f13e3f1f2f279766197a0e28e3339d) | `` gdm: 50.1 -> 50.2 ``                                                                   |
| [`5bf0d84c`](https://github.com/NixOS/nixpkgs/commit/5bf0d84cb1976de7c62584a7819c24724ab61a89) | `` CONTRIBUTING: clarify release note conventions ``                                      |
| [`00b95e75`](https://github.com/NixOS/nixpkgs/commit/00b95e754370c0e2e40ebfb8d2f2a1c74d135946) | `` firefox-devedition-unwrapped: 154.0b4 -> 154.0b8 ``                                    |
| [`2ea4ff95`](https://github.com/NixOS/nixpkgs/commit/2ea4ff95c3afa19deb34ad032871f7315deec861) | `` firefox-beta-unwrapped: 154.0b7 -> 154.0b8 ``                                          |
| [`b9639f0a`](https://github.com/NixOS/nixpkgs/commit/b9639f0ad501b0d59a4a2d15b85245ec7c6d1a03) | `` cosign: 3.1.1 -> 3.1.3 ``                                                              |
| [`9180d936`](https://github.com/NixOS/nixpkgs/commit/9180d936eca75f153986c0f8278db64b8bd92fc1) | `` keycloak: 26.7.0 -> 26.7.1 ``                                                          |
| [`839a0127`](https://github.com/NixOS/nixpkgs/commit/839a0127c567bb01607dc5335359598b83b20a0d) | `` megasync: 6.4.0.2 -> 6.5.1.0 ``                                                        |
| [`e7e336c7`](https://github.com/NixOS/nixpkgs/commit/e7e336c78ef2c9b2f4cc95198599394d46d81dce) | `` searchix: 0.4.9 -> 0.4.10 ``                                                           |
| [`2b2e7fda`](https://github.com/NixOS/nixpkgs/commit/2b2e7fda473c2632a726ee9f47d04156f8363de4) | `` rubyPackages.nokogiri: 1.18.10 -> 1.19.4 ``                                            |
| [`eca5b84a`](https://github.com/NixOS/nixpkgs/commit/eca5b84a97d4c5230650fcd369d524c94747f0c3) | `` rubyPackages.puma: 7.1.0 -> 7.2.1 ``                                                   |
| [`7bf023e9`](https://github.com/NixOS/nixpkgs/commit/7bf023e9260bffd35c3b551480b8d4acadcd98b0) | `` ledger-live-desktop: 4.13.0 -> 4.13.1 ``                                               |
| [`7e251080`](https://github.com/NixOS/nixpkgs/commit/7e251080c8fb7605fe9575f785b7f6872fc0934a) | `` stremio-linux-shell: 1.1.4 -> 1.2.0 ``                                                 |
| [`684c8ec1`](https://github.com/NixOS/nixpkgs/commit/684c8ec144298c788d160f32b07f102d85d6916d) | `` super: fix license ``                                                                  |
| [`44914b10`](https://github.com/NixOS/nixpkgs/commit/44914b109ac014b0e0594ed2052fbdfcb68efecf) | `` mongodb-7_0: 7.0.37 -> 7.0.39 ``                                                       |
| [`173f2b32`](https://github.com/NixOS/nixpkgs/commit/173f2b32af21d6a264b31c9d128a8215a39ce259) | `` noriskclient-launcher: add support for jdk25 ``                                        |
| [`9eb3d3f9`](https://github.com/NixOS/nixpkgs/commit/9eb3d3f95e472812e60e1637caabcc3f057a2d74) | `` noriskclient-launcher: fix build ``                                                    |
| [`f67ee675`](https://github.com/NixOS/nixpkgs/commit/f67ee67581d4e9a4fb1823918a0526efb91bcf41) | `` privatebin: 2.0.5 -> 2.0.6 ``                                                          |
| [`ce161a68`](https://github.com/NixOS/nixpkgs/commit/ce161a68bf9dcd919e1e8f13bdfc83f31c7027b7) | `` kitty-img: 1.1.0 -> 1.1.1 ``                                                           |
| [`61c26e31`](https://github.com/NixOS/nixpkgs/commit/61c26e31ddd9f4b68ad94ca38426ceda3025d1d7) | `` pangomm_2_48: 2.56.1 -> 2.56.2 ``                                                      |
| [`ac5bcf83`](https://github.com/NixOS/nixpkgs/commit/ac5bcf836504bceb4997c93a3a436dbdf9d7d00a) | `` mutter: 50.2 -> 50.3 ``                                                                |
| [`32a9045c`](https://github.com/NixOS/nixpkgs/commit/32a9045c3271f63a0bb5b15cb092d9a577e51ad5) | `` mm-common: 1.0.7 -> 1.0.8 ``                                                           |
| [`4bdced70`](https://github.com/NixOS/nixpkgs/commit/4bdced70179af3db6e4725616c3cb08f3fe7c05a) | `` gnome-shell: 50.2 -> 50.3 ``                                                           |
| [`1e72eed8`](https://github.com/NixOS/nixpkgs/commit/1e72eed83da8373653418fba8ec84a71d8efd230) | `` gnome-remote-desktop: 50.1 -> 50.2 ``                                                  |
| [`cb5db36e`](https://github.com/NixOS/nixpkgs/commit/cb5db36e02ee9ee84d064f8146e88eaee8c418cc) | `` libglycin: 2.1.1 -> 2.1.5 ``                                                           |
| [`93436a78`](https://github.com/NixOS/nixpkgs/commit/93436a780a815aeb44fe6a512f697c7db5e04ca1) | `` glibmm_2_68: 2.88.0 -> 2.88.1 ``                                                       |
| [`a151dcfb`](https://github.com/NixOS/nixpkgs/commit/a151dcfb133cd8da2d0ce1b0eaa2ef52fef4fc9b) | `` gexiv2_0_16: 0.16.0 -> 0.16.1 ``                                                       |
| [`ec453ced`](https://github.com/NixOS/nixpkgs/commit/ec453cedc4f323d03483d385c247cff41b34331e) | `` sub-store-frontend: 2.29.8 -> 2.29.10 ``                                               |
| [`2bae4732`](https://github.com/NixOS/nixpkgs/commit/2bae47320c9aae416c65fa8a200d24211c24a547) | `` sub-store-frontend: 2.28.6 -> 2.29.8 ``                                                |
| [`9073054e`](https://github.com/NixOS/nixpkgs/commit/9073054e61e80618ced4664f58c1376a64a0b47b) | `` sub-store-frontend: 2.27.3 -> 2.28.6 ``                                                |
| [`9d4fb54f`](https://github.com/NixOS/nixpkgs/commit/9d4fb54fedbe3988cc22e9fee750b227aafb655f) | `` traefik: 3.7.8 -> 3.7.10 ``                                                            |
| [`0a901c53`](https://github.com/NixOS/nixpkgs/commit/0a901c53461ebda24cbaef58813e72e807596797) | `` hey-mail: 1.3.3 -> 1.3.6 ``                                                            |
| [`309cc415`](https://github.com/NixOS/nixpkgs/commit/309cc415cb65bfba93fda9dde764cf648b05ad96) | `` alist: 3.57.0 -> 3.63.0 ``                                                             |
| [`e9407b6b`](https://github.com/NixOS/nixpkgs/commit/e9407b6bf6f0fb0b0b3ec35a7e5909cf638bc2a8) | `` epiphany: fix CVE-2026-18487 ``                                                        |
| [`8e31a7d6`](https://github.com/NixOS/nixpkgs/commit/8e31a7d6ce6437a35112c9653355332dd3e308be) | `` python3Packages.banks: 2.4.4 -> 2.4.5 ``                                               |
| [`f0327695`](https://github.com/NixOS/nixpkgs/commit/f0327695ddd2c094dd67dd48682513778fc22f37) | `` python3Packages.banks: 2.4.3 -> 2.4.4 ``                                               |
| [`42a46f29`](https://github.com/NixOS/nixpkgs/commit/42a46f2965cedd4d1af045fcc2909040963d8d5a) | `` python3Packages.banks: 2.4.2 -> 2.4.3 ``                                               |
| [`a24e24ce`](https://github.com/NixOS/nixpkgs/commit/a24e24cebcbac8362b6d4946683218dc218e82f2) | `` croaring: 4.7.2 -> 5.0.0 ``                                                            |
| [`aba9d1cb`](https://github.com/NixOS/nixpkgs/commit/aba9d1cbca9f8697481c18f2338a980cb18b6468) | `` mailpit: 1.30.5 -> 1.30.6 ``                                                           |
| [`15949e5e`](https://github.com/NixOS/nixpkgs/commit/15949e5ea990dca7b68207a55a2c12ab5c318b27) | `` obsidian: fix build on darwin ``                                                       |
| [`af38b712`](https://github.com/NixOS/nixpkgs/commit/af38b7121febf53f1a026bf84adb8b8d40a37e86) | `` firefox-beta-unwrapped: 153.0b13 -> 154.0b7 ``                                         |
| [`75e37523`](https://github.com/NixOS/nixpkgs/commit/75e3752362102d04e7631186a2ee48125889b646) | `` rclone: 1.74.4 -> 1.75.0 ``                                                            |
| [`7be77dd2`](https://github.com/NixOS/nixpkgs/commit/7be77dd2694b794ccb88441b184abfbbedb1a4a9) | `` coturn: 4.13.1 -> 4.16.0 ``                                                            |
| [`de795435`](https://github.com/NixOS/nixpkgs/commit/de795435c35029ea3d2ee9999ca40e7193a9c765) | `` siyuan: 3.7.1 -> 3.7.3 ``                                                              |
| [`3a81874b`](https://github.com/NixOS/nixpkgs/commit/3a81874bcf65392a7930298587f9cafeed6bb505) | `` nats-server: 2.14.3 -> 2.14.4 ``                                                       |
| [`12703f5b`](https://github.com/NixOS/nixpkgs/commit/12703f5b673612a1c38eb70b97c1792e50323029) | `` nats-server: 2.14.2 -> 2.14.3 ``                                                       |
| [`1e826ad0`](https://github.com/NixOS/nixpkgs/commit/1e826ad01023caf9c244973c182908bf415d9424) | `` nats-server: 2.14.1 -> 2.14.2 ``                                                       |
| [`350fcc31`](https://github.com/NixOS/nixpkgs/commit/350fcc3193994d85ada45b0d7ee4c5c2f6d19b1c) | `` brave: 1.92.144 -> 1.93.129 ``                                                         |
| [`b6fd937f`](https://github.com/NixOS/nixpkgs/commit/b6fd937f840810970298dfa0078becc3e055c377) | `` upower: 1.91.1 -> 1.91.2 ``                                                            |
| [`c2403b24`](https://github.com/NixOS/nixpkgs/commit/c2403b24a3e2e31914900b533700304e7d6ec06b) | `` nix-output-monitor: 2.1.8 -> 2.2.0 ``                                                  |
| [`e7d2ba1b`](https://github.com/NixOS/nixpkgs/commit/e7d2ba1b187b0c85f2e13b8951a18205c52d795d) | `` ocelot-desktop: avoid putting empty segments in PATH and LD_LIBRARY_PATH ``            |
| [`104ddd08`](https://github.com/NixOS/nixpkgs/commit/104ddd0803f67c0a20bd41dabb7c54f51e9092a3) | `` freeswitch: 1.10.12 -> 1.11.1 ``                                                       |
| [`446e8713`](https://github.com/NixOS/nixpkgs/commit/446e8713bbd1a9e1bce96d33f68c5203eb061c57) | `` plover_5: fix plover_build_utils.setup pyside6-rcc and pyside6-uic invocation ``       |
| [`12a56c34`](https://github.com/NixOS/nixpkgs/commit/12a56c34a857e2a76b359de6496a03dbe0e9547f) | `` python3Packages.plover-combo: init at 2.0.0-unstable-2025-09-11 ``                     |
| [`f6eaeda2`](https://github.com/NixOS/nixpkgs/commit/f6eaeda255d6957b6ab10fb6174b8a79e8b45480) | `` plover_4, plover_5: add optional-dependencies.gui-qt ``                                |
| [`3002121e`](https://github.com/NixOS/nixpkgs/commit/3002121e4431e52388c21980854e4c12f1d80b1b) | `` python3Packages.plover_5: handle PySide6-Essentials exclusion with pythonRemoveDeps `` |