### PR TITLE
fix(fredvps): ban via ipset, and alert on ban rate instead of ban totals

### DIFF
--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -546,33 +546,70 @@ in
                     {^LN-BEG}
     '';
 
-    # Host-wide, silent bans.
+    # Host-wide, silent bans, held in an ipset rather than in iptables rules.
     #
-    # Two deviations from the stock `iptables-multiport` + REJECT default,
-    # both deliberate.
+    # Three deviations from the stock `iptables-multiport` + REJECT default,
+    # all deliberate.
+    #
+    # IPSET, NOT ONE IPTABLES RULE PER ADDRESS. This is the load-bearing one.
+    # `iptables.conf` bans by inserting `-s <ip> -j DROP` into a per-jail
+    # chain, and an iptables chain is a LINEAR scan: a packet that matches
+    # nothing -- which is every packet from a legitimate client -- is compared
+    # against every rule in every f2b chain before it reaches nixos-fw. That
+    # cost is proportional to the ban count, and the ban count here is not
+    # small or stable. Measured on 2026-08-15, before this change:
+    #
+    #   f2b-recidive        407 rules
+    #   f2b-port-decoy       56
+    #   f2b-ssh-decoy        21
+    #   f2b-nginx-probe      14
+    #   total INPUT path    588
+    #
+    # recidive is a flat one-week ban (see the jail below), so its steady
+    # state is 7 x the daily intake, and daily intake went from ~25 to ~141
+    # when the decoy port list grew on 2026-08-12. That puts the chain on a
+    # path to ~1000 rules with no ceiling in sight, and f2b-recidive sits LAST
+    # in the INPUT jump order, so it is the full-length walk that every
+    # accepted packet pays for.
+    #
+    # `iptables-ipset.conf` replaces the whole per-jail chain with a single
+    # INPUT rule matching a kernel hash set:
+    #
+    #   -A INPUT -p tcp -m set --match-set f2b-recidive src -j DROP
+    #
+    # One rule per jail, O(1) lookup, and the ban count stops being a
+    # per-packet cost at all. Requires the `ipset` binary (see extraPackages
+    # below) and the xt_set / ip_set_hash_ip kernel modules, both present.
+    #
+    # WHERE THE BANS LIVE NOW. There is no f2b-<name> iptables chain under
+    # this action -- `iptables -L f2b-recidive` will report no such chain.
+    # Banned addresses are set members: `ipset list f2b-recidive`. The stock
+    # maxelem of 65536 is left alone; it is two orders of magnitude above the
+    # projected steady state. ipsettime is also left at 0, which means the set
+    # entries carry no kernel-side timeout and fail2ban continues to own
+    # unbanning -- identical expiry semantics to the iptables action, so the
+    # escalation ladder and the exported bantimes are unaffected.
     #
     # ALLPORTS, NOT MULTIPORT. The stock action installs the jump into INPUT
     # as `-p tcp -m multiport --dports http,https -j f2b-nginx-probe`, so a
-    # prober banned by an nginx jail was still free to hit sshd on 2269. Note
-    # that this is NOT visible in `iptables -L f2b-nginx-probe`: the per-
-    # address rules in that chain always read `all -- <ip> 0.0.0.0/0`, because
-    # the port match lives on the INPUT jump rule, not on the ban rules. The
-    # chain listing looks host-wide under both actions; `iptables -L INPUT -n`
-    # is where the difference actually shows. `type = allports` drops the port
-    # match from the jump, which makes the "all" in the chain listing mean
-    # what it appears to.
+    # prober banned by an nginx jail was still free to hit sshd on 2269.
+    # `type = allports` drops the port match, so the ban is genuinely
+    # host-wide. Under ipset this is visible directly in `iptables -S INPUT`:
+    # the match-set rule carries no --dports.
     #
     # DROP, NOT REJECT. The default answers with ICMP port-unreachable, which
     # tells a scanner immediately that it is blocked and frees it to move on.
     # DROP makes it wait for its own TCP timeout on every connection, and
     # since our bans are host-wide that cost applies to every port it tries.
     #
-    # blocktype is set for both families -- iptables.conf overrides it under
-    # [Init?family=inet6] for the ICMPv6 variant, so setting only the v4 value
-    # would leave IPv6 offenders on REJECT.
-    "fail2ban/action.d/iptables-allports-drop.conf".text = ''
+    # blocktype is set for both families. iptables-ipset.conf pulls in
+    # iptables.conf, which overrides blocktype under [Init?family=inet6] for
+    # the ICMPv6 variant, so setting only the v4 value would leave IPv6
+    # offenders on REJECT. The v6 set is a separate ipset (f2b-<name>6),
+    # created automatically by the family=inet6 init.
+    "fail2ban/action.d/iptables-ipset-allports-drop.conf".text = ''
       [INCLUDES]
-      before = iptables.conf
+      before = iptables-ipset.conf
 
       [Definition]
       type = allports
@@ -736,11 +773,16 @@ in
       maxretry = 5;
       bantime = "1h";
 
-      # Host-wide silent bans for every jail. See the action definition above
-      # for why allports and why DROP. Both are set because banaction-allports
-      # is what the recidive jail below uses.
-      banaction = "iptables-allports-drop";
-      banaction-allports = "iptables-allports-drop";
+      # Host-wide silent bans for every jail, backed by ipset. See the action
+      # definition above for why ipset, why allports and why DROP. Both are
+      # set because banaction-allports is what the recidive jail below uses.
+      banaction = "iptables-ipset-allports-drop";
+      banaction-allports = "iptables-ipset-allports-drop";
+
+      # The action above shells out to `ipset`, which is not otherwise on the
+      # unit's PATH. Without this every actionban fails and nothing is
+      # actually blocked, while fail2ban still reports the address as banned.
+      extraPackages = [ pkgs.ipset ];
 
       # How long ban history is retained, which is what the escalation above
       # counts against. The stock value is 1d, so an address that stays away

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -367,37 +367,58 @@ in
 
           mkdir -p "$TEXTFILE_DIR"
 
-          # Cap per jail. Only CURRENTLY banned addresses are emitted, so the
-          # short-bantime jails expire down on their own and sit well under
-          # this. recidive does not: its bantime is a flat week, so its steady
-          # state is 7 x the daily intake with no decay in between.
+          # Scratch for one jail's parsed bans, reused across jails. Kept out
+          # of TEXTFILE_DIR so a crash mid-run cannot leave a file that
+          # node_exporter would try to parse as metrics -- it reads every
+          # *.prom in that directory and rejects the whole scrape on one bad
+          # sample. Cleared with `: >` at the top of each jail rather than
+          # recreated, so the trap only has one path to clean up.
+          ROWS=$(mktemp -t fail2ban-ban-rows.XXXXXX) || exit 1
+          trap 'rm -f "$ROWS" "$TMP"' EXIT
+
+          # How many bans per jail get per-IP series, MOST RECENT FIRST.
           #
-          # This was 200, chosen against an observed peak of 84. The decoy port
-          # list grew on 2026-08-12 and recidive's daily intake went from ~25
-          # to ~141, which puts the steady state near 1000 -- so the old cap
-          # was not marginally small, it was ~5x short, and the alert on it
-          # would have been stuck on permanently rather than flagging an
-          # anomaly. 1500 restores headroom over the projected steady state.
+          # This is a display window, not a safety cap, and the distinction is
+          # the whole point. It was a cap (200, then briefly 1500) sized to sit
+          # above the expected concurrent ban count, with an alert when the
+          # count exceeded it. That framing was wrong twice over.
           #
