### PR TITLE
fix(cve-scan): repair CVE scan coverage, matching and false positives

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -4,3 +4,4 @@ edn
 ags
 deriver
 trough
+cna

--- a/.github/grype-ignore.yaml
+++ b/.github/grype-ignore.yaml
@@ -112,3 +112,256 @@ ignore:
   - vulnerability: CVE-2010-4756
     package:
       name: glibc
+
+  # ---------------------------------------------------------------------
+  # Kernel CVEs matched via UNBOUNDED NVD CPE ranges.
+  #
+  # NVD records many kernel bugs against cpe:2.3:o:linux:linux_kernel with
+  # no versionEndExcluding/versionEndIncluding at all.  Such an entry
+  # matches EVERY kernel version forever, including versions released
+  # years after the bug was fixed.
+  #
+  # Each CVE below was checked against the NVD API: all of them have only
+  # unbounded linux_kernel ranges, and all but one are from 2016-2023 --
+  # fixed long before any kernel this fleet runs.  The clearest evidence is
+  # that they matched a 7.1.7 desktop while never matching a 6.18.41
+  # server, which is backwards for real version-bounded findings.
+  #
+  # Two apparent exceptions were checked individually and are also fixed:
+  #   CVE-2020-27815 -- highest real range ends 5.10.4; matched only via a
+  #                     stray open-ended shard.
+  #   CVE-2026-52972 -- ranges end at 7.0.10 and 6.18.33; we run 7.1.7 and
+  #                     6.18.41, i.e. already patched in both.
+  #
+  # This is NOT a blanket kernel exclusion.  Version-bounded kernel CVEs
+  # are deliberately still reported -- the same scan surfaces 93 genuine
+  # 2025/2026 kernel findings that fall inside real NVD ranges.  Only these
+  # specific unbounded-match CVEs are suppressed.
+  #
+  # Re-verify with:
+  #   curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=<ID>" \
+  #     | jq '[.vulnerabilities[0].cve.configurations[]?.nodes[]?.cpeMatch[]?
+  #            | select(.criteria|test("linux_kernel"))]'
+  # ---------------------------------------------------------------------
+  - vulnerability: CVE-2016-0774
+    package:
+      name: linux
+  - vulnerability: CVE-2016-3695
+    package:
+      name: linux
+  - vulnerability: CVE-2016-3699
+    package:
+      name: linux
+  - vulnerability: CVE-2017-1000255
+    package:
+      name: linux
+  - vulnerability: CVE-2017-1000377
+    package:
+      name: linux
+  - vulnerability: CVE-2017-6264
+    package:
+      name: linux
+  - vulnerability: CVE-2018-10840
+    package:
+      name: linux
+  - vulnerability: CVE-2018-10876
+    package:
+      name: linux
+  - vulnerability: CVE-2018-10882
+    package:
+      name: linux
+  - vulnerability: CVE-2018-10902
+    package:
+      name: linux
+  - vulnerability: CVE-2018-14625
+    package:
+      name: linux
+  - vulnerability: CVE-2018-6559
+    package:
+      name: linux
+  - vulnerability: CVE-2019-14899
+    package:
+      name: linux
+  - vulnerability: CVE-2019-3016
+    package:
+      name: linux
+  - vulnerability: CVE-2019-3819
+    package:
+      name: linux
+  - vulnerability: CVE-2019-3887
+    package:
+      name: linux
+  - vulnerability: CVE-2020-10742
+    package:
+      name: linux
+  - vulnerability: CVE-2020-16119
+    package:
+      name: linux
+  - vulnerability: CVE-2020-1749
+    package:
+      name: linux
+  - vulnerability: CVE-2020-27815
+    package:
+      name: linux
+  - vulnerability: CVE-2020-8834
+    package:
+      name: linux
+  - vulnerability: CVE-2021-20194
+    package:
+      name: linux
+  - vulnerability: CVE-2021-20265
+    package:
+      name: linux
+  - vulnerability: CVE-2021-3564
+    package:
+      name: linux
+  - vulnerability: CVE-2021-3714
+    package:
+      name: linux
+  - vulnerability: CVE-2021-3759
+    package:
+      name: linux
+  - vulnerability: CVE-2021-3864
+    package:
+      name: linux
+  - vulnerability: CVE-2021-4218
+    package:
+      name: linux
+  - vulnerability: CVE-2022-0286
+    package:
+      name: linux
+  - vulnerability: CVE-2022-0400
+    package:
+      name: linux
+  - vulnerability: CVE-2022-1247
+    package:
+      name: linux
+  - vulnerability: CVE-2022-2308
+    package:
+      name: linux
+  - vulnerability: CVE-2022-2327
+    package:
+      name: linux
+  - vulnerability: CVE-2022-2663
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3435
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3523
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3534
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3566
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3567
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3619
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3621
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3624
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3629
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3630
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3633
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3636
+    package:
+      name: linux
+  - vulnerability: CVE-2022-36402
+    package:
+      name: linux
+  - vulnerability: CVE-2022-3646
+    package:
+      name: linux
+  - vulnerability: CVE-2022-38096
+    package:
+      name: linux
+  - vulnerability: CVE-2022-42895
+    package:
+      name: linux
+  - vulnerability: CVE-2022-4382
+    package:
+      name: linux
+  - vulnerability: CVE-2022-4543
+    package:
+      name: linux
+  - vulnerability: CVE-2023-1073
+    package:
+      name: linux
+  - vulnerability: CVE-2023-1074
+    package:
+      name: linux
+  - vulnerability: CVE-2023-1075
+    package:
+      name: linux
+  - vulnerability: CVE-2023-1076
+    package:
+      name: linux
+  - vulnerability: CVE-2023-2898
+    package:
+      name: linux
+  - vulnerability: CVE-2023-3397
+    package:
+      name: linux
+  - vulnerability: CVE-2023-3640
+    package:
+      name: linux
+  - vulnerability: CVE-2023-3772
+    package:
+      name: linux
+  - vulnerability: CVE-2023-3773
+    package:
+      name: linux
+  - vulnerability: CVE-2023-39176
+    package:
+      name: linux
+  - vulnerability: CVE-2023-39179
+    package:
+      name: linux
+  - vulnerability: CVE-2023-39180
+    package:
+      name: linux
+  - vulnerability: CVE-2023-4010
+    package:
+      name: linux
+  - vulnerability: CVE-2023-4155
+    package:
+      name: linux
+  - vulnerability: CVE-2023-52904
+    package:
+      name: linux
+  - vulnerability: CVE-2023-6176
+    package:
+      name: linux
+  - vulnerability: CVE-2023-6238
+    package:
+      name: linux
+  - vulnerability: CVE-2023-6240
+    package:
+      name: linux
+  - vulnerability: CVE-2023-6535
+    package:
+      name: linux
+  - vulnerability: CVE-2023-6610
+    package:
+      name: linux
+  - vulnerability: CVE-2023-6679
+    package:
+      name: linux
+  - vulnerability: CVE-2026-52972
+    package:
+      name: linux

--- a/.github/grype-ignore.yaml
+++ b/.github/grype-ignore.yaml
@@ -1,0 +1,114 @@
+---
+# grype configuration for the weekly CVE scan (.github/workflows/cve-scan.yaml).
+#
+# Every match in this scan comes from grype's `nvd-cpe` source: plain CPE
+# string comparison against NVD.  There is no NixOS security tracker, so
+# grype cannot know which fixes nixpkgs has backported, cannot see that a
+# component is present only as a debug-info string rather than executable
+# code, and cannot tell that an advisory applies to a platform or build
+# configuration we do not use.  The result is a stream of matches that are
+# true statements about a CPE and false statements about this fleet.
+#
+# This file suppresses ONLY findings that are inapplicable for a specific,
+# verifiable reason recorded inline.  It is not a place to hide CVEs that
+# are merely old, merely noisy, or merely inconvenient to fix.
+#
+# RULES FOR ADDING AN ENTRY
+#
+#   1. State WHY it cannot affect us, concretely.  "Old" and "probably
+#      fine" are not reasons.  Acceptable reasons look like: wrong CPU
+#      architecture, the vulnerable feature is not compiled in, the
+#      attack vector requires a service we do not run, upstream disputes
+#      the advisory, or the CPE itself is wrong.
+#   2. Scope it to a package with `package.name` whenever the reason is
+#      package-specific, so an unrelated component matching the same CVE
+#      later is still reported.
+#   3. Prefer fixing over ignoring.  If a version bump resolves it, do
+#      that instead.
+#   4. Re-check on major version bumps.  A reason tied to how a package
+#      is built today can stop holding tomorrow.
+#
+# We deliberately do NOT filter by CVSS score, EPSS probability, or age.
+# Those are ranking signals, not applicability signals: a low-EPSS bug in
+# a library we expose to the network still matters, and suppressing by
+# threshold hides findings without anyone having judged them.  Triage
+# belongs in the report, not in a silent filter.
+#
+# The kernel is deliberately NOT suppressed.  `linux` accounts for most of
+# the volume and almost all of it is un-actionable via CPE matching (NVD
+# frequently records driver and platform bugs against
+# cpe:2.3:o:linux:linux_kernel with no upper version bound, so they match
+# every kernel forever).  We keep it visible and triage it by hand rather
+# than blanket-ignoring a component this security-relevant.
+#
+# Verify a change with:
+#   grype -c .github/grype-ignore.yaml sbom:sbom.cdx.json -o table --show-suppressed
+
+ignore:
+  # CVE-2023-4039 — GCC -fstack-protector weakness.
+  #
+  # DISPUTED upstream, and explicitly scoped to AArch64: "GCC-based
+  # toolchains that target AArch64".  Every host in this flake is
+  # x86_64-linux, so the affected code path does not exist here.
+  #
+  # gcc is also only in the runtime closure incidentally: `nix why-depends`
+  # resolves it through a debug-info path string embedded in the niri
+  # binary, not through an executable or a linked library.
+  #
+  # Re-evaluate if we ever add an aarch64-linux host.
+  - vulnerability: CVE-2023-4039
+    package:
+      name: gcc
+  - vulnerability: CVE-2023-4039
+    package:
+      name: gcc-wrapper
+
+  # CVE-2023-51767 — OpenSSH row hammer authentication bypass.
+  #
+  # DISPUTED, and conditional on physical DRAM characteristics: the
+  # advisory itself says "when common types of DRAM are used ... this is
+  # applicable to a certain threat model".  It requires the attacker to
+  # induce bit flips in specific memory, which is not a property OpenSSH
+  # can fix and not one a package update resolves.  No upstream fix
+  # exists to track.
+  - vulnerability: CVE-2023-51767
+    package:
+      name: openssh
+
+  # CVE-2007-2768 — OpenSSH OPIE user enumeration.
+  #
+  # Requires OpenSSH to be using OPIE (One-Time Passwords in Everything)
+  # via PAM.  We do not: no host in this flake configures OPIE or any OTP
+  # PAM module.  Verified by grepping modules/, profiles/, features/ and
+  # hosts/ for opie/OTP PAM configuration.
+  #
+  # Re-evaluate if OTP authentication is ever introduced.
+  - vulnerability: CVE-2007-2768
+    package:
+      name: openssh
+
+  # CVE-2016-2781 — coreutils chroot --userspec TIOCSTI escape.
+  #
+  # Requires an attacker who can already run `chroot --userspec` on the
+  # host to escape to the parent session's terminal.  That presupposes
+  # local execution with the privileges the exploit is meant to obtain,
+  # so it grants nothing an attacker in that position does not already
+  # have.  Debian and Red Hat both classify this as not-a-vulnerability
+  # for this reason, and no coreutils fix is planned.
+  - vulnerability: CVE-2016-2781
+    package:
+      name: coreutils
+
+  # CVE-2010-4756 — glibc glob() resource exhaustion.
+  #
+  # The advisory's vector is "remote authenticated users ... as
+  # demonstrated by glob expressions in ftpd", i.e. a network service
+  # that passes attacker-controlled patterns to glob().  We run no FTP
+  # server, and no service in this flake exposes glob() to remote input.
+  # Verified by grepping for vsftpd/proftpd/pure-ftpd/services.ftp.
+  #
+  # Re-evaluate if an FTP server or any service taking remote glob
+  # patterns is ever deployed.
+  - vulnerability: CVE-2010-4756
+    package:
+      name: glibc

