### PR TITLE
fix(sddm): move sddm config to lua

### DIFF
--- a/hosts/linux/daytona/configuration.nix
+++ b/hosts/linux/daytona/configuration.nix
@@ -43,7 +43,12 @@
 
   system.activationScripts.sddm-hyprland-config = ''
     mkdir -p /var/lib/sddm/.config/hypr
-    cat <<EOF > /var/lib/sddm/.config/hypr/hyprland.conf
+    # hyprland.conf (hyprlang) is deprecated upstream; the Lua config is the
+    # supported format. No monitor rules are needed on this host -- the file
+    # only has to exist so Hyprland does not fall back to its shipped default.
+    rm -f /var/lib/sddm/.config/hypr/hyprland.conf
+    cat <<EOF > /var/lib/sddm/.config/hypr/hyprland.lua
+    -- Auto-generated for the SDDM Wayland session.
     EOF
     chown -R sddm:sddm /var/lib/sddm/.config
   '';

--- a/hosts/linux/maranello/configuration.nix
+++ b/hosts/linux/maranello/configuration.nix
@@ -83,6 +83,9 @@ in
 
   system.activationScripts.sddm-hyprland-config = ''
     mkdir -p /var/lib/sddm/.config/hypr
+    # hyprland.conf (hyprlang) is deprecated upstream; drop any stale copy left
+    # behind by a pre-Lua generation so Hyprland does not read it.
+    rm -f /var/lib/sddm/.config/hypr/hyprland.conf
     cat <<EOF > /var/lib/sddm/.config/hypr/hyprland.lua
     -- Auto-generated for the SDDM Wayland session.
     ${lib.concatStringsSep "\n    " hyprMonitors}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Hyprland session setup to remove deprecated configuration files.
  * Added support for generating the current Lua-based configuration format.
  * Documented the supported configuration format and monitor-rule behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->