### PR TITLE
Fix GitHub CI dashboard columns, monitor fredclausen, and adopt the exporter's atomic-publication fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         "rust-overlay": "rust-overlay_6"
       },
       "locked": {
-        "lastModified": 1786405223,
-        "narHash": "sha256-zt3WkJQwXLVCSBzYfTtmu3CSoqa6m8zXf2QLSqZDn1s=",
+        "lastModified": 1786488324,
+        "narHash": "sha256-AXBzJFPAF+spRprAZZVac5nff/oGzJjk8U4rYE48LRc=",
         "owner": "FredSystems",
         "repo": "github-ci-exporter",
-        "rev": "cbaeda658a1c360a4e6f2afc9b726ca9bf943a13",
+        "rev": "bec6c39387095595a805acc99d420b5d4f269255",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -609,11 +609,11 @@
         "rust-overlay": "rust-overlay_6"
       },
       "locked": {
-        "lastModified": 1786488324,
-        "narHash": "sha256-AXBzJFPAF+spRprAZZVac5nff/oGzJjk8U4rYE48LRc=",
+        "lastModified": 1786490882,
+        "narHash": "sha256-b+s41f0Dsu6v+ERg3mC2RRbgAPTni1LNvumkhlmzmjA=",
         "owner": "FredSystems",
         "repo": "github-ci-exporter",
-        "rev": "bec6c39387095595a805acc99d420b5d4f269255",
+        "rev": "1ea4e499f04fc19673610caa4bc7c757cc03edcb",
         "type": "github"
       },
       "original": {

--- a/modules/monitoring/master/dashboards/github-ci.json
+++ b/modules/monitoring/master/dashboards/github-ci.json
@@ -820,17 +820,8 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "github_pull_needs_attention{checks=\"failure\"} == 1",
-          "legendFormat": "",
-          "instant": true,
-          "format": "table"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "expr": "github_pull_needs_attention{mergeable=\"conflicting\"} == 1",
+          "refId": "A",
+          "expr": "github_pull_needs_attention{checks=\"failure\"} == 1 or github_pull_needs_attention{mergeable=\"conflicting\"} == 1",
           "legendFormat": "",
           "instant": true,
           "format": "table"
@@ -1106,7 +1097,7 @@
       "id": 8,
       "type": "table",
       "title": "Auto-Disabled and Stale Workflows",
-      "description": "Workflows GitHub switched off after 60 days of repository inactivity, plus workflows whose newest branch-state run is older than 90 days. Neither is failing; both mean CI is no longer telling you anything.",
+      "description": "Two different things, so read the Reason column. auto-disabled means GitHub switched the workflow off after 60 days of repository inactivity: it has silently stopped running and is a fault. 'no recent run' means the newest run against the default branch is over 90 days old, which is only a fault for a workflow that has a cadence -- on push or on schedule. A workflow driven by workflow_dispatch or repository_dispatch appears here simply because nothing has asked it to run lately, and a workflow that only runs on pull_request has no default-branch state at all; its failures belong in the pull request panels above. Neither reason means the workflow is failing.",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -1147,7 +1138,43 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reason"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "basic"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "auto-disabled": {
+                        "color": "orange",
+                        "index": 0,
+                        "text": "auto-disabled"
+                      },
+                      "stale": {
+                        "color": "text",
+                        "index": 1,
+                        "text": "no recent run"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "targets": [
         {
@@ -1155,17 +1182,8 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "github_workflow_enabled{state=\"disabled_inactivity\"} == 0",
-          "legendFormat": "",
-          "instant": true,
-          "format": "table"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "expr": "github_workflow_run_stale == 1",
+          "refId": "A",
+          "expr": "label_replace(github_workflow_enabled{state=\"disabled_inactivity\"} == 0, \"reason\", \"auto-disabled\", \"\", \"\") or label_replace(github_workflow_run_stale == 1, \"reason\", \"stale\", \"\", \"\")",
           "legendFormat": "",
           "instant": true,
           "format": "table"
@@ -1183,13 +1201,19 @@
               "instance": true,
               "hostname": true,
               "role": true,
-              "state": false
+              "state": true
             },
             "renameByName": {
               "org": "Org",
               "repo": "Repository",
               "workflow": "Workflow",
-              "state": "State"
+              "reason": "Reason"
+            },
+            "indexByName": {
+              "org": 0,
+              "repo": 1,
+              "workflow": 2,
+              "reason": 3
             }
           }
         }

