### PR TITLE
chore(flake/sops-nix-stable): `d1337e05` -> `a8627b21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1429,11 +1429,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786375908,
-        "narHash": "sha256-G7qDAT98nywA4EFmJCwIRO5wKvDlBBN3BWpsOnjAto8=",
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d1337e05ba0a8e88a75d2c0e1595d82f3b3e2ac4",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                 |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`7b92de85`](https://github.com/Mic92/sops-nix/commit/7b92de8552ecf573ea9a94767f9aab304b4d4641) | `` update vendorHash ``                                 |
| [`e9653635`](https://github.com/Mic92/sops-nix/commit/e9653635e7b128c15feb03757f5d7f50dd927fc4) | `` Bump google.golang.org/grpc from 1.79.3 to 1.82.1 `` |
| [`2b735bd5`](https://github.com/Mic92/sops-nix/commit/2b735bd5744566793f73aecd52d24c6dcffe7aef) | `` fix: use hostPlatform for platform checks ``         |
| [`f544f205`](https://github.com/Mic92/sops-nix/commit/f544f2052e4687afbee7d2225627f2423de99339) | `` update vendorHash ``                                 |
| [`ab752551`](https://github.com/Mic92/sops-nix/commit/ab7525510cbf23d02aadcf2626065c24876db341) | `` Bump golang.org/x/crypto from 0.51.0 to 0.52.0 ``    |