### PR TITLE
chore(flake/nixos-needsreboot): `7c72623c` -> `59fb34b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,15 +164,15 @@
     "flake-compat_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -561,15 +561,14 @@
     "git-hooks_4": {
       "inputs": {
         "flake-compat": "flake-compat_5",
-        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1763988335,
-        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -619,28 +618,6 @@
       "original": {
         "owner": "FredSystems",
         "repo": "github-ci-exporter",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixos-needsreboot",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -877,11 +854,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1785715923,
-        "narHash": "sha256-wLYdAvZ4TAmZFVuprvq5fydQYXqxdqbYAcaFm4q8XZo=",
+        "lastModified": 1786489158,
+        "narHash": "sha256-5d97C4JvzBjPIghfx6G9PkHhCveBhZZexrkZ7N3AwL4=",
         "owner": "fredclausen",
         "repo": "nixos-needsreboot",
-        "rev": "7c72623c2ea71853dd9f2ab07044188f1f50fe5b",
+        "rev": "59fb34b766ec1960a2d66f91e023262127babd63",
         "type": "github"
       },
       "original": {
@@ -953,11 +930,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1759417375,
-        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
+        "lastModified": 1782918843,
+        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
         "type": "github"
       },
       "original": {
@@ -969,11 +946,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1764406085,
-        "narHash": "sha256-CYbMp8hwuOf4umokSNp+t1s4Hjd4vxXq4S5CD+xvgNs=",
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9561691c9f450fad7c3526916e1c4f44be0d1192",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                                                             |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`59fb34b7`](https://github.com/fredclausen/nixos-needsreboot/commit/59fb34b766ec1960a2d66f91e023262127babd63) | `` Pin dependencies ``                                                              |
| [`2ad567d1`](https://github.com/fredclausen/nixos-needsreboot/commit/2ad567d18b6fbdd9883025759c8f80e48a7a1891) | `` docs: document the exit-status contract ``                                       |
| [`9e8c7915`](https://github.com/fredclausen/nixos-needsreboot/commit/9e8c79157acaea4600655a457cc14d194334eb2e) | `` refactor!: make the exit status a value, and fix the statuses that were wrong `` |
| [`c589818c`](https://github.com/fredclausen/nixos-needsreboot/commit/c589818c5a715613485736c270c589160be20441) | `` ci: run the test suite and package build as merge gates ``                       |
| [`b7289fae`](https://github.com/fredclausen/nixos-needsreboot/commit/b7289fae78c15ec39bde9f3fcffccce408fded03) | `` Update Rust crate sdre-rust-logging to v0.3.29 ``                                |
| [`6df0c522`](https://github.com/fredclausen/nixos-needsreboot/commit/6df0c522482729bd75c7b5afcd91ed3178dfd5de) | `` Update strum monorepo to 0.28.0 ``                                               |
| [`73c4b61d`](https://github.com/fredclausen/nixos-needsreboot/commit/73c4b61d9122722d624641af046767c1bee9dc7a) | `` Update actions/checkout action to v7 (#9) ``                                     |
| [`c46acd38`](https://github.com/fredclausen/nixos-needsreboot/commit/c46acd38dff255e9a08c36081958f8c7497781df) | `` chore(flake/nixpkgs): 9561691c -> b6018f87 ``                                    |
| [`26a2b44d`](https://github.com/fredclausen/nixos-needsreboot/commit/26a2b44d16320239128f26b6604f190ca2e4ee06) | `` chore(flake/git-hooks): 50b92388 -> 43b3c1ab ``                                  |
| [`4a5f53a0`](https://github.com/fredclausen/nixos-needsreboot/commit/4a5f53a05f6c447910dc34d9df9d7545975c85d3) | `` flakes ``                                                                        |
| [`6f0a792e`](https://github.com/fredclausen/nixos-needsreboot/commit/6f0a792e1708ba62eb96dceb7c911694cdf469a6) | `` flakes ``                                                                        |
| [`ccb2413b`](https://github.com/fredclausen/nixos-needsreboot/commit/ccb2413be74fd4f3066b06f2b8376a3831124aad) | `` flakes ``                                                                        |
| [`ecec44a1`](https://github.com/fredclausen/nixos-needsreboot/commit/ecec44a1d07979095c0bc86ed4653679998a496a) | `` reno ``                                                                          |