--- a/modules/monitoring/master/github-ci-exporter.nix
+++ b/modules/monitoring/master/github-ci-exporter.nix
@@ -1,7 +1,7 @@
 # modules/monitoring/master/github-ci-exporter.nix
 #
 # GitHub CI visibility: open issues, open pull requests, and Actions state
-# for every repository in the sdr-enthusiasts and fredsystems organisations.
+# for every repository owned by sdr-enthusiasts, fredsystems, or fredclausen.
 #
 # WHY
 #
@@ -23,14 +23,19 @@
 #
 # `github_pat_public_ro` is a classic PAT scoped to `public_repo` only. That
 # is the narrowest classic scope covering issues, pull requests, and Actions
-# across both organisations with one credential. It is separate from
+# across all three owners with one credential. It is separate from
 # `github_pat` (used for nix.conf access-tokens on every host) so that
 # rotating one does not disturb the other.
 #
 # `public_repo` does grant write on public repositories -- classic scopes have
-# no read-only variant. Only a per-organisation fine-grained token would be
-# truly read-only, and that would require one token per org. The exporter
-# itself issues no writes.
+# no read-only variant. Only a per-owner fine-grained token would be truly
+# read-only, and that would require one token per owner. The exporter itself
+# issues no writes.
+#
+# The scope also decides what is monitored: private repositories are invisible
+# to it, so the personal account contributes only its public repositories.
+# Widening to `repo` would grant write on every private repository in all
+# three owners, which is not worth CI visibility on scratch work.
 #
 # The secret is delivered via systemd `LoadCredential` rather than a sops
 # owner/mode, because the unit runs `DynamicUser = true` and so has no stable
@@ -60,9 +65,21 @@
     enable = true;
     package = inputs.github-ci-exporter.packages.${pkgs.stdenv.hostPlatform.system}.github-ci-exporter;
 
+    # Owners, not strictly organisations: `fredclausen` is a personal account.
+    # The exporter resolves both through GraphQL's `RepositoryOwner`
+    # interface, so a user and an org are interchangeable here. The option
+    # keeps the name `orgs` because it is also the `org` metric label, which
+    # every dashboard panel and alert rule selects on.
+    #
+    # Only the *public* repositories of the personal account are visible,
+    # because `github_pat_public_ro` is scoped to `public_repo` (see below).
+    # That is deliberate: monitoring the private ones would mean a token with
+    # write access to them, which is a bad trade for CI visibility on
+    # scratch repositories.
     orgs = [
       "sdr-enthusiasts"
       "fredsystems"
+      "fredclausen"
     ];
 
     listen = "127.0.0.1:9418";


### PR DESCRIPTION
Fixes the GitHub CI dashboard and monitoring, and adopts three exporter fixes. Deployed to sdrhub as a test partway through, which is how the last commit's regression was caught.

## `c88b54db` — dashboard: collapse multi-query tables into one frame

Broken Pull Requests and Auto-Disabled and Stale Workflows each ran two queries. Grafana names the value column of a multi-query table `Value #A` / `Value #B`, but both panels' `organize` transformation excluded a column called `Value` — so the exclusion silently missed and the raw columns rendered. Two unjoined frames also make Grafana offer a frame-selector dropdown, which is the `Value #A` / `Value #B` chooser that prompted this.

Neither panel needed two queries:

- **Broken Pull Requests** selects the same metric twice, so the selectors become one `or`. The `== 1` is what excludes drafts (`needs_attention` is already 0 for them), so the merged expression keeps the panel's stated non-draft semantics.
- **Auto-Disabled and Stale** combines two different metrics, so each side is tagged with a synthetic `reason` label via `label_replace`. That removes the second frame and makes the distinction explicit in a column rather than implied by which frame a row came from.

