### PR TITLE
Expand the port tripwire, fix a ban-injection hole, and monitor the home IP

### DIFF
--- a/flake/lib/mk-system.nix
+++ b/flake/lib/mk-system.nix
@@ -135,6 +135,11 @@ let
       }
     )
     ./../../modules/base/deployment-meta.nix
+    # Fleet-wide facts about the home network. Declares options only, so being
+    # in every host's module set costs nothing; the two hosts that read it
+    # (fredvps's ignoreIP, sdrhub's drift check) must agree on one value, and
+    # this is where that value lives.
+    ./../../modules/data/home-network.nix
     ./../../hosts/linux/${hostName}/configuration.nix
     ./../../modules/base/system.nix
     # NOTE: do NOT bake the flake's git revision into this system.

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -56,6 +56,113 @@ let
   # warns if they diverge -- so a stale entry is reported at deploy time
   # rather than discovered when a container refuses to start.
   tailscaleIP = "100.82.147.29";
+
+  # ---------------------------------------------------------------------
+  # DECOY PORTS -- the tripwire set feeding the port-decoy jail.
+  # ---------------------------------------------------------------------
+  #
+  # Nothing on this host listens on any of these, and nothing legitimate has
+  # any reason to dial them. That is the entire selection criterion, and it is
+  # what makes a single SYN here a zero-false-positive signal: it is a scanner
+  # every single time. The firewall already drops these packets; logging them
+  # is what puts the knock on the same escalation ladder as everything else.
+  #
+  # ADDING A PORT: the bar is "no legitimate party will ever dial this". Note
+  # that the risk is NOT a port this host serves -- an allowed port is
+  # ACCEPTed earlier in nixos-fw and never reaches the LOG rule (there is an
+  # assertion below enforcing that). The risk is a port some remote party
+  # still dials out of habit after we stopped serving it. This host has real
+  # history there: :30005 and :7007 were publicly reachable for months and had
+  # actual clients, and the home Comcast address had to be added to ignoreIP
+  # after a live test banned it. So a formerly-public port is exactly the wrong
+  # thing to put in this list, and every entry below is a port this host has
+  # never served.
+  #
+  # DELIBERATELY ABSENT:
+  #
+  #   - 5555, 4567, 8080-adjacent app ports. 5555 is a classic scan target
+  #     (Android ADB) but acars_router publishes it; 4567 is cAdvisor. Ports
+  #     in use anywhere on this host stay out even when they are only bound to
+  #     the loopback or the tailnet, because the whole point is that this list
+  #     needs no cross-checking against anything.
+  #   - 3000. Free today, but it is the port a future container is most likely
+  #     to want, and a stale decoy entry is worse than a missing one.
+  #   - Every UDP port. SSDP (1900), SNMP (161), NTP (123), memcached UDP and
+  #     friends are heavily probed, but they are probed for AMPLIFICATION, and
+  #     amplification probes carry a SPOOFED source -- the address in the
+  #     packet is the intended victim, not the attacker. Banning it would ban
+  #     an innocent third party, and our bans are host-wide and escalate to a
+  #     week. TCP-SYN-only keeps the "the source address is really the sender"
+  #     assumption that the whole ban ladder rests on.
+  #   - A blanket "log every refused SYN" rule. That is the logical endpoint of
+  #     this reasoning and it was considered, but it converts the curated
+  #     zero-false-positive set into an open-ended one: any port this host ever
+  #     served, or ever will, becomes a self-ban waiting to happen. The list is
+  #     the feature.
+  decoyPorts = [
+    21 # FTP
+    22 # SSH -- sshd is on 2269, so 22 has never served anything here
+    23 # Telnet
+    25 # SMTP -- no MTA on this host; open-relay hunting
+    110 # POP3
+    135 # MS RPC endpoint mapper
+    139 # NetBIOS session service
+    143 # IMAP
+    445 # SMB
+    1433 # MSSQL
+    1521 # Oracle TNS
+    1723 # PPTP
+    2375 # Docker API, plaintext -- this host runs Docker, so this one is pointed
+    2376 # Docker API, TLS
+    3128 # Squid / open-proxy hunting
+    3306 # MySQL
+    3389 # RDP
+    5432 # PostgreSQL
+    5900 # VNC
+    6379 # Redis
+    7547 # TR-069 / CWMP router management
+    8080 # HTTP alt -- the first entry to delete if anything ever needs it
+    8443 # HTTPS alt
+    9200 # Elasticsearch
+    11211 # memcached, TCP half only
+    27017 # MongoDB
+    32764 # Sercomm router backdoor
+  ];
+
+  # xt_multiport takes at most 15 ports per rule, so the list is emitted in
+  # chunks. Generated rather than hand-written so the port table above stays
+  # the single place to edit.
+  chunkPorts = xs: if xs == [ ] then [ ] else [ (lib.take 15 xs) ] ++ chunkPorts (lib.drop 15 xs);
+
+  # Appended to nixos-fw ahead of the final log-refuse jump. These only LOG --
+  # the packet still falls through to the normal refuse path, so this changes
+  # what is recorded, not what is allowed.
+  #
+  # ON THE RATE LIMIT. An unthrottled LOG on a scanned port is a self-inflicted
+  # journal flood, and this rule now covers 27 ports rather than one. The burst
+  # is sized to the port count on purpose: a scanner sweeping the whole set in
+  # one pass produces ~27 lines back to back, and a burst smaller than that
+  # would spend the budget on the first few ports and drop the rest, which
+  # matters because the budget is shared across all sources.
+  #
+  # Sustained 30/m is a ceiling that reality stays far below, because the
+  # system is self-limiting: fail2ban's action installs its jump with
+  # `iptables -I INPUT`, i.e. at position 1, ahead of the jump to nixos-fw. So
+  # a banned address is DROPped before it can reach this rule and stops
+  # consuming log budget entirely. Steady-state volume therefore tracks the
+  # arrival rate of NEW scanning addresses, not how loudly any of them scan.
+  #
+  # Per-source `-m hashlimit --hashlimit-mode srcip` was considered and
+  # rejected: it would give every source its own budget, which is precisely
+  # what turns a distributed sweep from thousands of addresses into the journal
+  # flood the limit exists to prevent.
+  decoyLogRules = lib.concatMapStringsSep "\n" (ports: ''
+    ip46tables -w -A nixos-fw -p tcp -m multiport --dports ${
+      lib.concatMapStringsSep "," toString ports
+    } --syn \
+      -m limit --limit 30/m --limit-burst 30 \
+      -j LOG --log-level info --log-prefix "port-decoy: "
+  '') (chunkPorts decoyPorts);
 in
 {
   imports = [
@@ -120,28 +227,28 @@ in
         2269
       ];
 
-      # Catches anything knocking on port 22, feeding the ssh-decoy jail.
-      #
-      # sshd listens on 2269, so nothing legitimate ever addresses 22 on this
-      # host. That makes a SYN to 22 a zero-false-positive signal: it is a
-      # scanner every single time. The firewall drops those packets anyway,
-      # but silently, so the address was free to keep probing everything else.
-      # Logging them gives fail2ban something to match, which puts a port-22
-      # knock on the same escalation ladder as everything else.
-      #
-      # Appended to nixos-fw ahead of the final log-refuse jump. It only LOGs
-      # -- the packet still falls through to the normal refuse path, so this
-      # changes what is recorded, not what is allowed. Rate-limited because
-      # this host is internet-facing and an unthrottled LOG on a scanned port
-      # is a self-inflicted journal flood; the jail needs 2 hits in a day, so
-      # the limit is far above what detection requires.
-      extraCommands = ''
-        ip46tables -w -A nixos-fw -p tcp --dport 22 --syn \
-          -m limit --limit 12/m --limit-burst 6 \
-          -j LOG --log-level info --log-prefix "ssh-decoy: "
-      '';
+      # Catches anything knocking on a closed port that nothing legitimate
+      # dials, feeding the port-decoy jail. Port table and full rationale are
+      # in the let block at the top of this file.
+      extraCommands = decoyLogRules;
     };
   };
+
+  # A decoy port that is also an open port is a silently dead decoy, not a
+  # self-ban: nixos-fw ACCEPTs allowed ports well before the appended LOG rules,
+  # so the knock is never recorded and the jail simply never fires for it. That
+  # failure is invisible in production -- the config still reads as though the
+  # port were being watched -- so it fails at eval time instead.
+  assertions = [
+    {
+      assertion = lib.intersectLists decoyPorts config.networking.firewall.allowedTCPPorts == [ ];
+      message =
+        "fredvps: decoy ports also declared open, so their LOG rule is unreachable: "
+        + lib.concatMapStringsSep ", " toString (
+          lib.intersectLists decoyPorts config.networking.firewall.allowedTCPPorts
+        );
+    }
+  ];
 
   # Per-IP ban metrics, for the "Active Bans" panel on the security dashboard.
   #
@@ -414,15 +521,49 @@ in
       blocktype = DROP
     '';
 
-    # Filter for the port-22 decoy rule (networking.firewall.extraCommands).
+    # Filter for the decoy LOG rules (networking.firewall.extraCommands).
     #