-          # The cap still exists because unbounded per-IP labels are how a
-          # metrics backend gets hurt, but note what it does and does not
-          # bound: it bounds CONCURRENT series, not distinct series over
-          # retention. Roughly 1900 unique addresses are banned here per day,
-          # each producing two series that live for Prometheus' full 90d
-          # retention, and that number is unaffected by this value. If the
-          # exporter ever needs a real cardinality diet, it is the churn that
-          # has to be addressed, not this cap.
+          # It does not scale. recidive holds a flat one-week ban, so its
+          # steady state is 7 x daily intake with no decay in between -- 405
+          # when the 200 cap first blew, and ~1000 projected at the intake that
+          # followed the 2026-08-12 decoy port expansion. Any number chosen
+          # here is overtaken by the next step change in scan volume.
           #
-          # Anything past the cap is counted, not emitted.
-          MAX_PER_JAIL=1500
+          # And a total is not the signal anyone wants. 10k standing bans is
+          # not an incident; going from 20 bans/hour to 100 is. Rate is what
+          # gets alerted on now (f2b_jail_bans_started_1h below), which leaves
+          # this free to be sized for READABILITY rather than for headroom.
+          # Nobody reads row 900 of a ban list, so 100 recent bans is a table
+          # and 1500 is a denial of service against the person on call.
+          #
+          # Selection is by ban START time, descending. Note that this is NOT
+          # the order fail2ban hands us: `banip --with-time` sorts ascending by
+          # EXPIRY, and expiry order only equals start order within a jail
+          # whose bans are all the same length. recidive happens to satisfy
+          # that today; the escalating jails do not, so the sort below is
+          # load-bearing rather than defensive.
+          #
+          # Cardinality note, so the next person does not mistake this for one:
+          # this bounds CONCURRENT series only. Roughly 1900 unique addresses
+          # are banned here per day, each producing series that live for
+          # Prometheus' full 90d retention, and that churn is untouched by this
+          # value. A real cardinality diet has to address the churn.
+          RECENT_PER_JAIL=100
 
           {
             echo "# HELP f2b_banned_ip_bantime_seconds Length of the current ban for this address."
             echo "# TYPE f2b_banned_ip_bantime_seconds gauge"
             echo "# HELP f2b_banned_ip_expiry_timestamp_seconds Unix time at which this ban expires."
             echo "# TYPE f2b_banned_ip_expiry_timestamp_seconds gauge"
-            echo "# HELP f2b_banned_ip_truncated Banned addresses omitted because the per-jail cap was hit."
-            echo "# TYPE f2b_banned_ip_truncated gauge"
+            echo "# HELP f2b_banned_ip_outside_window Active bans older than the most-recent-N window, so absent from the per-IP series."
+            echo "# TYPE f2b_banned_ip_outside_window gauge"
+            echo "# HELP f2b_jail_bans_started_1h Bans in this jail that started within the last hour."
+            echo "# TYPE f2b_jail_bans_started_1h gauge"
             echo "# HELP f2b_ban_metrics_generated_timestamp_seconds Unix time this file was last written."
             echo "# TYPE f2b_ban_metrics_generated_timestamp_seconds gauge"
             echo "# HELP f2b_ban_metrics_fail2ban_up Whether the jail list could be read from fail2ban."
@@ -406,7 +427,7 @@ in
             echo "# TYPE f2b_ban_metrics_parse_failures gauge"
             echo "# HELP f2b_ban_metrics_jail_query_failures Jails whose ban list could not be read."
             echo "# TYPE f2b_ban_metrics_jail_query_failures gauge"
-            echo "# HELP f2b_banned_ip_max_bantime_seconds Longest ban in force in this jail, including addresses omitted by the cap."
+            echo "# HELP f2b_banned_ip_max_bantime_seconds Longest ban in force in this jail, including addresses outside the window."
             echo "# TYPE f2b_banned_ip_max_bantime_seconds gauge"
 
             # Health, kept separate from freshness on purpose.
@@ -429,9 +450,13 @@ in
             parse_failures=0
             jail_query_failures=0
 
+            now=$(date +%s)
+            hour_ago=$((now - 3600))
+
             for jail in $jails; do
-              n=0
-              omitted=0
+              total=0
+              shown=0
+              started_1h=0
               max_bantime=0
 
               # Captured into a variable rather than piped directly into the
@@ -444,10 +469,16 @@ in
               # rather than clearing fail2ban_up.
               if ! banlist=$(fail2ban-client get "$jail" banip --with-time 2>/dev/null); then
                 jail_query_failures=$((jail_query_failures + 1))
-                printf 'f2b_banned_ip_truncated{jail="%s"} 0\n' "$jail"
+                printf 'f2b_banned_ip_outside_window{jail="%s"} 0\n' "$jail"
                 printf 'f2b_banned_ip_max_bantime_seconds{jail="%s"} 0\n' "$jail"
+                printf 'f2b_jail_bans_started_1h{jail="%s"} 0\n' "$jail"
                 continue
               fi
+
+              # Parsed rows, one per line, as "<start_epoch> <ip> <bantime>
+              # <expiry_epoch>". Collected first and emitted after, because
+              # picking the most recent N requires seeing all of them.
+              : > "$ROWS"
 
               # Output line: <ip> \t <start> + <bantime> = <expiry>
               while IFS= read -r line; do
@@ -470,41 +501,68 @@ in
                   continue
                 fi
 
-                # Tracked before the cap, so the aggregate stays correct even
-                # when per-IP series are dropped.
-                #
-                # `banip --with-time` returns bans sorted ascending by EXPIRY
-                # (banmanager.py getBanList -> lst.sort on end-of-ban), and
-                # expiry order is not bantime order -- a fresh 1h ban expires
-                # before an older 2h one. So the cap removes an arbitrary
-                # slice with respect to duration, and max() over the emitted
-                # series alone can under-report the longest ban in force.
-                # Which is exactly the number the "Longest Active Ban" panel
-                # exists to show, and exactly when it matters: a sweep large
-                # enough to hit the cap.
+                # Derived rather than parsed from the line's own start field,
+                # which is the same number but would cost a second `date`
+                # fork per ban. At ~400 bans every two minutes on a 3-core
+                # box, that is worth avoiding.
+                start=$((epoch - bantime))
+
+                # Tracked across every ban, not just the emitted ones, so the
+                # aggregate stays correct when the window drops rows. This is
+                # what the "Longest Active Ban" panel reads, and the moment it
+                # matters most is exactly the moment rows are being dropped.
                 if [ "$bantime" -gt "$max_bantime" ]; then
                   max_bantime=$bantime
                 fi
 
-                n=$((n + 1))
-                if [ "$n" -gt "$MAX_PER_JAIL" ]; then
-                  omitted=$((omitted + 1))
-                  continue
+                # The rate signal. Counted here rather than derived in
+                # Prometheus from f2b_jail_banned_total, because that counter
+                # is incremented by restored bans too: banmanager.py
+                # addBanTicket() bumps __banTotal, and actions.py calls it for
+                # restored tickets as well as new ones (it is the same call
+                # that logs "Restore Ban"). A fail2ban restart therefore reads
+                # as the entire ban list arriving at once -- 97 restores inside
+                # two seconds at the last restart -- which any rate() would
+                # report as a spike that never happened.
+                #
+                # Ban start times come from the sqlite database and survive
+                # restarts unchanged, so counting them is immune to that.
+                #
+                # Sound only while every jail's bantime is >= 1h: a ban that
+                # started within the last hour must still be active to appear
+                # in this list at all. The shortest bantime here is 1h exactly.
+                # Shorten any jail below that and this undercounts.
+                if [ "$start" -gt "$hour_ago" ]; then
+                  started_1h=$((started_1h + 1))
                 fi
 
-                # ban_id exists so the dashboard can join the two series on a
-                # key that is actually unique. An address in two jails at once
-                # is routine here -- the three nginx jails read the same log --
-                # and joining on ip alone pairs the wrong ban length with the
-                # wrong jail, producing a plausible-looking wrong row.
-                printf 'f2b_banned_ip_bantime_seconds{jail="%s",ip="%s",ban_id="%s:%s"} %s\n' \
-                  "$jail" "$ip" "$jail" "$ip" "$bantime"
-                printf 'f2b_banned_ip_expiry_timestamp_seconds{jail="%s",ip="%s",ban_id="%s:%s"} %s\n' \
-                  "$jail" "$ip" "$jail" "$ip" "$epoch"
+                total=$((total + 1))
+                printf '%s %s %s %s\n' "$start" "$ip" "$bantime" "$epoch" >> "$ROWS"
               done <<< "$banlist"
 
-              printf 'f2b_banned_ip_truncated{jail="%s"} %s\n' "$jail" "$omitted"
+              # Most recent N by ban start, newest first. The sort is required:
+              # the input is ordered by expiry, which only matches start order
+              # in a jail where every ban is the same length.
+              if [ "$total" -gt 0 ]; then
+                while read -r r_start r_ip r_bantime r_epoch; do
+                  [ -z "$r_start" ] && continue
+
+                  # ban_id exists so the dashboard can join the series on a key
+                  # that is actually unique. An address in two jails at once is
+                  # routine here -- the three nginx jails read the same log --
+                  # and joining on ip alone pairs the wrong ban length with the
+                  # wrong jail, producing a plausible-looking wrong row.
+                  printf 'f2b_banned_ip_bantime_seconds{jail="%s",ip="%s",ban_id="%s:%s"} %s\n' \
+                    "$jail" "$r_ip" "$jail" "$r_ip" "$r_bantime"
+                  printf 'f2b_banned_ip_expiry_timestamp_seconds{jail="%s",ip="%s",ban_id="%s:%s"} %s\n' \
+                    "$jail" "$r_ip" "$jail" "$r_ip" "$r_epoch"
+                  shown=$((shown + 1))
+                done <<< "$(sort -rn -k1,1 "$ROWS" | head -n "$RECENT_PER_JAIL")"
+              fi
+
+              printf 'f2b_banned_ip_outside_window{jail="%s"} %s\n' "$jail" "$((total - shown))"
               printf 'f2b_banned_ip_max_bantime_seconds{jail="%s"} %s\n' "$jail" "$max_bantime"
+              printf 'f2b_jail_bans_started_1h{jail="%s"} %s\n' "$jail" "$started_1h"
             done
 
             printf 'f2b_ban_metrics_parse_failures %s\n' "$parse_failures"

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -367,12 +367,29 @@ in
 
           mkdir -p "$TEXTFILE_DIR"
 
-          # Cap per jail. Only CURRENTLY banned addresses are emitted, so this
-          # normally sits around ten and expires down on its own -- but a
-          # distributed sweep during a 64h escalated bantime could pile up, and
-          # unbounded per-IP labels are how a metrics backend gets hurt. Anything
-          # past the cap is counted, not emitted.
-          MAX_PER_JAIL=200
+          # Cap per jail. Only CURRENTLY banned addresses are emitted, so the
+          # short-bantime jails expire down on their own and sit well under
+          # this. recidive does not: its bantime is a flat week, so its steady
+          # state is 7 x the daily intake with no decay in between.
+          #
+          # This was 200, chosen against an observed peak of 84. The decoy port
+          # list grew on 2026-08-12 and recidive's daily intake went from ~25
+          # to ~141, which puts the steady state near 1000 -- so the old cap
+          # was not marginally small, it was ~5x short, and the alert on it
+          # would have been stuck on permanently rather than flagging an
+          # anomaly. 1500 restores headroom over the projected steady state.
+          #
+          # The cap still exists because unbounded per-IP labels are how a
+          # metrics backend gets hurt, but note what it does and does not
+          # bound: it bounds CONCURRENT series, not distinct series over
+          # retention. Roughly 1900 unique addresses are banned here per day,
+          # each producing two series that live for Prometheus' full 90d
+          # retention, and that number is unaffected by this value. If the
+          # exporter ever needs a real cardinality diet, it is the churn that
+          # has to be addressed, not this cap.
+          #
+          # Anything past the cap is counted, not emitted.
+          MAX_PER_JAIL=1500
 
           {
             echo "# HELP f2b_banned_ip_bantime_seconds Length of the current ban for this address."

--- a/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
@@ -353,8 +353,13 @@ groups:
       # Critical rather than warning because of how it fails. Past maxelem,
       # `ipset add` returns an error, fail2ban logs it and carries on, and the
       # address stays listed as banned in every status query and on every
-      # dashboard panel -- while packets from it are delivered normally. The
-      # observable symptom is nothing at all. That is worse than an outage.
+      # dashboard panel -- while packets from it are delivered normally.
+      #
+      # Note the failure is NOT silent in the journal; it is silent everywhere
+      # anyone actually looks. Every monitoring surface reads green while the
+      # block does not exist, and the only evidence is a log line nobody has a
+      # reason to go looking for. That is worse than an outage, and it is why
+      # the annotation below sends responders to the journal explicitly.
       #
       # 30000 is ~2x headroom. Given recidive's week-long bans that is weeks of
       # lead time, which it needs: maxelem is fixed when the set is created and
@@ -372,10 +377,12 @@ groups:
           summary: "fail2ban jail {{ $labels.jail }} is approaching its ipset limit on {{ $labels.hostname }}"
           description: >-
             Jail {{ $labels.jail }} holds {{ $value }} bans against a per-set
-            maxelem of 65536. Past that ceiling `ipset add` fails silently:
-            fail2ban keeps reporting the address as banned while its packets
-            are delivered normally, so the dashboard stays green while the
-            block does not exist. Raising maxelem requires recreating the set
-            (`ipset -exist create` will not alter it), so treat this as
-            scheduled work, not a page to sit on. Raise hashsize from its 1024
-            default at the same time.
+            maxelem of 65536. Past that ceiling `ipset add` fails and fail2ban
+            logs the error, but it carries on and keeps reporting the address
+            as banned -- so every status query and dashboard panel stays green
+            while the packets are delivered normally. The journal is the only
+            place the failure is visible: check
+            `journalctl -u fail2ban | grep -i ipset`. Raising maxelem requires
+            recreating the set (`ipset -exist create` will not alter it), so
+            treat this as scheduled work, not a page to sit on. Raise hashsize
+            from its 1024 default at the same time.

--- a/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
@@ -169,7 +169,7 @@ groups:
             `fail2ban-client get <jail> banip --with-time` against the parser
             in hosts/linux/fredvps/configuration.nix.
 
-      # A jail exceeded the 200-address per-jail cap.
+      # A jail exceeded the 1500-address per-jail cap.
       #
       # Two possible meanings, both worth knowing about: either the host is
       # under a distributed sweep large enough to matter, or the cap needs
@@ -180,8 +180,18 @@ groups:
       # silently under-reported the longest active ban, so this alert would
       # have fired alongside a panel that was quietly wrong.
       #
-      # Peak concurrent bans in any jail to date is 84, so this has headroom
-      # and should not fire in normal operation.
+      # The cap was 200, sized against a then-peak of 84. On 2026-08-15 the
+      # recidive jail hit 405 and this fired for real: the decoy port list had
+      # grown three days earlier and recidive's daily intake went ~25 -> ~141.
+      # Because recidive bans are a flat week, steady state is 7 x intake, so
+      # the honest projection was ~1000 and the alert would have been stuck on
+      # rather than signalling an anomaly. Raised to 1500 for headroom over
+      # that projection.
+      #
+      # If this fires again, check the intake trend before reaching for the
+      # cap again -- a further step change in daily bans is the thing worth
+      # knowing about, and raising the cap is only the right response once the
+      # new steady state is understood.
       - alert: Fail2banBanListTruncated
         expr: f2b_banned_ip_truncated > 0
         for: 15m
@@ -191,7 +201,7 @@ groups:
           summary: "fail2ban jail {{ $labels.jail }} exceeded its ban-list cap on {{ $labels.hostname }}"
           description: >-
             {{ $value }} banned address(es) in jail {{ $labels.jail }} are
-            omitted from the exported metrics because the 200-per-jail cap was
-            hit. Aggregates stay correct, but the Active Bans table is
+            omitted from the exported metrics because the 1500-per-jail cap
+            was hit. Aggregates stay correct, but the Active Bans table is
             incomplete. Either an unusually large sweep is in progress or
             MAX_PER_JAIL needs raising.

--- a/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
@@ -270,3 +270,112 @@ groups:
             what is being caught, and confirm it is hostile before treating
             this as routine. Standing ban totals are not the concern here and
             are not alerted on.
+
+  # Saturation, not security. These two are about the machinery running out of
+  # room, and they are the only rules here whose thresholds come from measured
+  # limits of this host rather than from what its traffic normally looks like.
+  #
+  # WHAT DOES AND DOES NOT SCALE WITH BAN COUNT
+  #
+  # Since bans moved from per-address iptables rules to an ipset, per-packet
+  # cost no longer tracks the ban count at all. `hash:ip` resizes to keep
+  # bucket occupancy bounded (the live set reports `bucketsize 12`), so growing
+  # the set adds buckets rather than depth and a lookup does the same work at
+  # 1k entries as at 65k. Measured on the live set: ~55 bytes/entry, so even a
+  # full set is ~3.6 MB. Neither CPU nor memory is what runs out.
+  #
+  # Two things do:
+  #
+  #   Restore time. fail2ban replays every stored ban through one `ipset add`
+  #   subprocess at startup. Measured at the 2026-08-15 restart: 493 bans in
+  #   4 seconds, ~123/s. That is linear, and it is paid on every deploy.
+  #
+  #   maxelem. The per-set ceiling is 65536, fixed at set creation. Past it
+  #   `ipset add` fails while fail2ban still records the address as banned --
+  #   an address reported as blocked that is not actually blocked.
+  - name: fail2ban-capacity
+    rules:
+      # Standing bans far above the expected steady state.
+      #
+      # This is NOT a performance threshold. At 5000 the only real cost is
+      # about 40 seconds of restore, and the packet path does not care at all.
+      # Its job is to be the backstop for Fail2banBanRateSpike, which
+      # SELF-RESOLVES by design: a permanent step change is absorbed into its
+      # own 7-day baseline and goes quiet within about ten hours, so after that
+      # nothing is watching the cumulative result. This rule is what notices
+      # that the steady state moved and stayed moved.
+      #
+      # 5000 is ~10x the standing total at the time of writing (~490), so it
+      # takes a structural change to reach, not a busy week.
+      #
+      # This deliberately resembles the retired Fail2banBanListTruncated, and
+      # the difference is worth stating because the resemblance is the trap.
+      # That rule fired at 200 against a real steady state of 405 -- it sat
+      # BELOW normal and could never stop firing, and its only remedy was
+      # editing a display constant, which is not an action. This one sits an
+      # order of magnitude above normal, and if it fires there are real levers:
+      # shorten recidive's bantime, cut intake at the decoy ports, or decide
+      # the growth is legitimate and re-baseline. Re-baselining this threshold
+      # is a defensible response. It never was for the old one.
+      #
+      # Summed across jails on purpose. An address banned in three jails is
+      # three tickets, three ipset adds and three sqlite rows, so for restore
+      # cost the double count is the honest number. Do not "fix" it to count
+      # distinct addresses.
+      #
+      # 6h because standing totals move on the timescale of recidive's
+      # week-long bans. There is no such thing as an urgent change here, and a
+      # long window costs nothing.
+      - alert: Fail2banStandingBansHigh
+        expr: sum by (hostname) (f2b_jail_banned_current) > 5000
+        for: 6h
+        labels:
+          severity: warning
+        annotations:
+          summary: "fail2ban standing ban count is far above steady state on {{ $labels.hostname }}"
+          description: >-
+            {{ $value }} bans are in force across all jails, roughly 10x the
+            expected steady state. Nothing is broken -- the packet path is
+            unaffected by ban count and this is about 40s of fail2ban restore
+            time -- but the arrival rate has changed and stayed changed, which
+            Fail2banBanRateSpike stops reporting once the shift ages into its
+            baseline. Find what grew in the Ban Rate panel, then either reduce
+            intake, shorten the bantime of the jail responsible, or raise this
+            threshold deliberately if the growth is legitimate.
+
+      # A single jail approaching its ipset maxelem ceiling.
+      #
+      # PER JAIL, NOT SUMMED, and that is the whole point of this rule
+      # existing separately. maxelem is a property of each set, so
+      # `f2b-recidive` hits its wall at 65536 regardless of what the other
+      # jails hold. A total-based rule cannot see this coming.
+      #
+      # Critical rather than warning because of how it fails. Past maxelem,
+      # `ipset add` returns an error, fail2ban logs it and carries on, and the
+      # address stays listed as banned in every status query and on every
+      # dashboard panel -- while packets from it are delivered normally. The
+      # observable symptom is nothing at all. That is worse than an outage.
+      #
+      # 30000 is ~2x headroom. Given recidive's week-long bans that is weeks of
+      # lead time, which it needs: maxelem is fixed when the set is created and
+      # `ipset -exist create` will not change it, so raising it means editing
+      # the action, deploying, and destroying the set to force recreation. Not
+      # something to discover with hours to spare. Raise `hashsize` at the same
+      # time -- it defaults to 1024 and a set that large will otherwise rehash
+      # its way up.
+      - alert: Fail2banJailApproachingSetLimit
+        expr: f2b_jail_banned_current > 30000
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "fail2ban jail {{ $labels.jail }} is approaching its ipset limit on {{ $labels.hostname }}"
+          description: >-
+            Jail {{ $labels.jail }} holds {{ $value }} bans against a per-set
+            maxelem of 65536. Past that ceiling `ipset add` fails silently:
+            fail2ban keeps reporting the address as banned while its packets
+            are delivered normally, so the dashboard stays green while the
+            block does not exist. Raising maxelem requires recreating the set
+            (`ipset -exist create` will not alter it), so treat this as
+            scheduled work, not a page to sit on. Raise hashsize from its 1024
+            default at the same time.

--- a/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/fail2ban-alerts.yaml
@@ -3,12 +3,19 @@ groups:
   #
   # WHAT THIS GROUP DOES NOT ALERT ON
   #
-  # Bans. Not ban counts, not ban rate, not individual jails firing, not
-  # recidive, not port-decoy catching a scanner. All of that is the system
+  # Bans. Not ban counts, not standing totals, not individual jails firing,
+  # not recidive, not port-decoy catching a scanner. All of that is the system
   # working as designed, and on this host it happens constantly -- 161 bans in
   # a 48-hour window before the escalation fix. Paging on success trains the
   # channel to be ignored, which costs more than it buys. The "Bans Over Time"
   # and "Ban Rate" panels on the security dashboard already carry the trend.
+  #
+  # A standing total is explicitly not a signal. 10k addresses banned is not an
+  # incident; it is a week of the internet being the internet. What IS a signal
+  # is a step CHANGE in the arrival rate, which is a statement about the threat
+  # environment rather than about the control. That is the fail2ban-activity
+  # group at the bottom of this file, and it is the only place bans themselves
+  # are alerted on.
   #
   # Every rule here fires only when the security control itself is broken:
   # fail2ban unreachable, the generator stalled, or the data it produces
@@ -169,39 +176,97 @@ groups:
             `fail2ban-client get <jail> banip --with-time` against the parser
             in hosts/linux/fredvps/configuration.nix.
 
-      # A jail exceeded the 1500-address per-jail cap.
+      # NOTE: there is deliberately no alert on f2b_banned_ip_outside_window.
       #
-      # Two possible meanings, both worth knowing about: either the host is
-      # under a distributed sweep large enough to matter, or the cap needs
-      # raising. Per-IP rows beyond the cap are dropped from the table.
+      # There used to be one, on the metric's predecessor
+      # f2b_banned_ip_truncated, and it fired on 2026-08-15 when recidive held
+      # 405 bans against a 200 cap. It was retired rather than given a bigger
+      # number, deliberately. The
+      # metric measured a standing total against a fixed number, and a standing
+      # total has no stable value to alert against: recidive holds a flat
+      # one-week ban, so its level is 7 x whatever the arrival rate happens to
+      # be, and every step change in scan volume overtakes whatever number was
+      # chosen. The alert's only reachable steady state was permanently firing.
       #
-      # Safe to alert on only because f2b_banned_ip_max_bantime_seconds is
-      # computed BEFORE truncation. Until that fix, hitting the cap also
-      # silently under-reported the longest active ban, so this alert would
-      # have fired alongside a panel that was quietly wrong.
+      # The metric survives as a dashboard footnote -- "showing 100 of 405" --
+      # and the signal it was reaching for is now Fail2banBanRateSpike below.
+
+  # The only place in this file where bans themselves are alerted on.
+  #
+  # The distinction from the header comment is between level and derivative.
+  # A high standing ban count is the control working. A sudden change in how
+  # fast bans arrive is a statement about the outside world: a new scanner
+  # campaign, a newly-exposed service, or a filter that started matching
+  # something it should not.
+  - name: fail2ban-activity
+    rules:
+      # Ban arrival rate stepped up sharply against its own recent baseline.
       #
-      # The cap was 200, sized against a then-peak of 84. On 2026-08-15 the
-      # recidive jail hit 405 and this fired for real: the decoy port list had
-      # grown three days earlier and recidive's daily intake went ~25 -> ~141.
-      # Because recidive bans are a flat week, steady state is 7 x intake, so
-      # the honest projection was ~1000 and the alert would have been stuck on
-      # rather than signalling an anomaly. Raised to 1500 for headroom over
-      # that projection.
+      # WHY NOT rate(f2b_jail_banned_total)
       #
-      # If this fires again, check the intake trend before reaching for the
-      # cap again -- a further step change in daily bans is the thing worth
-      # knowing about, and raising the cap is only the right response once the
-      # new steady state is understood.
-      - alert: Fail2banBanListTruncated
-        expr: f2b_banned_ip_truncated > 0
-        for: 15m
+      # Because that counter counts restored bans. banmanager.py addBanTicket()
+      # increments __banTotal, and actions.py calls it for restored tickets as
+      # well as new ones -- the same call site that logs "Restore Ban". So a
+      # fail2ban restart resets the counter to zero and then replays the entire
+      # stored ban list into it: 97 bans inside two seconds at the 2026-08-12
+      # restart, which rate() would faithfully report as ~2900 bans/minute.
+      # Every deploy would page. f2b_jail_bans_started_1h is counted from ban
+      # START times, which are restored from sqlite unchanged, so a restart
+      # does not perturb it at all.
+      #
+      # WHY A RATIO AND NOT A FIXED THRESHOLD
+      #
+      # The jails are 30x apart in baseline rate. Measured over 7d:
+      #
+      #   jail                median/hr   peak/hr   mean/hr
+      #   port-decoy               61        90       29.9
+      #   ssh-decoy                 8        19        7.3
+      #   nginx-probe               5        40        5.8
+      #   recidive                  2        13        2.4
+      #   nginx-bad-request         1         3        0.13
+      #
+      # Any single number is either deaf to recidive or screaming at
+      # port-decoy. The ratio makes each jail its own reference.
+      #
+      # The absolute floor is what keeps the quiet jails quiet: without it,
+      # nginx-bad-request going from 0 to 2 bans is an infinite ratio.
+      #
+      # 4x against the 7d mean, checked against the table above: port-decoy
+      # would need 120/hr (peak seen: 90), ssh-decoy 29 (peak 19), recidive 25
+      # via the floor (peak 13). Only nginx-probe's outlier hour of 40 would
+      # have tripped it, which is a 7x jump over its median and arguably
+      # deserved the look.
+      #
+      # THIS ALERT SELF-RESOLVES, BY DESIGN
+      #
+      # A sustained step change is absorbed into the 7d baseline and the alert
+      # clears roughly 10 hours later, even though the new rate persists. That
+      # is intended: it is a change detector, not a level monitor, and the
+      # thing it exists to catch is the transition. The old truncation alert
+      # failed precisely by never clearing.
+      #
+      # It is also quiet on rollout: with only minutes of history the baseline
+      # equals the current value, the ratio is 1, and nothing fires.
+      #
+      # `for: 1h` filters single burst hours. The metric is a 1h trailing
+      # window, so one busy hour holds the condition for about an hour and
+      # sits right at the edge; anything genuinely sustained clears it easily.
+      - alert: Fail2banBanRateSpike
+        expr: |
+          f2b_jail_bans_started_1h > 25
+          and
+          f2b_jail_bans_started_1h > 4 * avg_over_time(f2b_jail_bans_started_1h[7d])
+        for: 1h
         labels:
           severity: warning
         annotations:
-          summary: "fail2ban jail {{ $labels.jail }} exceeded its ban-list cap on {{ $labels.hostname }}"
+          summary: "fail2ban ban rate in jail {{ $labels.jail }} stepped up on {{ $labels.hostname }}"
           description: >-
-            {{ $value }} banned address(es) in jail {{ $labels.jail }} are
-            omitted from the exported metrics because the 1500-per-jail cap
-            was hit. Aggregates stay correct, but the Active Bans table is
-            incomplete. Either an unusually large sweep is in progress or
-            MAX_PER_JAIL needs raising.
+            Jail {{ $labels.jail }} banned {{ $value }} address(es) in the last
+            hour, more than 4x its own 7-day average. Something changed
+            outside: a new scan campaign, a newly-exposed port, or a filter
+            that started matching traffic it should not. Check
+            `journalctl -u fail2ban --since '2 hours ago' | grep ' Ban '` for
+            what is being caught, and confirm it is hostile before treating
+            this as routine. Standing ban totals are not the concern here and
+            are not alerted on.

--- a/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
@@ -278,3 +278,98 @@ tests:
       - eval_time: 90m
         alertname: Fail2banBanRateSpike
         exp_alerts: []
+
+  #########################################################################
+  # Fail2banStandingBansHigh
+  #
+  # for: 6h, so the series has to outlast 360m of pending. interval stays at
+  # 5m per the staleness note at the top of this file.
+  #########################################################################
+  - interval: 5m
+    name: Fail2banStandingBansHigh fires on a sustained high standing total
+    input_series:
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="recidive", role="agent"}'
+        values: "6000+0x100"
+    alert_rule_test:
+      - eval_time: 400m
+        alertname: Fail2banStandingBansHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: fredvps
+            exp_annotations:
+              summary: "fail2ban standing ban count is far above steady state on fredvps"
+              description: "6000 bans are in force across all jails, roughly 10x the expected steady state. Nothing is broken -- the packet path is unaffected by ban count and this is about 40s of fail2ban restore time -- but the arrival rate has changed and stayed changed, which Fail2banBanRateSpike stops reporting once the shift ages into its baseline. Find what grew in the Ban Rate panel, then either reduce intake, shorten the bantime of the jail responsible, or raise this threshold deliberately if the growth is legitimate."
+
+  - interval: 5m
+    name: Fail2banStandingBansHigh sums across jails rather than watching one
+    input_series:
+      # No single jail is close to 5000, but the host is holding 6600 bans.
+      # Restore cost is per ticket, so the sum is what matters.
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="recidive"}'
+        values: "3000+0x100"
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="port-decoy"}'
+        values: "2400+0x100"
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="ssh-decoy"}'
+        values: "1200+0x100"
+    alert_rule_test:
+      - eval_time: 400m
+        alertname: Fail2banStandingBansHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              hostname: fredvps
+            exp_annotations:
+              summary: "fail2ban standing ban count is far above steady state on fredvps"
+              description: "6600 bans are in force across all jails, roughly 10x the expected steady state. Nothing is broken -- the packet path is unaffected by ban count and this is about 40s of fail2ban restore time -- but the arrival rate has changed and stayed changed, which Fail2banBanRateSpike stops reporting once the shift ages into its baseline. Find what grew in the Ban Rate panel, then either reduce intake, shorten the bantime of the jail responsible, or raise this threshold deliberately if the growth is legitimate."
+
+  - interval: 5m
+    name: Fail2banStandingBansHigh silent at a normal standing total
+    input_series:
+      # Roughly today's shape, an order of magnitude below the threshold.
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="recidive"}'
+        values: "410+0x100"
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="port-decoy"}'
+        values: "60+0x100"
+    alert_rule_test:
+      - eval_time: 400m
+        alertname: Fail2banStandingBansHigh
+        exp_alerts: []
+
+  #########################################################################
+  # Fail2banJailApproachingSetLimit
+  #########################################################################
+  - interval: 5m
+    name: Fail2banJailApproachingSetLimit fires for one oversized jail
+    input_series:
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="recidive", role="agent"}'
+        values: "35000+0x40"
+    alert_rule_test:
+      - eval_time: 120m
+        alertname: Fail2banJailApproachingSetLimit
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              hostname: fredvps
+              jail: recidive
+              role: agent
+            exp_annotations:
+              summary: "fail2ban jail recidive is approaching its ipset limit on fredvps"
+              description: "Jail recidive holds 35000 bans against a per-set maxelem of 65536. Past that ceiling `ipset add` fails silently: fail2ban keeps reporting the address as banned while its packets are delivered normally, so the dashboard stays green while the block does not exist. Raising maxelem requires recreating the set (`ipset -exist create` will not alter it), so treat this as scheduled work, not a page to sit on. Raise hashsize from its 1024 default at the same time."
+
+  - interval: 5m
+    name: Fail2banJailApproachingSetLimit ignores a high total spread over jails
+    input_series:
+      # 45000 bans on the host, but maxelem is per set and no set is near it.
+      # This is the case a summed rule would get wrong in the alarming
+      # direction; Fail2banStandingBansHigh is what covers the total.
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="recidive"}'
+        values: "15000+0x40"
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="port-decoy"}'
+        values: "15000+0x40"
+      - series: 'f2b_jail_banned_current{hostname="fredvps", jail="ssh-decoy"}'
+        values: "15000+0x40"
+    alert_rule_test:
+      - eval_time: 120m
+        alertname: Fail2banJailApproachingSetLimit
+        exp_alerts: []

