### PR TITLE
chore(flake/home-manager): `83b7606d` -> `c8058ecc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -654,11 +654,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786719456,
-        "narHash": "sha256-B74DLQs/VjlqyhnnX3tguWwghqJHWSJX30TKZuAljIg=",
+        "lastModified": 1786826571,
+        "narHash": "sha256-nNqmXIFmESRnU91KARtiekSox0+o+E3AS0d1TuUQ/9o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83b7606dcf44abe3a94b86e8bb2b3355d22e8797",
+        "rev": "c8058ecc1329a71a3c99c4d0353dba4009a66152",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`c8058ecc`](https://github.com/nix-community/home-manager/commit/c8058ecc1329a71a3c99c4d0353dba4009a66152) | `` mblaze: add to labeler mail entry `` |
| [`58405b3b`](https://github.com/nix-community/home-manager/commit/58405b3b0ce13e9cd4af7dc697687b4d9b74e56d) | `` mblaze: add module ``                |