### PR TITLE
chore(flake/home-manager): `0668fdbc` -> `83b7606d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -654,11 +654,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786603258,
-        "narHash": "sha256-j1lYPT7YxOQc/G7NcJKqdpQ5/A5yX2aZdhVKkJR6cM4=",
+        "lastModified": 1786719456,
+        "narHash": "sha256-B74DLQs/VjlqyhnnX3tguWwghqJHWSJX30TKZuAljIg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0668fdbc15bd602e463cab37ff64346021193652",
+        "rev": "83b7606dcf44abe3a94b86e8bb2b3355d22e8797",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`83b7606d`](https://github.com/nix-community/home-manager/commit/83b7606dcf44abe3a94b86e8bb2b3355d22e8797) | `` lorri: update deprecated `stdenv.*` alias `` |
| [`c554d344`](https://github.com/nix-community/home-manager/commit/c554d3441f725537854e877519f01cbd60680174) | `` lorri: add Darwin daemon ``                  |
| [`2d1bac51`](https://github.com/nix-community/home-manager/commit/2d1bac51b2513914ace47797765c3265164de78e) | `` tests: fix integration tests ``              |