### PR TITLE
feat(ci): close the opencode node_modules hash drift gap

### DIFF
--- a/.github/workflows/opencode-hash-guard.yaml
+++ b/.github/workflows/opencode-hash-guard.yaml
@@ -1,0 +1,144 @@
+---
+name: opencode-hash-guard
+
+# Catches the failure mode that produced commit a278fe87.
+#
+# overlays/opencode.nix pins the `node_modules` fixed-output hash, which is a
+# function of BOTH the opencode source AND nixpkgs' opencode packaging recipe.
+# update-opencode.yaml owns the first and revalidates the second daily, but a
+# nixpkgs bump can invalidate the hash the moment it lands. Without this guard
+# the bump PR simply fails both desktop builds with a hash mismatch and a human
+# has to work out why.
+#
+# So: when a PR moves the `nixpkgs` input, recompute the hash and push the
+# correction onto the PR branch, so the bump arrives already correct.
+#
+# WHY THE GATE IS A flake.lock READ AND NOT A BUILD
+#
+# The recompute is a cold `bun install` of a ~2.3 GiB tree, far too expensive
+# to run on every PR. The `nixpkgs` root input rev is read straight out of
+# flake.lock as JSON on both sides, which costs nothing, and a rev that has not
+# moved cannot have changed the recipe.
+#
+# WHY PUSHING TO THE PR BRANCH IS SAFE HERE
+#
+# If Renovate or flake-update-action later rebases and drops the fixup commit,
+# this workflow simply fires again on the new head and re-pushes. The
+# correction is idempotent and self-healing rather than a one-shot that can be
+# silently lost.
+
+on:
+  pull_request:
+    paths:
+      - "flake.lock"
+      - "overlays/opencode.nix"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  guard:
+    name: Verify opencode node_modules hash
+    # Fork PRs cannot see secrets.PAT and must not be pushed to.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ secrets.PAT }}
+          persist-credentials: true
+          ref: ${{ github.event.pull_request.head.ref }}
+          # Need the base commit too, to diff flake.lock across the PR.
+          fetch-depth: 0
+
+      - name: Did the nixpkgs input move?
+        id: gate
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          root_nixpkgs_rev() {
+            jq -r '.nodes.root.inputs.nixpkgs as $n | .nodes[$n].locked.rev'
+          }
+
+          # `.nodes.nixpkgs` is NOT the root input -- the root's `nixpkgs` is an
+          # alias that usually resolves to a suffixed node (nixpkgs_12 at time
+          # of writing), while a node literally named `nixpkgs` belongs to some
+          # transitive dependency. Resolving through .nodes.root.inputs is the
+          # only correct way to read it.
+          base_rev=$(git show "${BASE_SHA}:flake.lock" | root_nixpkgs_rev)
+          head_rev=$(root_nixpkgs_rev < flake.lock)
+
+          echo "base nixpkgs: $base_rev"
+          echo "head nixpkgs: $head_rev"
+
+          if [ "$base_rev" = "$head_rev" ]; then
+            echo "nixpkgs unchanged; the recipe cannot have moved"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        if: steps.gate.outputs.run == 'true'
+        with:
+          extra-conf: accept-flake-config = true
+
+      - name: Configure Git identity
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github[bot]"
+
+      - name: Recompute the node_modules hash
+        id: sync
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          set -uo pipefail
+
+          ./scripts/sync-opencode-hash.sh
+          rc=$?
+
+          case "$rc" in
+            0) echo "changed=false" >> "$GITHUB_OUTPUT" ;;
+            2) echo "changed=true"  >> "$GITHUB_OUTPUT" ;;
+            *) echo "sync failed with exit $rc" >&2; exit "$rc" ;;
+          esac
+
+      - name: Push the correction onto the PR branch
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          git add overlays/opencode.nix
+          git commit -m "fix(opencode): recompute node_modules hash for the nixpkgs bump"
+          git push origin "HEAD:${HEAD_REF}"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<'SUMMARY'
+          ### opencode node_modules hash corrected
+
+          This nixpkgs bump changed opencode's packaging recipe, which
+          invalidated the fixed-output hash pinned in
+          `overlays/opencode.nix`. The corrected hash has been pushed to
+          this branch.
+
+          Recomputed by forcing a placeholder hash, so the builder really
+          ran: a fixed-output derivation resolves by hash alone, and a
+          stale pin would otherwise substitute the old content from the
+          cache and prove nothing.
+          SUMMARY
+
+      - name: Report a clean result
+        if: steps.sync.outputs.changed == 'false'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'SUMMARY'
+          ### opencode node_modules hash is correct
+
+          The nixpkgs input moved, but the pinned fixed-output hash still
+          matches what the new recipe produces. Verified by a forced
+          rebuild, not by a cache hit.
+          SUMMARY

