### PR TITLE
chore(flake/home-manager): `c30c7955` -> `0668fdbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786356609,
-        "narHash": "sha256-ou8fYz5w9yhXC8YbvvExybFIa19MyW5G/8dEPqa90hM=",
+        "lastModified": 1786603258,
+        "narHash": "sha256-j1lYPT7YxOQc/G7NcJKqdpQ5/A5yX2aZdhVKkJR6cM4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c30c7955cec30d664a9baced6bc0112e263d4647",
+        "rev": "0668fdbc15bd602e463cab37ff64346021193652",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`0668fdbc`](https://github.com/nix-community/home-manager/commit/0668fdbc15bd602e463cab37ff64346021193652) | `` treewide: stdenv.is* -> stdenv.hostPlatform.is* ``    |
| [`e13ba5e5`](https://github.com/nix-community/home-manager/commit/e13ba5e5abbd9b912fa8c6979bd119e87ca7fdd9) | `` docs: link module pages without an invalid anchor ``  |
| [`a0d058ef`](https://github.com/nix-community/home-manager/commit/a0d058ef22fcdf325dad57c52b345aabc2f09162) | `` docs: link release note highlights to module pages `` |
| [`f8badd57`](https://github.com/nix-community/home-manager/commit/f8badd57bac448d07fb93a7884a207ecb0927e95) | `` vdirsyncer: add local read-only news ``               |
| [`ad952916`](https://github.com/nix-community/home-manager/commit/ad9529169459ad1369c60dc285f8355e9f3c94e9) | `` vdirsyncer: test read-only local storages ``          |
| [`40c28d28`](https://github.com/nix-community/home-manager/commit/40c28d282a3328fe1522ee3db0bf4aad42f199eb) | `` vdirsyncer: support read-only local storages ``       |
| [`99e84ee7`](https://github.com/nix-community/home-manager/commit/99e84ee7387ff24cd112ff51f71c3465eb9cb770) | `` pistol: revert config path for macOS (#9798) ``       |
| [`f404edbf`](https://github.com/nix-community/home-manager/commit/f404edbfa4117810c96b97048299242fc50e5362) | `` niri: preserve string context in generated config ``  |