--- a/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
@@ -217,7 +217,7 @@ tests:
               role: agent
             exp_annotations:
               summary: "fail2ban jail nginx-probe exceeded its ban-list cap on fredvps"
-              description: "12 banned address(es) in jail nginx-probe are omitted from the exported metrics because the 200-per-jail cap was hit. Aggregates stay correct, but the Active Bans table is incomplete. Either an unusually large sweep is in progress or MAX_PER_JAIL needs raising."
+              description: "12 banned address(es) in jail nginx-probe are omitted from the exported metrics because the 1500-per-jail cap was hit. Aggregates stay correct, but the Active Bans table is incomplete. Either an unusually large sweep is in progress or MAX_PER_JAIL needs raising."
 
   - interval: 1m
     name: Fail2banBanListTruncated silent when under the cap

--- a/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
@@ -199,34 +199,82 @@ tests:
         exp_alerts: []
 
   #########################################################################
-  # Fail2banBanListTruncated
+  # Fail2banBanRateSpike
+  #
+  # The baseline stretch has to be long relative to the spike, because the
+  # spike is inside its own avg_over_time window and dilutes the ratio it is
+  # being measured against. That is the self-resolving behaviour documented on
+  # the rule, and it is why these series run for hours rather than minutes.
   #########################################################################
   - interval: 1m