--- a/.github/workflows/opencode-hash-guard.yaml
+++ b/.github/workflows/opencode-hash-guard.yaml
@@ -33,9 +33,11 @@ on:
       - "flake.lock"
       - "overlays/opencode.nix"
 
+# Only what checkout needs. The push authenticates with a PAT supplied inline
+# at push time, so the job token never needs write access, and nothing here
+# touches the pull-requests API.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   guard:
@@ -46,8 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.PAT }}
-          persist-credentials: true
+          # Default GITHUB_TOKEN, and deliberately NOT persisted. This job runs
+          # code from the PR branch -- sync-opencode-hash.sh itself, plus
+          # whatever Nix that branch evaluates -- so any credential left in
+          # .git/config here is readable by that code. The PAT is introduced
+          # only in the final push step, after all branch code has run.
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.ref }}
           # Need the base commit too, to diff flake.lock across the PR.
           fetch-depth: 0
@@ -111,12 +117,20 @@ jobs:
         if: steps.sync.outputs.changed == 'true'
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PAT: ${{ secrets.PAT }}
         run: |
           set -euo pipefail
 
           git add overlays/opencode.nix
           git commit -m "fix(opencode): recompute node_modules hash for the nixpkgs bump"
-          git push origin "HEAD:${HEAD_REF}"
+
+          # PAT rather than GITHUB_TOKEN so the push re-triggers CI on the PR;
+          # a GITHUB_TOKEN push deliberately does not. Supplied inline instead
+          # of via checkout's `token:` so it is never sitting in .git/config
+          # while this branch's own code executes. Actions masks it in logs.
+          git push \
+            "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${HEAD_REF}"
 
           cat >> "$GITHUB_STEP_SUMMARY" <<'SUMMARY'
           ### opencode node_modules hash corrected

--- a/.github/workflows/update-opencode.yaml
+++ b/.github/workflows/update-opencode.yaml
@@ -5,9 +5,29 @@ name: update-opencode
 # nixpkgs' (frequently stale) version — see that file for why. Renovate
 # can't maintain it: bumping requires recomputing the `node_modules`
 # fixed-output-derivation hash, which means actually running a Nix build,
-# not just a version-string/hash lookup. This workflow does that dance
-# daily (opencode ships multiple releases a week) and only opens a PR if
-# the resulting package actually builds.
+# not just a version-string/hash lookup.
+#
+# This workflow watches BOTH inputs that hash depends on:
+#
+#     outputHash = f( opencode src , nixpkgs' node_modules recipe )
+#
+# It used to watch only the first — it compared the pinned version against
+# the newest upstream release and `exit 0`d when they matched, so between
+# opencode releases the pinned hash was never revalidated. A nixpkgs-side
+# recipe change (d07339e1, "drop bundled Windows executables from
+# node_modules") therefore went unnoticed until a nixpkgs bump PR failed both
+# desktop builds and had to be diagnosed by hand; see commit a278fe87.
+#
+# So the daily run now ALWAYS recomputes. A new opencode release is just an
+# extra thing to do first, not a precondition for checking anything.
+#
+# The recompute is trustworthy wherever it runs: sync-opencode-hash.sh forces
+# a placeholder hash, and Nix validates fixed-output content against its
+# declared hash on substitution as well as on build, so no cache can satisfy
+# it. That matters because a fixed-output derivation resolves by hash alone —
+# on the self-hosted runners a *stale* pinned hash will happily substitute the
+# old content and prove nothing, which is precisely the trap this workflow
+# exists to escape.
 
 on:
   schedule:
