### PR TITLE
monitoring: report every filesystem, not just the root one

### DIFF
--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -11,6 +11,63 @@ let
   # MAC, systemd unit state -- unauthenticated to the internet on fredvps.
   bindAddress =
     if config.deployment.internetFacing then config.deployment.tailscaleAddress else "0.0.0.0";
+
+  # Filesystem types the filesystem collector must not report.
+  #
+  # This is node_exporter 1.11's own default list with the network filesystems
+  # appended. It has to be restated in full rather than extended, because the
+  # flag replaces the default regex rather than adding to it.
+  #
+  # WHY EXCLUDE NETWORK MOUNTS
+  #
+  # The NAS shares (five on maranello, /mnt/media on fredhub) are not local
+  # capacity and are not this host's problem: every client mounting the same
+  # share reports the same usage, so one full NAS would alert once per client
+  # while telling nobody anything about the machine that fired. Nothing here
+  # monitors the NAS itself -- if that changes, it wants its own target rather
+  # than being inferred from whichever hosts happen to have it mounted.
+  #
+  # They also actively break inode monitoring: NFS reports
+  # node_filesystem_files = 0, so an inode-ratio rule evaluates 0/0 and yields
+  # NaN. Excluding them at the source is what lets NodeInodesLow cover every
+  # real filesystem instead of being pinned to "/".
+  #
+  # Excluded at the collector rather than in each query because the fstype
+  # exclusion list is already restated in several rule files; a series that
+  # does not exist cannot be forgotten by the next query someone writes.
+  filesystemTypesExcluded = lib.concatStringsSep "|" [
+    # node_exporter 1.11 defaults, verbatim.
+    "autofs"
+    "binfmt_misc"
+    "bpf"
+    "cgroup2?"
+    "configfs"
+    "debugfs"
+    "devpts"
+    "devtmpfs"
+    "fusectl"
+    "hugetlbfs"
+    "iso9660"
+    "mqueue"
+    "nsfs"
+    "overlay"
+    "proc"
+    "procfs"
+    "pstore"
+    "rpc_pipefs"
+    "securityfs"
+    "selinuxfs"
+    "squashfs"
+    "erofs"
+    "sysfs"
+    "tracefs"
+    # Network filesystems, added here.
+    "nfs"
+    "nfs4"
+    "cifs"
+    "smb3"
+    "fuse.sshfs"
+  ];
 in
 {
   systemd = {
@@ -497,6 +554,11 @@ in
 
       extraFlags = [
         "--collector.textfile.directory=/var/lib/node_exporter/textfiles"
+
+        # Drops NAS mounts from the filesystem collector. See
+        # `filesystemTypesExcluded` above for why this is done at the source
+        # rather than in each query.
+        "--collector.filesystem.fs-types-exclude=^(${filesystemTypesExcluded})$"
 
         # The systemd collector does not emit node_systemd_service_restart_total
         # unless this is set. Without it the DockerUnitFlapping alert selects

--- a/modules/monitoring/master/alert-rules/alert-rules.yaml
+++ b/modules/monitoring/master/alert-rules/alert-rules.yaml
@@ -29,6 +29,14 @@ groups:
           summary: "High memory usage on {{ $labels.hostname }}"
           description: "Node memory usage > 80% for 5 minutes."
 
+      # Deliberately not scoped to a mountpoint: every real filesystem counts,
+      # including secondary data volumes like nvrhub's /var/lib/frigate.
+      #
+      # The fstype exclusions cover pseudo-filesystems that either fill as a
+      # matter of course (tmpfs, ramfs) or are read-only by construction
+      # (squashfs). Network mounts are absent because they are dropped at the
+      # collector -- see modules/monitoring/agent/node_exporter.nix for why a
+      # NAS share is not a statement about the host that mounted it.
       - alert: NodeDiskLow
         expr: |
           (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs"}
@@ -193,15 +201,30 @@ groups:
           summary: "Targets for {{ $labels.job }} are DOWN"
           description: "Prometheus cannot scrape {{ $labels.instance }} for >2 minutes."
 
+      # Inode exhaustion on ANY real filesystem, not just the root one.
+      #
+      # This was pinned to mountpoint="/" and therefore blind to exactly the
+      # case it exists for: nvrhub's 3.6T /var/lib/frigate holds millions of
+      # small recording segments, a workload that runs out of inodes long
+      # before it runs out of bytes. A full volume there would have been caught
+      # by NodeDiskLow; an inode-exhausted one would not have been caught at
+      # all.
+      #
+      # vfat is excluded on top of the usual pseudo-filesystems because it has
+      # no inode table and reports node_filesystem_files = 0, which makes the
+      # ratio 0/0 -> NaN. Network filesystems report 0 for the same reason but
+      # are already dropped at the collector; see
+      # modules/monitoring/agent/node_exporter.nix.
       - alert: NodeInodesLow
-        expr: node_filesystem_files_free{mountpoint="/"}
-          / node_filesystem_files{mountpoint="/"} < 0.10
+        expr: |
+          (node_filesystem_files_free{fstype!~"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat"}
+           / node_filesystem_files{fstype!~"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat"}) < 0.10
         for: 15m
         labels:
           severity: warning
         annotations:
-          summary: "Low inodes on {{ $labels.hostname }}"
-          description: "Less than 10% of inodes remain on root filesystem."
+          summary: "Low inodes on {{ $labels.hostname }} ({{ $labels.mountpoint }})"
+          description: "Filesystem {{ $labels.mountpoint }} on {{ $labels.hostname }} has less than 10% of its inodes remaining. It will fail writes while still reporting free space."
 
       - alert: ClockSkewDetected
         expr: abs(node_timex_offset_seconds) > 0.1

--- a/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/alert-rules-test.yaml
@@ -994,3 +994,179 @@ tests:
             exp_annotations:
               summary: "All GitHub runners are down on fredhub"
               description: "No github-runner unit on fredhub has been active for 20 minutes. Self-hosted CI for this platform is stalled and the watchdog has not recovered it."
+
+  # ---------------------------------------------------------------------------
+  # Filesystem alerts.
+  #
+  # These had no coverage at all, which is how NodeInodesLow went unnoticed
+  # while pinned to mountpoint="/". The disk rules were in fact correct --
+  # mountpoint-agnostic all along -- but nothing proved it, so the gap was
+  # indistinguishable from the dashboard's root-only filter that prompted this.
+  # ---------------------------------------------------------------------------
+
+  # The case that started it: nvrhub's 3.6T recording volume. The alert must
+  # fire on a NON-root mountpoint, and must name it, or the operator is told a
+  # host is full without being told which filesystem.
+  - interval: 1m
+    name: NodeDiskLow fires for a secondary data volume
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "200e9+0x20"
+      - series: 'node_filesystem_size_bytes{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "4000e9+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NodeDiskLow
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              device: /dev/sda1
+              fstype: xfs
+              mountpoint: /var/lib/frigate
+              hostname: nvrhub
+              instance: nvrhub.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Disk almost full on nvrhub (/var/lib/frigate)"
+              description: "Filesystem /var/lib/frigate on nvrhub has less than 10% space available."
+
+  - interval: 1m
+    name: NodeDiskWarning fires between 20% and 10% free
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "600e9+0x20"
+      - series: 'node_filesystem_size_bytes{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "4000e9+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NodeDiskWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              device: /dev/sda1
+              fstype: xfs
+              mountpoint: /var/lib/frigate
+              hostname: nvrhub
+              instance: nvrhub.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Disk filling up on nvrhub (/var/lib/frigate)"
+              description: "Filesystem /var/lib/frigate on nvrhub has less than 20% space available."
+      # The critical rule must NOT fire at 15% free, or every warning would be
+      # accompanied by a spurious page.
+      - eval_time: 15m
+        alertname: NodeDiskLow
+        exp_alerts: []
+
+  - interval: 1m
+    name: Disk alerts stay silent on a healthy filesystem
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "3890e9+0x20"
+      - series: 'node_filesystem_size_bytes{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "4000e9+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NodeDiskWarning
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: NodeDiskLow
+        exp_alerts: []
+
+  # tmpfs fills as a matter of course and must never page.
+  - interval: 1m
+    name: Disk alerts ignore tmpfs
+    input_series:
+      - series: 'node_filesystem_avail_bytes{device="tmpfs", fstype="tmpfs", mountpoint="/run", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "1000+0x20"
+      - series: 'node_filesystem_size_bytes{device="tmpfs", fstype="tmpfs", mountpoint="/run", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "1000000+0x20"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: NodeDiskLow
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: NodeDiskWarning
+        exp_alerts: []
+
+  # Regression guard for the rule this change fixes. Inode exhaustion fails
+  # writes while df still reports free space, and Frigate's millions of small
+  # segments are exactly that workload. Pinned to mountpoint="/", this rule
+  # could not see the volume it matters most for.
+  - interval: 1m
+    name: NodeInodesLow fires on a non-root filesystem
+    input_series:
+      - series: 'node_filesystem_files_free{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "1000000+0x20"
+      - series: 'node_filesystem_files{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "390000000+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: NodeInodesLow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              device: /dev/sda1
+              fstype: xfs
+              mountpoint: /var/lib/frigate
+              hostname: nvrhub
+              instance: nvrhub.local:9100
+              job: node
+              role: agent
+            exp_annotations:
+              summary: "Low inodes on nvrhub (/var/lib/frigate)"
+              description: "Filesystem /var/lib/frigate on nvrhub has less than 10% of its inodes remaining. It will fail writes while still reporting free space."
+
+  - interval: 1m
+    name: NodeInodesLow still covers the root filesystem
+    input_series:
+      - series: 'node_filesystem_files_free{device="/dev/nvme0n1p2", fstype="ext4", mountpoint="/", hostname="sdrhub", instance="sdrhub.local:9100", job="node", role="master"}'
+        values: "1000000+0x20"
+      - series: 'node_filesystem_files{device="/dev/nvme0n1p2", fstype="ext4", mountpoint="/", hostname="sdrhub", instance="sdrhub.local:9100", job="node", role="master"}'
+        values: "30000000+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: NodeInodesLow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              device: /dev/nvme0n1p2
+              fstype: ext4
+              mountpoint: /
+              hostname: sdrhub
+              instance: sdrhub.local:9100
+              job: node
+              role: master
+            exp_annotations:
+              summary: "Low inodes on sdrhub (/)"
+              description: "Filesystem / on sdrhub has less than 10% of its inodes remaining. It will fail writes while still reporting free space."
+
+  # vfat has no inode table and reports files=0. Without the fstype exclusion
+  # the ratio is 0/0 -> NaN, which compares false and merely hides the bug;
+  # /boot would silently never be evaluable. Asserting no alert here documents
+  # that the exclusion is deliberate rather than incidental.
+  - interval: 1m
+    name: NodeInodesLow ignores filesystems with no inode table
+    input_series:
+      - series: 'node_filesystem_files_free{device="/dev/nvme0n1p1", fstype="vfat", mountpoint="/boot", hostname="sdrhub", instance="sdrhub.local:9100", job="node", role="master"}'
+        values: "0+0x20"
+      - series: 'node_filesystem_files{device="/dev/nvme0n1p1", fstype="vfat", mountpoint="/boot", hostname="sdrhub", instance="sdrhub.local:9100", job="node", role="master"}'
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: NodeInodesLow
+        exp_alerts: []
+
+  - interval: 1m
+    name: NodeInodesLow stays silent when inodes are plentiful
+    input_series:
+      - series: 'node_filesystem_files_free{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "389000000+0x20"
+      - series: 'node_filesystem_files{device="/dev/sda1", fstype="xfs", mountpoint="/var/lib/frigate", hostname="nvrhub", instance="nvrhub.local:9100", job="node", role="agent"}'
+        values: "390000000+0x20"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: NodeInodesLow
+        exp_alerts: []

--- a/modules/monitoring/master/dashboards/fleet-overview.json
+++ b/modules/monitoring/master/dashboards/fleet-overview.json
@@ -736,7 +736,7 @@
       "id": 21,
       "type": "table",
       "title": "Node Resource Summary",
-      "description": "CPU, memory, disk, and load average per node",
+      "description": "CPU, memory, disk, and load average per node. The disk figure is the FULLEST filesystem on each host, not the root one; see the per-filesystem table below for the breakdown",
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 19 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
@@ -821,7 +821,7 @@
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "Root Disk %" },
+            "matcher": { "id": "byName", "options": "Disk % (worst FS)" },
             "properties": [
               {
                 "id": "custom.cellOptions",
@@ -884,7 +884,7 @@
               "hostname": "Host",
               "Value #cpu": "CPU %",
               "Value #mem": "Memory %",
-              "Value #disk": "Root Disk %",
+              "Value #disk": "Disk % (worst FS)",
               "Value #load": "Load (1m)",
               "Value #uptime": "Uptime"
             },
@@ -899,7 +899,7 @@
               "Host": 0,
               "CPU %": 1,
               "Memory %": 2,
-              "Root Disk %": 3,
+              "Disk % (worst FS)": 3,
               "Load (1m)": 4,
               "Uptime": 5
             }
@@ -926,7 +926,7 @@
         {
           "refId": "disk",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "(1 - (node_filesystem_avail_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"})) * 100",
+          "expr": "max by (hostname) ((1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"})) * 100)",
           "instant": true,
           "format": "table",
           "legendFormat": "__auto"
