### PR TITLE
chore(opencode): update overlay to v1.18.18

### DIFF
--- a/overlays/opencode.nix
+++ b/overlays/opencode.nix
@@ -27,18 +27,18 @@
 }:
 opencode.overrideAttrs (
   _finalAttrs: prevAttrs: rec {
-    version = "1.18.16";
+    version = "1.18.18";
 
     src = fetchFromGitHub {
       owner = "anomalyco";
       repo = "opencode";
       tag = "v${version}";
-      hash = "sha256-AP2W443Zk/X8j6BWfMgAEbR4BQiJgnPpr1OG6JWIprE=";
+      hash = "sha256-rDVcv8j9KghTDwooPYriTloOMgTyVutud7xKLG2mTmk=";
     };
 
     node_modules = prevAttrs.node_modules.overrideAttrs (_: {
       inherit version src;
-      outputHash = "sha256-GBLs3nXtfSeXb4jXxSNM8ElMa/e/EB4sZn3c2inHnco=";
+      outputHash = "sha256-oU7qWOsY2TtVE+Gp2DhSXffm9OghTHcNhzDwwAovwZI=";
     });
   }
 )


### PR DESCRIPTION
Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: `nix build .#nixosConfigurations.Daytona.pkgs.opencode` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenCode to version 1.18.18.
  * Refreshed associated package integrity data for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->