-    name: Fail2banBanListTruncated fires when a jail exceeds the cap
+    name: Fail2banBanRateSpike fires on a sustained step change
     input_series:
-      - series: 'f2b_banned_ip_truncated{hostname="fredvps", jail="nginx-probe", role="agent"}'
-        values: "12+0x30"
+      # 10h at 5 bans/hour, then 90m at 100. At the 690m mark the 7d mean is
+      # ~17, so the 4x threshold is ~70 and the floor of 25 is well clear.
+      - series: 'f2b_jail_bans_started_1h{hostname="fredvps", jail="port-decoy", role="agent"}'
+        values: "5+0x600 100+0x90"
     alert_rule_test:
-      - eval_time: 20m
-        alertname: Fail2banBanListTruncated
+      - eval_time: 690m
+        alertname: Fail2banBanRateSpike
         exp_alerts:
           - exp_labels:
               severity: warning
               hostname: fredvps
-              jail: nginx-probe
+              jail: port-decoy
               role: agent
             exp_annotations:
-              summary: "fail2ban jail nginx-probe exceeded its ban-list cap on fredvps"
-              description: "12 banned address(es) in jail nginx-probe are omitted from the exported metrics because the 1500-per-jail cap was hit. Aggregates stay correct, but the Active Bans table is incomplete. Either an unusually large sweep is in progress or MAX_PER_JAIL needs raising."
+              summary: "fail2ban ban rate in jail port-decoy stepped up on fredvps"
+              description: "Jail port-decoy banned 100 address(es) in the last hour, more than 4x its own 7-day average. Something changed outside: a new scan campaign, a newly-exposed port, or a filter that started matching traffic it should not. Check `journalctl -u fail2ban --since '2 hours ago' | grep ' Ban '` for what is being caught, and confirm it is hostile before treating this as routine. Standing ban totals are not the concern here and are not alerted on."
 
   - interval: 1m
