### PR TITLE
chore(flake/nixpkgs-stable): `9f78f44a` -> `02e08985`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1786535285,
-        "narHash": "sha256-rG5HKMAgAhMgydvKGtco6rqTxRq4EDZQCx9USLvVqYw=",
+        "lastModified": 1786711500,
+        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f78f44a87948854445dae0b6bf82b2e87e4efb5",
+        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`7feae94c`](https://github.com/NixOS/nixpkgs/commit/7feae94c6a88cae67cf86a9a5974bc2a2e253f3e) | `` fittrackee: mark as insecure by GHSA-rc38-72q6-pc7w ``           |
| [`2849f555`](https://github.com/NixOS/nixpkgs/commit/2849f5553ff21150016651953724774834d7e77f) | `` prometheus-speedtest-exporter: 1.0.0 -> 1.1.0 ``                 |
| [`62353f74`](https://github.com/NixOS/nixpkgs/commit/62353f74b1ce81de92817e0290064f4cc7a56031) | `` kanidm_1_11: 1.11.0 -> 1.11.1 ``                                 |
| [`76bae500`](https://github.com/NixOS/nixpkgs/commit/76bae500720feb5e5f101e6eb3219448ca2ae60f) | `` go_1_25: 1.25.12 -> 1.25.13 ``                                   |
| [`37b50c9e`](https://github.com/NixOS/nixpkgs/commit/37b50c9e125aaca69122f818847424da44901748) | `` go_1_27: 1.27rc2 -> 1.27rc3 ``                                   |
| [`9d1dfa09`](https://github.com/NixOS/nixpkgs/commit/9d1dfa09bc6a207c8ceb8a1ebad7fce388023ec7) | `` xq-xml: 1.4.0 -> 1.5.0 ``                                        |
| [`4093de37`](https://github.com/NixOS/nixpkgs/commit/4093de37d692c0bdf1ddf1c3b5e92d69e533c167) | `` openocd-adi: 0.12.0-1.3.1-2 -> 0.12.0-1.4.0 ``                   |
| [`5c976b10`](https://github.com/NixOS/nixpkgs/commit/5c976b1024d77ca39357350a035f1e4d6e66893b) | `` wordpress_7_0: 7.0.3 -> 7.0.4 ``                                 |
| [`296a032e`](https://github.com/NixOS/nixpkgs/commit/296a032e8d8a2996d289f1ec14b1697fd7cfa11a) | `` wordpress_6_9: 6.9.6 -> 6.9.7 ``                                 |
| [`b904635f`](https://github.com/NixOS/nixpkgs/commit/b904635f3e267134e75096fe2df0796a2ff480e5) | `` wordpress_6_8: 6.8.7 -> 6.8.8 ``                                 |
| [`9b44e49d`](https://github.com/NixOS/nixpkgs/commit/9b44e49d0de68bd2017cfafa72880e3844387a5a) | `` fosrl-pangolin: pin nodejs to fix coredump ``                    |
| [`1757cecf`](https://github.com/NixOS/nixpkgs/commit/1757cecfa908c25620a07b8c7bdd1f309c10410d) | `` chiri: 0.9.2 -> 1.0.0 ``                                         |
| [`7e8abe3e`](https://github.com/NixOS/nixpkgs/commit/7e8abe3eb489cc5f69b410c37c38652561485994) | `` python311: 3.11.15 -> 3.11.16 ``                                 |
| [`6670a73d`](https://github.com/NixOS/nixpkgs/commit/6670a73d2ba09355e5cbd8672ce0aa4bb9be1626) | `` python312: 3.12.13 -> 3.12.14 ``                                 |
| [`dbaa578a`](https://github.com/NixOS/nixpkgs/commit/dbaa578a08bb56d569188315bbc90bde345fbe91) | `` regclient: 0.11.3 -> 0.11.5 ``                                   |
| [`64ec292e`](https://github.com/NixOS/nixpkgs/commit/64ec292e38d22c7855abc3fcffefaa201f850c96) | `` python3packages.udsoncan: fix failing tests in Darwin sandbox `` |
| [`9d80977e`](https://github.com/NixOS/nixpkgs/commit/9d80977ece9b31cfb30b65f83e9fba21b1ccc083) | `` libvirt: fix security vulnerabilities ``                         |
| [`93dd59c2`](https://github.com/NixOS/nixpkgs/commit/93dd59c2c957ad27cab56e6626895cfabda8610d) | `` buildbox: 1.4.15 -> 1.4.17 ``                                    |
| [`9f3bec81`](https://github.com/NixOS/nixpkgs/commit/9f3bec81473a680d10eaf13f97a7389c2eba5d26) | `` regclient: Remove usage of rec and with ``                       |
| [`01910c4a`](https://github.com/NixOS/nixpkgs/commit/01910c4a14a0a7e4dee2017e6d0ada9c20050d76) | `` microcode-intel: 20260811 -> 20260812 ``                         |
| [`d3c01fce`](https://github.com/NixOS/nixpkgs/commit/d3c01fced9dd0429700369918b24a13820c01bb0) | `` rsyslog: fix CVE-2026-19654 ``                                   |
| [`9c461e1f`](https://github.com/NixOS/nixpkgs/commit/9c461e1fb9919acba2115b531a058f29ebd22187) | `` fosrl-pangolin: 1.19.4 -> 1.21.0 ``                              |
| [`d6cfcc04`](https://github.com/NixOS/nixpkgs/commit/d6cfcc04359842a3a275a7f685cf6de55b04b0c7) | `` clamav: 1.4.4 -> 1.4.6 ``                                        |
| [`44185a91`](https://github.com/NixOS/nixpkgs/commit/44185a91dc87c02a2ffd7cbcfa656802854369fd) | `` fosrl-pangolin: Allow edition to be specified ``                 |
| [`9bd28a50`](https://github.com/NixOS/nixpkgs/commit/9bd28a500f7019eaef0edac5db9325abca14901b) | `` domination: 1.3.4 -> 1.3.5 ``                                    |
| [`a43caec1`](https://github.com/NixOS/nixpkgs/commit/a43caec1cd0971f3d293ef7b1a12018308298ec3) | `` freecad: add acuteaangle to maintainers ``                       |
| [`70d9875e`](https://github.com/NixOS/nixpkgs/commit/70d9875ee16df98afa38d35a7cce2734ee1e7315) | `` freecad: 1.1.1 -> 1.1.3 ``                                       |
| [`78747c32`](https://github.com/NixOS/nixpkgs/commit/78747c321e6a6f6b38ca437e3ce41e11fd34ec31) | `` freecad: set `meta.mainProgram` ``                               |
| [`4df232e9`](https://github.com/NixOS/nixpkgs/commit/4df232e986319dd8ea13d89da135a4c8da5fa932) | `` freecad: add `versionCheckHook` ``                               |
| [`10ecb7d8`](https://github.com/NixOS/nixpkgs/commit/10ecb7d8dfabb029e99271f3950f45c14fd29f3a) | `` rsyslog: 8.2512.0 -> 8.2606.0 ``                                 |
| [`60e9dc59`](https://github.com/NixOS/nixpkgs/commit/60e9dc59f5b5738e09647cd9b8f54cc63b8fff19) | `` tshark: 4.6.7 -> 4.6.8 ``                                        |
| [`8c98ef1b`](https://github.com/NixOS/nixpkgs/commit/8c98ef1b1f3b4eec2d564d48f0b8123e30198464) | `` openlinkhub: 0.8.9 -> 0.9.0 ``                                   |
| [`8ea6c838`](https://github.com/NixOS/nixpkgs/commit/8ea6c8382a4cae87d557ff37a4c7b67a0fc42b32) | `` freetube: 0.25.1 -> 0.25.2; pin electron version ``              |
| [`e09f7beb`](https://github.com/NixOS/nixpkgs/commit/e09f7bebe03e48de096006f6e793f37e2905425f) | `` radicle-node-unstable: 1.10.0 -> 1.10.1 ``                       |
| [`d5443626`](https://github.com/NixOS/nixpkgs/commit/d5443626656013caa2a908d3e95f9bbbf6d27fff) | `` radicle-node: 1.10.0 -> 1.10.1 ``                                |
| [`4aa14b22`](https://github.com/NixOS/nixpkgs/commit/4aa14b2298f7e1a88a1004eaaccd0df73b4e7d18) | `` python3Packages.pygame-ce: 2.5.7 -> 2.5.8 ``                     |
| [`d6b3ee1b`](https://github.com/NixOS/nixpkgs/commit/d6b3ee1b7ffe8259bbb66aab6c01dcdd89ccf02d) | `` cyan-skillfish-governor-smu: init at 0.4.12 ``                   |
| [`6e4091a3`](https://github.com/NixOS/nixpkgs/commit/6e4091a3b67b87bf5d7590744105d3585e981589) | `` radicle-ci-broker: 0.30.0 -> 0.31.0 ``                           |
| [`e8135515`](https://github.com/NixOS/nixpkgs/commit/e8135515ee1b3b2c24935b3ba35e7fe218074fa4) | `` carps-cups: fix version, homepage, license ``                    |
| [`7fe94e41`](https://github.com/NixOS/nixpkgs/commit/7fe94e41aaa8dc165386a17a87049c629f6cc8b5) | `` freifunk-meshviewer: 13.1.0 -> 13.2.0 ``                         |
| [`38e07d9b`](https://github.com/NixOS/nixpkgs/commit/38e07d9b303587e95e37ca89e08ce450d602cc07) | `` go-hass-agent: 14.15.0 -> 14.15.1 ``                             |
| [`5a14c40b`](https://github.com/NixOS/nixpkgs/commit/5a14c40bb2f8ad5c376ceb584b1deea0a91265c1) | `` go-hass-agent: 14.14.1 -> 14.15.0 ``                             |
| [`d160af90`](https://github.com/NixOS/nixpkgs/commit/d160af909b418f7fdb3fa46d32f9db73c7a1b8bf) | `` ungoogled-chromium: 151.0.7922.108-1 -> 151.0.7922.137-1 ``      |
| [`4d763be4`](https://github.com/NixOS/nixpkgs/commit/4d763be49a7d532ef3d69d5b3f80fff4a0c6772a) | `` chromium,chromedriver: 151.0.7922.108 -> 151.0.7922.137 ``       |
| [`6633dd90`](https://github.com/NixOS/nixpkgs/commit/6633dd90ce0bf1f540998b0433be6ba4e787464c) | `` go-hass-agent: 14.12.0 -> 14.14.1 ``                             |
| [`91599af9`](https://github.com/NixOS/nixpkgs/commit/91599af99b07ed81704daa3a531ca910b2aab7cc) | `` freetube: fix Darwin code signing ``                             |
| [`1c8fc7b4`](https://github.com/NixOS/nixpkgs/commit/1c8fc7b49b2c83d839155bb6e65a64ab2a4c9c52) | `` go-hass-agent: 14.11.0 -> 14.12.0 ``                             |
| [`ae4fa878`](https://github.com/NixOS/nixpkgs/commit/ae4fa878062f81ecc038389618c485e5f30c8c44) | `` gocatcli: 1.2.1 -> 1.3.1 ``                                      |
| [`b0c077e0`](https://github.com/NixOS/nixpkgs/commit/b0c077e01d24215006ee8e73b9c0ce08788c5f0d) | `` polychromatic: 0.9.7 -> 0.9.8 ``                                 |
| [`e3e28c7b`](https://github.com/NixOS/nixpkgs/commit/e3e28c7b0c2bbc2b9832af755cfdef8e4765778d) | `` golds: 0.8.5 -> 0.8.7 ``                                         |
| [`b86b5148`](https://github.com/NixOS/nixpkgs/commit/b86b514851825ce711897bdf66ce525c88b2822e) | `` opengist: 1.15.0 -> 1.15.1 ``                                    |
| [`c3b42251`](https://github.com/NixOS/nixpkgs/commit/c3b422514ba89a3e12659526cc1c8ddb9232db53) | `` golds: 0.8.4 -> 0.8.5 ``                                         |
| [`33f0f776`](https://github.com/NixOS/nixpkgs/commit/33f0f77673183a83a9ea0857a20904d6cec0b930) | `` dokieli: fix license ``                                          |
| [`e0800a94`](https://github.com/NixOS/nixpkgs/commit/e0800a94b047c5849ffd88996bbc226b4cfdc33a) | `` dokieli: 0-unstable-2026-05-08 -> 0-unstable-2026-08-10 ``       |
| [`2e6c773e`](https://github.com/NixOS/nixpkgs/commit/2e6c773e3a1647987ee89ec83ced024a78571548) | `` dokieli: fix homepage URL redirect ``                            |
| [`4a9122c5`](https://github.com/NixOS/nixpkgs/commit/4a9122c5ea7fc117a076359cce2020e921661553) | `` ferdium: 7.1.1 -> 7.1.2 ``                                       |
| [`307fae0c`](https://github.com/NixOS/nixpkgs/commit/307fae0cc88055d844d850a999caedae18117990) | `` fosrl-pangolin: 1.18.4 -> 1.19.4 ``                              |
| [`29546efb`](https://github.com/NixOS/nixpkgs/commit/29546efbca937de3aaf5228b4a8197528df7224c) | `` cargo-shear: 1.13.3 -> 1.13.4 ``                                 |
| [`fa044a5f`](https://github.com/NixOS/nixpkgs/commit/fa044a5fe887bc0bca5fabd05794aa863e356d14) | `` python3Packages.udsoncan: init at 1.26.1 ``                      |
| [`4fd13173`](https://github.com/NixOS/nixpkgs/commit/4fd13173ef2cba9b02954d03aa4f60cc5ff9ee7f) | `` maintainers: add WOnder93 ``                                     |
| [`50a61ade`](https://github.com/NixOS/nixpkgs/commit/50a61ade1bb16c6076539e0bacbcdd8a392f54d2) | `` maintainers: shackra -> elzorrorebelde ``                        |
| [`04cbd0d0`](https://github.com/NixOS/nixpkgs/commit/04cbd0d0c5d853895ddcfa1692dc33cf777930cf) | `` python3Packages.pypdf: 6.14.2 -> 6.15.0 ``                       |
| [`9f630fba`](https://github.com/NixOS/nixpkgs/commit/9f630fbacabb63eb9d638822c9d5a9a276395ddc) | `` kitty: 0.48.1 -> 0.48.2 ``                                       |
| [`02623c6b`](https://github.com/NixOS/nixpkgs/commit/02623c6ba4876aba63a35ed42d7c561a1dac26ce) | `` kitty: 0.48.0 -> 0.48.1 ``                                       |
| [`2b281d30`](https://github.com/NixOS/nixpkgs/commit/2b281d308c568c3e4894b3c4854802e443097bd9) | `` kitty: fix libxkbcommon runtime lookup ``                        |
| [`74bc4535`](https://github.com/NixOS/nixpkgs/commit/74bc45357dc8f4b9e1b4716b3fd18797444ef353) | `` kitty: 0.47.4 -> 0.48.0 ``                                       |
| [`4c0b00e6`](https://github.com/NixOS/nixpkgs/commit/4c0b00e6f8f38cfb94c21386bbc068478a8ee279) | `` kitty: 0.47.2->0.47.4 ``                                         |
| [`29ca5770`](https://github.com/NixOS/nixpkgs/commit/29ca57701f703524cf3602f5df28bd551169b1ee) | `` kitty: 0.47.1 -> 0.47.2 ``                                       |
| [`9bf55f03`](https://github.com/NixOS/nixpkgs/commit/9bf55f033611f1d212b936e14ac54e8379993572) | `` kitty: 0.47.0 -> 0.47.1 ``                                       |
| [`4ca553fd`](https://github.com/NixOS/nixpkgs/commit/4ca553fdfe08879226f3e720ee1fc47a9800ae2d) | `` python3Packages.python-statemachine: 3.2.0 -> 3.2.1 ``           |
| [`ae1fe028`](https://github.com/NixOS/nixpkgs/commit/ae1fe028e479922c88dc0576ab3b1179f49cc716) | `` archon-lite: 9.4.36 -> 9.5.0 ``                                  |
| [`dee2f938`](https://github.com/NixOS/nixpkgs/commit/dee2f938fc84c486e12a5753e42d2b29d7dfe3bc) | `` wordpressPackages: update plugins and languages ``               |
| [`bb29696e`](https://github.com/NixOS/nixpkgs/commit/bb29696e83427e30bd676da9ae3d29b8701fa9bc) | `` wordpress_7_0: 7.0.2 -> 7.0.3 ``                                 |
| [`462ea159`](https://github.com/NixOS/nixpkgs/commit/462ea1598e74d63f2404a8432a7545269148de28) | `` wordpress_6_9: 6.9.5 -> 6.9.6 ``                                 |
| [`ddf5392b`](https://github.com/NixOS/nixpkgs/commit/ddf5392b308aec0d91d10b97b06e1b2415f9c83d) | `` wordpress_6_8: 6.8.6 -> 6.8.7 ``                                 |
| [`e86b83ae`](https://github.com/NixOS/nixpkgs/commit/e86b83ae77e48a16b8eb5d4b1d125d19ad4ae986) | `` mattermost: 11.7.7 -> 11.7.8 ``                                  |
| [`03b30f1f`](https://github.com/NixOS/nixpkgs/commit/03b30f1f164500bee89d38049780c817ddc788c1) | `` python3Packages.whenever: 0.10.3 -> 0.10.4 ``                    |
| [`693d4e23`](https://github.com/NixOS/nixpkgs/commit/693d4e23696d01cd3af7838eb270b21840503ada) | `` python3Packages.whenever: 0.10.2 -> 0.10.3 ``                    |
| [`5a4d46a9`](https://github.com/NixOS/nixpkgs/commit/5a4d46a9c10eb3aab8818ec780eb5b29728a4476) | `` python3Packages.whenever: 0.10.0 -> 0.10.2 ``                    |
| [`97d31d0e`](https://github.com/NixOS/nixpkgs/commit/97d31d0eb14dcd8fc5c38a50d2af6232e8bacbf1) | `` samba: 4.23.8 -> 4.23.10 ``                                      |
| [`72e4c581`](https://github.com/NixOS/nixpkgs/commit/72e4c581f9ea10b7a82dbf6e851d41f5fd291040) | `` libgsf: 1.14.55 -> 1.14.58 ``                                    |
| [`305b133e`](https://github.com/NixOS/nixpkgs/commit/305b133e75859bf505c526358b401f0d8eaa8b34) | `` jetbrains.rider: 2026.2 -> 2026.2.0.1 ``                         |
| [`e6851207`](https://github.com/NixOS/nixpkgs/commit/e6851207c473395bfe90cd55e8d5c1a3816f31e3) | `` sushi: patch to use host gjs, set strictDeps ``                  |
| [`03880c41`](https://github.com/NixOS/nixpkgs/commit/03880c41bf98c58d56b96a1404852687e0d98c7b) | `` python3Packages.md-toc: fix build ``                             |
| [`f9c6740c`](https://github.com/NixOS/nixpkgs/commit/f9c6740c5960c0590b48005e310a4524197ac5b3) | `` recordbox: add gst_all_1.gst-libav ``                            |
| [`7f24919d`](https://github.com/NixOS/nixpkgs/commit/7f24919d62a4fd6c50aac6e26a1f9023bf4f36ff) | `` nixos/boinc: update documentation link ``                        |