### PR TITLE
chore(flake/freminal): `3e61d4b0` -> `25e9358e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1786401712,
-        "narHash": "sha256-jyKhtjtsqOGNuWnGA6dhrfZ86yKKjl4/Gjh+rxRjZ4c=",
+        "lastModified": 1786627138,
+        "narHash": "sha256-EiAJMwFoa8jvPTXGRFONJIcZUsQa/2dyRJKWFscsofU=",
         "owner": "FredSystems",
         "repo": "freminal",
-        "rev": "3e61d4b01a58b20cc30720aa15c1d76acd7208a3",
+        "rev": "25e9358e981832fd1d9bd549b56339866093a831",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`d5854361`](https://github.com/fredsystems/freminal/commit/d58543617fc0ce315e8bb3aaf5e87ca595bdccbf) | `` chore(deps): update taiki-e/install-action action to v2.85.12 ``       |
| [`8b5ddc56`](https://github.com/fredsystems/freminal/commit/8b5ddc56806741ca6098201fbd5b434e1b3833bf) | `` chore(deps): update swatinem/rust-cache action to v2.9.2 ``            |
| [`38971ef9`](https://github.com/fredsystems/freminal/commit/38971ef9b10f5034e5947e9974a88021674d4a89) | `` chore(deps): update dtolnay/rust-toolchain digest ``                   |
| [`e99c232e`](https://github.com/fredsystems/freminal/commit/e99c232ebb87c49b1e11c0030c5226634c90b953) | `` docs: fix the leftover ordering claim at the tracker call site ``      |
| [`c429b740`](https://github.com/fredsystems/freminal/commit/c429b740dbfa87af46ab0a7f49f4c722827708ad) | `` test: drop an overclaiming modifier-tracker test per PR #485 review `` |
| [`506f7aa4`](https://github.com/fredsystems/freminal/commit/506f7aa4a96cf83a85e9f621a1ef6a4c86aaf9fd) | `` fix: address PR #485 review ``                                         |
| [`06701ce8`](https://github.com/fredsystems/freminal/commit/06701ce8f3ec311fef6b1fbbdcf5bfcd096d364f) | `` chore(deps): update egui stack to 0.36.1, holding glow at 0.17 ``      |