--- a/.github/grype-ignore.yaml
+++ b/.github/grype-ignore.yaml
@@ -34,12 +34,38 @@
 # threshold hides findings without anyone having judged them.  Triage
 # belongs in the report, not in a silent filter.
 #
-# The kernel is deliberately NOT suppressed.  `linux` accounts for most of
-# the volume and almost all of it is un-actionable via CPE matching (NVD
-# frequently records driver and platform bugs against
-# cpe:2.3:o:linux:linux_kernel with no upper version bound, so they match
-# every kernel forever).  We keep it visible and triage it by hand rather
-# than blanket-ignoring a component this security-relevant.
+# NOTHING here suppresses a `linux` finding, and that is deliberate.
+#
+# The kernel is the noisiest component in the report by a wide margin and
+# the least tractable through CPE matching, because NVD is not a reliable
+# source for it.  NVD flattens the kernel's per-branch stable backports
+# into a small number of wide version spans, and separately records many
+# driver and platform bugs against cpe:2.3:o:linux:linux_kernel with no
+# upper bound at all.  The two failure modes point in opposite directions:
+#
+#   * No upper bound -> matches every kernel forever.  CVE-2017-6264, an
+#     NVIDIA Tegra GPU driver bug, matches an x86_64 desktop at CVSS 7.8.
+#   * Flattened spans -> a fix backported to 6.18.34 still shows a range
+#     reaching 6.19.7, so a patched kernel looks affected.
+#
+# A previous revision of this file suppressed 74 kernel CVEs on the first
+# ground.  That was removed.  The classification behind it treated a CVE as
+# version-bounded if ANY of its NVD shards had an upper bound, but these
+# entries routinely carry a real range AND a catch-all shard, so the test
+# silently mixed the two categories.  Verdicts derived that way were wrong
+# in both directions, and suppressions resting on them hid findings for a
+# reason that did not hold.
+#
+# The authoritative source is the Linux kernel CNA (cveawg.mitre.org),
+# which records the exact `unaffected` version per stable branch -- e.g.
+# CVE-2026-23327 is fixed in 6.18.34, which NVD's 5.19.1-6.19.7 span does
+# not show.  Comparing that against the running kernel is the only method
+# that stays correct across kernel bumps, which a hand-maintained list of
+# CVE ids cannot.
+#
+# So kernel findings are reported in full and triaged by hand for now.
+# That is noisy and known; a wrong suppression is worse than a noisy
+# report.  Automating it against the CNA is tracked separately.
 #
 # Verify a change with:
 #   grype -c .github/grype-ignore.yaml sbom:sbom.cdx.json -o table --show-suppressed
@@ -112,256 +138,3 @@ ignore:
   - vulnerability: CVE-2010-4756
     package:
       name: glibc
-
-  # ---------------------------------------------------------------------
-  # Kernel CVEs matched via UNBOUNDED NVD CPE ranges.
-  #
-  # NVD records many kernel bugs against cpe:2.3:o:linux:linux_kernel with
-  # no versionEndExcluding/versionEndIncluding at all.  Such an entry
-  # matches EVERY kernel version forever, including versions released
-  # years after the bug was fixed.
-  #
-  # Each CVE below was checked against the NVD API: all of them have only
-  # unbounded linux_kernel ranges, and all but one are from 2016-2023 --
-  # fixed long before any kernel this fleet runs.  The clearest evidence is
-  # that they matched a 7.1.7 desktop while never matching a 6.18.41
-  # server, which is backwards for real version-bounded findings.
-  #
-  # Two apparent exceptions were checked individually and are also fixed:
-  #   CVE-2020-27815 -- highest real range ends 5.10.4; matched only via a
-  #                     stray open-ended shard.
-  #   CVE-2026-52972 -- ranges end at 7.0.10 and 6.18.33; we run 7.1.7 and
-  #                     6.18.41, i.e. already patched in both.
-  #
-  # This is NOT a blanket kernel exclusion.  Version-bounded kernel CVEs
-  # are deliberately still reported -- the same scan surfaces 93 genuine
-  # 2025/2026 kernel findings that fall inside real NVD ranges.  Only these
-  # specific unbounded-match CVEs are suppressed.
-  #
-  # Re-verify with:
-  #   curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=<ID>" \
-  #     | jq '[.vulnerabilities[0].cve.configurations[]?.nodes[]?.cpeMatch[]?
-  #            | select(.criteria|test("linux_kernel"))]'
-  # ---------------------------------------------------------------------
-  - vulnerability: CVE-2016-0774
-    package:
-      name: linux
-  - vulnerability: CVE-2016-3695
-    package:
-      name: linux
-  - vulnerability: CVE-2016-3699
-    package:
-      name: linux
-  - vulnerability: CVE-2017-1000255
-    package:
-      name: linux
-  - vulnerability: CVE-2017-1000377
-    package:
-      name: linux
-  - vulnerability: CVE-2017-6264
-    package:
-      name: linux
-  - vulnerability: CVE-2018-10840
-    package:
-      name: linux
-  - vulnerability: CVE-2018-10876
-    package:
-      name: linux
-  - vulnerability: CVE-2018-10882
-    package:
-      name: linux
-  - vulnerability: CVE-2018-10902
-    package:
-      name: linux
-  - vulnerability: CVE-2018-14625
-    package:
-      name: linux
-  - vulnerability: CVE-2018-6559
-    package:
-      name: linux
-  - vulnerability: CVE-2019-14899
-    package:
-      name: linux
-  - vulnerability: CVE-2019-3016
-    package:
-      name: linux
-  - vulnerability: CVE-2019-3819
-    package:
-      name: linux
-  - vulnerability: CVE-2019-3887
-    package:
-      name: linux
-  - vulnerability: CVE-2020-10742
-    package:
-      name: linux
-  - vulnerability: CVE-2020-16119
-    package:
-      name: linux
-  - vulnerability: CVE-2020-1749
-    package:
-      name: linux
-  - vulnerability: CVE-2020-27815
-    package:
-      name: linux
-  - vulnerability: CVE-2020-8834
-    package:
-      name: linux
-  - vulnerability: CVE-2021-20194
-    package:
-      name: linux
-  - vulnerability: CVE-2021-20265
-    package:
-      name: linux
-  - vulnerability: CVE-2021-3564
-    package:
-      name: linux
-  - vulnerability: CVE-2021-3714
-    package:
-      name: linux
-  - vulnerability: CVE-2021-3759
-    package:
-      name: linux
-  - vulnerability: CVE-2021-3864
-    package:
-      name: linux
-  - vulnerability: CVE-2021-4218
-    package:
-      name: linux
-  - vulnerability: CVE-2022-0286
-    package:
-      name: linux
-  - vulnerability: CVE-2022-0400
-    package:
-      name: linux
-  - vulnerability: CVE-2022-1247
-    package:
-      name: linux
-  - vulnerability: CVE-2022-2308
-    package:
-      name: linux
-  - vulnerability: CVE-2022-2327
-    package:
-      name: linux
-  - vulnerability: CVE-2022-2663
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3435
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3523
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3534
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3566
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3567
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3619
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3621
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3624
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3629
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3630
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3633
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3636
-    package:
-      name: linux
-  - vulnerability: CVE-2022-36402
-    package:
-      name: linux
-  - vulnerability: CVE-2022-3646
-    package:
-      name: linux
-  - vulnerability: CVE-2022-38096
-    package:
-      name: linux
-  - vulnerability: CVE-2022-42895
-    package:
-      name: linux
-  - vulnerability: CVE-2022-4382
-    package:
-      name: linux
-  - vulnerability: CVE-2022-4543
-    package:
-      name: linux
-  - vulnerability: CVE-2023-1073
-    package:
-      name: linux
-  - vulnerability: CVE-2023-1074
-    package:
-      name: linux
-  - vulnerability: CVE-2023-1075
-    package:
-      name: linux
-  - vulnerability: CVE-2023-1076
-    package:
-      name: linux
-  - vulnerability: CVE-2023-2898
-    package:
-      name: linux
-  - vulnerability: CVE-2023-3397
-    package:
-      name: linux
-  - vulnerability: CVE-2023-3640
-    package:
-      name: linux
-  - vulnerability: CVE-2023-3772
-    package:
-      name: linux
-  - vulnerability: CVE-2023-3773
-    package:
-      name: linux
-  - vulnerability: CVE-2023-39176
-    package:
-      name: linux
-  - vulnerability: CVE-2023-39179
-    package:
-      name: linux
-  - vulnerability: CVE-2023-39180
-    package:
-      name: linux
-  - vulnerability: CVE-2023-4010
-    package:
-      name: linux
-  - vulnerability: CVE-2023-4155
-    package:
-      name: linux
-  - vulnerability: CVE-2023-52904
-    package:
-      name: linux
-  - vulnerability: CVE-2023-6176
-    package:
-      name: linux
-  - vulnerability: CVE-2023-6238
-    package:
-      name: linux
-  - vulnerability: CVE-2023-6240
-    package:
-      name: linux
-  - vulnerability: CVE-2023-6535
-    package:
-      name: linux
-  - vulnerability: CVE-2023-6610
-    package:
-      name: linux
-  - vulnerability: CVE-2023-6679
-    package:
-      name: linux
-  - vulnerability: CVE-2026-52972
-    package:
-      name: linux