@@ -53,78 +73,93 @@ jobs:
           echo "current: $current_version"
           echo "latest:  $latest_version"
 
+          # Deliberately NO early exit when these match. The hash still has to
+          # be revalidated against the current nixpkgs recipe.
           if [ "$current_version" = "$latest_version" ]; then
-            echo "already up to date"
-            echo "update=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "no new release; revalidating the pinned hash only"
+            echo "new_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "new_release=true" >> "$GITHUB_OUTPUT"
           fi
-
-          echo "update=true" >> "$GITHUB_OUTPUT"
           echo "version=$latest_version" >> "$GITHUB_OUTPUT"
 
-      - name: Bump version and source hash
-        if: steps.check.outputs.update == 'true'
+      - name: Sync version and node_modules hash
+        id: sync
         env:
+          NEW_RELEASE: ${{ steps.check.outputs.new_release }}
           NEW_VERSION: ${{ steps.check.outputs.version }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
-          sed -i "s/^\(\s*version = \)\".*\";/\1\"${NEW_VERSION}\";/" overlays/opencode.nix
-
-          src_hash=$(nix run nixpkgs#nix-prefetch-github -- anomalyco opencode --rev "v${NEW_VERSION}" \
-            | jq -r .hash)
-
-          # Unambiguous: the `src` fetch uses the `hash` key, while
-          # node_modules (updated in the next step) uses `outputHash`.
-          # `|` delimiter: SRI base64 hashes can contain `/`, which would
-          # break a `/`-delimited sed substitution.
-          sed -i "s|hash = \"sha256-.*\";|hash = \"${src_hash}\";|" overlays/opencode.nix
-
-      - name: Recompute node_modules fixed-output hash
-        if: steps.check.outputs.update == 'true'
-        run: |
-          set -euo pipefail
-
-          # Force a hash mismatch to learn the real one, mirroring the
-          # manual bump procedure documented in overlays/opencode.nix.
-          sed -i 's/outputHash = "sha256-.*";/outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";/' \
-            overlays/opencode.nix
-
-          build_log=$(nix build '.#nixosConfigurations.Daytona.pkgs.opencode.node_modules' --no-link 2>&1) && {
-            echo "expected a hash mismatch but the build succeeded outright" >&2
-            exit 1
-          }
-
-          real_hash=$(echo "$build_log" | grep -oP 'got:\s+\K\S+' || true)
-          if [ -z "$real_hash" ]; then
-            echo "$build_log" >&2
-            echo "could not extract the real node_modules hash from the build log above" >&2
-            exit 1
+          if [ "$NEW_RELEASE" = "true" ]; then
+            ./scripts/sync-opencode-hash.sh --version "$NEW_VERSION"
+          else
+            ./scripts/sync-opencode-hash.sh
           fi
+          rc=$?
 
-          sed -i "s|outputHash = \"sha256-.*\";|outputHash = \"${real_hash}\";|" overlays/opencode.nix
+          # 0 = already correct, 2 = overlay was updated, anything else = error.
+          case "$rc" in
+            0) echo "changed=false" >> "$GITHUB_OUTPUT" ;;
+            2) echo "changed=true"  >> "$GITHUB_OUTPUT" ;;
+            *) echo "sync failed with exit $rc" >&2; exit "$rc" ;;
+          esac
 
       - name: Verify the full package builds
-        if: steps.check.outputs.update == 'true'
+        if: steps.sync.outputs.changed == 'true'
         run: nix build '.#nixosConfigurations.Daytona.pkgs.opencode' --no-link
 
       - name: Commit, push, and open a PR
-        if: steps.check.outputs.update == 'true'
+        if: steps.sync.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.PAT }}
+          NEW_RELEASE: ${{ steps.check.outputs.new_release }}
           NEW_VERSION: ${{ steps.check.outputs.version }}
         run: |
           set -euo pipefail
 