@@ -950,18 +950,193 @@
       ]
     },
     {
+      "id": 47,
+      "type": "table",
+      "title": "Filesystem Usage — Every Watched Mount",
+      "description": "One row per filesystem per host: the exact set the disk alerts evaluate. The summary table above collapses each host to its fullest filesystem, so a secondary data volume (nvrhub /var/lib/frigate) is only visible here. Network mounts are absent by design -- they are excluded at the collector, because a NAS share says nothing about the host that mounted it.",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 27 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": { "show": false },
+        "sortBy": [{ "displayName": "Used %", "desc": true }]
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "left", "cellOptions": { "type": "auto" } },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Host" },
+            "properties": [{ "id": "custom.width", "value": 130 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Mount Point" },
+            "properties": [{ "id": "custom.width", "value": 200 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Device" },
+            "properties": [{ "id": "custom.width", "value": 170 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Type" },
+            "properties": [{ "id": "custom.width", "value": 80 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Size" },
+            "properties": [
+              { "id": "unit", "value": "bytes" },
+              { "id": "custom.width", "value": 100 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Available" },
+            "properties": [
+              { "id": "unit", "value": "bytes" },
+              { "id": "custom.width", "value": 110 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Used %" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "gradient" }
+              },
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
+              { "id": "min", "value": 0 },
+              { "id": "max", "value": 100 },
+              { "id": "custom.width", "value": 120 },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 80 },
+                    { "color": "red", "value": 90 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Inodes Used %" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "gradient" }
+              },
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
+              { "id": "min", "value": 0 },
+              { "id": "max", "value": 100 },
+              { "id": "custom.width", "value": 130 },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 80 },
+                    { "color": "red", "value": 90 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "instance": true,
+              "job": true,
+              "role": true,
+              "exporter": true,
+              "device_error": true
+            },
+            "renameByName": {
+              "hostname": "Host",
+              "mountpoint": "Mount Point",
+              "device": "Device",
+              "fstype": "Type",
+              "Value #size": "Size",
+              "Value #avail": "Available",
+              "Value #used": "Used %",
+              "Value #inodes": "Inodes Used %"
+            },
+            "indexByName": {
+              "Host": 0,
+              "Mount Point": 1,
+              "Device": 2,
+              "Type": 3,
+              "Size": 4,
+              "Available": 5,
+              "Used %": 6,
+              "Inodes Used %": 7
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "refId": "used",
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "100 * (1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}))",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "size",
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "avail",
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "__auto"
+        },
+        {
+          "refId": "inodes",
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "expr": "100 * (1 - (node_filesystem_files_free{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat\"} / node_filesystem_files{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat\"}))",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
       "id": 30,
       "type": "row",
       "title": "Failed Systemd Units",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 37 }
     },
     {
       "id": 31,
       "type": "table",
       "title": "Currently Failed Units",
       "description": "All systemd units currently in a failed state across the fleet",
-      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 28 },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 38 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "showHeader": true,
@@ -1045,14 +1220,14 @@
       "type": "row",
       "title": "Pending Firmware Updates",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 44 }
     },
     {
       "id": 36,
       "type": "table",
       "title": "Firmware Updates by Device",
       "description": "Devices across the fleet with firmware updates available (fwupd). Run `fwupdmgr update` on the affected host to apply.",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 35 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 45 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "showHeader": true,
@@ -1191,13 +1366,13 @@
       "type": "row",
       "title": "Resource Trends",
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 }
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 53 }
     },
     {
       "id": 41,
       "type": "timeseries",
       "title": "CPU Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 54 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1243,7 +1418,7 @@
       "id": 42,
       "type": "timeseries",
       "title": "Memory Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 44 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 54 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1289,7 +1464,7 @@
       "id": 43,
       "type": "timeseries",
       "title": "Network Receive — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 62 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1326,7 +1501,7 @@
       "id": 44,
       "type": "timeseries",
       "title": "Network Transmit — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 62 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1363,7 +1538,7 @@
       "id": 45,
       "type": "timeseries",
       "title": "System Load (1m) — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 60 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 70 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1399,8 +1574,9 @@
     {
       "id": 46,
       "type": "timeseries",
-      "title": "Root Disk Usage % — All Nodes",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 60 },
+      "title": "Disk Usage % — All Filesystems",
+      "description": "Every watched filesystem on every host, not just the root one. A secondary volume trending towards full -- nvrhub /var/lib/frigate, for instance -- is only visible here.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 70 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "desc" },
@@ -1437,8 +1613,8 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "(1 - (node_filesystem_avail_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{mountpoint=\"/\",fstype!~\"tmpfs|overlay\"})) * 100",
-          "legendFormat": "{{hostname}}"
+          "expr": "100 * (1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}))",
+          "legendFormat": "{{hostname}} {{mountpoint}}"
         }
       ]
     }

--- a/modules/monitoring/master/dashboards/fleet-overview.json
+++ b/modules/monitoring/master/dashboards/fleet-overview.json
@@ -890,6 +890,7 @@
             },
             "excludeByName": {
               "Time": true,
+              "__name__": true,
               "instance": true,
               "job": true,
               "role": true,
@@ -926,7 +927,7 @@
         {
           "refId": "disk",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "max by (hostname) ((1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"})) * 100)",