-    # Anchored on both the log prefix and DPT=22 so it cannot match any other
-    # kernel LOG line -- notably `logRefusedConnections`, if that is ever
-    # turned on, which uses the same field layout with a different prefix.
-    "fail2ban/filter.d/ssh-decoy.conf".text = ''
+    # Anchored on the log prefix, which is ours alone and is what keeps this
+    # from matching any other kernel LOG line -- notably
+    # `logRefusedConnections`, if that is ever turned on, which uses the same
+    # field layout with a different prefix.
+    #
+    # The port is deliberately NOT enumerated here. This filter previously
+    # pinned `DPT=22` as a second anchor, which was free when the rule watched
+    # exactly one port; carrying that forward would mean restating all 27 ports
+    # as a regex alternation that has to be kept in step with the Nix list, and
+    # a drift between the two fails open (the port gets logged and never
+    # banned). `DPT=` is still required so the line has to be the transport-
+    # layer shape the rule produces, but which port it was is the iptables
+    # rule's business, not the filter's.
+    #
+    # journalmatch IS A SECURITY CONTROL HERE, NOT AN OPTIMISATION.
+    #
+    # This jail runs on the systemd backend, and with no match restriction that
+    # backend reads the ENTIRE journal, not just kernel messages. Any process
+    # that can get attacker-controlled text into the journal can therefore
+    # forge a decoy hit, and <HOST> binds to whatever follows SRC= in the
+    # forged text -- which is an arbitrary-IP ban primitive, not merely a false
+    # positive. sshd is a live path to it: usernames are attacker-supplied and
+    # are logged verbatim, so
+    #
+    #   ssh -p 2269 'port-decoy: SRC=8.8.8.8 DPT=443 x'@fredvps
+    #
+    # yields `Invalid user port-decoy: SRC=8.8.8.8 DPT=443 x from ...`, and two
+    # of those get 8.8.8.8 banned host-wide on an escalating ladder that tops
+    # out at a week. Verified with fail2ban-regex, which extracted 8.8.8.8 from
+    # exactly that line. Restricting the jail to _TRANSPORT=kernel closes it:
+    # that field is set by journald from the message's origin and no userspace
+    # writer can claim it.
+    #
+    # This is also why the failregex below does not need to enumerate ports to
+    # be safe. Provenance is what makes the line trustworthy, and provenance is
+    # enforced here rather than guessed at from the message text.
+    "fail2ban/filter.d/port-decoy.conf".text = ''
       [Definition]
-      failregex = ^.*\bssh-decoy:\s.*\bSRC=<HOST>\b.*\bDPT=22\b
+      failregex = ^.*\bport-decoy:\s.*\bSRC=<HOST>\b.*\bDPT=\d+\b
       ignoreregex =
+      journalmatch = _TRANSPORT=kernel
     '';
   };
 
@@ -599,15 +740,33 @@ in
           enabled = true;
           port = "2269";
           filter = "sshd";
-          maxretry = 3;
+          maxretry = 2;
+          mode = "aggressive";
         };
 
-        # Anything that SYNs port 22.
+        # Anything that SYNs one of the decoy ports.
         #
-        # sshd is on 2269, so there is no legitimate traffic to 22 on this
-        # host and no false-positive surface at all -- one knock is already
-        # proof of a scan. maxretry = 2 rather than 1 only because a single
-        # retransmitted SYN can log twice.
+        # Nothing on this host serves any of them, so there is no
+        # false-positive surface at all -- one knock is already proof of a
+        # scan. maxretry = 2 rather than 1 only because a single retransmitted
+        # SYN can log twice.
+        #
+        # ONE JAIL FOR ALL DECOY PORTS, not one per port or per group. Ban
+        # counts are tracked per jail, so splitting them would mean an address
+        # that knocks once on 22 and once on 3306 sits on step 1 of two
+        # separate ladders and trips neither -- both under maxretry, banned by
+        # nothing, despite two unambiguous proofs of scanning. That is the
+        # exact fragmentation the recidive jail below exists to paper over, and
+        # there is no reason to manufacture more of it when every port here
+        # carries the identical signal and the identical settings.
+        #
+        # This jail was `ssh-decoy` when the rule watched only port 22.
+        # Renaming resets its ban history, since fail2ban keys escalation on
+        # the jail name -- a one-off cost, and the ladder rebuilds on its own
+        # within a day at the rate this host gets scanned. Nothing else keys
+        # on the old name: the ban-metrics generator above enumerates jails
+        # from `fail2ban-client status`, and the security dashboard reads the
+        # jail as a label rather than filtering on a literal.
         #
         # findtime is deliberately long. Slow scanners spread a sweep over
         # hours specifically to stay under short windows, and since the signal
@@ -615,9 +774,9 @@ in
         #
         # backend/logpath are inherited from DEFAULT (systemd), which is
         # correct: these lines come from the kernel via the journal.
-        ssh-decoy.settings = {
+        port-decoy.settings = {
           enabled = true;
-          filter = "ssh-decoy";
+          filter = "port-decoy";
           maxretry = 2;
           findtime = "1d";
         };
@@ -625,7 +784,7 @@ in
         # Escalation across jails, which is the part per-jail bans cannot do.
         #
         # Ban counts are tracked per jail, so an address that trips
-        # nginx-probe once, nginx-bad-request once and ssh-decoy once is on
+        # nginx-probe once, nginx-bad-request once and port-decoy once is on
         # step 1 of three separate ladders and never escalates, despite being
         # obviously hostile. This jail reads fail2ban's own Ban lines and
         # treats "banned anywhere, 3 times in a week" as its own offence.

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -822,6 +822,13 @@ in
       # therefore a live outage risk rather than a latent one, which is why the
       # address is monitored for drift rather than merely written down.
       #
+      # The address itself comes from shared.homePublicIPv4
+      # (modules/data/home-network.nix) rather than being a literal here,
+      # because sdrhub's drift check has to compare against the same value. Two
+      # independent copies would fail in the worst possible way: the monitor
+      # reporting "no drift" against its own stale copy while this list no
+      # longer matches the address that is actually arriving.
+      #
       # Anything added here in future needs the same test applied: not "is this
       # address mine today" but "what dials this host from it unattended, and
       # what happens the morning after the address changes".
@@ -829,7 +836,7 @@ in
         "127.0.0.1/8"
         "::1"
         "100.64.0.0/10"
-        "73.26.160.99"
+        config.shared.homePublicIPv4
         "209.40.70.5"
       ];
 

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -67,6 +67,29 @@ let
   # every single time. The firewall already drops these packets; logging them
   # is what puts the knock on the same escalation ladder as everything else.
   #
+  # PORT 22 IS DELIBERATELY NOT IN THIS LIST. It keeps its own rule, filter and
+  # jail (ssh-decoy, below) rather than being folded in here. fail2ban keys ban
+  # escalation on the jail name, so folding 22 into a renamed jail would have
+  # discarded its accumulated ban history -- and 22 is by far the most probed
+  # port on this host, so that history is the most valuable of the set. The
+  # split costs one extra iptables rule and one extra filter thread.
+  #
+  # Splitting the jails would normally cost detection, because ban counts are
+  # per jail: at maxretry = 2 an address knocking once on 22 and once on 3306
+  # would sit at 1-of-2 in each and trip neither, which measurement showed was
+  # not hypothetical -- 40% of port-22 knockers hit exactly once in 24h, and
+  # recidive cannot help since it feeds on Ban lines that were never written.
+  #
+  # BOTH JAILS THEREFORE RUN maxretry = 1, which closes that gap completely: one
+  # knock on any watched port is a ban, so it no longer matters which jail the
+  # evidence lands in and the split is purely about preserving history. It also
+  # makes detection robust against the rate limiter below -- at maxretry = 2 a
+  # dropped LOG line meant a scanner needed two surviving lines to be banned,
+  # where now it needs one.
+  #
+  # The price is that ignoreIP is now the ONLY thing standing between a single
+  # stray SYN and a host-wide escalating ban. See the note on that list.
+  #
   # ADDING A PORT: the bar is "no legitimate party will ever dial this". Note
   # that the risk is NOT a port this host serves -- an allowed port is
   # ACCEPTed earlier in nixos-fw and never reaches the LOG rule (there is an