-    name: Fail2banBanListTruncated silent when under the cap
+    name: Fail2banBanRateSpike silent below the absolute floor
     input_series:
-      - series: 'f2b_banned_ip_truncated{hostname="fredvps", jail="nginx-probe"}'
-        values: "0+0x30"
-      - series: 'f2b_banned_ip_truncated{hostname="fredvps", jail="recidive"}'
-        values: "0+0x30"
+      # A 20x ratio, but 20 bans/hour is not an incident on this host. The
+      # floor is what stops the low-volume jails screaming at every blip.
+      - series: 'f2b_jail_bans_started_1h{hostname="fredvps", jail="nginx-bad-request"}'
+        values: "1+0x600 20+0x90"
     alert_rule_test:
-      - eval_time: 20m
-        alertname: Fail2banBanListTruncated
+      - eval_time: 690m
+        alertname: Fail2banBanRateSpike
+        exp_alerts: []
+
+  - interval: 1m
+    name: Fail2banBanRateSpike silent on a high but steady rate
+    input_series:
+      # Well above the floor and never moves. A busy jail is not an alert.
+      - series: 'f2b_jail_bans_started_1h{hostname="fredvps", jail="port-decoy"}'
+        values: "60+0x690"
+    alert_rule_test:
+      - eval_time: 690m
+        alertname: Fail2banBanRateSpike
+        exp_alerts: []
+
+  - interval: 1m
+    name: Fail2banBanRateSpike silent on a single burst hour
+    input_series:
+      # Elevated for 30m only. `for: 1h` is what filters this out, and it is
+      # the difference between "one scanner had a moment" and "the environment
+      # changed".
+      - series: 'f2b_jail_bans_started_1h{hostname="fredvps", jail="nginx-probe"}'
+        values: "5+0x600 100+0x30"
+    alert_rule_test:
+      - eval_time: 630m
+        alertname: Fail2banBanRateSpike
+        exp_alerts: []
+
+  #########################################################################
+  # f2b_banned_ip_outside_window has no alert, deliberately.
+  #
+  # Regression guard for the retired Fail2banBanListTruncated: a large number
+  # of bans outside the display window must produce no alert at all. If
+  # somebody reintroduces a rule on standing totals, this fails.
+  #########################################################################
+  - interval: 1m
+    name: outside_window does not drive any ban-rate alert
+    input_series:
+      - series: 'f2b_banned_ip_outside_window{hostname="fredvps", jail="recidive"}'
+        values: "305+0x120"
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: Fail2banBanRateSpike
         exp_alerts: []