+          "expr": "max by (hostname) ((1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"})) * 100)",
           "instant": true,
           "format": "table",
           "legendFormat": "__auto"
@@ -934,7 +935,7 @@
         {
           "refId": "load",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "node_load1",
+          "expr": "max by (hostname) (node_load1)",
           "instant": true,
           "format": "table",
           "legendFormat": "__auto"
@@ -953,7 +954,7 @@
       "id": 47,
       "type": "table",
       "title": "Filesystem Usage — Every Watched Mount",
-      "description": "One row per filesystem per host: the exact set the disk alerts evaluate. The summary table above collapses each host to its fullest filesystem, so a secondary data volume (nvrhub /var/lib/frigate) is only visible here. Network mounts are absent by design -- they are excluded at the collector, because a NAS share says nothing about the host that mounted it.",
+      "description": "One row per filesystem per host: the exact set the disk alerts evaluate. The summary table above collapses each host to its fullest filesystem, so a secondary data volume (nvrhub /var/lib/frigate) is only visible here. /nix/store is omitted because it is a bind mount of / on the same device and reports byte-identical figures. Network mounts are omitted because they are excluded at the collector -- a NAS share says nothing about the host that mounted it.",
       "gridPos": { "h": 10, "w": 24, "x": 0, "y": 27 },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
       "options": {
@@ -1060,6 +1061,7 @@
           "options": {
             "excludeByName": {
               "Time": true,
+              "__name__": true,
               "instance": true,
               "job": true,
               "role": true,
@@ -1093,7 +1095,7 @@
         {
           "refId": "used",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "100 * (1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}))",
+          "expr": "100 * (1 - (max by (hostname, mountpoint, device, fstype) (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"}) / max by (hostname, mountpoint, device, fstype) (node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"})))",
           "instant": true,
           "format": "table",
           "legendFormat": "__auto"
@@ -1101,7 +1103,7 @@
         {
           "refId": "size",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}",
+          "expr": "max by (hostname, mountpoint, device, fstype) (node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"})",
           "instant": true,
           "format": "table",
           "legendFormat": "__auto"
@@ -1109,7 +1111,7 @@
         {
           "refId": "avail",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}",
+          "expr": "max by (hostname, mountpoint, device, fstype) (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"})",
           "instant": true,
           "format": "table",
           "legendFormat": "__auto"
