### PR TITLE
chore(flake/colmena): `a156fd91` -> `795155f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1785930890,
-        "narHash": "sha256-QN4Oy1B4Vma9DiMyXiyssrpgMuIPgkNyO8jb6k2H4oY=",
+        "lastModified": 1786550539,
+        "narHash": "sha256-2daPrjzt20J93nqxMdnsPqVz8ScEklDV5WYXy0IYheY=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "a156fd9146e69a577fe6f5542a7c6ed83a6888ce",
+        "rev": "795155f6b5d79710685899ae9d15d97cde7d7697",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                           |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`4aad1d67`](https://github.com/nix-community/colmena/commit/4aad1d671738bb2a5cc14849a0b948ae7d52312d) | `` key: loosen deployment.keys username/group validation regex `` |