-          branch="update-opencode-${NEW_VERSION}"
+          # Two distinct reasons to land a change, and they want different
+          # titles: a version bump is routine, whereas a hash correction with
+          # no version change means the nixpkgs recipe moved under us and is
+          # worth being able to spot in the log at a glance.
+          if [ "$NEW_RELEASE" = "true" ]; then
+            branch="update-opencode-${NEW_VERSION}"
+            title="chore(opencode): update overlay to v${NEW_VERSION}"
+            body=$(cat <<BODY
+          Automated bump of the opencode overlay (see overlays/opencode.nix) to
+          the latest upstream release.
+
+          The node_modules fixed-output hash was recomputed by forcing a
+          placeholder, so the builder really ran rather than resolving from a
+          cache, and \`nix build
+          .#nixosConfigurations.Daytona.pkgs.opencode\` succeeds.
+          BODY
+            )
+          else
+            branch="fix-opencode-hash-$(date -u +%Y%m%d)"
+            title="fix(opencode): recompute stale node_modules hash"
+            body=$(cat <<BODY
+          The pinned \`node_modules\` fixed-output hash no longer matches what
+          the current nixpkgs recipe produces, with no opencode version change
+          involved. nixpkgs altered its opencode packaging under us -- the
+          failure mode that previously surfaced only as a broken nixpkgs bump
+          PR, diagnosed by hand in commit a278fe87.
+
+          Recomputed by forcing a placeholder hash so an Attic cache hit
+          cannot mask it, and verified with \`nix build
+          .#nixosConfigurations.Daytona.pkgs.opencode\`.
+          BODY
+            )
+          fi
+
           git checkout -b "$branch"
           git add overlays/opencode.nix
-          git commit -m "chore(opencode): update overlay to v${NEW_VERSION}"
+          git commit -m "$title"
           git push origin "$branch" --force
 
           gh pr create \
-            --title "chore(opencode): update overlay to v${NEW_VERSION}" \
-            --body "Automated bump of the opencode overlay (see overlays/opencode.nix) to the latest upstream release. Verified locally: \`nix build .#nixosConfigurations.Daytona.pkgs.opencode\` succeeds." \
+            --title "$title" \
+            --body "$body" \
             --base main \
             --head "$branch" \
           || echo "PR already open for this branch"

--- a/scripts/sync-opencode-hash.sh
+++ b/scripts/sync-opencode-hash.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# sync-opencode-hash.sh -- keep overlays/opencode.nix's pinned hashes correct.
+#
+# WHY THIS EXISTS
+#
+# overlays/opencode.nix pins opencode to a newer upstream tag than nixpkgs
+# carries, which means it must also pin the `node_modules` fixed-output
+# derivation hash. That hash is a function of TWO independent variables:
+#
+#     outputHash = f( opencode src , nixpkgs' node_modules recipe )
+#
+# The original update-opencode.yaml only ever watched the first. It compared
+# the pinned version against the newest upstream release and exited early when
+# they matched, so between opencode releases the pinned hash was never
+# revalidated. When nixpkgs changed the recipe instead -- as it did in
+# d07339e1, "opencode: drop bundled Windows executables from node_modules" --
+# the hash silently went stale and nothing noticed until a nixpkgs bump PR
+# failed both desktop builds and a human diagnosed it by hand. That happened,
+# and the one-line fix is commit a278fe87.
+#
+# This script owns both variables. Workflows call it; it does not care why.
+#
+# THE CACHE HAZARD, AND WHY THE PLACEHOLDER IS THE ANSWER TO IT
+#
+# A fixed-output derivation's store path is determined by its `outputHash`
+# alone, NOT by its recipe. Change the recipe but keep the hash and the output
+# path is byte-identical, so if that path is substitutable Nix fetches it and
+# never runs the builder. A stale hash therefore looks perfectly healthy on any
+# machine that can reach a cache holding the old content.
+#
+# That is not hypothetical. Our desktop CI jobs run on self-hosted runners with
+# `substituters = http://192.168.31.14:8080/fred`, and a build of
+# opencode-node_modules-1.18.18 under a *changed* nixpkgs recipe was observed
+# resolving straight out of Attic with no verification whatsoever.
+#
+# The defence is the placeholder hash below, not a substituter flag. Nix
+# validates a fixed-output derivation's content against its declared hash on
+# substitution as well as on build, so a path claiming WRONG_HASH can never be
+# fetched from any cache — no such content exists. Forcing the placeholder
+# therefore guarantees the builder actually runs, on any machine, regardless of
+# what the caches hold.
+#
+# Note for anyone tempted to "harden" this with --no-substitute: don't. That
+# flag applies to the whole dependency closure, not just the target, so it
+# would rebuild bun, stdenv and everything else from source. It buys nothing
+# here — the placeholder already does the job.
+#
+# USAGE
+#
+#   sync-opencode-hash.sh [--check] [--version <v>]
+#
+#   (no args)     Recompute the node_modules hash for the currently pinned
+#                 version and rewrite overlays/opencode.nix if it differs.
+#   --check       Same, but never write. Exit 3 if the pinned hash is stale.
+#                 For CI gates that should report rather than mutate.
+#   --version <v> First repoint version + src hash at <v>, then recompute.
+#                 Omit to revalidate whatever is currently pinned -- which is
+#                 the case the old workflow could not express at all.
+#
+# EXIT CODES
+#
+#   0  Everything already correct, nothing written.
+#   1  Error.
+#   2  Updated overlays/opencode.nix (something was stale, now fixed).
+#   3  --check only: pinned hash is stale.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OVERLAY="${REPO_ROOT}/overlays/opencode.nix"
+
+# Any host works -- the overlay is host-independent. Daytona is used because it
+# is the desktop attr the manual bump procedure in overlays/opencode.nix names.
+readonly EVAL_HOST="Daytona"
+readonly NODE_MODULES_ATTR=".#nixosConfigurations.${EVAL_HOST}.pkgs.opencode.node_modules"
+
+# A syntactically valid SRI hash that cannot be the real one, used to force the
+# mismatch that reveals the true hash. lib.fakeHash is the idiomatic choice but
+# is not addressable from a bare sed, so an all-A hash serves the same purpose.
+readonly WRONG_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+CHECK_ONLY=0
+NEW_VERSION=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check)
+            CHECK_ONLY=1
+            shift
+            ;;
+        --version)
+            [[ $# -ge 2 ]] || {
+                echo "error: --version needs an argument" >&2
+                exit 1
+            }
+            NEW_VERSION="$2"
+            shift 2
+            ;;
+        *)
+            echo "error: unknown argument '$1'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+[[ -f "$OVERLAY" ]] || {
+    echo "error: $OVERLAY not found" >&2
+    exit 1
+}
+
+# Read a `<key> = "<value>";` assignment out of the overlay. Deliberately
+# anchored per-key: `src.hash` uses `hash` while node_modules uses
+# `outputHash`, and a loose pattern would clobber the wrong one.
+read_pin() {
+    sed -n "s/^[[:space:]]*$1 = \"\(.*\)\";/\1/p" "$OVERLAY" | head -1
+}
+
+# `|` as the sed delimiter throughout: SRI base64 can contain `/`, which would
+# terminate a `/`-delimited substitution mid-hash.
+write_pin() {
+    sed -i "s|^\([[:space:]]*\)$1 = \".*\";|\1$1 = \"$2\";|" "$OVERLAY"
+}
+
+CURRENT_VERSION="$(read_pin version)"
+[[ -n "$CURRENT_VERSION" ]] || {
+    echo "error: could not read the pinned version from $OVERLAY" >&2
+    exit 1
+}
+
+CHANGED=0
+
+if [[ -n "$NEW_VERSION" && "$NEW_VERSION" != "$CURRENT_VERSION" ]]; then
+    if [[ "$CHECK_ONLY" -eq 1 ]]; then
+        echo "error: --check and --version are mutually exclusive" >&2
+        exit 1
+    fi
+
+    echo "==> repointing opencode ${CURRENT_VERSION} -> ${NEW_VERSION}" >&2
+
+    src_hash="$(nix run nixpkgs#nix-prefetch-github -- \
+        anomalyco opencode --rev "v${NEW_VERSION}" | jq -r .hash)"
+    [[ -n "$src_hash" && "$src_hash" != "null" ]] || {
+        echo "error: could not prefetch the source hash for v${NEW_VERSION}" >&2
+        exit 1
+    }
+
+    write_pin version "$NEW_VERSION"
+    write_pin hash "$src_hash"
+    CURRENT_VERSION="$NEW_VERSION"
+    CHANGED=1
+fi
+
+PINNED_HASH="$(read_pin outputHash)"
+echo "==> pinned: opencode ${CURRENT_VERSION}, node_modules ${PINNED_HASH}" >&2
+
+# Force the mismatch that reveals the true hash. Restored on every exit path so
+# a failure part-way through cannot leave the placeholder committed -- that
+# would be a silently poisoned overlay.
+restore_overlay() {
+    if [[ -n "${OVERLAY_BACKUP:-}" && -f "$OVERLAY_BACKUP" ]]; then
+        mv "$OVERLAY_BACKUP" "$OVERLAY"
+    fi
+}
+OVERLAY_BACKUP="$(mktemp)"
+cp "$OVERLAY" "$OVERLAY_BACKUP"
+trap restore_overlay EXIT
+
+write_pin outputHash "$WRONG_HASH"
+
+echo "==> rebuilding node_modules (forced via placeholder hash)" >&2
+
+# The placeholder hash guarantees a real build rather than a cache hit; see the
+# header for why that is the right mechanism and --no-substitute is not.
+# The build is EXPECTED to fail: a fixed-output derivation whose content does
+# not match its declared hash is exactly how the real hash is discovered.
+BUILD_LOG="$(mktemp)"
+if nix build "$NODE_MODULES_ATTR" --no-link >"$BUILD_LOG" 2>&1; then
+    echo "error: expected a hash mismatch but the build succeeded." >&2
+    echo "       That means the placeholder hash was accepted, which should be" >&2
+    echo "       impossible -- check that write_pin actually rewrote outputHash." >&2
+    rm -f "$BUILD_LOG"
+    exit 1
+fi
+
+# Nix reports the real hash as `got:    sha256-...` on mismatch. Anything else
+# means the build failed for an unrelated reason and must not be papered over.
+REAL_HASH="$(grep -oP 'got:\s+\K\S+' "$BUILD_LOG" | head -1 || true)"
+if [[ -z "$REAL_HASH" ]]; then
+    echo "error: node_modules failed to build for a reason other than a hash" >&2
+    echo "       mismatch. Full log follows." >&2
+    cat "$BUILD_LOG" >&2
+    rm -f "$BUILD_LOG"
+    exit 1
+fi
+rm -f "$BUILD_LOG"
+
+restore_overlay
+trap - EXIT
+OVERLAY_BACKUP=""
+
+if [[ "$REAL_HASH" == "$PINNED_HASH" ]]; then
+    echo "==> node_modules hash is correct" >&2
+    [[ "$CHANGED" -eq 1 ]] && exit 2
+    exit 0
+fi
+
+echo "==> node_modules hash is STALE" >&2
+echo "      pinned: ${PINNED_HASH}" >&2
+echo "      actual: ${REAL_HASH}" >&2
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+    echo "==> --check: not writing" >&2
+    exit 3
+fi
+
+write_pin outputHash "$REAL_HASH"
+echo "==> updated ${OVERLAY}" >&2
+exit 2