@@ -1117,7 +1119,7 @@
         {
           "refId": "inodes",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "100 * (1 - (node_filesystem_files_free{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat\"} / node_filesystem_files{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat\"}))",
+          "expr": "100 * (1 - (max by (hostname, mountpoint, device, fstype) (node_filesystem_files_free{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat\",mountpoint!=\"/nix/store\"}) / max by (hostname, mountpoint, device, fstype) (node_filesystem_files{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs|vfat\",mountpoint!=\"/nix/store\"})))",
           "instant": true,
           "format": "table",
           "legendFormat": "__auto"
@@ -1190,6 +1192,7 @@
           "options": {
             "excludeByName": {
               "Time": true,
+              "__name__": true,
               "instance": true,
               "job": true,
               "state": true,
@@ -1340,6 +1343,7 @@
         {
           "id": "organize",
           "options": {
+            "excludeByName": { "__name__": true },
             "indexByName": {
               "host": 0,
               "device": 1,
@@ -1613,7 +1617,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
-          "expr": "100 * (1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\"}))",
+          "expr": "100 * (1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|devtmpfs|ramfs|autofs\",mountpoint!=\"/nix/store\"}))",
           "legendFormat": "{{hostname}} {{mountpoint}}"
         }
       ]


### PR DESCRIPTION
nvrhub's 3.6T `/var/lib/frigate` — mounted, in use, holding the NVR recordings —
was missing from the fleet overview.

## Where the bug actually was

Not where you'd expect. Checked each layer:

| Layer | Verdict |
| --- | --- |
| node_exporter on nvrhub | ✅ exports it correctly |
| Prometheus storage | ✅ stores it |
| Disk **alerts** | ✅ **already covered it** — match on fstype, never mountpoint |
| `fleet-overview.json` | ❌ hardcoded `mountpoint="/"` |

**So disk-usage alarms would have fired.** I evaluated `NodeDiskLow` /
`NodeDiskWarning` / `DiskFillPredicted` against live Prometheus to confirm the
frigate volume is in their result set. It was purely a visibility bug.

## Dashboard

- **New table, "Filesystem Usage — Every Watched Mount"**: one row per mount per
  host, which is exactly the set the alerts evaluate. Size, available, used %,
  and inode used %, with thresholds mirroring the alert rules (80% / 90%).
- **Trend graph** plots every filesystem instead of only root.
- **Summary table's** disk column becomes the *fullest* filesystem per host, so
  a host can't look healthy because its secondary volume is the one filling.
  Relabelled `Disk % (worst FS)` rather than left implying something it never
  measured.

## A real gap, not just cosmetic: `NodeInodesLow`

It was pinned to `mountpoint="/"`, so the frigate volume had **no inode
monitoring at all** — and millions of small recording segments is precisely the
workload that exhausts inodes while `df` still shows free space. Now
mountpoint-agnostic.

`vfat` is excluded because it has no inode table and reports `files=0`, which
makes the ratio `0/0` → NaN. `/boot` would otherwise have been silently
unevaluable.

## NAS mounts excluded at the collector

A share mounted on five hosts reports identical usage five times and says
nothing about any of them; nothing here monitors the NAS itself; and NFS
reporting `files=0` is what blocked a fleet-wide inode rule.

Verified with the same binary on maranello — only the flag differs:

| Run | `nfs` series |
| --- | --- |
| Without the flag (node_exporter default) | **5** |
| With the flag | **0** |

Note this takes effect **per host on deploy**. Confirmed gone fleet-wide after
redeploying.

## Second commit: defects found reviewing the rendered dashboard

Querying Prometheus directly did not surface these; looking at the actual table
did.

- **`__name__` appeared as a column.** Grafana turns every label into a field,
  and a bare metric selector carries `__name__` while arithmetic strips it. The
  new table mixed both kinds of target, so it survived the merge.
- **`device` / `fstype` / `mountpoint` were duplicated per query.** Same root
  cause: `merge` joins rows on matching fields, and the label sets differed
  across the four targets, so it emitted one column per query instead of
  collapsing them. All four targets now aggregate to an identical label set.
- **`/nix/store` was listed as its own filesystem.** It is a bind mount of `/`
  on the same device reporting byte-identical figures — confirmed on maranello,
  both `/dev/nvme1n1p2` at `1.8T/754G/45%`. Pure duplication, and it inflated
  the fleet's apparent filesystem count from 25 to 34. Now excluded.

The same `__name__` defect was **pre-existing** in three places, unrelated to
this change: `Node Resource Summary` (via its unaggregated `node_load1` target),
plus `Currently Failed Units` and `Firmware Updates by Device`, which both
select bare metrics. The latter two have no series at the moment, which is why
nobody had seen it, but both would have grown the column the moment a unit
failed or a firmware update appeared. Fixed alongside.

## Tests

The disk and inode rules had **zero** promtool coverage, which is how a rule
pinned to `/` survived unnoticed. Adds 8 cases: firing on a non-root volume, the
warning/critical boundary, tmpfs staying silent, inode exhaustion on both root
and non-root, and vfat being ignored.

## Verification

- `nix eval` on **all 10 hosts** (`modules/*` is `GLOBAL`) — pass
- `nix build .#checks.x86_64-linux.prometheus-alert-rules` (promtool check +
  test) — pass
- All four filesystem targets return the same four labels
  (`hostname, mountpoint, device, fstype`), **25 rows**, no `/nix/store`, no
  duplicate columns; `node_load1` returns 9 rows labelled by `hostname` alone
- nvrhub `/var/lib/frigate` shows `used=2.9%`, `inodes_used=0%`
- Dashboard JSON validated: no panel overlaps, no duplicate IDs, prettier-clean