@@ -101,7 +124,6 @@ let
   #     the feature.
   decoyPorts = [
     21 # FTP
-    22 # SSH -- sshd is on 2269, so 22 has never served anything here
     23 # Telnet
     25 # SMTP -- no MTA on this host; open-relay hunting
     110 # POP3
@@ -139,11 +161,11 @@ let
   # what is recorded, not what is allowed.
   #
   # ON THE RATE LIMIT. An unthrottled LOG on a scanned port is a self-inflicted
-  # journal flood, and this rule now covers 27 ports rather than one. The burst
-  # is sized to the port count on purpose: a scanner sweeping the whole set in
-  # one pass produces ~27 lines back to back, and a burst smaller than that
-  # would spend the budget on the first few ports and drop the rest, which
-  # matters because the budget is shared across all sources.
+  # journal flood, and these rules cover 26 ports rather than one. The burst is
+  # sized to the port count on purpose: a scanner sweeping the whole set in one
+  # pass produces ~26 lines back to back, and a burst smaller than that would
+  # spend the budget on the first few ports and drop the rest, which matters
+  # because the budget is shared across all sources.
   #
   # Sustained 30/m is a ceiling that reality stays far below, because the
   # system is self-limiting: fail2ban's action installs its jump with
@@ -156,13 +178,30 @@ let
   # rejected: it would give every source its own budget, which is precisely
   # what turns a distributed sweep from thousands of addresses into the journal
   # flood the limit exists to prevent.
-  decoyLogRules = lib.concatMapStringsSep "\n" (ports: ''
+  portDecoyLogRules = lib.concatMapStringsSep "\n" (ports: ''
     ip46tables -w -A nixos-fw -p tcp -m multiport --dports ${
       lib.concatMapStringsSep "," toString ports
     } --syn \
       -m limit --limit 30/m --limit-burst 30 \
       -j LOG --log-level info --log-prefix "port-decoy: "
   '') (chunkPorts decoyPorts);
+
+  # Port 22, kept byte-for-byte as it has run in production since c875c196.
+  #
+  # Deliberately NOT merged into the multiport rules above, and deliberately
+  # still on 12/m burst 6. This rule and its jail are the pair whose ban history
+  # is being preserved, so the less that changes about them the better: a
+  # different prefix would orphan the filter, and a different limit would change
+  # the sampling of a signal that has months of continuity behind it.
+  #
+  # 12/m is ample here despite being far below the port-decoy budget, because
+  # this rule watches exactly one port. Measured: 192 distinct addresses knocked
+  # on 22 in 24h, ~400 packets/day, i.e. under 0.3/min against a 12/min budget.
+  sshDecoyLogRule = ''
+    ip46tables -w -A nixos-fw -p tcp --dport 22 --syn \
+      -m limit --limit 12/m --limit-burst 6 \
+      -j LOG --log-level info --log-prefix "ssh-decoy: "
+  '';
 in
 {
   imports = [
@@ -228,9 +267,12 @@ in
       ];
 
       # Catches anything knocking on a closed port that nothing legitimate
-      # dials, feeding the port-decoy jail. Port table and full rationale are
-      # in the let block at the top of this file.
-      extraCommands = decoyLogRules;
+      # dials, feeding the ssh-decoy and port-decoy jails. Port table and full
+      # rationale are in the let block at the top of this file.
+      extraCommands = lib.concatStringsSep "\n" [
+        sshDecoyLogRule
+        portDecoyLogRules
+      ];
     };
   };
 
@@ -239,16 +281,22 @@ in
   # so the knock is never recorded and the jail simply never fires for it. That
   # failure is invisible in production -- the config still reads as though the
   # port were being watched -- so it fails at eval time instead.
-  assertions = [
-    {
-      assertion = lib.intersectLists decoyPorts config.networking.firewall.allowedTCPPorts == [ ];
-      message =
-        "fredvps: decoy ports also declared open, so their LOG rule is unreachable: "
-        + lib.concatMapStringsSep ", " toString (
-          lib.intersectLists decoyPorts config.networking.firewall.allowedTCPPorts
-        );
-    }
-  ];
+  assertions =
+    let
+      # 22 is watched by sshDecoyLogRule rather than being in decoyPorts, so it
+      # has to be added back here or the guard would have a hole exactly where
+      # the most-probed port is.
+      watched = decoyPorts ++ [ 22 ];
+      clash = lib.intersectLists watched config.networking.firewall.allowedTCPPorts;
+    in
+    [
+      {
+        assertion = clash == [ ];
+        message =
+          "fredvps: decoy ports also declared open, so their LOG rule is unreachable: "
+          + lib.concatMapStringsSep ", " toString clash;
+      }
+    ];
 
   # Per-IP ban metrics, for the "Active Bans" panel on the security dashboard.
   #
@@ -565,6 +613,22 @@ in
       ignoreregex =
       journalmatch = _TRANSPORT=kernel
     '';
+
+    # Port 22's filter, unchanged except for journalmatch.
+    #
+    # Still anchored on DPT=22 as well as the prefix. That is not redundant here
+    # the way it would be for port-decoy: it is what keeps this jail's evidence
+    # disjoint from the other rule's, so the two ban ladders stay independent.
+    #
+    # journalmatch is the same security control described above and matters just
+    # as much here -- more, in fact, since the sshd log lines that provide the
+    # injection vector arrive on the very port this filter watches.
+    "fail2ban/filter.d/ssh-decoy.conf".text = ''
+      [Definition]
+      failregex = ^.*\bssh-decoy:\s.*\bSRC=<HOST>\b.*\bDPT=22\b
+      ignoreregex =
+      journalmatch = _TRANSPORT=kernel
+    '';
   };
 
   # Backstop for the Docker/nixos-fw gap described at the top of this file.
@@ -725,8 +789,42 @@ in
       # vhost from home, which is a self-inflicted outage for the exact
       # behaviour someone debugging this host is most likely to produce.
       #
-      # This is a dynamic address, so it will eventually go stale. That fails
-      # safe: the entry stops matching and the jail simply applies normally.
+      # This is a dynamic address, so it will eventually go stale. THAT DOES
+      # NOT FAIL SAFE, in either direction, and this comment previously claimed
+      # it did.
+      #
+      # If Comcast moves us, the entry stops protecting the address we actually
+      # use and any jail can then ban home. If Comcast hands 73.26.160.99 to
+      # someone else, the entry whitelists a stranger across EVERY jail here --
+      # sshd, nginx-probe, nginx-bad-request, recidive. The second case is the
+      # nastier one, because nothing about it is visible from this host.
+      #
+      # The reason this was load-bearing rather than theoretical: a Synology
+      # task ("Backup VPS", daily 04:00 NAS-local) ran
+      #   rsync -av --delete root@fredclausen.com:/home/fred /volume1/vps
+      # with no port override, so it SYNed port 22 every single morning and was
+      # ignored only because of this entry. The NAS clock reads an hour behind
+      # (a non-DST timezone), which is why it landed at 05:00 in the journal.
+      # It had never worked against this host -- sshd has been on 2269 the whole
+      # time, and root login is refused regardless -- so it was deleted rather
+      # than repaired. Confirmed by rsync exit 255 on its last run.
+      #
+      # With that gone, nothing at home dials a decoy port on a schedule any
+      # more, so a stale entry can no longer produce a self-ban on a timer that
+      # escalates 1h -> 2h -> 4h unattended. The residual exposure is
+      # interactive only, which is recoverable because a human is present when
+      # it happens.
+      #
+      # THE DECOY JAILS RUN maxretry = 1, so this list is not a safety net any
+      # more -- it is the only guard. A single stray SYN to any of the 27
+      # watched ports from an address that is not listed here is an immediate
+      # host-wide ban, and the ban escalates on repeat. Staleness here is
+      # therefore a live outage risk rather than a latent one, which is why the
+      # address is monitored for drift rather than merely written down.
+      #
+      # Anything added here in future needs the same test applied: not "is this
+      # address mine today" but "what dials this host from it unattended, and
+      # what happens the morning after the address changes".
       ignoreIP = [
         "127.0.0.1/8"
         "::1"
@@ -744,29 +842,20 @@ in
           mode = "aggressive";
         };
 
-        # Anything that SYNs one of the decoy ports.
+        # Anything that SYNs port 22.
         #
-        # Nothing on this host serves any of them, so there is no
-        # false-positive surface at all -- one knock is already proof of a
-        # scan. maxretry = 2 rather than 1 only because a single retransmitted
-        # SYN can log twice.
+        # sshd is on 2269, so there is no legitimate traffic to 22 on this
+        # host and no false-positive surface at all -- one knock is already
+        # proof of a scan, which is why maxretry is 1 and not 2. A single
+        # retransmitted SYN logging twice is harmless when one is enough.
         #
-        # ONE JAIL FOR ALL DECOY PORTS, not one per port or per group. Ban
-        # counts are tracked per jail, so splitting them would mean an address
-        # that knocks once on 22 and once on 3306 sits on step 1 of two
-        # separate ladders and trips neither -- both under maxretry, banned by
-        # nothing, despite two unambiguous proofs of scanning. That is the
-        # exact fragmentation the recidive jail below exists to paper over, and
-        # there is no reason to manufacture more of it when every port here
-        # carries the identical signal and the identical settings.
-        #
-        # This jail was `ssh-decoy` when the rule watched only port 22.
-        # Renaming resets its ban history, since fail2ban keys escalation on
-        # the jail name -- a one-off cost, and the ladder rebuilds on its own
-        # within a day at the rate this host gets scanned. Nothing else keys
-        # on the old name: the ban-metrics generator above enumerates jails
-        # from `fail2ban-client status`, and the security dashboard reads the
-        # jail as a label rather than filtering on a literal.
+        # KEPT AS ITS OWN JAIL rather than folded into port-decoy below, purely
+        # to preserve its ban history: fail2ban keys escalation on the jail
+        # name, so a rename would reset every offender to step 1 of the ladder.
+        # 22 is the most-probed port on this host -- 192 distinct addresses in
+        # 24h -- so its history is the most valuable of the set. At maxretry = 1
+        # the split costs no detection; see the let block at the top of this
+        # file.
         #
         # findtime is deliberately long. Slow scanners spread a sweep over
         # hours specifically to stay under short windows, and since the signal
@@ -774,10 +863,29 @@ in
         #
         # backend/logpath are inherited from DEFAULT (systemd), which is
         # correct: these lines come from the kernel via the journal.