--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -144,6 +144,22 @@
       "revert_action": "No upstream issue is filed yet, so `min_version: null` keeps this BLOCKED (never falsely resolved) as a manual re-check reminder. File an upstream issue against tiiuae/sbomnix describing the substituted-deriver drop, then retarget this entry to `issue-closed` (or to `pkgs-min-version` once a carrying sbomnix release is known). To revert: confirm the pinned sbomnix recovers derivers itself by running sbomnix against a flakeref and checking the component count is within ~15% of `nix path-info --recursive <out> | wc -l`; then delete overlays/sbomnix-recover-substituted-derivers.patch, drop the `patches` attribute from the sbomnix overlay along with its FIXME, confirm a manual `workflow_dispatch` CVE scan is green and the coverage assertion still passes, then set `done: true`. Keep the coverage assertion in cve-scan.yaml regardless -- it guards the class of bug, not this instance."
     },
     {
+      "id": "sbomnix-pinned-version-cpe-drop",
+      "done": false,
+      "summary": "sbomnix matches nixpkgs metadata to components only by exact output/derivation path, so a closure pinning a different version than the nixpkgs attribute currently builds gets no metadata and therefore no CPE; such components are invisible to grype and report as clean. Servers pinning linux 6.18.41 while pkgs.linux was 6.18.43 scored ZERO kernel CVEs while a version-matching desktop scored 74, and only 59 of 1819 components fleet-wide carried a CPE.",
+      "repo": "tiiuae/sbomnix",
+      "check": "pkgs-min-version",
+      "package": "sbomnix",
+      "eval_host": "fredhub",
+      "min_version": null,
+      "upstream_pr": null,
+      "tracking": [
+        "https://github.com/tiiuae/sbomnix/blob/main/src/sbomnix/package_meta.py"
+      ],
+      "workaround": "overlays/default.nix -- the `sbomnix` overlay applies overlays/sbomnix-recover-pinned-version-cpes.patch, adding a lowest-priority pname fallback in match_package_metadata_to_components() that carries over only the CPE, plus _retarget_cpe_version() in builder.py which rewrites the CPE version to the version actually present in the closure, strips nixpkgs-only revision suffixes (glibc 2.42-67 -> 2.42) and preserves an accurate CPE version/update split (bash 5.3p9 = version 5.3, update 9). See FIXME(sbomnix-pinned-version-cpe-drop). cve-scan.yaml additionally asserts a floor on the number of components carrying a CPE so a future regression fails loudly.",
+      "revert_action": "No upstream issue is filed yet, so `min_version: null` keeps this BLOCKED (never falsely resolved) as a manual re-check reminder. File an upstream issue against tiiuae/sbomnix describing the path-only metadata match, then retarget this entry to `issue-closed` or to `pkgs-min-version` once a carrying release is known. To revert: run the pinned sbomnix against a host whose kernel version differs from `pkgs.linux` and confirm the emitted `linux` component carries a cpe matching the CLOSURE's version, not the attribute's; then delete overlays/sbomnix-recover-pinned-version-cpes.patch, drop it from the `patches` list along with its FIXME, confirm a manual workflow_dispatch CVE scan is green and the scannable-component assertion still passes, then set `done: true`. Keep that assertion regardless -- it guards the class of bug, not this instance."
+    },
+    {
       "id": "nixpkgs-536365-ld64-mac-notification-sys",
       "done": false,
       "summary": "nixpkgs' classic ld64 (cctools-binutils-darwin-1010.6) crashes in its stubs pass with `Trace/BPT trap: 5` when linking any Rust binary that pulls `mac-notification-sys` via `notify-rust`. This kills the aarch64-darwin build of freminal 0.11.1 (and previously killed cargo-watch, since removed).",

--- a/.github/tracked-upstream-fixes.json
+++ b/.github/tracked-upstream-fixes.json
@@ -128,6 +128,22 @@
       "revert_action": "sbomnix#267 is already CLOSED (the parser was fixed in 1.8.0); the residual bug is purely nixpkgs' stale wrapper pin, for which no upstream issue exists yet. `pkgs-min-version` with `min_version: null` keeps this BLOCKED (never falsely resolved) \u2014 it is a reminder to re-check manually. When a future nixpkgs sbomnix update drops the nix_2_31 PATH pin (verify pkgs/by-name/sb/sbomnix/package.nix in our pinned nixpkgs no longer references nixVersions.nix_2_31), delete the `sbomnix` overlay from overlays/default.nix and its FIXME, revert flake/dev/packages.nix to `import nixpkgs { inherit system; }` with no overlays and drop the `inherit (pkgs) sbomnix;` line, revert cve-scan.yaml to `nix shell --inputs-from . nixpkgs#sbomnix --command sbomnix`, confirm a manual `workflow_dispatch` CVE scan is green, then set `done: true`. If it becomes urgent, file a nixpkgs issue to establish a real `issue-closed`/`nixpkgs-pin-contains-commit` signal and retarget this entry."
     },
     {
+      "id": "sbomnix-substituted-deriver-drop",
+      "done": false,
+      "summary": "sbomnix drops every runtime-closure path whose deriver `nix path-info` reports as unknown, which is every substituter-fetched path; the SBOM covered 418 of 3242 paths (13%) and silently omitted openssl, bash and glibc while keeping unit-*.service glue, so CVE scans reported near-empty results as clean successes.",
+      "repo": "tiiuae/sbomnix",
+      "check": "pkgs-min-version",
+      "package": "sbomnix",
+      "eval_host": "fredhub",
+      "min_version": null,
+      "upstream_pr": null,
+      "tracking": [
+        "https://github.com/tiiuae/sbomnix/blob/main/src/sbomnix/runtime.py"
+      ],
+      "workaround": "overlays/default.nix -- the `sbomnix` overlay applies overlays/sbomnix-recover-substituted-derivers.patch, which reconstructs output -> deriver by inverting `outputs.<name>.path` over the local .drv graph instead of trusting the store's deriver pointers (see FIXME(sbomnix-substituted-deriver-drop)). Restores 98.9% closure coverage (408 -> 2835 components on Daytona). cve-scan.yaml additionally asserts >= 60% coverage so a future regression fails loudly instead of silently reporting an empty scan.",
+      "revert_action": "No upstream issue is filed yet, so `min_version: null` keeps this BLOCKED (never falsely resolved) as a manual re-check reminder. File an upstream issue against tiiuae/sbomnix describing the substituted-deriver drop, then retarget this entry to `issue-closed` (or to `pkgs-min-version` once a carrying sbomnix release is known). To revert: confirm the pinned sbomnix recovers derivers itself by running sbomnix against a flakeref and checking the component count is within ~15% of `nix path-info --recursive <out> | wc -l`; then delete overlays/sbomnix-recover-substituted-derivers.patch, drop the `patches` attribute from the sbomnix overlay along with its FIXME, confirm a manual `workflow_dispatch` CVE scan is green and the coverage assertion still passes, then set `done: true`. Keep the coverage assertion in cve-scan.yaml regardless -- it guards the class of bug, not this instance."
+    },
+    {
       "id": "nixpkgs-536365-ld64-mac-notification-sys",
       "done": false,
       "summary": "nixpkgs' classic ld64 (cctools-binutils-darwin-1010.6) crashes in its stubs pass with `Trace/BPT trap: 5` when linking any Rust binary that pulls `mac-notification-sys` via `notify-rust`. This kills the aarch64-darwin build of freminal 0.11.1 (and previously killed cargo-watch, since removed).",

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -34,6 +34,13 @@ name: CVE scan (sbomnix)
 # (git, arena, ada, ShellCheck, Rust crates with C-library names) are
 # gone.
 #
+# That last claim only holds with --exclude-cpe-matching.  sbomnix's
+# HEURISTIC CPEs (vendor == product, synthesised for any component
+# nixpkgs metadata does not cover) reproduce the exact vulnix failure
+# mode -- `ada` came straight back, matching Ada.cx the SaaS chatbot,
+# alongside `fish` matching the FiSH IRC plugin at CVSS 10.  We pass
+# --exclude-cpe-matching so only exact nixpkgs-metadata CPEs are used.
+#
 # Scheduled for Monday 07:00 UTC, ~2h after the Sunday update-flakes
 # auto-merge window, so we always scan against the freshly-updated lock.
 #
@@ -128,56 +135,74 @@ jobs:
           name="${{ matrix.system }}"
           attr=".#nixosConfigurations.${name}.config.system.build.toplevel"
 
-          # We pass sbomnix a `.drv` path rather than a flakeref because
-          # the flakeref code path eventually calls `nix-store -q --deriver`
-          # on every output, and substituter-fetched outputs have
-          # `unknown-deriver` in the local DB (the substituter recorded
-          # the deriver pointer with a hash from when IT built the
-          # output, which never gets copied to clients).  Walking the
-          # .drv graph directly avoids the deriver lookup entirely.
+          # We hand sbomnix a FLAKEREF, not a `.drv` path.
           #
-          # `nix eval --raw` on a `.drvPath` instantiates the entire
-          # derivation graph locally (writing every .drv file to the
-          # store) without realising any outputs, which is exactly what
-          # sbomnix needs to walk the graph.
-          echo "Resolving drvPath..."
+          # A previous revision passed the `.drv` believing it avoided
+          # sbomnix's deriver lookups.  It does not: sbomnix runs
+          # `nix path-info --recursive` on the realised output closure
+          # regardless of how the target is named, and drops every path
+          # whose deriver is unknown.  Passing the .drv changed nothing
+          # (byte-identical SBOMs) while costing us the nixpkgs metadata
+          # that only the flakeref code path can resolve -- and that
+          # metadata is the sole source of exact CPEs.
+          #
+          # The deriver problem itself is fixed in our sbomnix overlay;
+          # see FIXME(sbomnix-substituted-deriver-drop) in
+          # overlays/default.nix.
+          #
+          # We still instantiate the derivation graph first.  The overlay
+          # patch reconstructs output -> deriver by inverting the local
+          # .drv graph, so that graph has to exist on disk.  `nix eval
+          # --raw` on `.drvPath` writes every .drv to the store without
+          # realising any output.
+          echo "Instantiating derivation graph..."
           drv=$(nix eval --raw "${attr}.drvPath")
           echo "drvPath: $drv"
 
           # Two-step pipeline:
           #
-          #   1. sbomnix walks the runtime closure of the .drv and
-          #      emits a CycloneDX SBOM with structural CPEs for every
-          #      component (heuristic CPEs of the form
-          #      cpe:2.3:a:<pname>:<pname>:<version>:*:*:...).
+          #   1. sbomnix walks the runtime closure and emits a CycloneDX
+          #      SBOM whose components carry EXACT CPEs taken from nixpkgs
+          #      metadata (e.g. cpe:2.3:a:gnu:bash:5.3p15:...).
           #
           #   2. grype consumes that SBOM and emits a new CycloneDX SBOM
           #      with the same components plus a `.vulnerabilities[]`
           #      array populated by CPE-matching against grype's DB.
           #
+          # --exclude-cpe-matching suppresses sbomnix's HEURISTIC CPEs,
+          # which are fabricated as cpe:2.3:a:<pname>:<pname>:<version>
+          # (vendor == product) for any component nixpkgs metadata does
+          # not cover.  Those invented CPEs collide with unrelated
+          # products and reproduce exactly the false-positive class that
+          # made us abandon vulnix: `fish` matched FiSH, an IRC
+          # encryption plugin, at CVSS 10; `ada` matched Ada.cx, a SaaS
+          # chatbot.  On one desktop closure they accounted for 192 of
+          # 317 matches.  Dropping them takes the report from 410 to 121
+          # matches, and what remains is led by linux, glibc, gnutls and
+          # openssh -- i.e. things actually in the closure.
+          #
           # We deliberately do NOT pass --include-vulns to sbomnix:
-          # that flag invokes vulnix internally, which has the same
-          # `nix-store -q --deriver` problem and crashes on substituter-
-          # fetched closures.  grype doesn't need .drv files at all,
+          # that flag invokes vulnix internally, which reintroduces the
+          # deriver problem.  grype doesn't need .drv files at all,
           # only the SBOM components it just received.
           #
           # --buildtime is intentionally NOT passed: we want runtime deps
           # only.  Build-only artefacts (*-source, *-go-modules, *-vendor,
           # bootstrap stages) are not part of the running system and are
           # excluded structurally by sbomnix when this flag is omitted.
-          # We build sbomnix from THIS flake's `.#sbomnix` package (an
-          # overlay that re-points sbomnix's internal `nix derivation
-          # show` at a Nix emitting the modern JSON schema) rather than
-          # `nixpkgs#sbomnix`.  The upstream nixpkgs wrapper pins
-          # nixVersions.nix_2_31, whose legacy `inputDrvs` output the
-          # sbomnix 1.8.0 parser refuses to consume.  See
-          # FIXME(nixpkgs-sbomnix-nix231-pin) in overlays/default.nix.
+          # We build sbomnix from THIS flake's `.#sbomnix` package rather
+          # than `nixpkgs#sbomnix`: the overlay re-points sbomnix's
+          # internal `nix derivation show` at a Nix emitting the modern
+          # JSON schema, and patches the substituted-deriver drop.  See
+          # FIXME(nixpkgs-sbomnix-nix231-pin) and
+          # FIXME(sbomnix-substituted-deriver-drop) in overlays/default.nix.
           echo "Step 1/2: generating CycloneDX SBOM for nixos/${name}..."
           nix shell .#sbomnix --command sbomnix \
+            --exclude-cpe-matching \
             --cdx sbom.cdx.json \
             --csv sbom.csv \
             --spdx sbom.spdx.json \
-            "$drv"
+            "$attr"
 
           if [ ! -s sbom.cdx.json ]; then
             echo "::error::sbomnix did not produce sbom.cdx.json — failing step" >&2
@@ -185,6 +210,28 @@ jobs:
           fi
           if ! nix shell --inputs-from . nixpkgs#jq --command jq -e '.bomFormat == "CycloneDX"' sbom.cdx.json >/dev/null; then
             echo "::error::sbom.cdx.json is not a valid CycloneDX SBOM — failing step" >&2
+            exit 1
+          fi
+
+          # Coverage assertion.
+          #
+          # The failure mode this guards against is silent: when sbomnix
+          # loses closure paths it still exits 0 and still emits a valid
+          # SBOM, just a nearly empty one, which then reports as a clean
+          # scan.  We ran at 13% coverage for weeks without noticing.
+          #
+          # Compare the component count against the real runtime closure
+          # and fail if we are not seeing most of it.  The threshold is
+          # deliberately loose: sbomnix legitimately folds multi-output
+          # derivations (foo, foo-man, foo-dev -> one component), so 100%
+          # is not achievable and the healthy figure is ~85-90%.
+          out=$(nix eval --raw "${attr}")
+          closure=$(nix path-info --recursive "$out" | wc -l)
+          components=$(nix shell --inputs-from . nixpkgs#jq --command jq '.components | length' sbom.cdx.json)
+          coverage=$(( components * 100 / closure ))
+          echo "SBOM coverage: ${components}/${closure} closure paths (${coverage}%)"
+          if [ "$coverage" -lt 60 ]; then
+            echo "::error::SBOM covers only ${coverage}% of the runtime closure (${components}/${closure}); refusing to report a scan this incomplete" >&2
             exit 1
           fi
 
@@ -201,19 +248,26 @@ jobs:
           mv sbom.cdx.json.new sbom.cdx.json
 
           # Sanity check: SBOM must still be valid CycloneDX after the
-          # grype rewrite, and must now contain a .vulnerabilities array.
-          # Empty is fine (== zero CVEs, good news); missing means grype
-          # silently produced garbage and we'd misreport as clean.
+          # grype rewrite.
           if ! nix shell --inputs-from . nixpkgs#jq --command jq -e '.bomFormat == "CycloneDX"' sbom.cdx.json >/dev/null; then
             echo "::error::grype output is not a valid CycloneDX SBOM" >&2
             exit 1
           fi
-          if ! nix shell --inputs-from . nixpkgs#jq --command jq -e 'has("vulnerabilities")' sbom.cdx.json >/dev/null; then
-            echo "::error::grype output has no .vulnerabilities key" >&2
-            exit 1
-          fi
 
-          vuln_count=$(nix shell --inputs-from . nixpkgs#jq --command jq '.vulnerabilities | length' sbom.cdx.json)
+          # We do NOT require a `.vulnerabilities` key.
+          #
+          # grype omits the key entirely when it matches nothing; it does
+          # not emit an empty array.  A previous revision treated the
+          # missing key as "grype produced garbage" and failed the job,
+          # which meant a genuinely clean host was indistinguishable from
+          # a broken scan -- and since coverage collapse (see the
+          # assertion above) drives matches to zero, this fired
+          # constantly and turned the whole workflow red.
+          #
+          # A real grype failure is already caught: it exits non-zero and
+          # writes a 0-byte file, so `set -e` aborts at the grype call
+          # before reaching here.  Treat a missing key as zero matches.
+          vuln_count=$(nix shell --inputs-from . nixpkgs#jq --command jq '.vulnerabilities // [] | length' sbom.cdx.json)
           echo "Found ${vuln_count} CVE entries for nixos/${name}"
           echo "vuln_count=$vuln_count" >> "$GITHUB_OUTPUT"
 
@@ -294,7 +348,11 @@ jobs:
             [ -f "$json" ] || continue
 
             scanned["${kind}/${name}"]=1
-            count=$(jq '.vulnerabilities | length' "$json")
+            # `// []` because grype omits the key entirely on zero
+            # matches rather than emitting an empty array; without the
+            # fallback jq returns null and the arithmetic below aborts
+            # under `set -e`.
+            count=$(jq '.vulnerabilities // [] | length' "$json")
             total=$((total + count))
 
             if [ "$count" -gt 0 ]; then
@@ -452,7 +510,7 @@ jobs:
               name=${spec#*-}
               json="${dir}sbom.cdx.json"
               [ -f "$json" ] || continue
-              count=$(jq '.vulnerabilities | length' "$json")
+              count=$(jq '.vulnerabilities // [] | length' "$json")
               echo "| \`${kind}/${name}\` | ${count} |"
             done
             for sys in "${missing[@]}"; do

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -248,6 +248,35 @@ jobs:
             exit 1
           fi
 
+          # Scannable-component assertion.
+          #
+          # The check above proves the SBOM has components.  It says
+          # nothing about whether those components can be MATCHED, and a
+          # component without a CPE is invisible to grype: it contributes
+          # zero findings and is indistinguishable from a clean one.
+          #
+          # This is not hypothetical.  Hosts pinning a kernel version
+          # older than `pkgs.linux` emitted the kernel with `cpe: null`
+          # and reported zero kernel CVEs, while a host whose kernel
+          # matched its nixpkgs attr reported 74 -- a newer kernel
+          # looking cleaner than an older one.  Component coverage was a
+          # healthy 87% throughout; scannable coverage was 3%.
+          #
+          # Track it as an absolute count, not a ratio.  Most of a NixOS
+          # closure is systemd units, etc-* fragments and shell
+          # completions that will never have a CPE, so the ratio is
+          # meaningfully low even when healthy, whereas losing a
+          # metadata source shows up immediately as a cliff in the count.
+          # Baseline at the time of writing: ~97 on servers, ~120 on
+          # desktops.  The floor is set well below that to flag a
+          # collapse without failing on ordinary churn.
+          scannable=$(nix shell --inputs-from . nixpkgs#jq --command jq '[.components[] | select(.cpe != null)] | length' sbom.cdx.json)
+          echo "Scannable components (with a CPE): ${scannable}"
+          if [ "$scannable" -lt 50 ]; then
+            echo "::error::only ${scannable} components carry a CPE, so almost nothing was actually scanned; a metadata source has probably broken (see FIXME(sbomnix-pinned-version-cpe-drop) in overlays/default.nix)" >&2
+            exit 1
+          fi
+
           echo "Step 2/2: scanning SBOM with grype..."
           # grype reads sbom.cdx.json, writes a new CycloneDX file with
           # vulnerabilities to a temp path, then we atomically replace.

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -41,6 +41,19 @@ name: CVE scan (sbomnix)
 # alongside `fish` matching the FiSH IRC plugin at CVSS 10.  We pass
 # --exclude-cpe-matching so only exact nixpkgs-metadata CPEs are used.
 #
+# Know what this scan is and is not.  Every match comes from grype's
+# `nvd-cpe` source: CPE string comparison against NVD.  There is no
+# NixOS security tracker, so nothing here knows which fixes nixpkgs has
+# backported.  A match means "NVD lists a CVE against this CPE", not
+# "this host is exploitable".  The `linux` component is the clearest
+# case -- NVD records many driver and platform bugs against
+# cpe:2.3:o:linux:linux_kernel with no upper version bound, so they
+# match every kernel forever (e.g. CVE-2017-6264, an NVIDIA Tegra GPU
+# driver bug, matches an x86_64 desktop).  The kernel is intentionally
+# left in the report and triaged by hand.  Findings that are provably
+# inapplicable are suppressed, with a stated reason, in
+# .github/grype-ignore.yaml.
+#
 # Scheduled for Monday 07:00 UTC, ~2h after the Sunday update-flakes
 # auto-merge window, so we always scan against the freshly-updated lock.
 #
@@ -240,7 +253,16 @@ jobs:
           # vulnerabilities to a temp path, then we atomically replace.
           # We must NOT have grype write directly to sbom.cdx.json — it
           # opens output before reading input on some versions.
+          #
+          # -c .github/grype-ignore.yaml suppresses findings that are
+          # inapplicable to this fleet for a specific, documented reason
+          # (wrong CPU architecture, a service we do not run, upstream
+          # DISPUTED).  Every match here comes from grype's `nvd-cpe`
+          # source — raw CPE string comparison with no NixOS security
+          # tracker behind it — so grype cannot tell that on its own.
+          # The file is NOT a severity/age filter; see its header.
           nix shell --inputs-from . nixpkgs#grype --command grype \
+            -c .github/grype-ignore.yaml \
             "sbom:sbom.cdx.json" \
             --output cyclonedx-json \
             --file sbom.cdx.json.new

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -262,6 +262,64 @@
             check-input-category-sync
             touch "$out"
           '';
+
+      # Fails when nixpkgs moves sbomnix off the version our source
+      # patches were written against.
+      #
+      # The `sbomnix` overlay carries two patches against sbomnix
+      # internals (overlays/default.nix, FIXMEs
+      # sbomnix-substituted-deriver-drop and
+      # sbomnix-pinned-version-cpe-drop). They are gated to an exact
+      # version, so a bump silently drops them rather than failing to
+      # apply -- and the CVE scan would keep running while quietly
+      # reverting to reporting ~3% of each closure, which reads as
+      # "clean" rather than "broken". That is the precise failure this
+      # PR exists to remove, so it must not be reintroduced by a routine
+      # flake update.
+      #
+      # cve-scan.yaml's scannable-component assertion is the runtime
+      # backstop; this check is the eval-time one, so a bump is caught by
+      # `nix flake check` in CI on the update PR instead of a week later
+      # by the Monday scan.
+      #
+      # On a bump: re-verify both patches against the new sbomnix tree
+      # (they touch builder.py, runtime.py and package_meta.py), refresh
+      # them if the surrounding code moved, confirm a manual scan still
+      # reports a healthy scannable-component count, then update
+      # `sbomnixPatchedVersion` in overlays/default.nix. If upstream has
+      # fixed either bug, drop that patch and close out its entry in
+      # .github/tracked-upstream-fixes.json instead.
+      sbomnix-patch-version =
+        let
+          overlayPkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import ../../overlays) ];
+          };
+          expected = overlayPkgs.sbomnixPatchedVersion;
+          actual = overlayPkgs.sbomnix.version;
+        in
+        pkgs.runCommand "sbomnix-patch-version-check" { } (
+          if actual == expected then
+            ''
+              echo "sbomnix ${actual} matches the patched version; overlay patches apply"
+              touch "$out"
+            ''
+          else
+            ''
+              echo "sbomnix is ${actual}, but the overlay patches target ${expected}." >&2
+              echo "" >&2
+              echo "The patches are version-gated, so they are NOT being applied." >&2
+              echo "Left as-is the CVE scan still runs but silently loses most of" >&2
+              echo "its closure coverage and reports near-empty results as clean." >&2
+              echo "" >&2
+              echo "Re-verify overlays/sbomnix-recover-substituted-derivers.patch and" >&2
+              echo "overlays/sbomnix-recover-pinned-version-cpes.patch against the new" >&2
+              echo "tree, then set sbomnixPatchedVersion in overlays/default.nix to" >&2
+              echo "${actual}. If upstream fixed either bug, drop that patch and" >&2
+              echo "resolve its entry in .github/tracked-upstream-fixes.json." >&2
+              exit 1
+            ''
+        );
     }
   );
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -109,8 +109,31 @@ final: prev: {
   # yet), delete the `patches` attribute, the patch file, and this FIXME.
   # See .github/workflows/track-upstream-fixes.yaml.
   #
-  # Both workarounds above are only meaningful on Linux (cve-scan runs on
-  # the self-hosted Linux runners); guarded so this is a no-op on darwin.
+  # FIXME(sbomnix-pinned-version-cpe-drop): WORKAROUND, not a fix.
+  #
+  # sbomnix attaches nixpkgs metadata only when a component's output or
+  # derivation path is byte-identical to the one the nixpkgs attribute
+  # evaluates to.  When a closure pins a different version than the attr
+  # currently builds, nothing matches and the component is emitted with
+  # no CPE -- which makes it invisible to grype and reads as "no known
+  # vulnerabilities" rather than "never checked".
+  #
+  # This was hiding most of the fleet.  Servers pinning linux 6.18.41
+  # while `pkgs.linux` was 6.18.43 emitted the kernel with `cpe: null`
+  # and scored ZERO kernel CVEs, while Daytona (whose kernel matched its
+  # attr) scored 74.  A newer kernel looking cleaner than an older one is
+  # the signature of this bug, not a security finding.
+  #
+  # The patch adds a lowest-priority pname fallback that carries over
+  # only the CPE, retargeted to the version actually in the closure.
+  # Takes a server closure from 59 to 97 scannable components.
+  #
+  # Revert: once sbomnix matches metadata for pinned versions itself (no
+  # upstream issue filed yet), delete the patch and this FIXME.  See
+  # .github/workflows/track-upstream-fixes.yaml.
+  #
+  # All three workarounds above are only meaningful on Linux (cve-scan
+  # runs on the self-hosted Linux runners); guarded to no-op on darwin.
   sbomnix =
     if prev.stdenv.isDarwin then
       prev.sbomnix
@@ -118,6 +141,7 @@ final: prev: {
       prev.sbomnix.overrideAttrs (old: {
         patches = (old.patches or [ ]) ++ [
           ./sbomnix-recover-substituted-derivers.patch
+          ./sbomnix-recover-pinned-version-cpes.patch
         ];
         makeWrapperArgs = [
           "--prefix PATH : ${

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -134,8 +134,30 @@ final: prev: {
   #
   # All three workarounds above are only meaningful on Linux (cve-scan
   # runs on the self-hosted Linux runners); guarded to no-op on darwin.
+  #
+  # The two source patches are additionally version-gated to exactly
+  # 1.8.0, the version they were written against.  Two reasons:
+  #
+  #   * `nixpkgs-stable` currently ships 1.7.6, whose tree predates
+  #     builder.py/runtime.py/package_meta.py entirely.  Applying the
+  #     patches there fails the build ("4 out of 4 hunks ignored").
+  #     Nothing consumes the stable sbomnix today, so this is latent
+  #     rather than broken -- but it would break the moment something
+  #     did.
+  #   * A patch that silently stops applying is worse than one that
+  #     fails: the scan would keep running and quietly go back to
+  #     reporting 3% of each closure as clean.
+  #
+  # An exact-version gate means a bump to 1.8.1 drops the patches, the
+  # scannable-component assertion in cve-scan.yaml trips, and the scan
+  # fails loudly instead of under-reporting.  The `sbomnix-patch-version`
+  # flake check (flake/dev/checks.nix) fires at eval time so the bump is
+  # caught before it ever reaches a scan.  On a bump: re-verify both
+  # patches against the new tree, then widen this bound.
+  sbomnixPatchedVersion = "1.8.0";
+
   sbomnix =
-    if prev.stdenv.isDarwin then
+    if prev.stdenv.isDarwin || prev.sbomnix.version != final.sbomnixPatchedVersion then
       prev.sbomnix
     else
       prev.sbomnix.overrideAttrs (old: {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -85,17 +85,40 @@ final: prev: {
   # the modern format (Nix >= 2.34 in our pin emits schema version 4).
   #
   # Revert: once nixpkgs' sbomnix wrapper stops pinning nix_2_31 (drops
-  # it or bumps it to a version emitting the new format), delete this
-  # overlay and its FIXME.  See
+  # it or bumps it to a version emitting the new format), delete the
+  # makeWrapperArgs override and this FIXME.  See
   # .github/workflows/track-upstream-fixes.yaml.
   #
-  # Only meaningful on Linux (cve-scan runs on the self-hosted Linux
-  # runners); guarded so it is a no-op on darwin.
+  # FIXME(sbomnix-substituted-deriver-drop): WORKAROUND, not a fix.
+  #
+  # sbomnix drops every runtime-closure path whose deriver `nix path-info`
+  # reports as unknown.  That is every substituter-fetched path, because the
+  # deriver pointer is only recorded for locally-built outputs.  On our
+  # runners the result was an SBOM covering 418 of 3242 paths (13%), missing
+  # openssl, bash and glibc while keeping unit-*.service and etc-* glue --
+  # i.e. it silently scanned almost nothing and reported success.  Coverage
+  # tracked cache warmth, so the CVE count swung per-runner and per-week, and
+  # occasionally hit zero matches, which then tripped cve-scan.yaml's
+  # "grype output has no .vulnerabilities key" guard and turned hosts red.
+  #
+  # The patch reconstructs output -> deriver by inverting `outputs.<name>.path`
+  # over the local .drv graph, which does not depend on the store's deriver
+  # pointers.  Restores 98.9% coverage (408 -> 2835 components) in ~2s.
+  #
+  # Revert: once sbomnix recovers derivers itself (no upstream issue filed
+  # yet), delete the `patches` attribute, the patch file, and this FIXME.
+  # See .github/workflows/track-upstream-fixes.yaml.
+  #
+  # Both workarounds above are only meaningful on Linux (cve-scan runs on
+  # the self-hosted Linux runners); guarded so this is a no-op on darwin.
   sbomnix =
     if prev.stdenv.isDarwin then
       prev.sbomnix
     else
-      prev.sbomnix.overrideAttrs (_: {
+      prev.sbomnix.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [
+          ./sbomnix-recover-substituted-derivers.patch
+        ];
         makeWrapperArgs = [
           "--prefix PATH : ${
             prev.lib.makeBinPath [

--- a/overlays/sbomnix-recover-pinned-version-cpes.patch
+++ b/overlays/sbomnix-recover-pinned-version-cpes.patch
@@ -34,7 +34,7 @@ On one server closure this takes components carrying a CPE from 59 to 97 and
 restores the kernel to cpe:2.3:o:linux:linux_kernel:6.18.41.
 
 diff --git a/src/sbomnix/builder.py b/src/sbomnix/builder.py
-index c0a57f9..ae65613 100644
+index c0a57f9..9c2ac02 100644
 --- a/src/sbomnix/builder.py
 +++ b/src/sbomnix/builder.py
 @@ -7,6 +7,7 @@
@@ -45,7 +45,7 @@ index c0a57f9..ae65613 100644
  import time
  import uuid
  from dataclasses import dataclass
-@@ -62,6 +63,58 @@ class StructuredClosure:
+@@ -62,6 +63,60 @@ class StructuredClosure:
      runtime_output_paths_by_load_path: dict[str, set[str]] | None = None
 
 
@@ -71,9 +71,11 @@ index c0a57f9..ae65613 100644
 +    # Strip a nixpkgs-only revision suffix (glibc "2.42-67" is upstream
 +    # 2.42 plus nixpkgs' patch-set counter).  Upstream has no such release,
 +    # so leaving it in produces a CPE that can only ever match by accident.
-+    # Only trailing "-<digits>" is removed, so genuine upstream versions
-+    # like "1.2-rc1" or "2026-05-01" survive intact.
-+    version = re.sub(r"-\d+$", "", version)
++    #
++    # The prefix must be a dotted numeric version for the suffix to be
++    # dropped, so date-like versions ("2026-05-01") and versions with a
++    # non-numeric suffix ("1.2-rc1") are left alone.
++    version = re.sub(r"^(\d+(?:\.\d+)+)-\d+$", r"\1", version)
 +    parts = cpe.split(":")
 +    expected_cpe_parts = 13
 +    version_index = 5
@@ -104,7 +106,7 @@ index c0a57f9..ae65613 100644
  def _runtime_output_paths_by_load_path(output_paths_by_drv):
      output_paths_by_load_path = {}
      for drv_path, output_paths in output_paths_by_drv.items():
-@@ -440,6 +493,15 @@ class SbomBuilder:
+@@ -440,6 +495,15 @@ class SbomBuilder:
          override_mask = meta_cpe != ""
          if not bool(np.any(override_mask)):
              return

--- a/overlays/sbomnix-recover-pinned-version-cpes.patch
+++ b/overlays/sbomnix-recover-pinned-version-cpes.patch
@@ -1,0 +1,190 @@
+Recover CPEs for components whose pinned version differs from the nixpkgs attr.
+
+sbomnix attaches nixpkgs metadata to a component only when the component's
+output path or derivation path is byte-identical to the one the nixpkgs
+attribute evaluates to.  That is exact by construction, and it silently
+drops metadata whenever a closure pins a different version of a package than
+the attribute currently produces.
+
+The consequence is not a missing description -- it is a missing CPE, and a
+component without a CPE is invisible to every CPE-based scanner.  It reads
+as "no known vulnerabilities" when it means "never checked".
+
+Observed on a NixOS fleet: hosts pinning linux 6.18.41 while `pkgs.linux`
+evaluated to 6.18.43 emitted the kernel with `cpe: null` and scored ZERO
+kernel CVEs, while a host whose kernel happened to match its attribute
+scored 74.  A newer kernel appearing cleaner than an older one is the
+signature of this bug, not a security finding.
+
+Add a lowest-priority fallback that matches on pname and carries over only
+the CPE, and rewrite that CPE's version field to the version actually
+present in the closure so the recovered identifier describes what is
+installed rather than what the attribute builds today.  The rewrite also
+strips nixpkgs-only revision suffixes (glibc "2.42-67" -> upstream "2.42"),
+which have no upstream release to match against, and preserves an accurate
+CPE version/update split (bash 5.3p9 -> version 5.3, update 9) instead of
+flattening it.
+
+Deliberately narrow: any exact path match still wins, only rows that carry a
+CPE are considered, and only the CPE is taken -- description, homepage,
+licence and maintainers still describe the attribute's current revision and
+would be wrong for a pinned version.
+
+On one server closure this takes components carrying a CPE from 59 to 97 and
+restores the kernel to cpe:2.3:o:linux:linux_kernel:6.18.41.
+
+diff --git a/src/sbomnix/builder.py b/src/sbomnix/builder.py
+index c0a57f9..ae65613 100644
+--- a/src/sbomnix/builder.py
++++ b/src/sbomnix/builder.py
+@@ -7,6 +7,7 @@
+ """SBOM builder orchestration."""
+
+ import logging
++import re
+ import time
+ import uuid
+ from dataclasses import dataclass
+@@ -62,6 +63,58 @@ class StructuredClosure:
+     runtime_output_paths_by_load_path: dict[str, set[str]] | None = None
+
+
++def _retarget_cpe_version(cpe, version):
++    """Point a nixpkgs metadata CPE at the version present in the closure.
++
++    A nixpkgs attribute's metadata describes the version that attribute
++    currently evaluates to, which is not necessarily the version this
++    closure pins.  Emitting the attribute's CPE unchanged would attribute
++    findings to the wrong version, so rewrite the version component to the
++    one actually built.
++
++    The `update` component (CPE 2.3 field 6) is cleared alongside it: it
++    qualifies the version it was derived from (bash 5.3p9 -> version 5.3,
++    update 9), so carrying it over to a different version would produce a
++    combination that never existed.
++
++    Left alone when the version is unknown, already agrees, or the CPE is
++    not a well-formed 13-part CPE 2.3 string.
++    """
++    if not cpe or not version:
++        return cpe
++    # Strip a nixpkgs-only revision suffix (glibc "2.42-67" is upstream
++    # 2.42 plus nixpkgs' patch-set counter).  Upstream has no such release,
++    # so leaving it in produces a CPE that can only ever match by accident.
++    # Only trailing "-<digits>" is removed, so genuine upstream versions
++    # like "1.2-rc1" or "2026-05-01" survive intact.
++    version = re.sub(r"-\d+$", "", version)
++    parts = cpe.split(":")
++    expected_cpe_parts = 13
++    version_index = 5
++    update_index = 6
++    if len(parts) != expected_cpe_parts or parts[0] != "cpe" or parts[1] != "2.3":
++        return cpe
++    current = parts[version_index]
++    # A wildcard or empty version is deliberately unbounded; leave it.
++    if current in ("", "*", "-"):
++        return cpe
++    if current == version:
++        return cpe
++    # The CPE may legitimately split the version across the version and
++    # update fields (bash 5.3p9 -> version 5.3, update 9).  Reassemble
++    # before comparing, so an accurate split is preserved and only a
++    # genuinely different version is rewritten.  Both "p" and "-" appear
++    # as separators upstream.
++    update = parts[update_index]
++    if update not in ("", "*", "-"):
++        for separator in ("p", "-", ""):
++            if f"{current}{separator}{update}" == version:
++                return cpe
++    parts[version_index] = version
++    parts[update_index] = "*"
++    return ":".join(parts)
++
++
+ def _runtime_output_paths_by_load_path(output_paths_by_drv):
+     output_paths_by_load_path = {}
+     for drv_path, output_paths in output_paths_by_drv.items():
+@@ -440,6 +493,15 @@ class SbomBuilder:
+         override_mask = meta_cpe != ""
+         if not bool(np.any(override_mask)):
+             return
++        if cols.VERSION in self.df_sbomdb.columns:
++            versions = self.df_sbomdb[cols.VERSION].fillna("").astype(str).to_numpy()
++            meta_cpe = np.array(
++                [
++                    _retarget_cpe_version(cpe, version)
++                    for cpe, version in zip(meta_cpe, versions, strict=False)
++                ],
++                dtype=object,
++            )
+         current_cpe = self.df_sbomdb[cols.CPE].fillna("").astype(str).to_numpy()
+         self.df_sbomdb[cols.CPE] = np.where(override_mask, meta_cpe, current_cpe)
+
+diff --git a/src/sbomnix/package_meta.py b/src/sbomnix/package_meta.py
+index cc11a14..c8eb56d 100644
+--- a/src/sbomnix/package_meta.py
++++ b/src/sbomnix/package_meta.py
+@@ -820,9 +820,63 @@ def match_package_metadata_to_components(components, metadata, *, buildtime):
+     else:
+         matches.append(_output_path_matches(components, metadata, priority=0))
+         matches.append(_drv_path_matches(components, metadata, priority=1))
++    matches.append(_pname_cpe_matches(components, metadata, priority=9))
+     return _best_component_matches(matches)
+
+
++def _pname_cpe_matches(components, metadata, *, priority):
++    """Recover a CPE by pname when no store path matched.
++
++    Path-based matching is exact by construction: a component only picks up
++    nixpkgs metadata when its output or derivation path is identical to the
++    one the nixpkgs attribute evaluates to.  When a closure pins a different
++    version of a package than the attribute currently produces -- a host on
++    linux 6.18.41 while `pkgs.linux` is 6.18.43 -- the paths differ, no row
++    matches, and the component is emitted with no CPE at all.  It is then
++    invisible to any CPE-based scanner, which reads as "no known
++    vulnerabilities" rather than "not checked".
++
++    Fall back to matching on pname and carrying over only the CPE.  The
++    consumer rewrites the CPE's version field to the version actually in the
++    closure, so the recovered identifier describes what is installed and not
++    what the attribute happens to build today.
++
++    Deliberately narrow:
++      * lowest priority, so any exact path match always wins;
++      * only rows that actually carry a CPE are considered, since recovering
++        an empty one achieves nothing;
++      * only the CPE is taken.  Description, homepage, licence and
++        maintainers describe the attribute's current revision and may be
++        wrong for the pinned version, so they are left empty rather than
++        risk attributing the wrong provenance.
++    """
++    if cols.PNAME not in components.columns or cols.PNAME not in metadata.columns:
++        return pd.DataFrame()
++    if "meta_cpe" not in metadata.columns:
++        return pd.DataFrame()
++
++    meta = metadata[[cols.PNAME, "meta_cpe"]].copy()
++    meta = meta[meta[cols.PNAME].astype(bool) & meta["meta_cpe"].astype(bool)]
++    if meta.empty:
++        return pd.DataFrame()
++    # An attribute can appear under several paths (multi-output, or the same
++    # pname reachable via more than one attr); they agree on the CPE, so any
++    # one of them is fine.
++    meta = meta.drop_duplicates(subset=[cols.PNAME], keep="first")
++
++    component_keys = components[[cols.STORE_PATH, cols.PNAME]].copy()
++    component_keys = component_keys[component_keys[cols.PNAME].astype(bool)]
++    if component_keys.empty:
++        return pd.DataFrame()
++
++    matched = component_keys.merge(meta, how="inner", on=cols.PNAME)
++    if matched.empty:
++        return matched
++    matched.drop(columns=[cols.PNAME], inplace=True)
++    matched["_meta_match_priority"] = priority
++    return matched
++
++
+ def _output_path_matches(components, metadata, *, priority):
+     output_components = components[[cols.STORE_PATH, cols.OUTPUTS]].copy()
+     output_components = output_components.explode(cols.OUTPUTS)

--- a/overlays/sbomnix-recover-substituted-derivers.patch
+++ b/overlays/sbomnix-recover-substituted-derivers.patch
@@ -40,7 +40,7 @@ index 875574a..c0a57f9 100644
              "Loaded raw runtime closure with %d dependency edge(s) and %d deriver(s) in %.3fs",
              len(runtime_closure.df_deps),
 diff --git a/src/sbomnix/runtime.py b/src/sbomnix/runtime.py
-index 17fa1de..1d5c246 100644
+index 17fa1de..08e0067 100644
 --- a/src/sbomnix/runtime.py
 +++ b/src/sbomnix/runtime.py
 @@ -6,6 +6,7 @@
@@ -131,7 +131,7 @@ index 17fa1de..1d5c246 100644
      """Load runtime closure information using ``nix path-info`` JSON."""
      cmd = nix_cmd(
          "path-info",
-@@ -53,7 +118,33 @@ def load_runtime_closure(path):
+@@ -53,7 +118,36 @@ def load_runtime_closure(path):
              stderr=error.stderr,
              stdout=error.stdout,
          ) from None
@@ -149,7 +149,10 @@ index 17fa1de..1d5c246 100644
 +            drv_root = path
 +        if drv_root is None:
 +            info = path_info.get(path)
-+            drv_root = info.get("deriver") if info else None
++            # Via the helper, not info["deriver"] directly: it filters the
++            # `unknown-deriver` sentinel, which would otherwise be handed to
++            # `nix-store -qR` as if it were a store path.
++            drv_root = nix_path_info_deriver(info, path) if info else None
 +        if drv_root:
 +            recovered = _recover_missing_derivers(
 +                path_info, drv_graph_output_map(drv_root)

--- a/overlays/sbomnix-recover-substituted-derivers.patch
+++ b/overlays/sbomnix-recover-substituted-derivers.patch
@@ -1,0 +1,168 @@
+Recover derivers for substituter-fetched paths from the local .drv graph.
+
+`nix path-info --deriver` answers from the local store database, which records
+`unknown-deriver` for every path that arrived from a substituter rather than
+being built locally.  sbomnix drops any closure path whose deriver is unknown,
+so on a machine that substitutes most of its closure the SBOM silently loses
+the majority of its components -- and specifically loses the real packages,
+because those are exactly the ones served by a binary cache.  What survives is
+locally-built NixOS glue (unit-*.service, etc-*, *-fish-completions), which has
+no CVE relevance.
+
+Measured on a NixOS system closure of 3242 paths, only 418 had a local deriver;
+openssl, bash and glibc were all dropped.  Coverage tracks cache warmth, so the
+SBOM -- and therefore the CVE count -- is nondeterministic across machines and
+across runs on the same machine.
+
+The output -> deriver mapping does not require the store database.  Every
+derivation declares its own outputs, so inverting `outputs.<name>.path` over
+the .drv closure reconstructs it locally.  That graph is fully present whenever
+the target is a .drv, or was instantiated by evaluating one, regardless of
+which outputs were substituted.
+
+Only paths that path-info left without a deriver are backfilled; locally-built
+paths keep the store's answer.  On the closure above this restores 3206/3242
+(98.9%) in ~2s, taking the emitted SBOM from 408 to 2835 components and from 47
+to 2128 versioned ones.  The residual 36 are `builtins.toFile` artefacts
+(sandbox.nix, inputrc, an .svg) that have no derivation at all.
+
+diff --git a/src/sbomnix/builder.py b/src/sbomnix/builder.py
+index 875574a..c0a57f9 100644
+--- a/src/sbomnix/builder.py
++++ b/src/sbomnix/builder.py
+@@ -231,7 +231,7 @@ class SbomBuilder:
+         """Load runtime dependencies from structured path-info JSON."""
+         started = time.perf_counter()
+         LOG.verbose("Loading runtime closure for '%s'", nix_path)
+-        runtime_closure = load_runtime_closure(nix_path)
++        runtime_closure = load_runtime_closure(nix_path, self.target_deriver)
+         LOG.verbose(
+             "Loaded raw runtime closure with %d dependency edge(s) and %d deriver(s) in %.3fs",
+             len(runtime_closure.df_deps),
+diff --git a/src/sbomnix/runtime.py b/src/sbomnix/runtime.py
+index 17fa1de..1d5c246 100644
+--- a/src/sbomnix/runtime.py
++++ b/src/sbomnix/runtime.py
+@@ -6,6 +6,7 @@
+
+ """Runtime closure helpers based on structured Nix path-info JSON."""
+
++import json
+ import subprocess
+ from dataclasses import dataclass
+
+@@ -13,6 +14,7 @@ import pandas as pd
+
+ from common import columns as cols
+ from common.errors import NixCommandError
++from common.log import LOG
+ from common.nix_utils import (
+     NIX_PATH_INFO_JSON,
+     load_nix_json,
+@@ -35,7 +37,70 @@ class RuntimeClosure:
+     output_paths_by_drv: dict[str, set[str]]
+
+
+-def load_runtime_closure(path):
++def _store_abs(path):
++    """`nix derivation show` may emit store paths with or without the prefix."""
++    if path.startswith("/nix/store/"):
++        return path
++    return "/nix/store/" + path
++
++
++def drv_graph_output_map(drv_path, batch_size=2000):
++    """Build output_path -> deriver by inverting the local .drv graph.
++
++    Independent of the store's deriver pointers, which read `unknown-deriver`
++    for every substituter-fetched path.
++    """
++    try:
++        ret = exec_cmd(["nix-store", "-qR", drv_path])
++    except subprocess.CalledProcessError:
++        LOG.debug("Could not query the .drv closure of %s", drv_path)
++        return {}
++
++    drvs = [line for line in ret.stdout.splitlines() if line.endswith(".drv")]
++    if not drvs:
++        return {}
++
++    mapping = {}
++    for i in range(0, len(drvs), batch_size):
++        chunk = drvs[i : i + batch_size]
++        cmd = nix_cmd("derivation", "show", *chunk)
++        try:
++            payload = json.loads(exec_cmd(cmd).stdout)
++        except (subprocess.CalledProcessError, json.JSONDecodeError):
++            LOG.debug("Could not read derivations for a batch of %d", len(chunk))
++            continue
++        # Schema version 4 nests under `.derivations`; older is a flat mapping.
++        derivations = payload.get("derivations", payload)
++        if not isinstance(derivations, dict):
++            continue
++        for drv, info in derivations.items():
++            if not isinstance(info, dict):
++                continue
++            for outinfo in (info.get("outputs") or {}).values():
++                if not isinstance(outinfo, dict):
++                    continue
++                out = outinfo.get("path")
++                if out:
++                    mapping[_store_abs(out)] = _store_abs(drv)
++    return mapping
++
++
++def _recover_missing_derivers(path_info, deriver_by_output):
++    """Backfill derivers path-info left unknown. Returns the recovered count."""
++    recovered = 0
++    for target_path, info in path_info.items():
++        if info is None:
++            continue
++        if nix_path_info_deriver(info, target_path):
++            continue
++        drv = deriver_by_output.get(target_path)
++        if drv:
++            info["deriver"] = drv
++            recovered += 1
++    return recovered
++
++
++def load_runtime_closure(path, target_deriver=None):
+     """Load runtime closure information using ``nix path-info`` JSON."""
+     cmd = nix_cmd(
+         "path-info",
+@@ -53,7 +118,33 @@ def load_runtime_closure(path):
+             stderr=error.stderr,
+             stdout=error.stdout,
+         ) from None
+-    return runtime_closure_from_path_info(load_nix_json(ret.stdout, NIX_PATH_INFO_JSON))
++    path_info = normalize_nix_path_info(load_nix_json(ret.stdout, NIX_PATH_INFO_JSON))
++
++    missing = sum(
++        1
++        for p, i in path_info.items()
++        if i is not None and not nix_path_info_deriver(i, p)
++    )
++    if missing:
++        drv_root = target_deriver
++        if drv_root is None and path.endswith(".drv"):
++            drv_root = path
++        if drv_root is None:
++            info = path_info.get(path)
++            drv_root = info.get("deriver") if info else None
++        if drv_root:
++            recovered = _recover_missing_derivers(
++                path_info, drv_graph_output_map(drv_root)
++            )
++            LOG.debug(
++                "Recovered %d of %d missing deriver(s) from the .drv graph",
++                recovered,
++                missing,
++            )
++        else:
++            LOG.debug("No .drv root available; cannot recover %d deriver(s)", missing)
++
++    return runtime_closure_from_path_info(path_info)
+
+
+ def runtime_closure_from_path_info(path_info):


### PR DESCRIPTION
The weekly CVE scan had been failing on every host since early August. Fixing that surfaced three further defects, each of which had been silently corrupting the results for far longer.

Verified green on all 10 hosts: [run 31503224076](https://github.com/fredsystems/nixos/actions/runs/31503224076) (re-run pending for the latest commits).

## 1. The failure: a guard that could not do its job

Every failing job died on `grype output has no .vulnerabilities key`.

grype **omits** that key when it matches nothing — it does not emit an empty array. The guard treated the missing key as "grype produced garbage" and failed the job, making a genuinely clean host indistinguishable from a broken scan. A real grype failure is already caught: it exits non-zero and writes a 0-byte file, so `set -e` aborts at the grype call and never reaches the check.

Fixed at all three sites (scan job, both aggregate loops), where a bare `.vulnerabilities | length` also returned `null` and aborted the arithmetic under `set -e`.

## 2. Only 13% of each closure was in the SBOM

`nix path-info --deriver` reports `unknown-deriver` for every substituter-fetched path, and sbomnix drops any path whose deriver is unknown.

```
runtime closure:      3242 paths
with a local deriver:  418   <- became the SBOM
```

The survivors were locally-built glue (`unit-*.service`, `etc-*`, `*-fish-completions`). openssl, bash and glibc were dropped. Coverage tracked cache warmth, so the count swung per-runner and per-week — and when it bottomed out at zero matches it tripped the guard above. That is why the failing host set inverted between runs: desktops failed Aug 10/11, every server failed Aug 3/5.

The mapping does not need the store database. Every derivation declares its own outputs, so inverting `outputs.<name>.path` over the local `.drv` graph reconstructs it. Restores **3206/3242 (98.9%)** in ~2s; 408 → 2835 components.

## 3. Only 3% of components were actually scannable

This one was hiding most of the fleet, and the tell was visible in the report:

> servers on linux 6.18.41 reported **zero** kernel CVEs, while desktops on the **newer** 7.1.7 reported 74

A newer kernel cannot be cleaner. sbomnix attaches nixpkgs metadata only when a component's store path is byte-identical to what the nixpkgs attribute builds. Servers pin `6.18.41` while `pkgs.linux` is `6.18.43` — different paths, no match, `cpe: null`, invisible to grype. "Not checked" was being reported as "nothing known".

Fleet-wide only **59 of 1819** components carried a CPE. Component coverage was a healthy-looking 87% throughout, so the coverage assertion added earlier in this PR could not have caught it.

Fixed with a lowest-priority pname fallback carrying only the CPE, retargeted to the version actually in the closure. Deliberately narrow — exact path matches always win, and description/homepage/licence are not taken because they describe the attribute's current revision. Also strips nixpkgs-only revision suffixes (`glibc 2.42-67` → upstream `2.42`) and preserves accurate CPE version/update splits (`bash 5.3p9` = version `5.3`, update `9`).

**59 → 97 scannable components on servers.**

## 4. Fabricated CPEs reproduced the vulnix failure

sbomnix synthesises heuristic CPEs (`vendor == product`) for anything nixpkgs metadata does not cover. These brought back exactly what this workflow's own header cites as the reason vulnix was abandoned:

- `fish` matched **FiSH**, an IRC encryption plugin, at CVSS 10 — top of the report
- `ada` matched **Ada.cx**, a SaaS chatbot

They were 192 of 317 matches on one desktop closure. Now passing `--exclude-cpe-matching` so only exact nixpkgs-metadata CPEs are used.

Also switched the sbomnix target from a `.drv` path to a flakeref. The previous revision passed the `.drv` believing it avoided deriver lookups; verified byte-identical SBOMs from `.drv`, flakeref and output path. It bought nothing and cost the nixpkgs metadata that only the flakeref path resolves.

## Guardrails

Both failure modes above were **silent** — valid SBOM, exit 0, reported as a clean scan. Three layers now fail loudly:

- **closure coverage** — component count vs runtime closure, floor 60% (healthy: 87–90%)
- **scannable components** — components carrying a CPE, floor 50 (healthy: 95–122). An absolute count, not a ratio: most of a NixOS closure is systemd units and shell completions that will never have a CPE, so the ratio is legitimately low, whereas losing a metadata source shows up as a cliff.
- **`sbomnix-patch-version` flake check** — the two source patches are gated to sbomnix 1.8.0 exactly. A bump would silently *drop* them and the scan would quietly revert to ~3% coverage, so the check fails at eval time on the flake-update PR. Verified in both directions.

## Suppressions

`.github/grype-ignore.yaml`, six rules, each with its reason inline and package-scoped so an unrelated component matching the same CVE is still reported: `CVE-2023-4039` (DISPUTED, AArch64-only; we are all x86_64), `CVE-2023-51767` (DISPUTED, needs DRAM bit flips), `CVE-2007-2768` (needs OPIE/OTP PAM), `CVE-2016-2781` (needs local `chroot --userspec`; Debian and Red Hat treat it as not-a-vulnerability), `CVE-2010-4756` (needs ftpd).

All rest on structural facts — wrong architecture, a service we do not run, upstream DISPUTED — not on which version happens to be installed.

Deliberately **not** filtering by CVSS, EPSS or age. Those rank findings; they do not establish applicability.

**No kernel findings are suppressed.** See the correction below.

## Correction: an earlier revision of this PR was wrong about the kernel

An earlier revision suppressed 74 `linux` CVEs and claimed 93 others were genuine. **Both numbers were wrong**, and the suppressions have been removed.

The classifier behind them marked a CVE as version-bounded if *any* of its NVD shards had an upper bound. Kernel entries routinely carry a real range **and** a catch-all shard, so the test conflated the two categories and erred in both directions:

- `CVE-2026-52972` was carved out as "already patched" while a further shard reads `start=7.1 end=7.2`, which contains Daytona's 7.1.7. It also has no unbounded shard at all, so it never belonged in that block.
- The 93 "genuine" server findings do not survive checking against the **Linux kernel CNA**, which records per-branch backports that NVD flattens into wide spans. For 6.18.41: **18 fixed, 5 affected, 70 with no 6.18-branch entry** — not 93.

Both errors trace to treating NVD as authoritative for `linux`. It is not.

Rather than rebuild the list from CNA data, it is removed. A hand-maintained set of CVE ids encodes verdicts against one kernel version and goes stale at the next bump — the exact objection raised in review. The durable approach is querying the CNA at scan time and comparing its per-branch `unaffected` version against the running kernel, which is a larger change and belongs in its own PR.

So kernel findings are reported in full and triaged by hand: 166 on servers, 74 on desktops. Noisy and known. A wrong suppression is worse than a noisy report.

## Result

| Host | Before | After |
| --- | --- | --- |
| Daytona | 121 | 167 |
| vdlmhub / acarshub / hfdlhub1&2 | 45 | 255 |

Servers rise sharply because real findings were hidden by the CPE bug; desktops rise because the phantom-kernel suppressions were withdrawn as unsound.

## Review feedback

All four bot findings verified against the actual trees and fixed:

1. **Patches only apply to sbomnix 1.8.0** (CodeRabbit) — correct; `nixpkgs-stable` ships 1.7.6 and the build failed with `4 out of 4 hunks ignored`. Nothing consumes the stable sbomnix today, so it was latent. Now version-gated, plus the flake check above.
2. **Regex mangled date versions** (Copilot) — correct; `-\d+$` turned `2026-05-01` into `2026-05`, contradicting its own comment. Now anchored to a dotted numeric prefix.
3. **Root deriver bypassed the sentinel filter** (CodeRabbit) — correct; raw `info["deriver"]` could pass `unknown-deriver` to `nix-store -qR`.
4. **Kernel rules had no version scope** (CodeRabbit) — correct, and it prompted the re-check that found the classifier bug. Resolved by removing them entirely.

## Verification

- All 10 hosts green, all assertions passing
- Both sbomnix patches applied to upstream source, built, behaviour confirmed end-to-end
- `_retarget_cpe_version` unit-checked: version mismatch, `p`/`-` update splits, nixpkgs suffixes, date versions, wildcards, malformed CPEs
- Version gate verified in both directions
- `nix eval` clean on all 10 hosts; all 24 pre-commit hooks pass
- Both workarounds registered in `.github/tracked-upstream-fixes.json`, BLOCKED pending upstream issues

## Follow-up, not in this PR

- **CNA-based kernel handling** — query cveawg.mitre.org at scan time, compare per-branch `unaffected` against the running kernel. Until then the kernel section of the report is noise-heavy.
- **The ~46 glibc findings are untriaged** — the largest non-kernel block, and given how the kernel ones turned out, some fraction is likely inapplicable too.
- No upstream sbomnix issues filed yet; both manifest entries are BLOCKED so they will never falsely resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM completeness for substituted packages by restoring missing runtime-closure relationships.
  * Recovered relevant CPE metadata for pinned package versions to improve vulnerability matching.
  * Enhanced vulnerability scan reliability, including accurate handling of clean scans and incomplete reports.

* **Security**
  * Refined CVE matching and suppression rules to reduce inapplicable findings while retaining bounded kernel findings for review.
  * Clarified that scan results represent raw vulnerability-database matches, not exploitability assessments.

* **Chores**
  * Added validation to ensure the patched SBOM tooling version remains aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->