--- a/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/fail2ban-alerts-test.yaml
@@ -266,17 +266,30 @@ tests:
   # f2b_banned_ip_outside_window has no alert, deliberately.
   #
   # Regression guard for the retired Fail2banBanListTruncated: a large number
-  # of bans outside the display window must produce no alert at all. If
-  # somebody reintroduces a rule on standing totals, this fails.
+  # of bans sitting outside the display window must not fire anything.
+  #
+  # Scope, stated honestly because the obvious reading is wrong: promtool has
+  # no "assert nothing at all fired" mode. `alert_rule_test` evaluates exactly
+  # the rule named in `alertname`, so this can only cover rules that exist
+  # today, enumerated below. A brand-new rule under a new name would pass
+  # unnoticed until someone adds it here. That is a real gap and not one this
+  # file can close; it is written down so the next person does not mistake
+  # this for a guarantee it cannot make.
   #########################################################################
   - interval: 1m
-    name: outside_window does not drive any ban-rate alert
+    name: outside_window drives none of the existing fail2ban alerts
     input_series:
       - series: 'f2b_banned_ip_outside_window{hostname="fredvps", jail="recidive"}'
         values: "305+0x120"
     alert_rule_test:
       - eval_time: 90m
         alertname: Fail2banBanRateSpike