--- a/scripts/sync-opencode-hash.sh
+++ b/scripts/sync-opencode-hash.sh
@@ -183,9 +183,26 @@ if nix build "$NODE_MODULES_ATTR" --no-link >"$BUILD_LOG" 2>&1; then
     exit 1
 fi
 
-# Nix reports the real hash as `got:    sha256-...` on mismatch. Anything else
-# means the build failed for an unrelated reason and must not be papered over.
-REAL_HASH="$(grep -oP 'got:\s+\K\S+' "$BUILD_LOG" | head -1 || true)"
+# Nix reports a mismatch as an adjacent pair:
+#
+#     specified: <declared hash>
+#        got:    <actual hash>
+#
+# Take the `got:` belonging to the pair whose `specified:` is our placeholder,
+# NOT simply the first `got:` in the log. A dependency that fails its own hash
+# check earlier in the build emits the same shape, and picking that one would
+# write another derivation's hash into outputHash -- a silently poisoned pin
+# that still looks well-formed. Only our target can have WRONG_HASH declared,
+# so pairing on it identifies the right block unambiguously.
+#
+# Anything else means the build failed for an unrelated reason and must not be
+# papered over, so an absent pair keeps the error path below.
+REAL_HASH="$(
+    awk -v wrong_hash="$WRONG_HASH" '
+        $1 == "specified:" && $2 == wrong_hash { want_got = 1; next }
+        want_got && $1 == "got:" { print $2; exit }
+    ' "$BUILD_LOG"
+)"
 if [[ -z "$REAL_HASH" ]]; then
     echo "error: node_modules failed to build for a reason other than a hash" >&2
     echo "       mismatch. Full log follows." >&2


