### PR TITLE
chore(flake/nixpkgs): `f13ff45a` -> `2fcb964d`

### DIFF
--- a/features/desktop/stockfish/default.nix
+++ b/features/desktop/stockfish/default.nix
@@ -1,8 +1,8 @@
 import ../../../modules/lib/mk-simple-package-module.nix {
   optionPath = "desktop.stockfish";
-  description = "Stockfish chess engine and Arena GUI";
+  description = "Stockfish chess engine and ChessX GUI";
   packages = pkgs: [
     pkgs.stockfish
-    pkgs.arena
+    pkgs.chessx
   ];
 }

--- a/flake.lock
+++ b/flake.lock
@@ -985,11 +985,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                   |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`99863205`](https://github.com/NixOS/nixpkgs/commit/99863205bf561639e278bf66f5a59605bbef47d1) | `` python3Packages.django-jquery-js: format to pyproject ``                                               |
| [`d3af7c18`](https://github.com/NixOS/nixpkgs/commit/d3af7c189414d4d34a06a2d1241827f7c3b8c33b) | `` python3Packages.anova-wifi: enable previously failing test ``                                          |
| [`132634b9`](https://github.com/NixOS/nixpkgs/commit/132634b95893021ad8746cb59df1eddcf41c9aa0) | `` python3Packages.anova-wifi: migrate to finalAttrs ``                                                   |
| [`f7c65467`](https://github.com/NixOS/nixpkgs/commit/f7c65467ff7444ca29ce95a3b8ef65423ea4eed0) | `` python3Packages.homematicip: 2.13.4 -> 2.14.0 ``                                                       |
| [`965d4f4d`](https://github.com/NixOS/nixpkgs/commit/965d4f4d0aa8cba33cc6e1cd27f592b7b241844a) | `` python3Packages.anova-wifi: 1.0.2 -> 2.0.0 ``                                                          |
| [`97ddb0d2`](https://github.com/NixOS/nixpkgs/commit/97ddb0d2df260f0a7d6440984b7366b8bf9afe1c) | `` mdbook-rss-feed: 1.7.0 -> 1.8.1 ``                                                                     |
| [`955384b9`](https://github.com/NixOS/nixpkgs/commit/955384b9145b438962d9fa587a0cee7058220bd3) | `` github-backup: 0.65.0 -> 0.65.1 ``                                                                     |
| [`6d93a8d7`](https://github.com/NixOS/nixpkgs/commit/6d93a8d764e5312ed96168bee088e6fbad8e4fae) | `` python3.pkgs.dscribe: fix version metadata mismatch ``                                                 |
| [`7e882473`](https://github.com/NixOS/nixpkgs/commit/7e882473f79b7a16f6b2dc93bfda21fe9792eebc) | `` python3.pkgs.iodata: 1.0.0a4 -> 1.0.1 ``                                                               |
| [`b260a408`](https://github.com/NixOS/nixpkgs/commit/b260a4080d0d1d5572d82fb474f1482bb7908fd3) | `` mcp-grafana: 1.0.0 -> 1.1.0 ``                                                                         |
| [`a995290e`](https://github.com/NixOS/nixpkgs/commit/a995290e82ad046b5d6b34a9435f724f200e4f51) | `` misconfig-mapper: 1.17.0 -> 1.18.5 ``                                                                  |
| [`741494f0`](https://github.com/NixOS/nixpkgs/commit/741494f04db5124a8af24fd1bdca17eb7149e59e) | `` lib: replace `map (x: x.attr)` with `catAttrs` ``                                                      |
| [`5a20f0e8`](https://github.com/NixOS/nixpkgs/commit/5a20f0e8bfb2505ac20c25f8f6d5fd827339f322) | `` confy-tui: 3.0.0 -> 3.1.0 ``                                                                           |
| [`be5df434`](https://github.com/NixOS/nixpkgs/commit/be5df4340fae1bbc7598803a3c079ceca2a76a43) | `` ollama: 0.32.6 -> 0.32.7 ``                                                                            |
| [`4527cad2`](https://github.com/NixOS/nixpkgs/commit/4527cad2dcc5625c9f9c9c67f2f574fce7402938) | `` lemmy: follow packaging and module guidelines ``                                                       |
| [`b51748b6`](https://github.com/NixOS/nixpkgs/commit/b51748b64af15d7604260a7da3935fc050b74050) | `` lemmy: add lucasew and NGI team as maintainers ``                                                      |
| [`4e50f62e`](https://github.com/NixOS/nixpkgs/commit/4e50f62e4d74bf8cb053b14957ef42f793e087b7) | `` fdroidserver: fix build, 2.4.3 -> 2.4.5 ``                                                             |
| [`5d9a8c53`](https://github.com/NixOS/nixpkgs/commit/5d9a8c53bd998843740e7eae1b73cb66d1d9f8e0) | `` nixosTests.containers-imperative: fix after libcap-text-verifier ``                                    |
| [`ca5951df`](https://github.com/NixOS/nixpkgs/commit/ca5951dfa6746b75d508da490f516e4e57b27f9f) | `` discord: respect `DISCORD_USER_DATA_DIR` ``                                                            |
| [`d5f71647`](https://github.com/NixOS/nixpkgs/commit/d5f716474b4596db2d667ad927296fd865193c94) | `` python3Packages.imap-tools: 1.14.0 -> 1.15.0 ``                                                        |
| [`6006b2a6`](https://github.com/NixOS/nixpkgs/commit/6006b2a6a323df3f093767617e51bcce2f609344) | `` git-repo: 2.65 -> 2.66 ``                                                                              |
| [`0bc573d0`](https://github.com/NixOS/nixpkgs/commit/0bc573d060ead03364153830fa82624038d95380) | `` kvrocks: fix build ``                                                                                  |
| [`5c66f121`](https://github.com/NixOS/nixpkgs/commit/5c66f12191cbb31735a12c8ea4878d051456fb85) | `` moji: init at 0.7.0 ``                                                                                 |
| [`ccdbd5b5`](https://github.com/NixOS/nixpkgs/commit/ccdbd5b50807aabe826266481ec8be192d3ff2c5) | `` sing-box: 1.13.16 -> 1.13.18 ``                                                                        |
| [`66e8778b`](https://github.com/NixOS/nixpkgs/commit/66e8778bbf49756c8d9d98c6fcefb034433550ee) | `` cronet-go: 148.0.7778.96-1-unstable-2026-07-12 -> 150.0.7871.63-1 ``                                   |
| [`d4fae58d`](https://github.com/NixOS/nixpkgs/commit/d4fae58df13d46bc8e4ae2a5d545b04895c54381) | `` diskbloom: init at 0.1.0 ``                                                                            |
| [`f92166e0`](https://github.com/NixOS/nixpkgs/commit/f92166e0c8752c95be9d7bd5c0bb223f9044c2e5) | `` python3Packages.otcextensions: 0.34.4 -> 0.34.7 ``                                                     |
| [`821d02ef`](https://github.com/NixOS/nixpkgs/commit/821d02ef62c43cbf5a7c0f9eb7d36bba469e42b1) | `` overused-grotesk: init at 0.5-alpha.2 ``                                                               |
| [`0679060a`](https://github.com/NixOS/nixpkgs/commit/0679060a614a5902c547164c2ec4e3ccfb54b2d7) | `` nototools: 0.3.2 -> 0.4.1 ``                                                                           |
| [`a666a99c`](https://github.com/NixOS/nixpkgs/commit/a666a99cc69b06a58306fa03860871f6bb315bf1) | `` gitea-actions-runner: 2.2.0 -> 3.1.0 ``                                                                |
| [`bae2e15e`](https://github.com/NixOS/nixpkgs/commit/bae2e15e53bfcbcad4f76fccf99bbc86622d0300) | `` nix-eval-jobs: 2.35.0 -> 2.35.1 ``                                                                     |
| [`19872032`](https://github.com/NixOS/nixpkgs/commit/19872032105eecfd9cd354ad0152027d00544f05) | `` proton-pass-cli: 2.2.5 -> 2.2.6 ``                                                                     |
| [`08e379d9`](https://github.com/NixOS/nixpkgs/commit/08e379d97c285061efc6e240a1369373f1721689) | `` flying-carpet: 10.0.2 -> 10.0.3 ``                                                                     |
| [`00874f58`](https://github.com/NixOS/nixpkgs/commit/00874f58013b20256c77d23915234ec1a4e51fbd) | `` necesse-server: 1.3.1-24494674 -> 1.3.2-24574169 ``                                                    |
| [`e4494824`](https://github.com/NixOS/nixpkgs/commit/e4494824d22f9e3e5ac30a1eeea328d63bd303b2) | `` retroarch-assets: 1.22.0-unstable-2026-06-27 -> 1.22.0-unstable-2026-08-08 ``                          |
| [`6eb3f914`](https://github.com/NixOS/nixpkgs/commit/6eb3f91474b4676efc905bbe2deed4ca0d1bc3c1) | `` azure-cli-extensions.vm-repair: 2.2.1 -> 2.2.3 ``                                                      |
| [`2709c014`](https://github.com/NixOS/nixpkgs/commit/2709c014f52b191d7495c11eb07c6a41f15f13a2) | `` truehdd: 0.5.1 -> 0.5.3 ``                                                                             |
| [`91b05d00`](https://github.com/NixOS/nixpkgs/commit/91b05d008375201a4fab5edd1f2050181952d9de) | `` tuxvdmtool: use pname instead of name ``                                                               |
| [`791a71d0`](https://github.com/NixOS/nixpkgs/commit/791a71d03ae8e64738d6dc7d27d7483746e5b47f) | `` python3Packages.runtype: use pname instead of name ``                                                  |
| [`15696e89`](https://github.com/NixOS/nixpkgs/commit/15696e8919884381e6fb6b940fe9c1044631d305) | `` elmPackages.elm-wrap: use pname instead of name ``                                                     |
| [`b86b6d9a`](https://github.com/NixOS/nixpkgs/commit/b86b6d9a3c2d591369d681730172b8e80641900e) | `` python3Packages.tencentcloud-sdk-python: 3.1.152 -> 3.1.153 ``                                         |
| [`af726863`](https://github.com/NixOS/nixpkgs/commit/af726863b0810b839327831fc86bce6566bb75ec) | `` python3Packages.tencentcloud-sdk-python: 3.1.151 -> 3.1.152 ``                                         |
| [`5e4b3810`](https://github.com/NixOS/nixpkgs/commit/5e4b381048d9244632c6ec527d64138a66b436da) | `` zulu: fix eval on unsupported systems ``                                                               |
| [`24432311`](https://github.com/NixOS/nixpkgs/commit/24432311d26c009fabf86cac9f7a917bf8f147c1) | `` hayabusa-sec: fix eval of update script ``                                                             |
| [`5d136c13`](https://github.com/NixOS/nixpkgs/commit/5d136c135fff39de76ff59e6f2d7a0589ced8ea5) | `` symfony-cli: 5.18.2 -> 5.19.0 ``                                                                       |
| [`6a227e78`](https://github.com/NixOS/nixpkgs/commit/6a227e78593519c45f78a098128520db3f742f6c) | `` upower: 1.91.2 -> 1.91.3 ``                                                                            |
| [`23259437`](https://github.com/NixOS/nixpkgs/commit/232594377388c8653560d53a61583c8f3ef7bd76) | `` discord: various update ``                                                                             |
| [`32751bee`](https://github.com/NixOS/nixpkgs/commit/32751beeeb8cd89f881843a9880e53b914aa1f5e) | `` doc/readme: tidy up meta commentary ``                                                                 |
| [`59d05ae7`](https://github.com/NixOS/nixpkgs/commit/59d05ae716f5592ab3808309ac1983281f7977c3) | `` wild-unwrapped: 0.9.0 -> 0.10.0 ``                                                                     |
| [`68e532a1`](https://github.com/NixOS/nixpkgs/commit/68e532a19161b6e394da263b25fd41f2520882aa) | `` python3Packages.newversion: modernize ``                                                               |
| [`4c1d0ea2`](https://github.com/NixOS/nixpkgs/commit/4c1d0ea2269c5922509dc79a0b57c76f40e2d653) | `` ku: 0.10.0 -> 0.11.0 ``                                                                                |
| [`36ba106e`](https://github.com/NixOS/nixpkgs/commit/36ba106ed356837f964311831fb6098bb0eb0b4c) | `` ocamlPackages.tls: 2.1.0 → 2.1.2 ``                                                                    |
| [`747743e6`](https://github.com/NixOS/nixpkgs/commit/747743e6e2b305d200e5c24370a1991c4f8e5567) | `` python3Packages.pylitterbot: 2025.6.2 -> 2025.6.4 ``                                                   |
| [`fe94b0a9`](https://github.com/NixOS/nixpkgs/commit/fe94b0a95053c0bbf339b174130b2ba84613faeb) | `` rmux: 0.9.1 -> 0.10.0 ``                                                                               |
| [`4348e45a`](https://github.com/NixOS/nixpkgs/commit/4348e45a8dd0cdc1997524f60e0e988711066d18) | `` ocamlPackages.ppx_deriving_variant_string: disable tests with OCaml < 4.12 ``                          |
| [`e890a51e`](https://github.com/NixOS/nixpkgs/commit/e890a51e6ae318d1ff3d6d2465342c460e5b93c1) | `` xevd: 0.5.0 -> 0.7.0 ``                                                                                |
| [`2a29d282`](https://github.com/NixOS/nixpkgs/commit/2a29d282d5ae968afa9697109c82f6880ac4ee3d) | `` xeve: 0.5.1 -> 0.7.0 ``                                                                                |
| [`34984cfa`](https://github.com/NixOS/nixpkgs/commit/34984cfa97b860469ac415cef6e00839f63279c5) | `` python3Packages.intellifire4py: 4.5.0 -> 4.5.1 ``                                                      |
| [`bf998612`](https://github.com/NixOS/nixpkgs/commit/bf99861276e81fef588d3707f8382c80294d23d0) | `` python3Packages.iamdata: 0.1.202608091 -> 0.1.202608101 ``                                             |
| [`92321603`](https://github.com/NixOS/nixpkgs/commit/923216034b81bd53842af1c5d1a4d60acb6a6745) | `` python3Packages.iamdata: 0.1.202608081 -> 0.1.202608091 ``                                             |
| [`6c74807e`](https://github.com/NixOS/nixpkgs/commit/6c74807efcf5eafc050f79a91d28aa19a8b8981a) | `` nixos/zapret2: init module ``                                                                          |
| [`9bcda64a`](https://github.com/NixOS/nixpkgs/commit/9bcda64afddd4e4e4b767147bba3f89f9e47056f) | `` console-setup: make work with upstream unifont structure ``                                            |
| [`e03fea0a`](https://github.com/NixOS/nixpkgs/commit/e03fea0a1284f9da856c91e7d04bee39b9a30c3c) | `` grub2: make work with upstream unifont structure ``                                                    |
| [`517c9f1a`](https://github.com/NixOS/nixpkgs/commit/517c9f1a0513a40726fc7bae867c5ef30aa08770) | `` metabigor: modernize ``                                                                                |
| [`180bb059`](https://github.com/NixOS/nixpkgs/commit/180bb059891edb2ec0fafdc0fc120a2525496267) | `` ocamlPackages.jingoo: 1.5.2 → 1.5.4 ``                                                                 |
| [`34ab6dd2`](https://github.com/NixOS/nixpkgs/commit/34ab6dd2b5c3baa5374d02f05adbb62b5a1b0a69) | `` burpsuite: 2026.7.2 -> 2026.7.3 ``                                                                     |
| [`76c75b4d`](https://github.com/NixOS/nixpkgs/commit/76c75b4d6771b60a9ac764d6cfcb3b750d8e8291) | `` linux_xanmod_latest: 7.1.6 -> 7.1.8 ``                                                                 |
| [`6832340e`](https://github.com/NixOS/nixpkgs/commit/6832340e943cbefbbdef9ded3bf1b307d3970d4b) | `` linux_xanmod: 6.18.42 -> 6.18.44 ``                                                                    |
| [`32ac5d25`](https://github.com/NixOS/nixpkgs/commit/32ac5d251335cecf7f2649e1bf91f4089697b970) | `` editorconfig-checker: 3.8.0 -> 3.11.1 ``                                                               |
| [`4c458414`](https://github.com/NixOS/nixpkgs/commit/4c45841463f0723928f93d20af55e43c8da05b24) | `` python3Packages.alibabacloud-ecs20140526: 7.9.4 -> 7.9.6 ``                                            |
| [`2e081737`](https://github.com/NixOS/nixpkgs/commit/2e081737988c8a5f0c8b79911c41fb2b87c6b38c) | `` nixos/tests/installer: add missing libcap-text-verifier ``                                             |
| [`8acc52a0`](https://github.com/NixOS/nixpkgs/commit/8acc52a012b0778fc7fca0ff9141e5d4273b837d) | `` terraform-providers.tencentcloudstack_tencentcloud: 1.83.18 -> 1.83.21 ``                              |
| [`b663521b`](https://github.com/NixOS/nixpkgs/commit/b663521bd71a7409c88f07ab737e074bcae042a8) | `` forge-mtg: 2.0.13 -> 2.0.14 ``                                                                         |
| [`b9c2149b`](https://github.com/NixOS/nixpkgs/commit/b9c2149b058de955c21dc454bf2197d9c9521453) | `` valeStyles.microsoft: 0.15.0 -> 0.15.1 ``                                                              |
| [`ddcc249e`](https://github.com/NixOS/nixpkgs/commit/ddcc249e50ce9c5d010103e543a010c57cc3c1d6) | `` python3Packages.pyexploitdb: 0.3.38 -> 0.3.39 ``                                                       |
| [`77452ddd`](https://github.com/NixOS/nixpkgs/commit/77452ddd423d3d7ce1bc61c4f7754982a974346f) | `` python3Packages.django-compression-middleware: format to pyproject ``                                  |
| [`61a49964`](https://github.com/NixOS/nixpkgs/commit/61a499643796f418958e5ca210d85c672d189ea6) | `` nextvi: 7.1 -> 7.3 ``                                                                                  |
| [`af67d90f`](https://github.com/NixOS/nixpkgs/commit/af67d90f57efbfdabe6c9b9a0f24be2a2361c02c) | `` python3Packages.django-celery-email: format to pyproject ``                                            |
| [`55e56704`](https://github.com/NixOS/nixpkgs/commit/55e56704920e1f3931f61d3f6f8db42d88545fec) | `` jgmenu: 4.5.0 -> 4.6.0 ``                                                                              |
| [`cbebe72f`](https://github.com/NixOS/nixpkgs/commit/cbebe72fff3b48ba7ecee554dc39bcf73ea03168) | `` vimPlugins.fff-nvim: 0.10.1 -> 0.10.3 ``                                                               |
| [`6d698baf`](https://github.com/NixOS/nixpkgs/commit/6d698baf594703bdd8624106ee0f907e488f1224) | `` terraform-providers.trozz_pocketid: 2.1.0 -> 2.3.0 ``                                                  |
| [`3e5b2cb8`](https://github.com/NixOS/nixpkgs/commit/3e5b2cb8797cee8c90aa1984a9f68d23d9a1db40) | `` scala-cli: 1.15.0 -> 1.16.0 ``                                                                         |
| [`5e74e449`](https://github.com/NixOS/nixpkgs/commit/5e74e4494dd933598b2b81a5dc1988f7ea22e562) | `` terraform-providers.aminueza_minio: 3.38.5 -> 3.40.1 ``                                                |
| [`b6703d3a`](https://github.com/NixOS/nixpkgs/commit/b6703d3a5829fbf5c97ddcbd38478880de5d0b35) | `` parla: 0.7.4 -> 0.7.6 ``                                                                               |
| [`0461bc85`](https://github.com/NixOS/nixpkgs/commit/0461bc85b7d23f5212454ba71de4fa8e004fea95) | `` python3Packages.pykeepass: 4.1.1.post1 -> 4.2.0 ``                                                     |
| [`d36eca31`](https://github.com/NixOS/nixpkgs/commit/d36eca3181751314942cbf69446dac66bc23d56a) | `` lux-cli: 0.40.1 -> 0.40.5 ``                                                                           |
| [`470b49c0`](https://github.com/NixOS/nixpkgs/commit/470b49c01a388287a2f9ade0f664d902e8738c1f) | `` zapzap: 7.2 -> 7.4 ``                                                                                  |
| [`8850290a`](https://github.com/NixOS/nixpkgs/commit/8850290aecfc4b517f3640e0a1d8361392b7e89e) | `` python3Packages.python-backoff: 2.3.1 -> 2.4.0 ``                                                      |
| [`d4b596aa`](https://github.com/NixOS/nixpkgs/commit/d4b596aab692083c90c90123d0840137fb94605a) | `` python3Packages.python-statemachine: 3.2.0 -> 3.2.1 ``                                                 |
| [`2f46a2de`](https://github.com/NixOS/nixpkgs/commit/2f46a2def95c7063ff8d97c4a107cc2a14515ba2) | `` devin-cli: 3000.3.22 -> 3000.3.27 ``                                                                   |
| [`1cb7763f`](https://github.com/NixOS/nixpkgs/commit/1cb7763fa8130de9066210adef86f4d9f80ede08) | `` python3Packages.cyscale: 0.7.0 -> 0.8.0 ``                                                             |
| [`7854a554`](https://github.com/NixOS/nixpkgs/commit/7854a554740db405392b8cc9db42ae48a2bd9023) | `` koffan: 2.12.3 -> 2.13.0 ``                                                                            |
| [`e5eec852`](https://github.com/NixOS/nixpkgs/commit/e5eec852a6238bd81f898af591329616604d8bbc) | `` python3Packages.monarchmoneycommunity: 1.5.1 -> 1.5.2 ``                                               |
| [`427cf9d6`](https://github.com/NixOS/nixpkgs/commit/427cf9d688cec5b8d241d78146b5986f81f22851) | `` atmos: 1.224.1 -> 1.225.0 ``                                                                           |
| [`eb8cd6df`](https://github.com/NixOS/nixpkgs/commit/eb8cd6dfc2eedba572ef465dc260f2edf2a81927) | `` wappalyzergo: 0.2.91 -> 0.2.93 ``                                                                      |
| [`30b5ff9e`](https://github.com/NixOS/nixpkgs/commit/30b5ff9e84eef92999aec8bdc1bdd29682ffa836) | `` terraform-providers.hashicorp_aws: 6.57.1 -> 6.58.0 ``                                                 |
| [`4d7654a9`](https://github.com/NixOS/nixpkgs/commit/4d7654a9c38126b52158991652440da3eaef5971) | `` schemat: 0.5.3 -> 0.5.4 ``                                                                             |
| [`ed11f2c0`](https://github.com/NixOS/nixpkgs/commit/ed11f2c00d78d369593f7ec510d180d5ecbf017e) | `` linux_6_6: 6.6.150 -> 6.6.151 ``                                                                       |
| [`2226b96b`](https://github.com/NixOS/nixpkgs/commit/2226b96ba4e595905159a7f17af13570980d69da) | `` linux_6_12: 6.12.102 -> 6.12.103 ``                                                                    |
| [`510f4c4b`](https://github.com/NixOS/nixpkgs/commit/510f4c4b5c9937bfabb088d84cec199371dbbee1) | `` linux_6_18: 6.18.43 -> 6.18.44 ``                                                                      |
| [`256b6f72`](https://github.com/NixOS/nixpkgs/commit/256b6f72edd8585ebce6cf082e2af2d38f78df1c) | `` linux_7_1: 7.1.7 -> 7.1.8 ``                                                                           |
| [`63e225c4`](https://github.com/NixOS/nixpkgs/commit/63e225c4442a04d68dda0be02e9fcc79552e994e) | `` linux_testing: 7.2-rc6 -> 7.2-rc7 ``                                                                   |
| [`a31fdcf0`](https://github.com/NixOS/nixpkgs/commit/a31fdcf0cea962d5097d12df7c9bea7c19493c8f) | `` vscode-extensions.arktypeio.arkdark: init at 6.6.0 ``                                                  |
| [`fcd6f01d`](https://github.com/NixOS/nixpkgs/commit/fcd6f01d8a0036c6f16704fe3d05f92cb8a96a25) | `` whatsapp-for-mac: 2.26.19.17 -> 2.26.31.27 ``                                                          |
| [`52914d44`](https://github.com/NixOS/nixpkgs/commit/52914d446fb7c684fffdbd1ba125e5229acc0ed2) | `` python3Packages.types-openpyxl: 3.1.5.20260724 -> 3.1.5.20260807 ``                                    |
| [`8bdfb3ec`](https://github.com/NixOS/nixpkgs/commit/8bdfb3ec30769b57df312b51e8b512859ebbfd61) | `` python3Packages.types-futures: modernize ``                                                            |
| [`48a71f0e`](https://github.com/NixOS/nixpkgs/commit/48a71f0ee6bc51ab87a4ccbaf616b1756478188d) | `` fittrackee: 1.3.3 -> 1.3.4 ``                                                                          |
| [`3022ad37`](https://github.com/NixOS/nixpkgs/commit/3022ad3793420ec7ae12d1701a899e2c15a72b0b) | `` python3Packages.aioredis: modernize ``                                                                 |
| [`43df9458`](https://github.com/NixOS/nixpkgs/commit/43df94588eca3f531b45979ff6b6396b5fe3f50c) | `` python3Packages.sgmllib3k: modernize ``                                                                |
| [`16ff60e0`](https://github.com/NixOS/nixpkgs/commit/16ff60e07a8661082efba4b1b7f5e767064f01cf) | `` python3Packages.qdrant-client: 1.18.0 -> 1.19.0 ``                                                     |
| [`98d169f6`](https://github.com/NixOS/nixpkgs/commit/98d169f6d3945f96e27dfa17013cdd7a78586f36) | `` cudaPackages.nccl-tests: 2.19.6 -> 2.19.7 ``                                                           |
| [`1747ed63`](https://github.com/NixOS/nixpkgs/commit/1747ed63a0e6bb5ed4a975447d698b724b985f26) | `` freeradius: run networkmanager eap tests in passthru ``                                                |
| [`e0cdac98`](https://github.com/NixOS/nixpkgs/commit/e0cdac98fae7ab02bb35fc8651ce4ef6c29dee3a) | `` nixosTests.networkmanager.eap{,files}: fix log match ``                                                |
| [`a61e0179`](https://github.com/NixOS/nixpkgs/commit/a61e0179cbd354668f53825f412577d043ed9e8c) | `` networkmanager: make passthru tests an unnested attrset ``                                             |
| [`cfd18c9b`](https://github.com/NixOS/nixpkgs/commit/cfd18c9b6187152ffd7d4a54f86745696270d3e2) | `` networkmanager: modernize, sort, clean ``                                                              |
| [`33ece8ba`](https://github.com/NixOS/nixpkgs/commit/33ece8ba82d5908b446d93063fa5649a6f29daf9) | `` networkmanager: 1.56.0 -> 1.58.0 ``                                                                    |
| [`1330bf0e`](https://github.com/NixOS/nixpkgs/commit/1330bf0e6b447f2714e31a3ab1f2817d3d099443) | `` talhelper: 3.1.15 -> 3.1.16 ``                                                                         |
| [`0c185296`](https://github.com/NixOS/nixpkgs/commit/0c18529692022694b8f6fd7a88498f2a410c9276) | `` camunda-modeler: 5.50.0 -> 5.50.1 ``                                                                   |
| [`4b10d768`](https://github.com/NixOS/nixpkgs/commit/4b10d768e80989656dee8a071de41a9eb38c7b45) | `` signal-cli: 0.14.6 -> 0.14.7 ``                                                                        |
| [`2a3f8c8e`](https://github.com/NixOS/nixpkgs/commit/2a3f8c8ec0198e64d95545c78ff6e79d5b3bf380) | `` dealii: 9.7.1 -> 9.8.0 ``                                                                              |
| [`eced40fe`](https://github.com/NixOS/nixpkgs/commit/eced40fea4c26ecd8cf7d4f7f428d30c0f912776) | `` context7-mcp: 3.2.5 -> 4.0.0 ``                                                                        |
| [`c6e52ea0`](https://github.com/NixOS/nixpkgs/commit/c6e52ea056b60aa214bab3623c2295a355bff73c) | `` betterleaks: 1.7.2 -> 1.7.3 ``                                                                         |
| [`d07ea1c2`](https://github.com/NixOS/nixpkgs/commit/d07ea1c2186432c211dc61ed34850bd2505d2cc1) | `` actual-server: 26.8.0 -> 26.8.1 ``                                                                     |
| [`97f68d9a`](https://github.com/NixOS/nixpkgs/commit/97f68d9a4e9daec2c737a78dd9c6644ede87f74c) | `` python3Packages.pydantic-ai-slim: 2.21.0 -> 2.27.0 ``                                                  |
| [`4116e644`](https://github.com/NixOS/nixpkgs/commit/4116e6448451d200c9462e131f7fb64b99e6016f) | `` hyprland: 0.56.1 -> 0.56.2 ``                                                                          |
| [`3e5a2ebc`](https://github.com/NixOS/nixpkgs/commit/3e5a2ebc12553b77fe90051dea221bcb0c9e5841) | `` python3Packages.pydantic-graph: 2.21.0 -> 2.27.0 ``                                                    |
| [`c1daf4bc`](https://github.com/NixOS/nixpkgs/commit/c1daf4bc819f4971f6907e16cd5c77ff33806145) | `` python3Packages.genai-prices: 0.1.0 -> 0.1.1 ``                                                        |
| [`27d4f761`](https://github.com/NixOS/nixpkgs/commit/27d4f761679f321eaa2788dc5e0f495ba91c5910) | `` rattler-build: 0.72.0 -> 0.72.2 ``                                                                     |
| [`99f66da2`](https://github.com/NixOS/nixpkgs/commit/99f66da263fab1e08ab7f6626466f3e7d74d489d) | `` spruce: 1.35.14 -> 1.35.15 ``                                                                          |
| [`0db916e6`](https://github.com/NixOS/nixpkgs/commit/0db916e67d1b36f89460ff45adc22bf36d7cabdd) | `` mqttui: 0.23.0 -> 0.24.0 ``                                                                            |
| [`7f70eccd`](https://github.com/NixOS/nixpkgs/commit/7f70eccdf8a7ce426c61aad996214c2fda27da4e) | `` libation: 13.7.5 -> 13.7.7 ``                                                                          |
| [`09f3307a`](https://github.com/NixOS/nixpkgs/commit/09f3307ad3f872ecab1e3eb5fb964b9d046bd870) | `` phpunit: 13.2.6 -> 13.3.0 ``                                                                           |
| [`d4cc798e`](https://github.com/NixOS/nixpkgs/commit/d4cc798ef8f676c9d2225d8ec940c4a798e776cf) | `` Revert "Reapply "nixos/nixpkgs.config: make use of the module defined in config.nix"" ``               |
| [`6878ba18`](https://github.com/NixOS/nixpkgs/commit/6878ba189c01136bf1371f19965b4feda674c793) | `` home-assistant-custom-components.homematicip_local: 2.8.3 -> 2.9.0 ``                                  |
| [`abc9328e`](https://github.com/NixOS/nixpkgs/commit/abc9328e746bea86c3e17af9c030030040c49f26) | `` python3Packages.openccu-loom-types: 0.1.53 -> 0.3.3 ``                                                 |
| [`704bb4c7`](https://github.com/NixOS/nixpkgs/commit/704bb4c7a9a2e744b18e06d340441af47677e2f2) | `` python3Packages.openccu-loom-client: 2026.7.6 -> 2026.8.6 ``                                           |
| [`888dd555`](https://github.com/NixOS/nixpkgs/commit/888dd5550c06cf0c0040fb0aa051603212e74bce) | `` python3Packages.openccu-data: 2026.6.1 -> 2026.7.2 ``                                                  |
| [`7000faf0`](https://github.com/NixOS/nixpkgs/commit/7000faf038a713c89ca261735a078b990a0cf9f3) | `` python3Packages.aiohomematic-config: 2026.5.0 -> 2026.8.0 ``                                           |
| [`8488a85e`](https://github.com/NixOS/nixpkgs/commit/8488a85e3621108f73d3c5938b0ce934d41cb30d) | `` python3Packages.aiohomematic: 2026.7.6 -> 2026.8.1 ``                                                  |
| [`8950a029`](https://github.com/NixOS/nixpkgs/commit/8950a02982fb3e1c8f9fd4b818be3eeb072d6b83) | `` python3Packages.ha-garmin: 0.1.31 -> 0.1.33 ``                                                         |
| [`8cc04b1b`](https://github.com/NixOS/nixpkgs/commit/8cc04b1b02e839176cf5a4589a43b080ddb825c5) | `` matrix-tuwunel: 1.8.2 -> 1.8.3 ``                                                                      |
| [`eac93b6d`](https://github.com/NixOS/nixpkgs/commit/eac93b6d4bdbf034209aaf0ffdea7f39512e9d89) | `` wakatime-cli: 2.23.0 -> 2.24.0 ``                                                                      |
| [`1f60fb9e`](https://github.com/NixOS/nixpkgs/commit/1f60fb9e5a1290aeb53e79ab984fbc4ffb304fbc) | `` adapta-gtk-theme: restrict platforms to unix instead of linux ``                                       |
| [`af46b891`](https://github.com/NixOS/nixpkgs/commit/af46b891fdb2283e93639ddfc57f859731e85567) | `` python3Packages.htmldate: fix tests with dateparser 1.4.2 ``                                           |
| [`7af5d3cd`](https://github.com/NixOS/nixpkgs/commit/7af5d3cd11c0af97e8b8af2bcbaec524dc22f770) | `` adapta-gtk-theme: enable `__structuredAttrs` and `strictDeps` ``                                       |
| [`9d8c16c7`](https://github.com/NixOS/nixpkgs/commit/9d8c16c73c21dc0314d325368b45c36a8af280ac) | `` python3Packages.nccl4py: 0.3.0 -> 0.3.1 ``                                                             |
| [`c6d9db24`](https://github.com/NixOS/nixpkgs/commit/c6d9db2496bb338af9020a050bbcfbe1e9cb9a12) | `` adapta-gtk-theme: fix and try to clarify licensing ``                                                  |
| [`abb8a9f7`](https://github.com/NixOS/nixpkgs/commit/abb8a9f7e746c572a5cdb4066929fc9476708db4) | `` Revert "python3Packages.cuda-tile: fix compilation error caused by deprecated setuptools parameter" `` |
| [`c0295f7d`](https://github.com/NixOS/nixpkgs/commit/c0295f7d231cc6575f79b5002305267730be219c) | `` mcron: 1.2.1 -> 1.2.3 ``                                                                               |
| [`b6200cde`](https://github.com/NixOS/nixpkgs/commit/b6200cdeed062f4904192000fcc45fed79fba526) | `` moshi: 0.2.5 -> 0.2.12 ``                                                                              |
| [`c12a08c9`](https://github.com/NixOS/nixpkgs/commit/c12a08c93cdf40234e2ec402758944503122f580) | `` python3Packages.pyais: 3.2.0 -> 3.2.1 ``                                                               |
| [`5d9cc5fa`](https://github.com/NixOS/nixpkgs/commit/5d9cc5faca07222c6381088755c33e1e8bb2b763) | `` ao3downloader: remove explicit pythonImportsCheckHook ``                                               |
| [`3c360b92`](https://github.com/NixOS/nixpkgs/commit/3c360b92b88d30cc8e2721cf7f5b4b755346a630) | `` static-web-server: 2.43.0 -> 2.44.0 ``                                                                 |
| [`9e4b9f8f`](https://github.com/NixOS/nixpkgs/commit/9e4b9f8fb0ce18b1b3cc11722126dde4e9d78520) | `` python313Packages.blackrenderer: 0.6.0 -> 0.8.2 ``                                                     |
| [`09cfdac3`](https://github.com/NixOS/nixpkgs/commit/09cfdac38e02499e737dc88c9ef764b8ac0efc42) | `` newelle: fix browser and mcp ``                                                                        |
| [`d82d2db1`](https://github.com/NixOS/nixpkgs/commit/d82d2db131e80811c6cf98074bbe64acd9a24cc6) | `` vimPlugins.yankcraft-nvim: init at 0.1.0 ``                                                            |
| [`77b21fad`](https://github.com/NixOS/nixpkgs/commit/77b21fad9fe0c8ce050a1d2e6fc6103f5a71591a) | `` CONTRIBUTING: clarify release note conventions ``                                                      |
| [`01cc62cd`](https://github.com/NixOS/nixpkgs/commit/01cc62cd183a35da0205b2011d02e697e918cbd2) | `` nixos/noctalia-greeter: init ``                                                                        |
| [`7844d638`](https://github.com/NixOS/nixpkgs/commit/7844d6384d12d7b82256f7fb5c41e6059f24832a) | `` gelly: 1.9.5 -> 1.9.7 ``                                                                               |
| [`6f7e99c5`](https://github.com/NixOS/nixpkgs/commit/6f7e99c5aef7ad6919f9a61bb112320244119327) | `` gloox: added maintainer ``                                                                             |
| [`8d87f68c`](https://github.com/NixOS/nixpkgs/commit/8d87f68c7d518df8993360f1e355b60f225f56b9) | `` gloox: cleaner buildinputs ``                                                                          |
| [`cb25efc1`](https://github.com/NixOS/nixpkgs/commit/cb25efc174d49bbbb68642b74de5d60187837eca) | `` gloox: switched to a subinplace ``                                                                     |
| [`7466e485`](https://github.com/NixOS/nixpkgs/commit/7466e48509fa614648bfdd1a3f863daa2baec06c) | `` gloox: patch for openssl ``                                                                            |
| [`5a2f14e6`](https://github.com/NixOS/nixpkgs/commit/5a2f14e6197f511c625510a57da5b9cf0b15c2d0) | `` python3Packages.gflanguages: add jopejoe1 as maintainer ``                                             |
| [`9f88999e`](https://github.com/NixOS/nixpkgs/commit/9f88999ebae7f046bc4bdad38e471c4329549e1f) | `` python3Packages.axisregistry: add jopejoe1 to maintainers ``                                           |
| [`38292042`](https://github.com/NixOS/nixpkgs/commit/3829204281631cefac1bf2a1ccba20bdf2878fd3) | `` python313Packages.gftools: 0.9.996 -> 0.9.998 ``                                                       |
| [`94551f69`](https://github.com/NixOS/nixpkgs/commit/94551f6993a3f42bcd4ed76879a0f278f88ac6a6) | `` python313Packages.axisregistry: 0.4.16 -> 0.4.20 ``                                                    |
| [`ac9af82f`](https://github.com/NixOS/nixpkgs/commit/ac9af82f4cfda17baede53f798b37c026c1020c2) | `` python313Packages.gflanguages: 0.7.7 -> 0.7.9 ``                                                       |
| [`0bc04376`](https://github.com/NixOS/nixpkgs/commit/0bc043768381f5cffbcb490fb7a6bd9254564c6e) | `` gfmetadata: init at 0.2.5 ``                                                                           |
| [`f45d236b`](https://github.com/NixOS/nixpkgs/commit/f45d236b9fb921e92c4cc870d09e69e860d44f98) | `` cocom: 1.1.3 -> 1.2.0 ``                                                                               |
| [`9587ab48`](https://github.com/NixOS/nixpkgs/commit/9587ab48599dc8b33855cb4515362f077ec4ac0b) | `` sqlfluff: 4.2.2 -> 4.3.0 ``                                                                            |
| [`bd8f7b03`](https://github.com/NixOS/nixpkgs/commit/bd8f7b0363baaf05c206d889d97a3f3cc945a3c3) | `` oboete: 0.2.5 -> 0.2.6 ``                                                                              |
| [`a0cbda75`](https://github.com/NixOS/nixpkgs/commit/a0cbda756976586ea61c180ce98736f44d4ed572) | `` mdbook-rss-feed: init at 1.7.0 ``                                                                      |
| [`6526c61f`](https://github.com/NixOS/nixpkgs/commit/6526c61f7537dc7927b090fc3f05be06a72ad272) | `` rainfrog: 0.4.2 -> 0.4.3 ``                                                                            |
| [`fe482c17`](https://github.com/NixOS/nixpkgs/commit/fe482c170c66acfa2c35ce539cb3bb993af1290b) | `` terraform-providers.argoproj-labs_argocd: 7.15.3 -> 7.16.0 ``                                          |
| [`ab1172d0`](https://github.com/NixOS/nixpkgs/commit/ab1172d03ae9b2627cb8d1b390ab2524f6eb0bd4) | `` nixos/rtorrent: network.port_{range,random}.set -> network.listen.port.{range,random}.set ``           |
| [`9045d539`](https://github.com/NixOS/nixpkgs/commit/9045d5396e5cfffca88b0cfeb33b365e2b40e34d) | `` cudaPackages.tensorrt: 10.14.1 -> 10.16.1 ``                                                           |
| [`86832dd7`](https://github.com/NixOS/nixpkgs/commit/86832dd7e0af9fd22e5346a60a6a4288e316bc09) | `` profanity: fix Darwin build ``                                                                         |
| [`d1ca460d`](https://github.com/NixOS/nixpkgs/commit/d1ca460de801d2003fa836c48cea6debe72ea23e) | `` libgphoto2: fix build on macOS ``                                                                      |
| [`60aa73e5`](https://github.com/NixOS/nixpkgs/commit/60aa73e5db89155e3a0fbff3e5edc44e4e58ef82) | `` mu: 1.14.2 -> 1.14.3 ``                                                                                |
| [`004b2b22`](https://github.com/NixOS/nixpkgs/commit/004b2b225fe3fa1981309e18bd9ef2ea03c22fc1) | `` python3Packages.bumpfontversion: drop ``                                                               |
| [`da0810d5`](https://github.com/NixOS/nixpkgs/commit/da0810d5136cfd2fdae87ac6e8ccc1441cce0cb2) | `` parallel-launcher: 9.0.5 -> 9.0.6 ``                                                                   |
| [`0dbed1c3`](https://github.com/NixOS/nixpkgs/commit/0dbed1c37f64000d25d2aa4565e940e03a05d444) | `` python3Packages.transformer-engine: 2.16.1 -> 2.17.1 ``                                                |
| [`c648a8f0`](https://github.com/NixOS/nixpkgs/commit/c648a8f049f36369f3ae45acb0b4a38b361abaca) | `` python313Packages.vfblib: 0.11.1 -> 0.11.6 ``                                                          |
| [`9072ca1a`](https://github.com/NixOS/nixpkgs/commit/9072ca1a4ab1a2d46ed8cfcf3b6630930426768d) | `` livi: 0.4.0 -> 0.5.0 ``                                                                                |
| [`abca02f3`](https://github.com/NixOS/nixpkgs/commit/abca02f3a19be1f63e2214e566165cb364ba63a7) | `` python3Packages.scikit-base: 1.0.2 -> 1.1.0 ``                                                         |
| [`b804f6c0`](https://github.com/NixOS/nixpkgs/commit/b804f6c0f9efc153a3579c04fc4f68f5ca2c9a6f) | `` atomgit-cli: 0.6.0 -> 0.7.1 ``                                                                         |
| [`86ab8743`](https://github.com/NixOS/nixpkgs/commit/86ab874347525c8c3c879e01667ad0deeefceefa) | `` python3Packages.sabctools: 9.6.2 -> 9.6.3 ``                                                           |
| [`9eeb54d2`](https://github.com/NixOS/nixpkgs/commit/9eeb54d21400ef9bc400e2fc326e80ee1b94cd06) | `` libreoffice: set JAVA_HOME ``                                                                          |
| [`0bf60bde`](https://github.com/NixOS/nixpkgs/commit/0bf60bde36c22463259f821e4702f56135d35e56) | `` adminneo: 5.5.0 -> 5.5.1 ``                                                                            |
| [`eee76196`](https://github.com/NixOS/nixpkgs/commit/eee761967785d218446d012a8202133832c06e7b) | `` bdf2psf: 1.248 -> 1.249 ``                                                                             |
| [`22d8bafd`](https://github.com/NixOS/nixpkgs/commit/22d8bafd8c94f8701c818fa42cb69b7f75708fb1) | `` ocamlPackages.ctypes-foreign: fix build for darwin ocaml 5.5 ``                                        |
| [`a6ea38cb`](https://github.com/NixOS/nixpkgs/commit/a6ea38cbc8e48a9567e95ba2dfe7c0fbd10b3000) | `` ocamlPackages.async_rpc_websocket: fix build on darwin ``                                              |
| [`daf876f6`](https://github.com/NixOS/nixpkgs/commit/daf876f6c4858477c2bda62071be7cbcbd8b6df5) | `` ocamlPackages.cohttp_async_websocket: fix build on darwin ``                                           |
| [`ebc7ecf6`](https://github.com/NixOS/nixpkgs/commit/ebc7ecf6d0540ae694f64f618f51e67fe240b6f9) | `` ocamlPackages.cohttp_static_handler: fix build on darwin ``                                            |
| [`69411a37`](https://github.com/NixOS/nixpkgs/commit/69411a37a2d24de04b91a131adf2045f9b82084c) | `` ocamlPackages.cohttp-eio: fix build on darwin ``                                                       |
| [`4d790b7f`](https://github.com/NixOS/nixpkgs/commit/4d790b7f3fe5d03638b4849d6cb0cf50b1156adc) | `` ocamlPackages.cohttp-async: fix build on darwin ``                                                     |
| [`ca7f3603`](https://github.com/NixOS/nixpkgs/commit/ca7f36037ab16923bab4b45d6bfe6e3879bed8e0) | `` claude-agent-acp: 0.64.0 -> 0.66.0 ``                                                                  |
| [`f35e655b`](https://github.com/NixOS/nixpkgs/commit/f35e655b297146e81f46f07314bfb5673d5d1dd6) | `` sioyek: 2.0.0-unstable-2026-07-21 -> 2.0.0-unstable-2026-08-05 ``                                      |
| [`9ac8839b`](https://github.com/NixOS/nixpkgs/commit/9ac8839b3b446bf4c5ed4949b9b11971dc174077) | `` pkgs/README: explain better why to use a `passthru.updateScript` ``                                    |
| [`7501b924`](https://github.com/NixOS/nixpkgs/commit/7501b924dd45f3ead91bd0042eaac530a49acfd4) | `` pkgs/README: use headers for valid updateScript value types ``                                         |
| [`d0bca1fb`](https://github.com/NixOS/nixpkgs/commit/d0bca1fbec5413980e0ce84ffe8c24a001063997) | `` python3Packages.types-aiobotocore: 3.8.0 -> 3.9.0 ``                                                   |
| [`ecf0b1f5`](https://github.com/NixOS/nixpkgs/commit/ecf0b1f5983037fca0359732e59ba8b548a95b78) | `` python3Packages.nccl4py: fix typo ``                                                                   |
| [`a1b95e8a`](https://github.com/NixOS/nixpkgs/commit/a1b95e8adfa6168d9f66007d17acf8d51943b9fa) | `` hunk: 0.17.7 -> 0.18.0 ``                                                                              |
| [`444c5826`](https://github.com/NixOS/nixpkgs/commit/444c58264011624ed5bc6f43f6c92227f882d7c1) | `` gnome-settings-daemon: add meta description & homepage ``                                              |
| [`a8421b0e`](https://github.com/NixOS/nixpkgs/commit/a8421b0ee8e54df96e98f47e2150eda7b84db217) | `` gnome-settings-daemon: cleanup dependencies ``                                                         |
| [`c2c08cdf`](https://github.com/NixOS/nixpkgs/commit/c2c08cdf3f04fb2a257c2027de2f18988661e11e) | `` rush-lyrics: 6.5.1 -> 6.5.2 ``                                                                         |
| [`8704b408`](https://github.com/NixOS/nixpkgs/commit/8704b408d760807b5bf5efd5f238240d02ba1921) | `` Revert "n8n: 2.32.6 -> 2.33.7" ``                                                                      |
| [`04c2004d`](https://github.com/NixOS/nixpkgs/commit/04c2004dc99a3d694e741e6c79deab170de7539c) | `` snx-rs: 6.2.1 -> 6.2.3 ``                                                                              |
| [`52d739b2`](https://github.com/NixOS/nixpkgs/commit/52d739b263b9be97356ed32ce6f94088ba73e596) | `` go-hass-agent: 14.15.0 -> 14.15.1 ``                                                                   |
| [`ded227d6`](https://github.com/NixOS/nixpkgs/commit/ded227d63bf94b0ea7b4bc0f344d38c1a16eed9f) | `` python3Packages.nccl4py: add support for `cudaPackages.nccl-ep` ``                                     |
| [`bdf21daa`](https://github.com/NixOS/nixpkgs/commit/bdf21daa1b72a5cc2dee35f5c33063b6eb208f01) | `` nixos/home-assistant: remove frontend firewalling option ``                                            |
| [`55e0aa48`](https://github.com/NixOS/nixpkgs/commit/55e0aa48117325c9f05a96c71c4612e7a2969177) | `` vscode-extensions.charliermarsh.ruff: 2026.68.0 -> 2026.70.0 ``                                        |
| [`4c525329`](https://github.com/NixOS/nixpkgs/commit/4c525329781e01dc6e316ae991eff366e1a33d45) | `` firefox-devedition-unwrapped: 154.0b4 -> 154.0b8 ``                                                    |
| [`05f072e8`](https://github.com/NixOS/nixpkgs/commit/05f072e8ca6c8487e339e46bec4d011c67ebcf06) | `` firefox-beta-unwrapped: 154.0b7 -> 154.0b8 ``                                                          |
| [`41492c4e`](https://github.com/NixOS/nixpkgs/commit/41492c4ec7483d926f849448845f521128e8632e) | `` noto-fonts: 2026.07.01 -> 2026.08.01 ``                                                                |
| [`892e394a`](https://github.com/NixOS/nixpkgs/commit/892e394af45ebd93800aa2e216e87f385ac39516) | `` prometheus-redis-exporter: 1.88.0 -> 1.89.0 ``                                                         |
| [`a2d36b9e`](https://github.com/NixOS/nixpkgs/commit/a2d36b9e72e6368945300b218f1e1081d9c4087c) | `` olympus-unwrapped: 26.07.27.01 -> 26.08.04.01 ``                                                       |
| [`0091b3d1`](https://github.com/NixOS/nixpkgs/commit/0091b3d1990c83324bb9c4da69ef56ba166f99b3) | `` python3Packages.mopeka-iot-ble: migrate to finalAttrs ``                                               |
| [`5b5a703b`](https://github.com/NixOS/nixpkgs/commit/5b5a703bc251daa42670c63017a10864ff1ebd5f) | `` spirit: 0.15.1 -> 0.16.0 ``                                                                            |
| [`c443f400`](https://github.com/NixOS/nixpkgs/commit/c443f4009b547543dda807008cfb0d95968bb557) | `` vscode-extensions.visualjj.visualjj: 0.32.1 -> 0.33.3 ``                                               |
| [`1d04101d`](https://github.com/NixOS/nixpkgs/commit/1d04101d570a166d47f5a63744aac6c4824469d1) | `` aerion: 0.3.2 -> 0.3.3 ``                                                                              |
| [`2b396535`](https://github.com/NixOS/nixpkgs/commit/2b396535ada1f3576cdc181afe06ae352a93f5e8) | `` verilator: fix build on darwin ``                                                                      |
| [`52d6eea5`](https://github.com/NixOS/nixpkgs/commit/52d6eea53d1252dea09ee953f1030d7e3f48014c) | `` {free,net,open}bsd: index for search and ci ``                                                         |
| [`1995ba69`](https://github.com/NixOS/nixpkgs/commit/1995ba69fc3a523067806c45211d81f862079a7d) | `` valeStyles.google: 0.7.0 -> 0.7.1 ``                                                                   |
| [`16ed7513`](https://github.com/NixOS/nixpkgs/commit/16ed75137d408908ebdb135081ba7f21625ddb90) | `` kdePackages.kio-s3: init at 1.0.2 ``                                                                   |
| [`d40fcdd5`](https://github.com/NixOS/nixpkgs/commit/d40fcdd5aed5e5be79501c78d1eec31fa481f340) | `` stremio-linux-shell: 1.1.4 -> 1.2.0 ``                                                                 |
| [`e7b2fe62`](https://github.com/NixOS/nixpkgs/commit/e7b2fe624d0e2585d8393177ffabe877231e1e28) | `` searchix: 0.4.9 -> 0.4.10 ``                                                                           |
| [`3d7a241f`](https://github.com/NixOS/nixpkgs/commit/3d7a241fe97c8ee5f9316b1d22c6519c2c4bf6ad) | `` folia-major: 0.6.8 -> 0.6.15 ``                                                                        |
| [`b9fcc23f`](https://github.com/NixOS/nixpkgs/commit/b9fcc23f55bd68079913ea9a52d745070a1e0ac6) | `` python3Packages.cuda-core: add `cuda-bindings` to `dependencies` ``                                    |
| [`51ddddec`](https://github.com/NixOS/nixpkgs/commit/51ddddecd17eeadb7632df53d2780e71a7aa1fdd) | `` cudaPackages.nccl-ep: init at 2.30.7-1 ``                                                              |
| [`85615ea4`](https://github.com/NixOS/nixpkgs/commit/85615ea409d3c1fff3e8a1889e260bd28350c0e8) | `` archon-lite: 9.4.36 -> 9.5.0 ``                                                                        |
| [`673b83fb`](https://github.com/NixOS/nixpkgs/commit/673b83fbd458d5f22322ef95ca960b2d807e3b9b) | `` emacs.pkgs.slack: 20260807.1358 -> 20260808.1935 ``                                                    |
| [`01569341`](https://github.com/NixOS/nixpkgs/commit/01569341181f7ef969a2f929d6efdd8e9cf7cb09) | `` python3Packages.exa-py: 2.16.2 -> 2.17.0 ``                                                            |
| [`e813c6ff`](https://github.com/NixOS/nixpkgs/commit/e813c6ff356a4500887787135c0390c4b91f8ca5) | `` terraform-providers.spotinst_spotinst: 1.238.1 -> 1.239.0 ``                                           |
| [`8afda7e3`](https://github.com/NixOS/nixpkgs/commit/8afda7e337c90719a93e1eb440bdda5b81f8570d) | `` metasploit: 6.5.0 -> 6.5.1 ``                                                                          |
| [`bd8e0e34`](https://github.com/NixOS/nixpkgs/commit/bd8e0e346f63a54329fd654ef2fe03a09621bb8e) | `` home-manager: 0-unstable-2026-07-21 -> 0-unstable-2026-08-06 ``                                        |
| [`b4452777`](https://github.com/NixOS/nixpkgs/commit/b4452777532632af0f5f9a8c3383ec6931d2932d) | `` n8n: 2.32.6 -> 2.33.7 ``                                                                               |
| [`141cd452`](https://github.com/NixOS/nixpkgs/commit/141cd452a2f848c7f84038c55d34194d4868ca77) | `` user-scanner: 1.4.2 -> 1.4.3.1 ``                                                                      |
| [`0db1fa51`](https://github.com/NixOS/nixpkgs/commit/0db1fa51d858e61f1c5bcc5a9597e5c4a149f0a3) | `` tootik: 0.23.3 -> 0.24.0 ``                                                                            |
| [`bd8ac620`](https://github.com/NixOS/nixpkgs/commit/bd8ac62097dc5dcebf3b96460c2f7c0151aba8ca) | `` python3Packages.digi-xbee: add meta.changelog ``                                                       |
| [`056c7d8c`](https://github.com/NixOS/nixpkgs/commit/056c7d8cec3fb9d0c004e9455673e93c69863e39) | `` python3Packages.digi-xbee: use finalAttrs, __structuredAttrs ``                                        |
| [`31ec2bbd`](https://github.com/NixOS/nixpkgs/commit/31ec2bbd4eff310589ee301df482bbbcbeeebec0) | `` python3Packages.digi-xbee: migrate to pyproject ``                                                     |
| [`9dec1311`](https://github.com/NixOS/nixpkgs/commit/9dec1311864de0e19a639e6b83f92fd37fa1e9e7) | `` lulu: 4.3.1 -> 4.5.1 and added metadata ``                                                             |
| [`56282877`](https://github.com/NixOS/nixpkgs/commit/56282877ccd5c5417ee07ba010ec00a60e55c5f6) | `` tabularis: 0.17.0 -> 0.18.0 ``                                                                         |
| [`9376a7b5`](https://github.com/NixOS/nixpkgs/commit/9376a7b52964f96522198c4c9329e7ac39219dd5) | `` thunderbird-latest-unwrapped: 153.0.1 -> 153.0.2 ``                                                    |
| [`4a8d2aa6`](https://github.com/NixOS/nixpkgs/commit/4a8d2aa6c4c5c6322a08080e5c2b34d4a5ba3aaf) | `` skills: 1.5.21 -> 1.5.22 ``                                                                            |
| [`dab05b16`](https://github.com/NixOS/nixpkgs/commit/dab05b16117a15c9635d30ba6799585fed8e9a18) | `` ggml: 0.18.0 -> 0.19.0 ``                                                                              |
| [`354bf6d9`](https://github.com/NixOS/nixpkgs/commit/354bf6d9b74a55df9f51083c9b14d7388c6892d1) | `` python3Packages.somajo: actually run tests ``                                                          |
| [`b05e5d0e`](https://github.com/NixOS/nixpkgs/commit/b05e5d0e044b6f021780e1f1d580283c46615b7d) | `` gvm-libs: 23.9.1 -> 23.9.2 ``                                                                          |
| [`30f0d59b`](https://github.com/NixOS/nixpkgs/commit/30f0d59baf33968c9104a7fa2ec87406d63c5fbf) | `` stevenblack-blocklist: 3.16.102 -> 3.16.104 ``                                                         |
| [`420dfdd4`](https://github.com/NixOS/nixpkgs/commit/420dfdd437eeede76a4462b0f390216dca324321) | `` python3Packages.aiomysql: cleanup, fix ``                                                              |
| [`d6c28e8e`](https://github.com/NixOS/nixpkgs/commit/d6c28e8e1fcadfc5ef161c791ef6e034fd3d8500) | `` caffe: modernize derivation ``                                                                         |
| [`20c2da3f`](https://github.com/NixOS/nixpkgs/commit/20c2da3f73b94b2f4ce09e5327b2cd69c7b1a35e) | `` caffe: migrate to by-name ``                                                                           |
| [`9fcaec41`](https://github.com/NixOS/nixpkgs/commit/9fcaec41fde7f3595df7147472cec6fab92f6748) | `` thunderbird-esr-bin-unwrapped: 153.0.1esr -> 153.0.2esr ``                                             |
| [`24ec9dc1`](https://github.com/NixOS/nixpkgs/commit/24ec9dc16f7e87d10d5b96bbf5f988a582d5efb3) | `` samrewritten: 1.4.6 -> 1.4.7 ``                                                                        |
| [`eccf1176`](https://github.com/NixOS/nixpkgs/commit/eccf11767ed007311e5d0db8e3085afc3d74ec9c) | `` python3Packages.euporie: relax imagesize ``                                                            |
| [`ead97728`](https://github.com/NixOS/nixpkgs/commit/ead9772816d6a2d6b8b72c5187ad6f5ace1a41c2) | `` python3Packages.fica: fix ``                                                                           |
| [`09a18751`](https://github.com/NixOS/nixpkgs/commit/09a1875187824c595597a26dc8cd2bf773996ab7) | `` python3Packages.python-kadmin-rs: remove explicit pythonImportsCheckHook, use finalAttrs, tag ``       |
| [`95f3ca0b`](https://github.com/NixOS/nixpkgs/commit/95f3ca0b8671e20b355361d7c844b23c268e7504) | `` python3Packages.beziers: fix pythonImportsCheck, use finalAttrs, tag ``                                |
| [`e197e431`](https://github.com/NixOS/nixpkgs/commit/e197e431473a19c658e2b371b0fb0af7cc76da36) | `` nipap-cli: remove explicit pythonImportsCheckHook ``                                                   |
| [`0c4cbd80`](https://github.com/NixOS/nixpkgs/commit/0c4cbd80abbfa96d1ddd13621d69957c8a07fd6e) | `` python3.pkgs.css-inline: 0.21.0 -> 0.21.1 ``                                                           |
| [`b4097cb1`](https://github.com/NixOS/nixpkgs/commit/b4097cb14747c1ef3e0b6041a93171b51b76fc2d) | `` python3Packages.spotipyfree: 1.9.13 -> 1.9.14 ``                                                       |
| [`2d6a8684`](https://github.com/NixOS/nixpkgs/commit/2d6a86848549e917b3f2ab60fbee5d9ec30d1587) | `` vimPlugins.jupytext-nvim: fix healthcheck on neovim 0.11+ ``                                           |
| [`dd64a9ac`](https://github.com/NixOS/nixpkgs/commit/dd64a9acc3b891ef69664073366c8cc44819896d) | `` terraform-providers.hashicorp_google-beta: 7.42.0 -> 7.43.0 ``                                         |
| [`700763c6`](https://github.com/NixOS/nixpkgs/commit/700763c6ccfcf1b1d59f0fa29f33d4f50f9031cf) | `` ucx: add meta.downloadPage and meta.changelog ``                                                       |
| [`18047bb0`](https://github.com/NixOS/nixpkgs/commit/18047bb0ff6bbe34d8aecf82ca04a6dfab848f28) | `` cdncheck: 1.2.46 -> 1.2.47 ``                                                                          |
| [`0fa14b14`](https://github.com/NixOS/nixpkgs/commit/0fa14b149bac798c1172dff57ba6fa64775821cf) | `` python3Packages.aioftp: 0.27.2 -> 0.28.0 ``                                                            |
| [`f2f53984`](https://github.com/NixOS/nixpkgs/commit/f2f539845c48ec1bcb1f081c3f88b1d7fa8ff20b) | `` python3Packages.somajo: 2.4.3 -> 2.5.0 ``                                                              |
| [`0441f7ff`](https://github.com/NixOS/nixpkgs/commit/0441f7ff642eefeb6a57a89ef4825dfedd00e461) | `` python3Packages.qtile: remove myself from maintainence ``                                              |
| [`5b8edf74`](https://github.com/NixOS/nixpkgs/commit/5b8edf74024e197623f26635c2c6645cb93c95f5) | `` nerd-fonts: 3.4.0 -> 3.5.0 ``                                                                          |
| [`0769187c`](https://github.com/NixOS/nixpkgs/commit/0769187c79a1a3a84470649f73bcb37a550f05b7) | `` python3Packages.mastodon-py: 2.2.1 -> 2.2.2 ``                                                         |
| [`0c2518e5`](https://github.com/NixOS/nixpkgs/commit/0c2518e5116bcd0f2e9462b45057781fbce14c80) | `` python3Packages.zbar: rename from python3Packages.python-zbar ``                                       |
| [`a12d3f00`](https://github.com/NixOS/nixpkgs/commit/a12d3f00e58b8810c1fb4b07e33c5ac01e0f661e) | `` eslint: 10.8.0 -> 10.8.1 ``                                                                            |
| [`23daff0e`](https://github.com/NixOS/nixpkgs/commit/23daff0e8309e3f11e0fd81b74327b3ec8042cae) | `` libretro.beetle-wswan: 0-unstable-2026-04-20 -> 0-unstable-2026-07-31 ``                               |
| [`4d7e2ec1`](https://github.com/NixOS/nixpkgs/commit/4d7e2ec1a880f91130058ff1ccceba73bf5013e4) | `` enzyme: 0.0.289 -> 0.0.290 ``                                                                          |
| [`3d072e88`](https://github.com/NixOS/nixpkgs/commit/3d072e88ad52d331ebb74c1d14a0b48f353d7e6b) | `` ocamlPackages.magic-trace: set to x86_64-linux only ``                                                 |
| [`b057c0db`](https://github.com/NixOS/nixpkgs/commit/b057c0db68ecb8d6acdde43d29b8821d6ed8506f) | `` python3Packages.kserve: 0.19.0 -> 0.20.0 ``                                                            |
| [`7faf6164`](https://github.com/NixOS/nixpkgs/commit/7faf61649280bcf5510978f1b7f682ecd0af76c4) | `` wayshot: 1.5.0 -> 1.6.0 & fix manpages & update packaging & update meta ``                             |
| [`0c239423`](https://github.com/NixOS/nixpkgs/commit/0c2394234284e7181135d60e6751f3ed425415e1) | `` nano-syntax-highlighting: 2026.07.01 -> 2026.08.01 ``                                                  |
| [`918890bb`](https://github.com/NixOS/nixpkgs/commit/918890bb6d33315fb70cb8d5f6e5d12a5fe7646e) | `` synfigstudio: modernize ``                                                                             |
| [`1cfaa964`](https://github.com/NixOS/nixpkgs/commit/1cfaa9648a01e067ec1cde980ae5f782cdd1f274) | `` synfigstudio: 1.5.3 -> 1.5.5 ``                                                                        |
| [`f312f626`](https://github.com/NixOS/nixpkgs/commit/f312f62614ecd3d38252746423110cede7084ed9) | `` python3Packages.pywizlight: 0.6.4 -> 0.6.6 ``                                                          |
| [`648e7fc9`](https://github.com/NixOS/nixpkgs/commit/648e7fc9bce572f247b49def164c42f9bdfd0542) | `` vscode-extensions.anthropic.claude-code: 2.1.224 -> 2.1.226 ``                                         |
| [`e30bb055`](https://github.com/NixOS/nixpkgs/commit/e30bb05520339a35751de09c65e50ff58eb69507) | `` claude-code: 2.1.224 -> 2.1.226 ``                                                                     |
| [`1142b4cb`](https://github.com/NixOS/nixpkgs/commit/1142b4cbad8f18bf12ba4499c069b1628c10722c) | `` python3Packages.htmlgen: use finalAttrs, __structuredAttrs ``                                          |
| [`1554a1a7`](https://github.com/NixOS/nixpkgs/commit/1554a1a7f0b401aa340610284041f1ce82513ce2) | `` python3Packages.htmlgen: use unittestCheckHook ``                                                      |
| [`b0d43eb1`](https://github.com/NixOS/nixpkgs/commit/b0d43eb197e63df86cf0870333165ad83269a5a6) | `` obscura: 0.1.10 -> 0.2.0 ``                                                                            |
| [`edb944c7`](https://github.com/NixOS/nixpkgs/commit/edb944c739d0b8b422daa15951554ca54b940885) | `` rapidraw: 1.6.0 -> 1.6.1 ``                                                                            |
| [`67166d12`](https://github.com/NixOS/nixpkgs/commit/67166d12283d94e21ccce43fcefd810153662c75) | `` kubectl-klock: 0.9.1 -> 0.9.2 ``                                                                       |
| [`c8f92301`](https://github.com/NixOS/nixpkgs/commit/c8f9230169bfe74b36549dcf516ee425931bb526) | `` nvpy: use python3Packages directly ``                                                                  |
| [`5dca4722`](https://github.com/NixOS/nixpkgs/commit/5dca4722f4246b6de71cb9a73c42fdf8ee8855a7) | `` libkcapi: 1.5.0 -> 1.5.1 ``                                                                            |
| [`6f608acf`](https://github.com/NixOS/nixpkgs/commit/6f608acf7d572117d9afe79a9a795b64e5315364) | `` anubis: 1.26.2 -> 1.27.0 ``                                                                            |
| [`cb742086`](https://github.com/NixOS/nixpkgs/commit/cb742086e8d1121bf2ad651a5f2798e95054e3d3) | `` metabigor: 2.1.0 -> 2.2.0 ``                                                                           |
| [`6ab5cfe6`](https://github.com/NixOS/nixpkgs/commit/6ab5cfe6f3cb7721928d0c8f8a9461fcf47d4866) | `` stalwart_0_16: revert back to JEMALLOC_SYS_WITH_LG_PAGE ``                                             |
| [`7e1b8e5f`](https://github.com/NixOS/nixpkgs/commit/7e1b8e5f711b0af687230aba458c5b4efd742700) | `` python3Modules.pymupdf: filter out unwanted releases on update ``                                      |
| [`f2711835`](https://github.com/NixOS/nixpkgs/commit/f271183536ff5714bcc33cd271908247bdae77f2) | `` python3Packages.textualeffects: use finalAttrs pattern ``                                              |
| [`c2a0a3ea`](https://github.com/NixOS/nixpkgs/commit/c2a0a3ea9bde3da2ae72ff6a30c2edb69cf50ecf) | `` mutter: 50.3 -> 50.4 ``                                                                                |
| [`427f4afb`](https://github.com/NixOS/nixpkgs/commit/427f4afb492dbe1e88b4fba0ba1bef81edfc39b1) | `` libshumate: 1.6.2 -> 1.6.3 ``                                                                          |
| [`72f9c0ee`](https://github.com/NixOS/nixpkgs/commit/72f9c0ee7a0c7a9e7c83399020d50f69bb8a1202) | `` gvfs: 1.60.1 -> 1.60.2 ``                                                                              |
| [`e5de747a`](https://github.com/NixOS/nixpkgs/commit/e5de747a122536b5adc48b1cb4904cabe5dc492a) | `` gnome-user-docs: 50.2 -> 50.4 ``                                                                       |
| [`99853d1a`](https://github.com/NixOS/nixpkgs/commit/99853d1a585e300e65ecf22c7f9c3321fa1ca363) | `` gnome-shell: 50.3 -> 50.4 ``                                                                           |
| [`bf330246`](https://github.com/NixOS/nixpkgs/commit/bf330246df564f6656676cca358b19087156989c) | `` gnome-maps: 50.2 -> 50.3 ``                                                                            |
| [`3e9fa491`](https://github.com/NixOS/nixpkgs/commit/3e9fa4911aac51970d3056f3f38d39626c369ea2) | `` gnome-initial-setup: 50.0 -> 50.1 ``                                                                   |
| [`34c4f17a`](https://github.com/NixOS/nixpkgs/commit/34c4f17ab7c4e5421e96e24dd43e311a5a7864b5) | `` gnome-control-center: 50.3 -> 50.4 ``                                                                  |
| [`6ce4213e`](https://github.com/NixOS/nixpkgs/commit/6ce4213ebd64842530956c450815212ecb2d087e) | `` gexiv2_0_16: 0.16.1 -> 0.16.2 ``                                                                       |
| [`949db84c`](https://github.com/NixOS/nixpkgs/commit/949db84c7c5c4b588e4422a70eba717e906caca5) | `` gdm: 50.1 -> 50.2 ``                                                                                   |
| [`077465ba`](https://github.com/NixOS/nixpkgs/commit/077465ba513e9652f34c546ac38848f871766c82) | `` paratest: 7.23.1 -> 7.24.0 ``                                                                          |
| [`b1932c0d`](https://github.com/NixOS/nixpkgs/commit/b1932c0dc11b497c7e6240c9f925739906edbb55) | `` restate: 1.7.2 -> 1.7.3 ``                                                                             |
| [`438e555b`](https://github.com/NixOS/nixpkgs/commit/438e555b4f15dc945f104bed1629cc7005faacce) | `` apt: 3.3.1 -> 3.3.2 ``                                                                                 |
| [`84a8896b`](https://github.com/NixOS/nixpkgs/commit/84a8896bed645910db2e04d3e8f273f99630b23d) | `` arena: drop ``                                                                                         |
| [`ea4d81ab`](https://github.com/NixOS/nixpkgs/commit/ea4d81ab3677f9e5fab0c015d72e1dcf227b3acc) | `` faust2alsa: drop ``                                                                                    |
| [`164321ff`](https://github.com/NixOS/nixpkgs/commit/164321ffcce7e068fed6d0dc0dbb266bce059dd8) | `` python313Packages.brother-ql-next: rename from brother-ql ``                                           |
| [`0d087a33`](https://github.com/NixOS/nixpkgs/commit/0d087a33bb45891757cdd01a2409c69b88441d6e) | `` emacs.pkgs.ada-mode: mark as broken ``                                                                 |

*... and 703 more commits (truncated)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the desktop package listing to reference ChessX instead of Arena.
  * Retained Stockfish in the available package list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->