### PR TITLE
chore(flake/colmena): `795155f6` -> `dc22786a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1786550539,
-        "narHash": "sha256-2daPrjzt20J93nqxMdnsPqVz8ScEklDV5WYXy0IYheY=",
+        "lastModified": 1786742289,
+        "narHash": "sha256-r61K9svFDQkI5jONYksneDtDT5c4SkWrZVD3ni5O6Ak=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "795155f6b5d79710685899ae9d15d97cde7d7697",
+        "rev": "dc22786a43315b212eeafe13409a7203328e5a30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`b094be4c`](https://github.com/nix-community/colmena/commit/b094be4cdbe5f4f5aa316c68d10492a112deb81c) | `` ci: bump JamesIves/github-pages-deploy-action in the actions group `` |
| [`20e7699b`](https://github.com/nix-community/colmena/commit/20e7699bc15d5ae00f01de4dee2ef80cfe86cba0) | `` cargo: bump the cargo group with 3 updates ``                         |