### PR TITLE
chore(flake/nixpkgs-stable): `fcb8fcd6` -> `9f78f44a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -937,11 +937,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1786313170,
-        "narHash": "sha256-9BG7OgUWdu0ONDO5X2q6+K4bsuBITkX/3W4nNJu1Ito=",
+        "lastModified": 1786535285,
+        "narHash": "sha256-rG5HKMAgAhMgydvKGtco6rqTxRq4EDZQCx9USLvVqYw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d",
+        "rev": "9f78f44a87948854445dae0b6bf82b2e87e4efb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`42134ad6`](https://github.com/NixOS/nixpkgs/commit/42134ad62fd8b66ea939f107d08491abe07f12b9) | `` google-chrome: 151.0.7922.108 -> 151.0.7922.137 ``                      |
| [`c37755ab`](https://github.com/NixOS/nixpkgs/commit/c37755ab3e43a95f37ebcfb6618f28f5d477a8cb) | `` python3Packages.pymedio: drop ``                                        |
| [`24a8499d`](https://github.com/NixOS/nixpkgs/commit/24a8499da573285b8ea7e13fa5ad29882e476515) | `` angie: 1.11.8 -> 1.12.1 ``                                              |
| [`ce8773e2`](https://github.com/NixOS/nixpkgs/commit/ce8773e2b2b39a5eb104e7d7cea721558e0e732d) | `` microcode-intel: 20260512 -> 20260811 ``                                |
| [`62886890`](https://github.com/NixOS/nixpkgs/commit/628868905d1d9ce1eebadea678c627feeab13385) | `` baikal: 0.11.1 -> 0.12.1 ``                                             |
| [`db2a473e`](https://github.com/NixOS/nixpkgs/commit/db2a473ec29fced9c08aca8de5fd6579727d4201) | `` linuxKernel.kernels.linux_zen: 7.1.5 -> 7.1.8 ``                        |
| [`08b1622e`](https://github.com/NixOS/nixpkgs/commit/08b1622efff02d91f58ec85ccb936aaa7bb63423) | `` matrix-continuwuity: backport SEC26 ``                                  |
| [`80dab2a8`](https://github.com/NixOS/nixpkgs/commit/80dab2a822c9bbc2a9b1030ff6778b068da87306) | `` matrix-continuwuity: backport SEC28 ``                                  |
| [`1ec92d25`](https://github.com/NixOS/nixpkgs/commit/1ec92d25473bc3126179b0b54fd9991829766a59) | `` turn-rs: 4.1.4 -> 4.1.5 ``                                              |
| [`f9a86257`](https://github.com/NixOS/nixpkgs/commit/f9a86257f37d8b0b3f6ab4d1b55f59285d99b64f) | `` bind: fix riscv64-linux build ``                                        |
| [`dbac8e51`](https://github.com/NixOS/nixpkgs/commit/dbac8e51caee6c2c83648c8fae5f197742c82c52) | `` tritonclient: fix eval on unsupported systems ``                        |
| [`09c6bdfc`](https://github.com/NixOS/nixpkgs/commit/09c6bdfcc687385b110b95f99018e0e448d9e456) | `` pgsql-tools: fix eval on unsupported systems ``                         |
| [`f8800d39`](https://github.com/NixOS/nixpkgs/commit/f8800d39067282bf0ebad92c5a4faf2dcfc42107) | `` swift: fix eval on unsupported systems ``                               |
| [`352750ea`](https://github.com/NixOS/nixpkgs/commit/352750ea1774d31bfec96cbbca4ddeda46c9a07e) | `` ovmf: fix eval on unsupported systems ``                                |
| [`c7be74d1`](https://github.com/NixOS/nixpkgs/commit/c7be74d1fddbf2e74c1188c049e66c315af7b11a) | `` sunshine: fix eval on unsupported systems ``                            |
| [`e7a7e167`](https://github.com/NixOS/nixpkgs/commit/e7a7e167ed790c14a40ec944bddff4dd2e39bf16) | `` furmark: fix eval on unsupported systems ``                             |
| [`0276525a`](https://github.com/NixOS/nixpkgs/commit/0276525add3c7e5c423d170b6aa65ac54ea31c2e) | `` prl-tools: 26.4.0-57513 -> 26.4.1-57516 ``                              |
| [`d4651aef`](https://github.com/NixOS/nixpkgs/commit/d4651aefb9ce3086708c7ee221fb203232f04f5d) | `` palemoon-bin: 34.3.1 -> 34.3.2 ``                                       |
| [`b002c85a`](https://github.com/NixOS/nixpkgs/commit/b002c85a5f90d23513b32aa384f77a8d401337f5) | `` firefox-devedition-unwrapped: 154.0b8 -> 154.0b9 ``                     |
| [`8b9dd666`](https://github.com/NixOS/nixpkgs/commit/8b9dd666bc46f68a18035a8aa53fcacd7e208f79) | `` firefox-beta-unwrapped: 154.0b8 -> 154.0b9 ``                           |
| [`ed83849f`](https://github.com/NixOS/nixpkgs/commit/ed83849fe5d979d29d697ba23a58859903377d3f) | `` postfix: 3.11.5 -> 3.11.6 ``                                            |
| [`10182657`](https://github.com/NixOS/nixpkgs/commit/101826571b20ed8a91e6bfe5a7727c9c6604426d) | `` firefox-bin-unwrapped: 153.0.3 -> 153.0.4 ``                            |
| [`2d088f14`](https://github.com/NixOS/nixpkgs/commit/2d088f14e464ca2cd62b2274ae09e4c9e2a710bb) | `` firefox-unwrapped: 153.0.3 -> 153.0.4 ``                                |
| [`e13e0793`](https://github.com/NixOS/nixpkgs/commit/e13e07938c7e3ce68ad5d0be386a677e9e4f6736) | `` pcloud: 2.1.1 -> 2.2.1 ``                                               |
| [`c58c9f67`](https://github.com/NixOS/nixpkgs/commit/c58c9f67a96aa281681c3cbfef817cb7c8b5e74f) | `` pcloud: 2.1.0 -> 2.1.1 ``                                               |
| [`bf586a9a`](https://github.com/NixOS/nixpkgs/commit/bf586a9a673fdf3bbc489d5554f56f44d00c8f10) | `` morgen: 4.0.4 -> 4.0.6 ``                                               |
| [`70b2bcf4`](https://github.com/NixOS/nixpkgs/commit/70b2bcf4e00d24037bcf5482eec489b8616b01bb) | `` emacs30, emacs30-macport: backport ACE mitigation for bug#80574 ``      |
| [`c1f86317`](https://github.com/NixOS/nixpkgs/commit/c1f863178c7e78ca039b8e7873bee3a86a599881) | `` arti: 2.5.0 -> 2.5.1 ``                                                 |
| [`fb45cd4f`](https://github.com/NixOS/nixpkgs/commit/fb45cd4fccdc0404c032288c544a8a1e72908686) | `` libvirt: fix CVE-2026-61478 and CVE-2026-61477 ``                       |
| [`e0b5f49f`](https://github.com/NixOS/nixpkgs/commit/e0b5f49f510f845b3b1f12b3fe4ce7878f468c04) | `` ladybird: mark vulnerable to CVE-2026-58592 ``                          |
| [`5f92ca5e`](https://github.com/NixOS/nixpkgs/commit/5f92ca5e8ecbceca9fd7c71a437458f0d5d097d8) | `` nezha: 2.3.0 -> 2.3.2 ``                                                |
| [`43cbfa68`](https://github.com/NixOS/nixpkgs/commit/43cbfa684c656f17e30e447b4a6cba083f76ed2c) | `` sing-box: 1.13.16 -> 1.13.18 ``                                         |
| [`c4f7b229`](https://github.com/NixOS/nixpkgs/commit/c4f7b229e9a6bd6390a295554050da668e2c4a37) | `` turn-rs: 4.1.3 -> 4.1.4 ``                                              |
| [`e23bb18f`](https://github.com/NixOS/nixpkgs/commit/e23bb18fa9e376dc42d0b9be9a84e6af08eed868) | `` ci/github-script/check-target-branch: convert to TypeScript ``          |
| [`8e8424fb`](https://github.com/NixOS/nixpkgs/commit/8e8424fbf02b964e0a48adee0bd1e1d54471b6ce) | `` ci/github-script: check types by default ``                             |
| [`e3405282`](https://github.com/NixOS/nixpkgs/commit/e34052828ca4068799e49963af6151336a9421d2) | `` ci/github-script/run: correct variable name ``                          |
| [`ca4cf44b`](https://github.com/NixOS/nixpkgs/commit/ca4cf44ba58ce73a8e606e757acd05a1cf58694c) | `` ci/github-script/.gitignore: add comparison artifact ``                 |
| [`97c27c3c`](https://github.com/NixOS/nixpkgs/commit/97c27c3c5be1e5112fbde4c765a9e6894b3f3fcb) | `` editorconfig: indent TS the same as JS ``                               |
| [`6781c2fe`](https://github.com/NixOS/nixpkgs/commit/6781c2fe927ee6085c2bd95808c2a39f123e8727) | `` jetbrains.*: switch binary IDEs to use jdk-no-jcef ``                   |
| [`075a746c`](https://github.com/NixOS/nixpkgs/commit/075a746c884981c95dba5643f75d9c9e7b58ee6a) | `` jetbrains.*: Make libraries for jcef plugin available ``                |
| [`749a05e9`](https://github.com/NixOS/nixpkgs/commit/749a05e998e54aad7fa08d94399ead3a06ffa3dc) | `` .github/dependabot.yml: run on .github/actions/*/* too ``               |
| [`b4627648`](https://github.com/NixOS/nixpkgs/commit/b4627648ae4cd41c77a5a7aec8c20a99bde1e6b3) | `` .github/actions/checkout: bump actions/github-script from 8 to 9 ``     |
| [`42aa7305`](https://github.com/NixOS/nixpkgs/commit/42aa7305e18d9a59493bb7951cdbbe6346f8fe20) | `` maintainers/github-teams.json: Automated sync ``                        |
| [`3043fb8c`](https://github.com/NixOS/nixpkgs/commit/3043fb8cf49616fc4142a2da0343e85408918d60) | `` linux-firmware: 20260622 -> 20260810 ``                                 |
| [`b4146a22`](https://github.com/NixOS/nixpkgs/commit/b4146a228d21213fd97493b635c05507272f2621) | `` tabbyapi: 0-unstable-2026-07-31 -> 0-unstable-2026-08-08 ``             |
| [`26c49a1f`](https://github.com/NixOS/nixpkgs/commit/26c49a1f35b84f529839f87b644d9e54228c58f5) | `` python3Packages.exllamav3: 1.3.0 -> 1.4.1 ``                            |
| [`1e96e496`](https://github.com/NixOS/nixpkgs/commit/1e96e496b2beedf33756e3295a108e04c3554374) | `` nixos/misskey: fixes for attrTag submodule docs ``                      |
| [`3b08159f`](https://github.com/NixOS/nixpkgs/commit/3b08159f45c6bf38b10fcc4d2bed5e59030b1066) | `` forge-mtg: 2.0.13 -> 2.0.14 ``                                          |
| [`70e75b38`](https://github.com/NixOS/nixpkgs/commit/70e75b38567afbe2e861f2dbb538154b708e34e1) | `` necesse-server: 1.3.1-24494674 -> 1.3.2-24574169 ``                     |
| [`77c78e74`](https://github.com/NixOS/nixpkgs/commit/77c78e74fbb0b311d0a08c29720f5e0987d9aa00) | `` linux_xanmod_latest: 7.1.6 -> 7.1.8 ``                                  |
| [`3d9ba17b`](https://github.com/NixOS/nixpkgs/commit/3d9ba17bdfba610d09ee9a7b7978a644797edb18) | `` linux_xanmod: 6.18.42 -> 6.18.44 ``                                     |
| [`71cfc765`](https://github.com/NixOS/nixpkgs/commit/71cfc7651f9fa68b61fe4d33672b3df859be1a9a) | `` gelly: 1.9.5 -> 1.9.7 ``                                                |
| [`da289955`](https://github.com/NixOS/nixpkgs/commit/da289955fc9b6ef099abbb3adb8c70f343acc21d) | `` github-runner: add myself as maintainer ``                              |
| [`2801ceb8`](https://github.com/NixOS/nixpkgs/commit/2801ceb8987c1ac2d05835b6dd8ee4994fb82e0d) | `` github-runner: 2.335.1 -> 2.336.0 ``                                    |
| [`161eddce`](https://github.com/NixOS/nixpkgs/commit/161eddce848f768a375b5493399cea8cad4c2c71) | `` blackfire: 2026.7.0 -> 2026.8.0 ``                                      |
| [`1690636b`](https://github.com/NixOS/nixpkgs/commit/1690636bbe990711e0ab57adae4e7f8fb0774d45) | `` zulu: fix eval on unsupported systems ``                                |
| [`3f4b2341`](https://github.com/NixOS/nixpkgs/commit/3f4b234187745afb6fd6e028b8c8d3b941ae479f) | `` matrix-tuwunel: 1.8.2 -> 1.8.3 ``                                       |
| [`0bb45013`](https://github.com/NixOS/nixpkgs/commit/0bb45013a71e092a695fdbf171188db96fff6ffc) | `` thunderbird-latest-unwrapped: 153.0.1 -> 153.0.2 ``                     |
| [`2c942a8d`](https://github.com/NixOS/nixpkgs/commit/2c942a8dad9dbdba5f0b4fdd7830cde8d1f23e8f) | `` thunderbird-esr-bin-unwrapped: 153.0.1esr -> 153.0.2esr ``              |
| [`12b1837f`](https://github.com/NixOS/nixpkgs/commit/12b1837faf1e97b386bc250add92188adc602eb7) | `` linux_6_6: 6.6.150 -> 6.6.151 ``                                        |
| [`a806b249`](https://github.com/NixOS/nixpkgs/commit/a806b2496560e853615440250a4db3c4641a8e71) | `` linux_6_12: 6.12.102 -> 6.12.103 ``                                     |
| [`5057e4c8`](https://github.com/NixOS/nixpkgs/commit/5057e4c81176dd975321e1f5cfe860d6f61d4a0d) | `` linux_6_18: 6.18.43 -> 6.18.44 ``                                       |
| [`0e4315ce`](https://github.com/NixOS/nixpkgs/commit/0e4315ce4324ed5df6a2834588c588846306fd2c) | `` linux_7_1: 7.1.7 -> 7.1.8 ``                                            |
| [`8c242464`](https://github.com/NixOS/nixpkgs/commit/8c242464b0dbd67779cdf45ade31ada62000b180) | `` linux_testing: 7.2-rc6 -> 7.2-rc7 ``                                    |
| [`6049ede1`](https://github.com/NixOS/nixpkgs/commit/6049ede12ae85fcf05f85d679d67fa22aca1ae2b) | `` sonarr: 4.0.18.2971 -> 4.0.19.2979 ``                                   |
| [`d010f507`](https://github.com/NixOS/nixpkgs/commit/d010f50785deae6310262dc9228d1e1f4f2af5b8) | `` nixos/technitium-dns-server: set WorkingDirectory on systemd service `` |
| [`8a184f58`](https://github.com/NixOS/nixpkgs/commit/8a184f583045efd25463db1fa8dc529e12d04229) | `` jackett: 0.24.2288 -> 0.24.2335 ``                                      |
| [`0bcb22df`](https://github.com/NixOS/nixpkgs/commit/0bcb22dfaa716661d8474fa28866672e7680b58f) | `` bitwarden-desktop: use npmDepsFetcherVersion 2 ``                       |
| [`ab285a3b`](https://github.com/NixOS/nixpkgs/commit/ab285a3bb47831c6dc50786e211425d1275ee6db) | `` bitwarden-desktop: 2026.6.1 -> 2026.7.0 ``                              |
| [`befd7d83`](https://github.com/NixOS/nixpkgs/commit/befd7d83bd47732f750df810ec2fc2aae98d1553) | `` bitwarden-desktop: 2026.6.0 -> 2026.6.1 ``                              |
| [`cf5e3981`](https://github.com/NixOS/nixpkgs/commit/cf5e3981d6a9b813a0fe92c808d0553b26b5faaa) | `` bitwarden-desktop: 2026.5.0 -> 2026.6.0, migrated to finalAttrs ``      |
| [`1e1f63fe`](https://github.com/NixOS/nixpkgs/commit/1e1f63fe00b761be09cc9608d1f06189c22023e2) | `` maintainers: add tree-sapii ``                                          |
| [`238cff8c`](https://github.com/NixOS/nixpkgs/commit/238cff8c3f471ba741ebb66dcd643ab78371d86a) | `` matrix-authentication-service: 1.21.0 -> 1.22.0 ``                      |
| [`703e84ae`](https://github.com/NixOS/nixpkgs/commit/703e84ae9389c6d34d691eec511c615e4c03a373) | `` bitwarden-desktop: drop LLVM pin on macOS ``                            |
| [`514632ee`](https://github.com/NixOS/nixpkgs/commit/514632eedc8e44c70c252af296347c4f1be8b5d0) | `` docker-compose: 5.3.1 -> 5.4.0 ``                                       |
| [`9c79876f`](https://github.com/NixOS/nixpkgs/commit/9c79876f951b6f1ff2b159466428ea99a5e5e7ee) | `` docker-compose: 5.3.0 -> 5.3.1 ``                                       |
| [`f2f80daf`](https://github.com/NixOS/nixpkgs/commit/f2f80daf5da39a033232be82bc60f0746f56702f) | `` docker-compose: 5.2.0 -> 5.3.0 ``                                       |
| [`7551c66a`](https://github.com/NixOS/nixpkgs/commit/7551c66a0a583c5fbccf589cb15d4784df7f47aa) | `` docker-compose: 5.1.4 -> 5.2.0 ``                                       |
| [`482ea6f0`](https://github.com/NixOS/nixpkgs/commit/482ea6f02cbd2c1316fcd91b2dd3107f6e3c762d) | `` nixos/feishin: init module ``                                           |
| [`74b58cab`](https://github.com/NixOS/nixpkgs/commit/74b58cab8819ccc1881365a5f3dbf027b14bb68a) | `` maintainers: add rharish ``                                             |
| [`73b33109`](https://github.com/NixOS/nixpkgs/commit/73b331096b5f6aeb62825eb2fb63937d774969fa) | `` goshs: fix CVE-2026-5160 ``                                             |
| [`c0443402`](https://github.com/NixOS/nixpkgs/commit/c0443402183a0bb074f37cfd8f71563a0a8db491) | `` goshs: 2.1.4 -> 2.1.5 ``                                                |
| [`d5cebb7d`](https://github.com/NixOS/nixpkgs/commit/d5cebb7d79e6dfff99b1d8b860cba9165b77fa9e) | `` goshs: fix CVE-2026-66063 and CVE-2026-66064 ``                         |
| [`a397b485`](https://github.com/NixOS/nixpkgs/commit/a397b48592f94bee3529e4605f42c81162ed4c73) | `` goshs: 2.1.3 -> 2.1.4 ``                                                |
| [`f283f883`](https://github.com/NixOS/nixpkgs/commit/f283f883f67a373bdad99983cad210183bfabec8) | `` goshs: 2.1.2 -> 2.1.3 ``                                                |
| [`7459911e`](https://github.com/NixOS/nixpkgs/commit/7459911ed512a72dbb2547f63a7c1319f85c4464) | `` goshs: 2.1.1 -> 2.1.2 ``                                                |
| [`f34b06ab`](https://github.com/NixOS/nixpkgs/commit/f34b06ab3f195f3d74f6ac224c342c8aa6f1fdaf) | `` goshs: 2.1.0 -> 2.1.1 ``                                                |
| [`93331ab3`](https://github.com/NixOS/nixpkgs/commit/93331ab340e1f6b9483578e88d842219d581216b) | `` goshs: 2.0.9 -> 2.1.0 ``                                                |
| [`ea345420`](https://github.com/NixOS/nixpkgs/commit/ea3454208b14179ef852791f8e494a50a9fe93e2) | `` goshs: 2.0.8 -> 2.0.9 ``                                                |
| [`10f83513`](https://github.com/NixOS/nixpkgs/commit/10f8351334fbdc586e2e87345c679961e765159c) | `` nextcloudPackages: add pantry ``                                        |
| [`1ecbc850`](https://github.com/NixOS/nixpkgs/commit/1ecbc850e85960a70d2027e65b583feb06578353) | `` nextcloudPackages: update apps ``                                       |
| [`9ddb0a94`](https://github.com/NixOS/nixpkgs/commit/9ddb0a94c22dbb4f9ebb78e6dde603967e9fb870) | `` gnome-shell: patch to use host gjs, set strictDeps ``                   |
| [`03d97180`](https://github.com/NixOS/nixpkgs/commit/03d971804f0bb1f53e9c39f38abeb7f7fe048b2b) | `` gnomeExtensions.arcmenu: 67.2 -> 69.2 ``                                |