Those two reasons are not the same kind of event and should not have looked alike. `auto-disabled` means GitHub stopped running the workflow — a fault, and coloured for it. A run past the 90-day horizon only indicates a fault for a workflow with a cadence; it now renders as neutral "no recent run", and the description says where to look instead.

Verified against the live Prometheus: both expressions return a single frame, `reason` populates for every row, and no other panel in the dashboard is a multi-query table.

## `f1f75cc0` — exporter → `bec6c39` (fredsystems/github-ci-exporter#12)

Three fixes. The significant one: **each collection cycle is now published atomically.** The exporter previously cleared its metric families and refilled them as it walked repositories, serving every intermediate state for the ~80s a cycle takes. At this fleet's 15s scrape interval roughly six scrapes per cycle landed in that gap, and an absent sample resets an alert's `for:` timer — so `GitHubCIFailingDefaultBranch`, on a 15m clause, could never accumulate its 15 minutes for a repository late in the rebuild order. **A genuinely failing workflow went unalerted for its entire lifetime** while Prometheus and Alertmanager both worked correctly.

Reproduced against this host before the fix: `count(github_workflow_run_status)` climbing `47 → 63 → 84 → 102` over 48 seconds.

Also: personal accounts are discoverable, and staleness is now decided by how a workflow is triggered — a gap since the last default-branch run only indicates a fault for a workflow GitHub runs unprompted (`push` / `schedule`).

## `d8768ef2` — monitor the `fredclausen` personal account

Only public repositories. `github_pat_public_ro` is scoped to `public_repo` and cannot see private ones; widening to `repo` would grant write access to every private repository across all three owners, which is not a trade worth making for CI visibility on scratch work. The token comment records that so the omission does not later read as an oversight.

The upstream option is still called `orgs` because it is also the `org` metric label, which every panel and alert rule selects on. Read it as "owners".

## `0ffde961` — exporter → `1ea4e49` (fredsystems/github-ci-exporter#13)

Fixes a regression the previous bump introduced **on this host**, found by deploying it.

`sdr-e-base-repo-setup`'s `Lint` came back as `conclusion="failure"` and drove `GitHubCIFailingDefaultBranch` into pending. The exporter caches a *reduction* of the runs listing, keyed by a fingerprint of each workflow's path, name, and triggers. Teaching it to drop workflows with no default-branch state changed what that reduction contains without changing any of those — so the key matched, the persisted version matched, and every entry still deserialised. GitHub answered `304`, a pre-filter reduction was replayed, and the fossil run the filter existed to remove came straight back. Because such a workflow is no longer masked as stale, it published as an outright failure: worse than before the filter existed.

`CACHE_FORMAT_VERSION` is now 2, discarding the inherited file, and the filter is enforced at publication as well as at reduction so the rule holds regardless of a reduction's provenance.

## Deploy behaviour

Self-healing. A new store path is a new unit, and the version check rejects the on-disk cache on first start, so no manual intervention is needed. Expect one uncached sweep — roughly 6% of the hourly API budget — then `Lint` disappears and the alert resolves. `github_exporter_budget_exhausted` should stay `0` throughout.

Worth watching after deploy:

- `count(github_workflow_run_status)` holds one value instead of ramping
- `github_workflow_run_status{conclusion="stale"}` returns exactly one row, `docker-jaero / Deploy`
- `github_repo_monitored{org="fredclausen"}` appears, public repos only
- The Auto-Disabled panel shows a `Reason` column, no frame dropdown

## Verification

`nix eval` clean on all ten hosts at every commit. The new closure's binary carries the publication guard's log message while the previously-deployed one does not, and the generated exporter config renders the expected owner list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded GitHub monitoring to include public repositories under an additional account.
  - Combined broken pull request indicators for failing checks and merge conflicts.
  - Added workflow status reasons, including auto-disabled and stale classifications.
  - Improved workflow inventory tables with clearer labels and column ordering.

- **Documentation**
  - Updated monitoring documentation to describe repository ownership coverage and public-repository scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->