+        ssh-decoy.settings = {
+          enabled = true;
+          filter = "ssh-decoy";
+          maxretry = 1;
+          findtime = "1d";
+        };
+
+        # The same tripwire for the other 26 ports. Identical settings on
+        # purpose -- the signal is identical, only the port set differs, and
+        # the split exists for history preservation rather than for any
+        # behavioural reason. maxretry must stay in step with ssh-decoy above;
+        # if these two ever diverge, the same port knock means different things
+        # depending on which rule logged it.
+        #
+        # New jail, so it starts with an empty ban history and builds its own
+        # ladder. Nothing external keys on the name: the ban-metrics generator
+        # above enumerates jails from `fail2ban-client status`, and the security
+        # dashboard reads the jail as a label rather than filtering on a
+        # literal, so both pick this up with no change.
         port-decoy.settings = {
           enabled = true;
           filter = "port-decoy";
-          maxretry = 2;
+          maxretry = 1;
           findtime = "1d";
         };
 

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -149,16 +149,6 @@ let
     11211 # memcached, TCP half only
     27017 # MongoDB
     32764 # Sercomm router backdoor
-
-    # below are ports that we had actors on messing about before, sucking data
-    30005
-
-    # 30002 (raw out), 30003 (SBS/BaseStation out) and 30047 have no
-    # observed clients at all. Same reasoning: keep the mapping, drop
-    # the public exposure.
-    30002
-    30003
-    30047
   ];
 
   # xt_multiport takes at most 15 ports per rule, so the list is emitted in

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -149,6 +149,16 @@ let
     11211 # memcached, TCP half only
     27017 # MongoDB
     32764 # Sercomm router backdoor
+
+    # below are ports that we had actors on messing about before, sucking data
+    30005
+
+    # 30002 (raw out), 30003 (SBS/BaseStation out) and 30047 have no
+    # observed clients at all. Same reasoning: keep the mapping, drop
+    # the public exposure.
+    30002
+    30003
+    30047
   ];
 
   # xt_multiport takes at most 15 ports per rule, so the list is emitted in

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -134,7 +134,7 @@ let
     1433 # MSSQL
     1521 # Oracle TNS
     1723 # PPTP
-    2375 # Docker API, plaintext -- this host runs Docker, so this one is pointed
+    2375 # Docker API, plaintext -- not hypothetical here, this host runs Docker
     2376 # Docker API, TLS
     3128 # Squid / open-proxy hunting
     3306 # MySQL
@@ -287,7 +287,22 @@ in
       # has to be added back here or the guard would have a hole exactly where
       # the most-probed port is.
       watched = decoyPorts ++ [ 22 ];