+        exp_alerts: []
+      - eval_time: 90m
+        alertname: Fail2banStandingBansHigh
+        exp_alerts: []
+      - eval_time: 90m
+        alertname: Fail2banJailApproachingSetLimit
         exp_alerts: []
 
   #########################################################################
@@ -355,7 +368,7 @@ tests:
               role: agent
             exp_annotations:
               summary: "fail2ban jail recidive is approaching its ipset limit on fredvps"
-              description: "Jail recidive holds 35000 bans against a per-set maxelem of 65536. Past that ceiling `ipset add` fails silently: fail2ban keeps reporting the address as banned while its packets are delivered normally, so the dashboard stays green while the block does not exist. Raising maxelem requires recreating the set (`ipset -exist create` will not alter it), so treat this as scheduled work, not a page to sit on. Raise hashsize from its 1024 default at the same time."
+              description: "Jail recidive holds 35000 bans against a per-set maxelem of 65536. Past that ceiling `ipset add` fails and fail2ban logs the error, but it carries on and keeps reporting the address as banned -- so every status query and dashboard panel stays green while the packets are delivered normally. The journal is the only place the failure is visible: check `journalctl -u fail2ban | grep -i ipset`. Raising maxelem requires recreating the set (`ipset -exist create` will not alter it), so treat this as scheduled work, not a page to sit on. Raise hashsize from its 1024 default at the same time."
 
   - interval: 5m
     name: Fail2banJailApproachingSetLimit ignores a high total spread over jails

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -109,7 +109,7 @@
       "id": 3,
       "type": "stat",
       "title": "Banned (all time)",