### PR DESCRIPTION
The opencode `node_modules` fixed-output hash is a function of **two** independent variables:

```
outputHash = f( opencode src , nixpkgs' node_modules recipe )
```

Only the first was ever watched. `update-opencode.yaml` compared the pinned version against the newest upstream release and `exit 0`d when they matched, so between opencode releases the hash was never revalidated. A nixpkgs-side recipe change invalidates it just as thoroughly, and went unnoticed until a bump PR broke both desktops — see commit `a278fe87`, which fixed it by hand.

## Changes

| # | Change | Covers |
| --- | --- | --- |
| 1 | `scripts/sync-opencode-hash.sh` — owns both variables; callers ask for "revalidate what's pinned" or "repoint at vX then revalidate" | shared mechanics |
| 2 | `update-opencode.yaml` — early exit removed, so the daily run **always** recomputes | nixpkgs recipe drift, within 24h |
| 3 | `opencode-hash-guard.yaml` — on PRs that move the `nixpkgs` input, recompute and push the correction onto the branch | the bump PR arrives already correct |

## Two things worth reviewing closely

**The rebuild is forced by a placeholder hash, not `--no-substitute`.** Nix validates fixed-output content against its declared hash on substitution as well as on build, so a path claiming the placeholder can never be served by any cache — the builder is guaranteed to run. `--no-substitute` would apply to the *whole dependency closure* and rebuild bun, stdenv and everything else from source: hours of work on a fresh runner for no extra assurance. I had it in the first draft and removed it; the script header explains why at length, because the plausible-but-wrong version of this reasoning is easy to reach.

