### PR TITLE
monitoring: suppress the stuck docker-vesselalert PR, and fix two bogus CI failures

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         "rust-overlay": "rust-overlay_6"
       },
       "locked": {
-        "lastModified": 1786387197,
-        "narHash": "sha256-MZcal4PU4vEnSCsnJG0VSRG4rNNoAKb46CZKtpaxHGo=",
+        "lastModified": 1786405223,
+        "narHash": "sha256-zt3WkJQwXLVCSBzYfTtmu3CSoqa6m8zXf2QLSqZDn1s=",
         "owner": "FredSystems",
         "repo": "github-ci-exporter",
-        "rev": "765031b02fd7f00bf4971418861b2f4b119ee3c4",
+        "rev": "cbaeda658a1c360a4e6f2afc9b726ca9bf943a13",
         "type": "github"
       },
       "original": {

--- a/modules/monitoring/master/github-ci-exporter.nix
+++ b/modules/monitoring/master/github-ci-exporter.nix
@@ -78,6 +78,22 @@
     # those filters and still is not worth watching.
     denylist = [ ];
 
+    # Individual pull requests that are stuck and are not ours to unstick.
+    #
+    # docker-vesselalert#32 is open against a repository we do not own. It
+    # conflicts with the base branch, the maintainer has shown no interest in
+    # it, and it is not ours to close or convert to a draft -- the two actions
+    # that would otherwise clear the alert. Left alone it fires
+    # GitHubPullRequestChecksFailing indefinitely, which is the shape of alert
+    # that teaches the operator to ignore the whole class.
+    #
+    # This suppresses only the per-PR series, so the repository's CI and every
+    # other pull request on it stay monitored. Using `denylist` instead would
+    # blind the exporter to all of it.
+    ignorePulls = [
+      "sdr-enthusiasts/docker-vesselalert#32"
+    ];
+
     tokenFile = config.sops.secrets.github_pat_public_ro.path;
   };
 }


### PR DESCRIPTION
Three CI failures and one PR alert were firing on sdrhub. **One was real.**

## The PR alert: `docker-vesselalert#32`

Open against a repository we do not own, conflicting, and the maintainer has
not engaged with it. It is not ours to close or convert to a draft — the two
actions that would otherwise clear `GitHubPullRequestChecksFailing` — so it
fires indefinitely. That is the shape of alert that teaches you to ignore the
whole class.

```nix
ignorePulls = [ "sdr-enthusiasts/docker-vesselalert#32" ];
```

This drops it from the **per-PR series only**, so the repository's CI state and
every future PR on it stay monitored — `denylist` would have blinded the
exporter to all of it. The suppression is published as
`github_repo_pulls_ignored` rather than being silent, so a hidden PR is
explainable instead of looking like a collection bug.

## The two bogus failures: frext and bike-fitter-1000

Both reported months-old `push` failures for a `ci.yml` that declares only
`pull_request`. Those repos dropped their push trigger long ago and the runs
will never be re-run, so the alert was unclearable.

A filter for exactly this shipped in the exporter previously — and had **never
been active**. The ETag cache stores projections, so when the cached workflow
definition gained a trigger list its shape changed while every persisted
entry's ETag stayed valid. GitHub answered `304` forever, the cached body no
longer decoded, and a failed definition lookup means "triggers unknown", which
is treated as *accept any event*.

The exporter bump here carries that fix (fredsystems/github-ci-exporter#11):
the cache file is versioned, and an undecodable entry is a cache miss rather
than an error, so a forgotten version bump cannot silently disable a filter
again.

## What remains

The **nixos CVE scan (sbomnix)** failure is genuine and deliberately untouched.

## Verification

- `nix eval` on **all 10 hosts** — `modules/*` is a `GLOBAL` change. All pass.
- `services.github-ci-exporter.ignorePulls` resolves as expected on sdrhub.
- Both changes were run against the live GitHub API before merge: `#32` is
  absent from every per-PR series while `repo_pulls_open` still reports 1 and
  `repo_pulls_ignored` reports 1; frext and bike-fitter-1000 no longer report
  their superseded `push` failures; and a warm restart accepts the versioned
  cache without a cold sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monitoring now ignores pull request `sdr-enthusiasts/docker-vesselalert#32` while continuing to monitor the repository and its other pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->