-      "description": "Total bans since the exporter started. Resets when fail2ban restarts.",
+      "description": "Total bans since the fail2ban daemon last started, not since the beginning of time. f2b_jail_banned_total resets on restart and is then re-incremented by every ban restored from sqlite, so it jumps back to roughly the standing ban count within seconds of a deploy. Treat it as a since-restart figure.",
       "gridPos": {
         "h": 5,
         "w": 5,
@@ -370,7 +370,7 @@
       "id": 32,
       "type": "stat",
       "title": "Longest Active Ban",
-      "description": "Highest ban length currently in force. Climbs as the escalation ladder engages. Computed across every active ban, including any the table below omits when a jail exceeds its 1500-address cap, so this stays correct during a large sweep.",
+      "description": "Highest ban length currently in force. Climbs as the escalation ladder engages. Computed across every active ban, including the ones the table below leaves out as older than its recency window, so this stays correct during a large sweep.",
       "gridPos": {
         "h": 5,
         "w": 5,
@@ -503,8 +503,8 @@
     {
       "id": 31,
       "type": "table",
-      "title": "Currently Banned Addresses",
-      "description": "Every address banned right now, across all jails, with how long the ban runs and how much is left. Ban Length grows with repeat offences: 1h, 2h, 4h, 8h, 16h, 32h, 64h, 128h, then 168h. Bans are host-wide and silent (DROP on all ports), so a listed address cannot reach any service. Sourced from a node_exporter textfile, since the fail2ban exporter publishes only per-jail totals.",
+      "title": "Recent Bans",
+      "description": "The 100 most recently started bans in each jail, with how long the ban runs and how much is left. NOT every active ban: recidive alone holds ~1000, and a thousand-row table is not something anyone reads. The exporter selects the window by ban start time, so what is here is always the newest; the column sort below is just how they are arranged once selected. Use the Jail Status table for totals. Ban Length grows with repeat offences: 1h, 2h, 4h, 8h, 16h, 32h, 64h, 128h, then 168h. Bans are host-wide and silent (DROP on all ports, via ipset), so a listed address cannot reach any service.",
       "gridPos": {
         "h": 11,
         "w": 14,
@@ -952,7 +952,7 @@
       "id": 10,
       "type": "timeseries",
       "title": "Ban Rate (per hour)",
-      "description": "New bans per jail. Sustained non-zero means an active campaign rather than background noise.",
+      "description": "New bans per jail in the trailing hour, counted from ban START times rather than from increase(f2b_jail_banned_total). That counter is incremented by restored bans too, so a fail2ban restart replayed the whole stored ban list into it -- 97 bans in two seconds at the last restart -- and this panel used to show a spike that never happened every time the host was deployed to. Ban start times come from sqlite and survive restarts unchanged. This is also the series Fail2banBanRateSpike alerts on.",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -1000,7 +1000,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "increase(f2b_jail_banned_total[1h])",
+          "expr": "f2b_jail_bans_started_1h",
           "legendFormat": "{{jail}}"
         }
       ]
@@ -1111,7 +1111,7 @@
       "id": 14,
       "type": "timeseries",
       "title": "Ban Events (per hour, by jail)",
-      "description": "Derived from the fail2ban log rather than the exporter, so it survives an exporter restart.",
+      "description": "Ban events per hour by jail, from the journal. Excludes \"Restore Ban\", which fail2ban logs for every ban it reloads from sqlite at startup -- without that filter a restart reads as a fleet-wide scanning surge.",
       "gridPos": {
         "h": 10,
         "w": 12,
@@ -1159,7 +1159,7 @@
             "type": "loki",
             "uid": "${ds_loki}"
           },
-          "expr": "sum by (jail) (count_over_time({host=\"fredvps\", unit=\"fail2ban.service\"} |~ \"NOTICE.*Ban \" | regexp \"\\\\[(?P<jail>[^\\\\]]+)\\\\] Ban\" [1h]))",
+          "expr": "sum by (jail) (count_over_time({host=\"fredvps\", unit=\"fail2ban.service\"} |~ \"NOTICE.*Ban \" != \"Restore Ban\" | regexp \"\\\\[(?P<jail>[^\\\\]]+)\\\\] Ban\" [1h]))",
           "legendFormat": "{{jail}}"
         }
       ]

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -501,6 +501,63 @@
       ]
     },
     {
+      "id": 34,
+      "type": "stat",
+      "title": "Hidden From Table",
+      "description": "Active bans too old to appear in Recent Bans, which shows only the 100 most recently started per jail. These addresses are still fully banned -- this is a display limit, not an enforcement one. Normally this is entirely recidive, whose week-long bans accumulate far past what is worth rendering as a table; the short-bantime jails expire below the window on their own and contribute nothing here. Add this to the table's row count to reconcile against Currently Banned. A non-zero value is expected and is not a fault.",
+      "gridPos": {
+        "h": 6,
+        "w": 10,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "sum(f2b_banned_ip_outside_window)",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "id": 31,
       "type": "table",
       "title": "Recent Bans",

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -108,7 +108,7 @@
     {
       "id": 3,
       "type": "stat",
-      "title": "Banned (all time)",
+      "title": "Banned (since restart)",
       "description": "Total bans since the fail2ban daemon last started, not since the beginning of time. f2b_jail_banned_total resets on restart and is then re-incremented by every ban restored from sqlite, so it jumps back to roughly the standing ban count within seconds of a deploy. Treat it as a since-restart figure.",
       "gridPos": {
         "h": 5,

--- a/modules/monitoring/master/dashboards/security.json
+++ b/modules/monitoring/master/dashboards/security.json
@@ -370,7 +370,7 @@
       "id": 32,
       "type": "stat",
       "title": "Longest Active Ban",
-      "description": "Highest ban length currently in force. Climbs as the escalation ladder engages. Computed across every active ban, including any the table below omits when a jail exceeds its 200-address cap, so this stays correct during a large sweep.",
+      "description": "Highest ban length currently in force. Climbs as the escalation ladder engages. Computed across every active ban, including any the table below omits when a jail exceeds its 1500-address cap, so this stays correct during a large sweep.",
       "gridPos": {
         "h": 5,
         "w": 5,


### PR DESCRIPTION
Started from `Fail2banBanListTruncated` firing on fredvps (recidive holding 405 bans against a 200-address cap) and ended up replacing both how bans are enforced and what gets alerted on. Already deployed to fredvps and sdrhub; all verification below is against the live fleet.

## Enforcement: iptables -> ipset

An iptables chain is a linear scan, so every packet matching nothing — i.e. every packet from a legitimate client — was compared against every ban rule before reaching `nixos-fw`. Measured before the change:

```text
f2b-recidive        407 rules
f2b-port-decoy       56
f2b-ssh-decoy        21
f2b-nginx-probe      14
total INPUT path    588
```

That cost tracked the ban count, and the ban count was neither small nor stable: the decoy port list grew on 2026-08-12 and total bans went from ~350/day to ~2200/day. `iptables-ipset.conf` replaces each per-jail chain with one INPUT rule matching a kernel hash set. `allports`, `DROP` and `ipsettime = 0` all carry over, so ban scope and expiry semantics are unchanged.

Measured after deploy:

| | before | after |
| --- | --- | --- |
| INPUT-path rules | 588 | 83 |
| restore rate | ~50/s | ~123/s |
| per-packet cost | O(ban count) | O(1) |

The restore improvement is asymptotic, not a constant factor — `iptables -I` rebuilds the whole ruleset per call, so it was O(n) in a chain that was itself growing.

## Alerting: level -> derivative

`Fail2banBanListTruncated` measured a standing total against a fixed number. recidive holds a flat one-week ban, so its level is 7x whatever the arrival rate happens to be, and every step change in scan volume overtakes whatever cap was chosen. Its only reachable steady state was firing forever. Retired, not resized.

- **`Fail2banBanRateSpike`** (warning) — 4x a jail's own 7d mean, plus an absolute floor of 25. Ratio-based because the jails are 30x apart in baseline rate (port-decoy 30/hr, nginx-bad-request 0.13/hr); a single threshold is either deaf to recidive or screaming at port-decoy. Replayed against 7d of real data, only nginx-probe's one 7x outlier hour would have tripped it.
- **`Fail2banStandingBansHigh`** (warning, >5000 summed) — backstop for the above, which self-resolves by design once a shift ages into its own baseline.
- **`Fail2banJailApproachingSetLimit`** (critical, >30000 per jail) — guards `maxelem`, which is per-set, so a summed rule cannot see it coming. Critical because past the ceiling `ipset add` fails while fail2ban still reports the address as banned: the dashboard stays green while the block does not exist.

## Restart contamination

`banmanager.py` `addBanTicket()` increments `__banTotal`, and `actions.py` calls it for restored tickets too — the same call site that logs `Restore Ban`. So `f2b_jail_banned_total` counts restores, and a restart resets it then replays the whole ban list into it (97 bans in two seconds, measured). Anything built on `rate()` of it reported ~2900 bans/minute on every deploy.

Fixed in three places: the new rate metric counts ban *start* times (restored from sqlite, so restart-immune), the "Ban Rate" panel switched to it, and the Loki panel now excludes `Restore Ban`. "Banned (all time)" is left as-is — there is no restart-immune all-time counter to point it at — but its description now says so.

## Display

`MAX_PER_JAIL` was a safety cap; it is now `RECENT_PER_JAIL=100`, a display window selected by ban start time. The sort is load-bearing: `banip --with-time` returns bans ordered by *expiry*, which equals start order only in a jail where every ban is the same length — so taking the tail would have kept the **oldest** bans in exactly the escalating jails where it matters. A new "Hidden From Table" stat surfaces the gap (182 shown vs 489 banned was previously unexplained on the dashboard).

## Verification

- Exporter shell logic tested against a mock harness: 120-ban jail, a jail whose expiry order is the exact reverse of its start order, a failing jail, and malformed lines. Window boundary, `outside_window`, the 1h counter's exclusive edge, and temp-file cleanup all exact.
- promtool: all rules pass, including tests pinning the per-jail vs summed distinction in both directions.
- All 10 hosts eval clean, zero evaluation warnings. nixfmt/statix/deadnix/codespell/prettier green.
- Live on fredvps: ipset membership matches fail2ban exactly on all 4 jails, 0 parse failures, 0 jail-query failures, window respected.
- Live on sdrhub: 8 fail2ban rules loaded, all `health=ok`, none firing. Current headroom 490 total / 407 largest jail against thresholds of 5000 / 30000.

## Note for review

`e3fa9005` raises the cap to 1500 and `08c7560a` then replaces the cap entirely. It is dead weight — kept because each commit is atomic and green and the history reflects how the decision actually evolved. Happy to drop it in a rebase if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring & Alerts**
  - Added alerts for sudden ban-rate spikes, high aggregate bans, and jails nearing capacity.
  - Improved ban metric tracking and handling across jails.
  - Removed the obsolete truncated-ban-list alert.

- **Dashboard**
  - Updated ban-rate and recent-ban views for clearer monitoring.
  - Added visibility into active bans outside the recent display window.
  - Excluded restored bans from ban-event counts.

- **Security**
  - Improved ban enforcement with efficient host-wide blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->