**The guard resolves `.nodes.root.inputs.nixpkgs`, not `.nodes.nixpkgs`.** Those are different: the root input is an alias currently resolving to `nixpkgs_12`, while the node literally named `nixpkgs` belongs to a transitive dependency on an unrelated rev. Verified against real history before wiring it up:

```
pre-bump  (61d04433): 2fcb964de67fcf60b43471c55d5d99e61a9ccb5a
post-bump (84c52623): 0e251e24a4f24e036a084b6b4b2d2491af4167f4
naive .nodes.nixpkgs: 104240a772428cc2e20d8fd86c9ddbb886bbaff2   <- wrong input
```

## Verification

- `shellcheck` and `actionlint` clean
- every `run:` block extracted and checked with `bash -n` (the heredocs inside YAML block scalars are indentation-sensitive)
- `read_pin`/`write_pin` unit-checked: `hash` and `outputHash` stay distinct, and SRI hashes containing `/` survive
- **end-to-end against the live tree**: `./scripts/sync-opencode-hash.sh --check` forced a real rebuild, recovered the true hash, and confirmed the currently pinned `sha256-oU7qWOsY...` is correct under the new nixpkgs recipe — settling by measurement the question left open when the overlay was repaired for the `passthru` move
- `--check` left `overlays/opencode.nix` byte-identical, confirming the EXIT-trap restore works and no placeholder can leak into a commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation and synchronization of the pinned opencode dependency hash.
  * Added daily checks to detect hash changes even when no new opencode release is available.
  * Added pull request automation for release updates and hash-only corrections.

* **Bug Fixes**
  * Improved detection and correction of stale or incorrect dependency hashes.
  * Prevented unnecessary builds when no update is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->