### PR TITLE
chore(flake/precommit-base): `edd622fd` -> `42c10474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1183,11 +1183,11 @@
         "rust-overlay": "rust-overlay_7"
       },
       "locked": {
-        "lastModified": 1786642535,
-        "narHash": "sha256-pZ9Tbmj5AUUezFpFLpK6p5GihP0GOZxaF+hR5r1wI5U=",
+        "lastModified": 1786691678,
+        "narHash": "sha256-As8gQAwfN9UFfI0w62bPz60PF2GBa6QYL+MoP7PhWro=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "edd622fddbac6968ee7185e28abb3a7b9bc289f1",
+        "rev": "42c10474772f46184668827c86ed97fc7fbd3fb3",
         "type": "github"
       },
       "original": {
@@ -1389,11 +1389,11 @@
         "nixpkgs": "nixpkgs_15"
       },
       "locked": {
-        "lastModified": 1786638241,
-        "narHash": "sha256-KJhq0HYg2gIZjpsj47z1kWrjoUUAqSqdD2mMWAsOg4k=",
+        "lastModified": 1786680812,
+        "narHash": "sha256-5lDFwethgqSULdupYl3Eu5n80jfcbb85gSJX/jb58GQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "892c035d7c2ff75acd5da10424a47ab454e1f3dc",
+        "rev": "f1dcc7e4ea4fdb6d8f276face22f353832b161e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`42c10474`](https://github.com/fredsystems/pre-commit-checks/commit/42c10474772f46184668827c86ed97fc7fbd3fb3) | `` chore(flake/rust-overlay): 892c035d -> f1dcc7e4 `` |