-      clash = lib.intersectLists watched config.networking.firewall.allowedTCPPorts;
+
+      fw = config.networking.firewall;
+
+      # Every way nixos-fw can ACCEPT a port before the appended LOG rules is
+      # reached, not just the obvious one. An earlier version of this assertion
+      # checked allowedTCPPorts alone, which left three holes of exactly the
+      # same kind: a decoy port inside allowedTCPPortRanges, or allowed on a
+      # single interface, is ACCEPTed just as effectively and produces the same
+      # silently dead decoy. 8080 and 8443 are plausible members of a future
+      # range, so this was reachable rather than theoretical.
+      ifaces = lib.attrValues fw.interfaces;
+      ranges = fw.allowedTCPPortRanges ++ lib.concatMap (i: i.allowedTCPPortRanges) ifaces;
+      openPorts = fw.allowedTCPPorts ++ lib.concatMap (i: i.allowedTCPPorts) ifaces;
+      inAnyRange = p: lib.any (r: p >= r.from && p <= r.to) ranges;
+
+      clash = lib.filter (p: lib.elem p openPorts || inAnyRange p) watched;
     in
     [
       {

--- a/hosts/linux/fredvps/discord-backup.nix
+++ b/hosts/linux/fredvps/discord-backup.nix
@@ -12,7 +12,8 @@
 # pattern as the adsbDockerCompose activationScript above) — how (or
 # whether) /mnt/discord-storage is actually backed by something else
 # (NFS, a separate disk, etc.) is handled outside this repo.
-_: {
+{ pkgs, ... }:
+{
   system.activationScripts.discordDirs = {
     text = ''
       install -d -m0755 -o nik -g users /mnt/discord
@@ -32,14 +33,54 @@ _: {
         Group = "users";
       };
 
+      # WHY sqlite3 .backup AND NOT cp
+      #
+      # This was `cp` guarded by a wait on discord_db.sqlite-journal. Both
+      # halves were wrong, because the database runs in WAL mode (see the
+      # test-site notes in configuration.nix: the reader needs directory write
+      # access precisely so SQLite can create -wal/-shm).
+      #
+      #   * WAL mode never creates a `-journal` file -- it creates `-wal` and
+      #     `-shm` -- so the guard could not fire and never once waited.
+      #   * `cp` copied only the main database, leaving every transaction still
+      #     in the WAL out of the backup. Anything committed since the last
+      #     checkpoint was silently missing.
+      #   * `cp` is not atomic against a live writer. A checkpoint landing
+      #     mid-copy yields a torn file, which surfaces as "database disk image
+      #     is malformed" at restore time -- i.e. the one moment it matters.
+      #
+      # `.backup` uses SQLite's online backup API: it takes a read lock, folds
+      # the WAL in, and restarts itself if a writer interferes, so the output is
+      # a consistent snapshot of a real commit boundary. It is also why no
+      # wait-loop is needed any more -- concurrency is the API's problem now.
+      #
+      # Written to a .part path and moved into place, so a name that looks like
+      # a backup only ever exists once it IS one. This matters beyond local
+      # tidiness: the NAS pulls this directory nightly with `rsync --delete`, so
+      # a half-written file under a real backup name would be replicated and
+      # counted as a good copy at both ends. NixOS runs `script` under `set -e`,
+      # so a failed .backup aborts before the move.
+      #
+      # Stale .part files are cleared at the start rather than trusted to the
+      # retention sweep, which only fires at +14 days and would leave a corpse
+      # visible to the NAS for two weeks.
+      #
+      # VACUUM INTO would also work and would compact as it goes, which is
+      # tempting at ~1 GB per copy times 14 copies. Not used here because it
+      # rewrites the whole file every night, which would defeat rsync's ability
+      # to delta successive backups against each other when the NAS pulls them.
       script = ''
-        while [ -e /mnt/discord/discord_db.sqlite-journal ]; do
-                sleep 5
-        done
+        rm -f /mnt/discord-storage/backups/*.part
 
-        cp /mnt/discord/discord_db.sqlite /mnt/discord-storage/backups/discord_db-$(date +"%Y-%m-%d-%H%M").sqlite
+        dest=/mnt/discord-storage/backups/discord_db-$(date +"%Y-%m-%d-%H%M").sqlite
 
+        ${pkgs.sqlite}/bin/sqlite3 /mnt/discord/discord_db.sqlite \
+          ".backup '$dest.part'"
 
+        mv "$dest.part" "$dest"
+
+        # Retention. Safe to run unconditionally: by here the only files present
+        # are completed backups.
         find /mnt/discord-storage/backups -mtime +14 -type f -delete
       '';
     };

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -61,6 +61,7 @@ in
     ../../../modules/monitoring/agent
     ../../../modules/services/tailscale
     ../../../modules/hardware/usbfs.nix
+    ./home-ip-drift.nix
   ];
 
   deployment.role = "monitoring-master";

--- a/hosts/linux/sdrhub/home-ip-drift.nix
+++ b/hosts/linux/sdrhub/home-ip-drift.nix
@@ -1,0 +1,185 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  expected = config.shared.homePublicIPv4;
+in
+{
+  # Drift detection for the home public IPv4 address.
+  #
+  # WHAT THIS PROTECTS
+  #
+  # fredvps's fail2ban ignoreIP list contains the home address, and its decoy
+  # jails run maxretry = 1. A single SYN to any of the 27 watched ports from an
+  # address not on that list is an immediate host-wide DROP ban that escalates
+  # to a week on repeat. Comcast rotates residential addresses, so the day the
+  # address changes, that list silently stops protecting us -- and the reverse
+  # is worse: the address we vacate gets handed to a stranger who is then
+  # whitelisted across every jail on the internet-facing host.
+  #
+  # Neither failure is visible from fredvps. This makes it visible.
+  #
+  # WHY THE ORACLE IS OUR OWN NGINX LOG
+  #
+  # The question that matters is not "what is our public IP" in the abstract,
+  # it is "what source address does fredvps attribute our traffic to", because
+  # that is precisely the string ignoreIP has to match. Those can differ, and
+  # only the second one is actionable.
+  #
+  # We already have the answer, continuously, for free: this host's blackbox
+  # exporter probes ~30 public URLs on fredvps (see blackbox.nix -- they are
+  # https:// targets, so they resolve to the public address and egress through
+  # the home NAT rather than the tailnet), and fredvps's nginx logs the source
+  # address of every one. Alloy ships that log here. Measured: 273 requests
+  # carrying User-Agent "Blackbox-Exporter/0.28.0" in a 30-minute window.
+  #
+  # So the check is a local Loki query and nothing else. Rejected alternatives:
+  #
+  #   * A third-party echo service (ifconfig.me, api.ipify.org, OpenDNS
+  #     myip.opendns.com). Puts an external dependency inside a security
+  #     control, and answers the abstract question rather than the useful one.
+  #   * A /whoami endpoint on fredvps returning $remote_addr. Self-hosted and
+  #     direct, but adds public surface to the one internet-facing host in the
+  #     fleet, which is the opposite of the direction that host has been moving.
+  #   * ssh -p 2269 fredvps 'echo $SSH_CLIENT'. No new HTTP surface, but adds a
+  #     scheduled login, sshd auth noise, and key management for a datum we are
+  #     already logging.
+  #
+  # The cost of this choice is a four-link dependency chain: blackbox probing,
+  # nginx logging, Alloy shipping, Loki retaining. Any link breaking means the
+  # address cannot be determined -- which is why that case is reported as
+  # up == 0 and alerted on separately, rather than being allowed to look like
+  # agreement.
+  # Alerts registered here rather than in prometheus.nix's central ruleFiles
+  # list, following blackbox.nix and smartctl.nix: the module that owns the
+  # metric owns its alerts, so the two cannot be added or removed separately.
+  # ruleFiles is a list option, so this merges with the central list.
+  services.prometheus.ruleFiles = [
+    ../../../modules/monitoring/master/alert-rules/home-ip-alerts.yaml
+  ];
+
+  systemd = {
+    services.home-ip-drift-metric = {
+      description = "Compare the observed home public IP against the expected one";
+      after = [ "loki.service" ];
+      wants = [ "loki.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        # Same lack of sandboxing as the other textfile generators on this
+        # fleet: it needs to write into the root-owned directory node_exporter
+        # reads. See modules/monitoring/agent/node_exporter.nix.
+        ExecStart = pkgs.writeShellScript "home-ip-drift-metric.sh" ''
+          set -uo pipefail
+
+          export PATH=${
+            lib.makeBinPath [
+              pkgs.curl
+              pkgs.jq
+              pkgs.gnugrep
+              pkgs.gawk
+              pkgs.coreutils
+            ]
+          }
+
+          TEXTFILE_DIR=/var/lib/node_exporter/textfiles
+          OUT="$TEXTFILE_DIR/home_public_ip.prom"
+          TMP="$OUT.$$"
+
+          mkdir -p "$TEXTFILE_DIR"
+
+          EXPECTED="${expected}"
+          observed=""
+          up=0
+
+          # Newest matching line wins: limit=1 with direction=backward. The
+          # 30-minute window is far wider than the blackbox probe interval, so a
+          # single missed scrape cannot empty the result, but it is still short
+          # enough that a rotation is reflected within minutes.
+          if body=$(curl -sf --max-time 15 -G \
+              http://127.0.0.1:5678/loki/api/v1/query_range \
+              --data-urlencode 'query={host="fredvps", unit="nginx-access"} |= `Blackbox-Exporter/`' \
+              --data-urlencode 'limit=1' \
+              --data-urlencode 'since=30m' \
+              --data-urlencode 'direction=backward'); then
+
+            # nginx's combined format puts the client address first, so the
+            # first whitespace-delimited field is the answer.
+            candidate=$(printf '%s' "$body" \
+              | jq -r '.data.result[0].values[0][1] // empty' \
+              | awk '{ print $1 }')
+
+            # Validated rather than trusted. An empty result, a Loki error
+            # object, or a log-format change would otherwise be published as an
+            # "observed address" that cannot possibly match, turning a broken
+            # check into a false drift alert -- the failure mode most likely to
+            # get this alert muted.
+            if printf '%s' "$candidate" | grep -Eq '^[0-9]{1,3}(\.[0-9]{1,3}){3}$'; then
+              observed="$candidate"
+              up=1
+            fi
+          fi
+
+          {
+            echo "# HELP home_public_ip_check_up Whether the observed home public IP could be determined."
+            echo "# TYPE home_public_ip_check_up gauge"
+            echo "home_public_ip_check_up $up"
+
+            # Both addresses ride along as LABELS rather than as separate _info
+            # series, so the alert body is derivable from the alert itself.
+            # The alternative -- annotations using `{{ with query ... }}` to look
+            # up sibling series -- renders at notification time and therefore
+            # needs Prometheus to be reachable exactly when something is already
+            # wrong, and it is untestable without reproducing the sibling series
+            # in every promtool case.
+            #
+            # The label set changing on rotation is deliberate and correct: the
+            # old series ends, a new one begins, and the alert's `for:` clause
+            # starts accumulating against the new state rather than inheriting
+            # the old one's pending time. Cardinality is one series.
+            echo "# HELP home_public_ip_matches_expected Whether the address fredvps observes matches the configured one."
+            echo "# TYPE home_public_ip_matches_expected gauge"
+
+            # Emitted only when the lookup succeeded. Publishing 0 on a failed
+            # lookup would fire the drift alert for a monitoring fault, which is
+            # exactly the conflation home_public_ip_check_up exists to prevent.
+            if [ "$up" = "1" ]; then
+              if [ "$observed" = "$EXPECTED" ]; then
+                matches=1
+              else
+                matches=0
+              fi
+              printf 'home_public_ip_matches_expected{observed="%s",expected="%s"} %s\n' \
+                "$observed" "$EXPECTED" "$matches"
+            fi
+
+            echo "# HELP home_public_ip_check_timestamp_seconds Unix time this file was last written."
+            echo "# TYPE home_public_ip_check_timestamp_seconds gauge"
+            printf 'home_public_ip_check_timestamp_seconds %s\n' "$(date +%s)"
+          } > "$TMP"
+
+          # Atomic replace: node_exporter reads this directory on every scrape
+          # and must never see a partially written file.
+          mv "$TMP" "$OUT"
+        '';
+      };
+    };
+
+    timers.home-ip-drift-metric = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        # Every 10 minutes, matching the other textfile generators. A residential
+        # address rotates on the order of months, so this is already far more
+        # often than the event it watches for; the alert's `for:` clause is what
+        # actually sets how fast we hear about it.
+        OnBootSec = "5min";
+        OnUnitActiveSec = "10min";
+        AccuracySec = "30s";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/hosts/linux/sdrhub/home-ip-drift.nix
+++ b/hosts/linux/sdrhub/home-ip-drift.nix
@@ -99,6 +99,13 @@ in
           # 30-minute window is far wider than the blackbox probe interval, so a
           # single missed scrape cannot empty the result, but it is still short
           # enough that a rotation is reflected within minutes.
+          #
+          # `since` is a documented query_range parameter (it derives start from
+          # end, and an explicit start would supersede it), not a Grafana-ism.
+          # Called out because it reads like one: if Loki ignored it the window
+          # would collapse and this check would report up=0 forever while Loki
+          # was perfectly healthy. Verified against the live instance, which
+          # returned the expected address for this exact request.
           if body=$(curl -sf --max-time 15 -G \
               http://127.0.0.1:5678/loki/api/v1/query_range \
               --data-urlencode 'query={host="fredvps", unit="nginx-access"} |= `Blackbox-Exporter/`' \

--- a/modules/data/home-network.nix
+++ b/modules/data/home-network.nix
@@ -1,0 +1,63 @@
+{ lib, ... }:
+{
+  # Facts about the home network that more than one host needs to agree on.
+  #
+  # WHY THIS EXISTS AT ALL
+  #
+  # The home public address started life as a single literal in fredvps's
+  # fail2ban ignoreIP list, where a hardcoded constant was the right shape --
+  # one consumer, one file. It stopped being the right shape when sdrhub gained
+  # a drift monitor for the same address, because the two would then have to be
+  # kept in step by hand, and the failure mode of them disagreeing is the worst
+  # possible one: the monitor reports "no drift" against its own stale copy
+  # while fredvps bans the address the monitor is not watching.
+  #
+  # WHY NOT A FLAKE INPUT
+  #
+  # Flake inputs are pinned external sources resolved at lock time. Putting a
+  # local, mutable fact in one would mean a flake.lock bump to record a new
+  # address, and -- worse -- every input in this repo must be classified in four
+  # separate places to satisfy the input-category sync invariant (flake.nix
+  # comments, ci-linux.yaml, ci-darwin.yaml, and the impacted-hosts script).
+  # A home IP address does not have a CI rebuild category. `shared.*` data
+  # modules are the established pattern here; see nas-mounts.nix and
+  # sync-hosts.nix alongside this file.
+  #
+  # COST OF LIVING HERE
+  #
+  # This is imported by mk-system.nix, so it is in every host's module set and
+  # `modules/` matches CI's broad rebuild pattern. Changing the address triggers
+  # a full-fleet rebuild. That is the right trade for a value that moves every
+  # few months and whose staleness is an outage: cheap to change, expensive to
+  # get wrong.
+  options.shared.homePublicIPv4 = lib.mkOption {
+    # strMatching rather than plain str, so a typo is an eval error rather than
+    # a silently non-matching ignoreIP entry -- which would look exactly like
+    # "correctly configured" right up until a ban.
+    type = lib.types.strMatching "^[0-9]{1,3}(\\.[0-9]{1,3}){3}$";
+    default = "73.26.160.99";
+    description = ''
+      Current public IPv4 address of the home network, as observed by an
+      off-site host.
+
+      This is a Comcast residential address and therefore rotates. Two things
+      depend on it being accurate:
+
+        * fredvps's fail2ban ignoreIP list. The decoy jails run maxretry = 1,
+          so a single SYN to any watched port from an address not on that list
+          is an immediate host-wide ban that escalates on repeat. A stale entry
+          here is a live outage risk, not a latent one.
+        * sdrhub's home-ip-drift check, which compares this value against what
+          fredvps actually observes and alerts on mismatch.
+
+      When it rotates: update this value, deploy fredvps and sdrhub, and the
+      HomePublicIPDrifted alert clears on the next check.
+
+      IPv4 only, deliberately. Neither the home network nor fredclausen.com
+      currently has usable IPv6 (no AAAA record, no global v6 at home), so
+      there is no v6 path to ignore or monitor. If that changes, both the
+      ignoreIP list and this module need a v6 sibling -- the decoy rules are
+      installed with ip46tables and already log v6 knocks.
+    '';
+  };
+}

--- a/modules/data/home-network.nix
+++ b/modules/data/home-network.nix
@@ -34,7 +34,16 @@
     # strMatching rather than plain str, so a typo is an eval error rather than
     # a silently non-matching ignoreIP entry -- which would look exactly like
     # "correctly configured" right up until a ban.
-    type = lib.types.strMatching "^[0-9]{1,3}(\\.[0-9]{1,3}){3}$";
+    #
+    # Octets are range-checked rather than just "one to three digits". The
+    # looser pattern accepted 999.26.160.99, which defeats the entire point:
+    # a fat-fingered octet is the most likely typo here and it would have
+    # sailed through to ignoreIP as an address that can never match.
+    type =
+      let
+        octet = "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])";
+      in
+      lib.types.strMatching "^${octet}(\\.${octet}){3}$";
     default = "73.26.160.99";
     description = ''
       Current public IPv4 address of the home network, as observed by an

--- a/modules/data/sync-hosts.nix
+++ b/modules/data/sync-hosts.nix
@@ -1,4 +1,4 @@
-{ lib, user, ... }:
+{ lib, ... }:
 {
   # Define standard sync-compose hosts that can be imported by any system
   options.shared.syncHosts = lib.mkOption {
@@ -44,14 +44,17 @@
         port = "22";
         legacyScp = false;
       }
-      {
-        name = "vps";
-        ip = "fredclausen.com";
-        directory = "vps";
-        remotePath = "/home/${user}";
-        port = "22";
-        legacyScp = false;
-      }
+      # NO "vps" ENTRY. It was removed rather than repaired.
+      #
+      # It pointed at fredclausen.com with the default port 22, but fredvps's
+      # sshd is on 2269, so `sync-compose <dir> vps` could never connect -- it
+      # just SYNed a closed port and tripped the ssh-decoy tripwire. Deploys to
+      # that host go through colmena (flake/hosts/servers.nix, which correctly
+      # sets targetPort = 2269), so this predated colmena and had no remaining
+      # caller.
+      #
+      # Fixing the port was the wrong repair: it would have preserved a second,
+      # undocumented deploy path to the one internet-facing host in the fleet.
       {
         name = "brandon";
         ip = "73.242.200.187";

--- a/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
@@ -4,7 +4,7 @@ groups:
   # WHAT THIS GROUP DOES NOT ALERT ON
   #
   # Bans. Not ban counts, not ban rate, not individual jails firing, not
-  # recidive, not ssh-decoy catching a scanner. All of that is the system
+  # recidive, not port-decoy catching a scanner. All of that is the system
   # working as designed, and on this host it happens constantly -- 161 bans in
   # a 48-hour window before the escalation fix. Paging on success trains the
   # channel to be ignored, which costs more than it buys. The "Bans Over Time"

--- a/modules/monitoring/master/alert-rules/home-ip-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/home-ip-alerts.yaml
@@ -1,0 +1,120 @@
+groups:
+  # Alerts about the home public IPv4 address drifting away from the value the
+  # fleet is configured for.
+  #
+  # WHY THIS IS A SECURITY ALERT AND NOT HOUSEKEEPING
+  #
+  # fredvps's fail2ban ignoreIP list contains this address, and its decoy jails
+  # run maxretry = 1. One SYN to any of 27 watched ports from an address that is
+  # not on that list is an immediate host-wide DROP ban, escalating to a week on
+  # repeat. So a stale entry has two distinct consequences, and both matter:
+  #
+  #   * The address we now use is unprotected, so ordinary interactive traffic
+  #     from home can lock itself out of every vhost and out of sshd on 2269
+  #     simultaneously.
+  #   * The address we vacated stays whitelisted, so whoever Comcast hands it to
+  #     next is exempt from every jail on the only internet-facing host in the
+  #     fleet -- sshd, nginx-probe, nginx-bad-request, recidive.
+  #
+  # Neither is observable from fredvps itself, which is the whole reason this
+  # group exists.
+  #
+  # The check runs on sdrhub (hosts/linux/sdrhub/home-ip-drift.nix) and is
+  # sourced from fredvps's own nginx access log, so "observed" means the address
+  # fredvps actually attributes to this network -- the same string ignoreIP has
+  # to match, rather than an approximation of it from a third party.
+  #
+  # Rules deliberately do NOT pin hostname="sdrhub", following the convention in
+  # fail2ban-alerts.yaml: if the generator is ever added to a second host,
+  # unpinned rules cover it automatically. The absent() rule is the one
+  # exception, since it cannot work without naming the host it expects.
+  - name: home-public-ip
+    rules:
+      # The configured address no longer matches reality.
+      #
+      # critical, because this is the state in which a security control is
+      # pointed at the wrong address. It is also trivially fixable -- update
+      # shared.homePublicIPv4 and deploy -- so there is no reason to let it sit.
+      #
+      # 30m rather than something tighter: the check runs every 10 minutes, and
+      # a single anomalous sample should not page. Three consecutive
+      # disagreements is a rotation, not a blip.
+      - alert: HomePublicIPDrifted
+        expr: home_public_ip_matches_expected == 0
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Home public IP has drifted from the configured value"
+          description: >-
+            fredvps observes this network as {{ $labels.observed }}, but the
+            fleet is configured for {{ $labels.expected }}. fredvps's fail2ban
+            ignoreIP list no longer covers this network and the decoy jails ban
+            on the first knock. Update shared.homePublicIPv4 in
+            modules/data/home-network.nix and deploy fredvps and sdrhub.
+
+      # The check itself cannot determine the address.
+      #
+      # Separate from HomePublicIPDrifted on purpose, and the generator
+      # deliberately emits no matches_expected sample in this state, so a broken
+      # check can never masquerade as drift. Without this rule the failure would
+      # be invisible: a missing series looks like a quiet, healthy system.
+      #
+      # warning, not critical: nothing is mis-enforced while this fires, we have
+      # simply stopped watching. It depends on a four-link chain -- blackbox
+      # probing fredvps, nginx logging it, Alloy shipping it, Loki retaining it
+      # -- so it can also be a symptom of a problem those pipelines will alert
+      # on more precisely.
+      #
+      # 1h because the chain includes log shipping, which tolerates short gaps
+      # by design and recovers on its own.
+      - alert: HomePublicIPCheckFailing
+        expr: home_public_ip_check_up == 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Home public IP drift check cannot determine the address"
+          description: >-
+            The Loki query for fredvps's most recent Blackbox-Exporter request
+            returned nothing usable, so drift is no longer being detected. Check
+            that blackbox is probing fredvps, that Alloy on fredvps is shipping
+            nginx-access, and that Loki is ingesting it.
+
+      # The generator has stopped running.
+      #
+      # Distinct from CheckFailing: that one means the unit ran and could not get
+      # an answer, this one means it is not running at all, in which case every
+      # other series here is frozen at its last value and will keep looking
+      # healthy indefinitely. Compares against time(), so it needs no companion
+      # series.
+      - alert: HomePublicIPCheckStale
+        expr: time() - home_public_ip_check_timestamp_seconds > 3600
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Home public IP drift check has stopped updating"
+          description: >-
+            home-ip-drift-metric.service last wrote its textfile over an hour
+            ago, so the drift comparison is showing stale data. Check the
+            home-ip-drift-metric timer and service on {{ $labels.hostname }}.
+
+      # The series never appeared at all.
+      #
+      # The one rule here that must name the host, because absent() cannot
+      # express "on whichever host is supposed to have this". Catches the case
+      # the three rules above structurally cannot: a generator that was never
+      # deployed, or whose textfile was removed, produces no series for any of
+      # them to evaluate.
+      - alert: HomePublicIPCheckMissing
+        expr: absent(home_public_ip_check_up{hostname="sdrhub"})
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Home public IP drift check is not reporting at all"
+          description: >-
+            No home_public_ip_check_up series exists for sdrhub, so the drift
+            check is either not deployed or not being scraped. fredvps's
+            ignoreIP list is unmonitored while this fires.

--- a/modules/monitoring/master/alert-rules/tests/home-ip-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/home-ip-alerts-test.yaml
@@ -1,0 +1,197 @@
+# promtool unit tests for the home public IP drift rules.
+#
+# Gotcha, documented in smart-alerts-test.yaml and fail2ban-alerts-test.yaml and
+# re-stated here because it bites every new file in this directory: rules
+# evaluate at the top-level evaluation_interval, but samples are spaced at each
+# test's own `interval`. If `interval` exceeds Prometheus' 5m lookback delta the
+# series is stale at most evaluation steps and a `for:` clause never accumulates
+# a continuous pending period. Keep every interval <= 5m and make input_series
+# long enough to cover the rule's `for:` plus eval_time.
+#
+# Two rules here need care beyond that:
+#
+#   - HomePublicIPCheckStale compares against time(), so timestamp values must be
+#     absolute epoch seconds consistent with the test clock, which starts at 0. A
+#     series holding 0 is therefore "written at epoch 0" and is already an hour
+#     stale by eval_time 90m, which is what the firing case relies on. The
+#     not-firing case has to advance in step with the clock instead.
+#   - HomePublicIPCheckMissing uses absent() and pins hostname="sdrhub", so its
+#     firing case must supply some unrelated series for the rule to evaluate
+#     against while the named one is genuinely absent.
+#
+# The drift rule is tested in both directions on purpose. The important negative
+# case is that a FAILED CHECK does not fire it: the generator emits no
+# matches_expected sample when it cannot determine the address, so the series is
+# absent rather than 0, and this is the test that pins that behaviour.
+rule_files:
+  - ../home-ip-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  #########################################################################
+  # HomePublicIPDrifted
+  #########################################################################
+  - interval: 1m
+    name: HomePublicIPDrifted fires when the observed address disagrees
+    input_series:
+      - series: 'home_public_ip_matches_expected{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master", observed="73.26.161.5", expected="73.26.160.99"}'
+        values: "0+0x60"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: HomePublicIPDrifted
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: sdrhub
+              instance: sdrhub.tailc21fc7.ts.net:9100
+              job: node
+              role: master
+              observed: 73.26.161.5
+              expected: 73.26.160.99
+            exp_annotations:
+              summary: "Home public IP has drifted from the configured value"
+              description: >-
+                fredvps observes this network as 73.26.161.5, but the fleet is
+                configured for 73.26.160.99. fredvps's fail2ban ignoreIP list no
+                longer covers this network and the decoy jails ban on the first
+                knock. Update shared.homePublicIPv4 in
+                modules/data/home-network.nix and deploy fredvps and sdrhub.
+
+  - interval: 1m
+    name: HomePublicIPDrifted stays quiet while the address matches
+    input_series:
+      - series: 'home_public_ip_matches_expected{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master", observed="73.26.160.99", expected="73.26.160.99"}'
+        values: "1+0x60"
+    alert_rule_test:
+      - eval_time: 45m
+        alertname: HomePublicIPDrifted
+        exp_alerts: []
+
+  - interval: 1m
+    name: HomePublicIPDrifted does not fire when the check merely failed
+    input_series:
+      # up = 0 and NO matches_expected series, which is exactly what the
+      # generator emits on a failed lookup. Drift must stay silent here and
+      # HomePublicIPCheckFailing must carry it instead.
+      - series: 'home_public_ip_check_up{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master"}'
+        values: "0+0x120"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: HomePublicIPDrifted
+        exp_alerts: []
+
+  #########################################################################
+  # HomePublicIPCheckFailing
+  #########################################################################
+  - interval: 1m
+    name: HomePublicIPCheckFailing fires when the address cannot be determined
+    input_series:
+      - series: 'home_public_ip_check_up{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master"}'
+        values: "0+0x120"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: HomePublicIPCheckFailing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: sdrhub
+              instance: sdrhub.tailc21fc7.ts.net:9100
+              job: node
+              role: master
+            exp_annotations:
+              summary: "Home public IP drift check cannot determine the address"
+              description: >-
+                The Loki query for fredvps's most recent Blackbox-Exporter
+                request returned nothing usable, so drift is no longer being
+                detected. Check that blackbox is probing fredvps, that Alloy on
+                fredvps is shipping nginx-access, and that Loki is ingesting it.
+
+  - interval: 1m
+    name: HomePublicIPCheckFailing stays quiet on a healthy lookup
+    input_series:
+      - series: 'home_public_ip_check_up{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master"}'
+        values: "1+0x120"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: HomePublicIPCheckFailing
+        exp_alerts: []
+
+  #########################################################################
+  # HomePublicIPCheckStale
+  #########################################################################
+  - interval: 1m
+    name: HomePublicIPCheckStale fires when the textfile stops advancing
+    input_series:
+      # Frozen at epoch 0, so its age equals the test clock.
+      #
+      # eval_time is 100m, not 90m, and that is load-bearing. The expression is
+      # strictly `> 3600`, so at t=60m the age is exactly 3600 and the condition
+      # is still false; it first becomes true at 60m1s, which with a 1m
+      # evaluation interval means the pending period starts at 61m and the alert
+      # fires at 91m. Evaluating at 90m catches it one minute short, pending
+      # rather than firing.
+      - series: 'home_public_ip_check_timestamp_seconds{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master"}'
+        values: "0+0x150"
+    alert_rule_test:
+      - eval_time: 100m
+        alertname: HomePublicIPCheckStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: sdrhub
+              instance: sdrhub.tailc21fc7.ts.net:9100
+              job: node
+              role: master
+            exp_annotations:
+              summary: "Home public IP drift check has stopped updating"
+              description: >-
+                home-ip-drift-metric.service last wrote its textfile over an
+                hour ago, so the drift comparison is showing stale data. Check
+                the home-ip-drift-metric timer and service on sdrhub.
+
+  - interval: 1m
+    name: HomePublicIPCheckStale stays quiet while the generator keeps writing
+    input_series:
+      # Advances 60s per 1m sample, i.e. in step with the test clock, so the age
+      # stays at 0 and never crosses the threshold.
+      - series: 'home_public_ip_check_timestamp_seconds{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master"}'
+        values: "0+60x120"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: HomePublicIPCheckStale
+        exp_alerts: []
+
+  #########################################################################
+  # HomePublicIPCheckMissing
+  #########################################################################
+  - interval: 1m
+    name: HomePublicIPCheckMissing fires when sdrhub reports no series at all
+    input_series:
+      # Unrelated series so there is something to evaluate against while
+      # home_public_ip_check_up{hostname="sdrhub"} is genuinely absent.
+      - series: 'up{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master"}'
+        values: "1+0x120"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: HomePublicIPCheckMissing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: sdrhub
+            exp_annotations:
+              summary: "Home public IP drift check is not reporting at all"
+              description: >-
+                No home_public_ip_check_up series exists for sdrhub, so the
+                drift check is either not deployed or not being scraped.
+                fredvps's ignoreIP list is unmonitored while this fires.
+
+  - interval: 1m
+    name: HomePublicIPCheckMissing stays quiet once the series exists
+    input_series:
+      - series: 'home_public_ip_check_up{hostname="sdrhub", instance="sdrhub.tailc21fc7.ts.net:9100", job="node", role="master"}'
+        values: "1+0x120"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: HomePublicIPCheckMissing
+        exp_alerts: []

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -1195,6 +1195,432 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 40,
+      "type": "row",
+      "title": "Decoy Port Knocks",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "panels": []
+    },
+    {
+      "id": 41,
+      "type": "stat",
+      "title": "Decoy Knocks",
+      "description": "Every SYN to a port nothing on this host serves, over the dashboard range. Sourced from the kernel LOG lines the decoy firewall rules emit, NOT from fail2ban ban events. That is deliberate: a ban record contains only the address -- the action is allports, so the port appears nowhere in it -- so the kernel line is the only authoritative record of WHICH port was touched. It also covers knocks that never became bans.",
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 57
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${ds_loki}"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${ds_loki}"
+          },
+          "refId": "A",
+          "queryType": "instant",
+          "expr": "sum(count_over_time({host=\"fredvps\", job=\"journal\"} |~ `(ssh|port)-decoy:` [$__range]))"
+        }
+      ]
+    },
+    {
+      "id": 42,
+      "type": "stat",
+      "title": "Distinct Scanners",
+      "description": "Unique source addresses that touched a decoy port over the range. Both decoy jails run maxretry = 1, so with rare exceptions each of these earned a ban. Your own home address appears here too (it is in fail2ban's ignoreIP, so it is never banned). That is not a fault: it is how the Synology backup job dialling port 22 was found.",
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 57
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${ds_loki}"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${ds_loki}"
+          },
+          "refId": "A",
+          "queryType": "instant",
+          "expr": "count(sum by (src) (count_over_time({host=\"fredvps\", job=\"journal\"} |~ `(ssh|port)-decoy:` | regexp \"SRC=(?P<src>[^ ]+)\" [$__range])))"
+        }
+      ]
+    },
+    {
+      "id": 43,
+      "type": "stat",
+      "title": "Decoy Ports Touched",
+      "description": "How many of the 27 watched ports saw traffic over the range. Port 22 is watched by its own rule (ssh-decoy) and the other 26 by port-decoy; this counts across both.",
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 57
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${ds_loki}"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${ds_loki}"
+          },
+          "refId": "A",
+          "queryType": "instant",
+          "expr": "count(sum by (dpt) (count_over_time({host=\"fredvps\", job=\"journal\"} |~ `(ssh|port)-decoy:` | regexp \"DPT=(?P<dpt>[0-9]+)\" [$__range])))"
+        }
+      ]
+    },
+    {
+      "id": 44,
+      "type": "timeseries",
+      "title": "Knocks by Port (per hour)",
+      "description": "Rolling one-hour count per destination port. This is the panel that answers 'which bait is actually catching anything' -- and expect port 22 to dominate by an order of magnitude, since sshd moved off it and every scanner on the internet still tries it first. Sourced from the kernel LOG lines the decoy firewall rules emit, NOT from fail2ban ban events. That is deliberate: a ban record contains only the address -- the action is allports, so the port appears nowhere in it -- so the kernel line is the only authoritative record of WHICH port was touched. It also covers knocks that never became bans.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${ds_loki}"
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": ["lastNotNull", "max", "sum"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${ds_loki}"
+          },
+          "refId": "A",
+          "queryType": "range",
+          "expr": "sum by (dpt) (count_over_time({host=\"fredvps\", job=\"journal\"} |~ `(ssh|port)-decoy:` | regexp \"DPT=(?P<dpt>[0-9]+)\" [1h]))",
+          "legendFormat": ":{{dpt}}"
+        }
+      ]
+    },
+    {
+      "id": 45,
+      "type": "table",
+      "title": "Top Source x Port",
+      "description": "Which address hit which port, over the range. Capped at 100 rows. Sourced from the kernel LOG lines the decoy firewall rules emit, NOT from fail2ban ban events. That is deliberate: a ban record contains only the address -- the action is allports, so the port appears nowhere in it -- so the kernel line is the only authoritative record of WHICH port was touched. It also covers knocks that never became bans. Your own home address appears here too (it is in fail2ban's ignoreIP, so it is never banned). That is not a fault: it is how the Synology backup job dialling port 22 was found.",
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${ds_loki}"
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value": "Knocks",
+              "src": "Source",
+              "dpt": "Port"
+            },
+            "indexByName": {
+              "src": 0,
+              "dpt": 1,
+              "Value": 2
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Knocks",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${ds_loki}"
+          },
+          "refId": "A",
+          "queryType": "instant",
+          "expr": "topk(100, sum by (src, dpt) (count_over_time({host=\"fredvps\", job=\"journal\"} |~ `(ssh|port)-decoy:` | regexp \"SRC=(?P<src>[^ ]+).*?DPT=(?P<dpt>[0-9]+)\" [$__range])))"
+        }
+      ]
+    },
+    {
+      "id": 46,
+      "type": "table",
+      "title": "Knocks by Port",
+      "description": "The same data collapsed to one row per port -- the ranking of which bait is drawing traffic. Sourced from the kernel LOG lines the decoy firewall rules emit, NOT from fail2ban ban events. That is deliberate: a ban record contains only the address -- the action is allports, so the port appears nowhere in it -- so the kernel line is the only authoritative record of WHICH port was touched. It also covers knocks that never became bans.",
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${ds_loki}"
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value": "Knocks",
+              "dpt": "Port"
+            },
+            "indexByName": {
+              "dpt": 0,
+              "Value": 1
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Knocks",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${ds_loki}"
+          },
+          "refId": "A",
+          "queryType": "instant",
+          "expr": "sum by (dpt) (count_over_time({host=\"fredvps\", job=\"journal\"} |~ `(ssh|port)-decoy:` | regexp \"DPT=(?P<dpt>[0-9]+)\" [$__range]))"
+        }
+      ]
+    },
+    {
+      "id": 47,
+      "type": "logs",
+      "title": "Decoy Knocks (live)",
+      "description": "Raw kernel LOG lines from the decoy rules, newest first. Left unparsed on purpose: the fields this panel would otherwise hide (TTL, WINDOW, SPT, retransmit spacing) are what identify a sender's TCP stack, which is how the daily 05:00 knock was traced to a Synology on DSM 7 rather than to any host in this fleet. Prefix ssh-decoy: is port 22, port-decoy: is the other 26.",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${ds_loki}"
+      },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${ds_loki}"
+          },
+          "refId": "A",
+          "queryType": "range",
+          "expr": "{host=\"fredvps\", job=\"journal\"} |~ `(ssh|port)-decoy:`"
+        }
+      ]
     }
   ]
 }

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -233,7 +233,7 @@
       "id": 5,
       "type": "stat",
       "title": "Jails Active",
-      "description": "fail2ban jails currently loaded. Should be 4.",
+      "description": "fail2ban jails currently loaded. Should be 7: sshd, ssh-decoy, port-decoy, recidive, nginx-probe, nginx-limit-req, nginx-bad-request. Red below that, because a jail failing to load is silent everywhere else -- enforcement just stops for whatever it covered. Update this and the threshold together when the jail set changes.",
       "gridPos": {
         "h": 5,
         "w": 4,
@@ -267,7 +267,7 @@
               },
               {
                 "color": "green",
-                "value": 4
+                "value": 7
               }
             ]
           },

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -1481,12 +1481,14 @@
             "renameByName": {
               "Value": "Knocks",
               "src": "Source",
-              "dpt": "Port"
+              "dpt": "Port",
+              "Value #A": "Knocks"
             },
             "indexByName": {
               "src": 0,
               "dpt": 1,
-              "Value": 2
+              "Value": 2,
+              "Value #A": 2
             }
           }
         },
@@ -1556,11 +1558,13 @@
             },
             "renameByName": {
               "Value": "Knocks",
-              "dpt": "Port"
+              "dpt": "Port",
+              "Value #A": "Knocks"
             },
             "indexByName": {
               "dpt": 0,
-              "Value": 1
+              "Value": 1,
+              "Value #A": 1
             }
           }
         },


### PR DESCRIPTION
Started as "extend the port-22 decoy to more ports" and turned up three
unrelated problems along the way. Each is its own commit.

## Decoy tripwire

Port 22's `ssh-decoy` tripwire now has a sibling, `port-decoy`, covering 26
more ports that nothing on this host serves — FTP, telnet, SMB/RPC, the
databases, Redis/Mongo/Elastic/memcached, VNC, RDP, Squid, TR-069, and both
Docker API ports. Generated from a single Nix port table and chunked at 15,
`xt_multiport`'s hard limit.

Kept as **two** jails, not one. fail2ban keys ban escalation on the jail
name, so folding 22 in would have discarded the accumulated history for the
most-probed port on the host (192 distinct addresses in 24h). Both jails run
`maxretry = 1`: one knock on a port nothing serves is already proof of a
scan, and it closes the gap that splitting would otherwise create, since ban
counts are per-jail.

An eval-time assertion rejects any decoy port that is also in
`allowedTCPPorts` — such a rule is silently *unreachable*, because allowed
ports ACCEPT before the appended LOG rules.

## Ban-injection hole (pre-existing)

The decoy filters ran on fail2ban's systemd backend with no `journalmatch`,
which reads the **entire** journal rather than just kernel messages. Since
`<HOST>` binds to whatever follows `SRC=`, anything that can get text into
the journal could forge a decoy hit and choose the banned address. sshd is a
live path, because usernames are attacker-supplied and logged verbatim:

    ssh -p 2269 'port-decoy: SRC=8.8.8.8 DPT=443 x'@fredvps

`fail2ban-regex` confirmed it extracts `8.8.8.8`. Two of those and a stranger
picks who you ban, host-wide, on a ladder topping out at a week. Closed with
`journalmatch = _TRANSPORT=kernel`, which journald sets from message origin
and no userspace writer can claim.

## Home IP drift monitoring

`maxretry = 1` makes fail2ban's `ignoreIP` list the only thing between a
stray SYN and a host-wide escalating ban, so a stale entry there is a live
outage risk. It is also dangerous in reverse: the address we vacate stays
whitelisted across every jail for whoever Comcast hands it to next.

The address is promoted to `shared.homePublicIPv4`
(`modules/data/home-network.nix`) so fredvps and sdrhub cannot disagree, and
sdrhub gains a drift check with four alerts.

The oracle is our own nginx log. sdrhub's blackbox exporter already probes
~30 `https://` targets on fredvps, which egress through the home NAT, and
nginx logs the source of every one — 273 requests in a 30-minute sample. So
the check is a local Loki query: no new public surface on the internet-facing
host, no third-party dependency, no extra traffic. It also answers the right
question, "what address does fredvps attribute to us", which is the string
`ignoreIP` must match.

## Discord DB backup (pre-existing)

The nightly backup was `cp` guarded by a wait on `...sqlite-journal`. Both
halves were wrong: the database is in WAL mode, so that file never exists and
the guard never waited, and `cp` omitted the `-wal` — silently dropping every
transaction since the last checkpoint — while also being non-atomic against a
live writer. Now `sqlite3 .backup`, written to `.part` and moved into place.

## Dead deploy path

`shared.syncHosts` had a `vps` entry pointing at port 22 when sshd is on
2269, so it could never connect. It was the cause of a decoy hit from home.
Deleted rather than repointed — colmena already deploys that host correctly,
and fixing the port would have preserved a second undocumented path to the
only internet-facing node.

## Dashboard

A "Decoy Port Knocks" section on the security dashboard, read from the kernel
LOG lines rather than ban events — a ban record contains only the address
(`allports`), so the kernel line is the only authoritative record of *which*
port was touched, and it also covers knocks that never became bans.

## Verification

- filters match real v4/v6 kernel lines and reject `refused connection:`; the two are disjoint so the ladders stay independent
- all rules accepted by real `iptables`/`ip6tables` in a throwaway netns
- assertion fails correctly for `22` and for `8080`
- `nix eval` on all 10 hosts, no `evaluation warning:`, home-manager activation OK
- promtool check plus 11 new unit tests
- the drift query run against live Loki, with an empty-result negative control
- post-deploy on fredvps/sdrhub: 4 knocks produced 4 bans, `ssh-decoy` history intact, 7 jail series in the exporter, drift metric reporting `matches_expected=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring and alerts for home public IPv4 changes, failed checks, stale data, and missing metrics.
  * Added shared home-network configuration with IPv4 validation.
  * Added security dashboard panels for decoy-port activity, scanners, targeted ports, and live events.

* **Security**
  * Improved decoy-port protection with rate-limited logging, conflict checks, and immediate blocking for detected probes.

* **Reliability**
  * Improved backup safety using consistent database snapshots and atomic file replacement.

* **Maintenance**
  * Removed an obsolete synchronization host configuration and updated related monitoring documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->