### PR TITLE
fix(monitoring): price workflow staleness additively, not multiplicatively

### DIFF
--- a/features/desktop/thunderbird/default.nix
+++ b/features/desktop/thunderbird/default.nix
@@ -97,17 +97,17 @@ in
           NATCA = {
             primary = false;
             realName = "Fred Clausen";
-            address = "fclausen@natca.net";
-            userName = "fclausen@natca.net";
+            address = "fclausen@natca.org";
+            userName = "fclausen@natca.org";
 
             imap = {
-              host = "secure.emailsrvr.com";
+              host = "mail.natca.org";
               port = 993;
               tls.enable = true;
             };
 
             smtp = {
-              host = "secure.emailsrvr.com";
+              host = "mail.natca.org";
               port = 587;
               authentication = "login";
               tls = {

--- a/flake.lock
+++ b/flake.lock
@@ -590,11 +590,11 @@
         "rust-overlay": "rust-overlay_6"
       },
       "locked": {
-        "lastModified": 1786642808,
-        "narHash": "sha256-w4c3jUSLfinxpXnGmnYnBaqudWc4AxQQjEStUvD6m0Y=",
+        "lastModified": 1786922433,
+        "narHash": "sha256-QR7fgIQ/gVf6B2HAbpagSgG1QQDT//BYqNeAedI/u6M=",
         "owner": "FredSystems",
         "repo": "github-ci-exporter",
-        "rev": "580520590f70e31abaaaaf1dab29210c954e2eac",
+        "rev": "f8f11a0fbb7746f984603970869f905ce21c1fa7",
         "type": "github"
       },
       "original": {

--- a/modules/monitoring/master/alert-rules/github-alerts.yaml
+++ b/modules/monitoring/master/alert-rules/github-alerts.yaml
@@ -62,16 +62,42 @@ groups:
       # derived from the workflow's own cron expression, so the threshold
       # adapts to weekly vs daily schedules rather than being a fixed guess.
       #
-      # 3x rather than 2x: GitHub's scheduled runs are best-effort and are
-      # routinely delayed under load, so 2x produces false positives on hourly
-      # crons. The `unless` guard suppresses this for workflows already known
-      # to be disabled, which GitHubWorkflowAutoDisabled reports with a more
+      # The slack term is purely ADDITIVE, with no multiplier at all. GitHub
+      # delays scheduled runs by a roughly fixed amount that does not scale
+      # with cadence: measured over 907 intervals across this fleet, lateness
+      # is p90 36-90m and never exceeded 220m, and the 6-hourly cron showed
+      # the WORST p90 of any cadence. A multiplier therefore misprices both
+      # ends. The previous 3x gave a monthly cron 84 days of slack - long
+      # enough for a dead workflow to stay invisible for a quarter - while
+      # giving an hourly cron only 3 hours, which is less than GitHub's own
+      # median delay for high-frequency schedules. That produced sustained
+      # false positives on sdr-enthusiasts/docker-shipfeeder and no useful
+      # coverage on the monthly crons.
+      #
+      # 4h was backtested against 60 days of real run history for every
+      # scheduled workflow in the fleet: zero false positives, and it roughly
+      # halves time-to-detection for a genuinely dead workflow (monthly
+      # 84d -> 31d4h, weekly 21d -> 7d4h, daily 3d -> 28h, hourly 3h -> 5h).
+      #
+      # Note the margin is thin by construction: 4h is only ~20 minutes above
+      # the worst lateness ever observed, and that worst case was a
+      # correlated GitHub incident that delayed five unrelated repositories
+      # at once. If this starts crying wolf, raise the constant rather than
+      # reintroducing a multiplier - the multiplier is what was wrong.
+      #
+      # This threshold assumes the exporter reports the LONGEST legitimate gap
+      # for a cron, not the first one. github-ci-exporter got that wrong until
+      # f8f11a0: `0 0 1 * *` resolved to 28 days rather than 31, which made
+      # every monthly workflow look permanently three days late.
+      #
+      # The `unless` guard suppresses this for workflows already known to be
+      # disabled, which GitHubWorkflowAutoDisabled reports with a more
       # accurate description.
       - alert: GitHubScheduledWorkflowStale
         expr: |
           (
             time() - github_workflow_run_timestamp_seconds
-              > 3 * github_workflow_expected_interval_seconds
+              > github_workflow_expected_interval_seconds + (4 * 60 * 60)
           )
           unless on (org, repo, workflow) (
             github_workflow_enabled == 0
@@ -81,7 +107,7 @@ groups:
           severity: warning
         annotations:
           summary: "Scheduled workflow {{ $labels.workflow }} has not run in {{ $labels.org }}/{{ $labels.repo }}"
-          description: "Last run was {{ $value | humanizeDuration }} ago, more than three times its configured schedule interval."
+          description: "Last run was {{ $value | humanizeDuration }} ago, well past its configured schedule interval plus the delay GitHub normally adds to scheduled runs."
 
       # An open PR whose checks are failing. Distinct from
       # GitHubCIFailingDefaultBranch: that rule describes what has already

--- a/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
@@ -175,12 +175,12 @@ tests:
   # GitHubScheduledWorkflowStale
   # ---------------------------------------------------------------------------
 
-  # Daily cron: 3x the interval is 72h. Rather than advancing eval_time for
-  # four days (which at a 5m sample spacing would need ~1150 samples), the
-  # last-run timestamp is set four days in the past, so a short evaluation
-  # window still exercises the threshold.
+  # Daily cron: the threshold is interval + 4h = 28h. Rather than advancing
+  # eval_time for four days (which at a 5m sample spacing would need ~1150
+  # samples), the last-run timestamp is set four days in the past, so a short
+  # evaluation window still exercises the threshold.
   - interval: 5m
-    name: GitHubScheduledWorkflowStale fires past three intervals
+    name: GitHubScheduledWorkflowStale fires for a stale daily cron
     input_series:
       - series: 'github_workflow_run_timestamp_seconds{org="sdr-enthusiasts", repo="docker-xng", workflow="update-flakes", job="github-ci"}'
         values: "-345600+0x30"
@@ -200,10 +200,10 @@ tests:
               job: github-ci
             exp_annotations:
               summary: "Scheduled workflow update-flakes has not run in sdr-enthusiasts/docker-xng"
-              description: "Last run was 4d 1h 0m 0s ago, more than three times its configured schedule interval."
+              description: "Last run was 4d 1h 0m 0s ago, well past its configured schedule interval plus the delay GitHub normally adds to scheduled runs."
 
-  # The same four-day-old run against a weekly cron must NOT fire: 3x a week
-  # is 21 days. Guards against a fixed threshold silently replacing the
+  # The same four-day-old run against a weekly cron must NOT fire: a week plus
+  # 4h is 7d4h. Guards against a fixed threshold silently replacing the
   # cron-derived one.
   - interval: 5m
     name: GitHubScheduledWorkflowStale respects a weekly interval
@@ -235,6 +235,93 @@ tests:
       - eval_time: 1h
         alertname: GitHubScheduledWorkflowStale
         exp_alerts: []
+
+  # Regression test for the additive slack term. GitHub's scheduling delay is
+  # a roughly fixed number of hours regardless of cadence, so a short-interval
+  # cron running a few hours late is healthy, not stale. Under the old purely
+  # multiplicative 3x threshold an hourly cron got only 3h of slack and this
+  # case fired continuously on sdr-enthusiasts/docker-shipfeeder. A flat 4h
+  # gives 5h, which absorbs the worst delay observed across the fleet.
+  - interval: 5m
+    name: GitHubScheduledWorkflowStale tolerates GitHub delay on an hourly cron
+    input_series:
+      - series: 'github_workflow_run_timestamp_seconds{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", job="github-ci"}'
+        values: "-10800+0x30"
+      - series: 'github_workflow_expected_interval_seconds{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", job="github-ci"}'
+        values: "3600+0x30"
+      - series: 'github_workflow_enabled{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", state="active", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: GitHubScheduledWorkflowStale
+        exp_alerts: []
+
+  # The other side of the same boundary: tolerating GitHub's delay must not
+  # cost coverage. An hourly cron that has genuinely stopped still pages.
+  - interval: 5m
+    name: GitHubScheduledWorkflowStale still fires for a dead hourly cron
+    input_series:
+      - series: 'github_workflow_run_timestamp_seconds{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", job="github-ci"}'
+        values: "-43200+0x30"
+      - series: 'github_workflow_expected_interval_seconds{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", job="github-ci"}'
+        values: "3600+0x30"
+      - series: 'github_workflow_enabled{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", state="active", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: GitHubScheduledWorkflowStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              org: sdr-enthusiasts
+              repo: docker-shipfeeder
+              workflow: Deploy on aiscatcher changes
+              job: github-ci
+            exp_annotations:
+              summary: "Scheduled workflow Deploy on aiscatcher changes has not run in sdr-enthusiasts/docker-shipfeeder"
+              description: "Last run was 13h 0m 0s ago, well past its configured schedule interval plus the delay GitHub normally adds to scheduled runs."
+
+  # The tightest margin in the whole rule. A monthly cron's real gaps run
+  # 28-31 days, and the exporter reports the longest (31d), so a healthy
+  # monthly workflow may legitimately be 31d plus GitHub's usual lateness.
+  # 31d2h must stay quiet.
+  - interval: 5m
+    name: GitHubScheduledWorkflowStale tolerates a late monthly cron
+    input_series:
+      - series: 'github_workflow_run_timestamp_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
+        values: "-2685600+0x30"
+      - series: 'github_workflow_expected_interval_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
+        values: "2678400+0x30"
+      - series: 'github_workflow_enabled{org="fredsystems", repo="fred-cal", workflow="update-flakes", state="active", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: GitHubScheduledWorkflowStale
+        exp_alerts: []
+
+  # A monthly workflow that has actually missed its slot does still page.
+  - interval: 5m
+    name: GitHubScheduledWorkflowStale fires for a missed monthly cron
+    input_series:
+      - series: 'github_workflow_run_timestamp_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
+        values: "-2764800+0x30"
+      - series: 'github_workflow_expected_interval_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
+        values: "2678400+0x30"
+      - series: 'github_workflow_enabled{org="fredsystems", repo="fred-cal", workflow="update-flakes", state="active", job="github-ci"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: GitHubScheduledWorkflowStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              org: fredsystems
+              repo: fred-cal
+              workflow: update-flakes
+              job: github-ci
+            exp_annotations:
+              summary: "Scheduled workflow update-flakes has not run in fredsystems/fred-cal"
+              description: "Last run was 32d 1h 0m 0s ago, well past its configured schedule interval plus the delay GitHub normally adds to scheduled runs."
 
   # ---------------------------------------------------------------------------
   # GitHubPullRequestChecksFailing

--- a/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
+++ b/modules/monitoring/master/alert-rules/tests/github-alerts-test.yaml
@@ -242,11 +242,16 @@ tests:
   # multiplicative 3x threshold an hourly cron got only 3h of slack and this
   # case fired continuously on sdr-enthusiasts/docker-shipfeeder. A flat 4h
   # gives 5h, which absorbs the worst delay observed across the fleet.
+  #
+  # Sits exactly ON the boundary: at eval_time 1h the age is 5h, which is
+  # interval + 4h. The comparison is strict, so 4h of slack stays quiet while
+  # anything tighter fires - a 3h regression fails this test rather than
+  # sliding under it.
   - interval: 5m
     name: GitHubScheduledWorkflowStale tolerates GitHub delay on an hourly cron
     input_series:
       - series: 'github_workflow_run_timestamp_seconds{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", job="github-ci"}'
-        values: "-10800+0x30"
+        values: "-14400+0x30"
       - series: 'github_workflow_expected_interval_seconds{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", job="github-ci"}'
         values: "3600+0x30"
       - series: 'github_workflow_enabled{org="sdr-enthusiasts", repo="docker-shipfeeder", workflow="Deploy on aiscatcher changes", state="active", job="github-ci"}'
@@ -284,12 +289,12 @@ tests:
   # The tightest margin in the whole rule. A monthly cron's real gaps run
   # 28-31 days, and the exporter reports the longest (31d), so a healthy
   # monthly workflow may legitimately be 31d plus GitHub's usual lateness.
-  # 31d2h must stay quiet.
+  # Also sits exactly on the boundary: at eval_time 1h the age is 31d4h.
   - interval: 5m
     name: GitHubScheduledWorkflowStale tolerates a late monthly cron
     input_series:
       - series: 'github_workflow_run_timestamp_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
-        values: "-2685600+0x30"
+        values: "-2689200+0x30"
       - series: 'github_workflow_expected_interval_seconds{org="fredsystems", repo="fred-cal", workflow="update-flakes", job="github-ci"}'
         values: "2678400+0x30"
       - series: 'github_workflow_enabled{org="fredsystems", repo="fred-cal", workflow="update-flakes", state="active", job="github-ci"}'


### PR DESCRIPTION
## Why

`GitHubScheduledWorkflowStale` fires constantly on one workflow while never firing on genuinely dead ones. Both symptoms have the same cause: the threshold was `3 × expected_interval`, and that multiplier assumes GitHub's scheduling delay scales with cadence.

It doesn't. Measured over **907 intervals across the fleet**:

| nominal | p50 late | p90 late | max late |
| ------- | -------- | -------- | -------- |
| 6h | -12m | 90m | 220m |
| 12h | -1m | 58m | 82m |
| daily | -1m | 39m | 167m |
| weekly | -1m | 36m | 136m |

Flat, and the *shortest* cadence has the worst p90. The delay is a fixed number of hours regardless of how often the cron fires — the >2h events are correlated GitHub incidents (2026-06-22 delayed five unrelated repos within minutes of each other), not per-workflow faults.

So a multiplier misprices both ends simultaneously:

- **hourly got 3h of slack** — less than GitHub's median delay for high-frequency schedules. `sdr-enthusiasts/docker-shipfeeder` paged on 40% of its intervals.
- **monthly got 84 days** — long enough for a dead workflow to stay invisible for a quarter. That is the exact failure this alert was written for after `fredsystems/fred-cal`.

## What changed

Flat `interval + 4h`, no multiplier.

| cadence | old 3x | new +4h |
| ------- | ------ | ------- |
| hourly | 3.0h | 5h |
| 6h | 18h | 10h |
| daily | 72h | 28h |
| weekly | 21d | 7d 4h |
| monthly | 84d | 31d 4h |

Backtested against 60 days of real run history for every scheduled workflow in the fleet: **zero false positives**, while roughly halving time-to-detection everywhere. Candidate slack values and their spurious-page counts over that window:

```text
1.5h -> 10    3h -> 1
2.0h ->  6    4h -> 0
```

4h is the tightest zero-false-positive value. The margin is deliberately thin — ~20 min above the worst lateness ever observed — and the comment says to raise the constant rather than reintroduce a multiplier if it proves noisy.

## Exporter dependency

Bumps `github-ci-exporter` to `f8f11a0` (fredsystems/github-ci-exporter#14). The new threshold depends on it, because the exporter was feeding the rule wrong intervals:

- `0 0 1 * *` resolved to **28 days instead of 31** (it measured the gap between the first two fires after the Unix epoch, which landed in February 1970), so every monthly workflow read as permanently ~3 days late.
- POSIX Sunday-as-zero (`0 5 * * 0`) **failed to parse and was silently dropped**. That left **32 workflows publishing no interval at all** — no cadence, so no staleness coverage whatsoever — and left `fredsystems/nixos` publishing a monthly cadence for a workflow that runs weekly.

Input is categorised `server`; only `modules/monitoring/master` (sdrhub) references it, so other servers' closures are unchanged.

## Tests

Six cases in `github-alerts-test.yaml`, including the two that motivated this:

- hourly cron 4h late must **not** fire (fired continuously under `3x`)
- hourly cron 13h stale must still fire
- monthly cron at 31d2h must **not** fire (the tightest margin in the rule)
- monthly cron at 32d must fire
- weekly cron 4d old must not fire
- disabled workflows stay suppressed

Verified: `nix build .#checks.x86_64-linux.prometheus-alert-rules` green, `nix eval` clean on `sdrhub` and `Daytona`.

## Unrelated

Second commit points the Thunderbird NATCA account at `natca.org` — it moved off the Rackspace-hosted `natca.net` domain. Folded in here rather than opening a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Updated the NATCA Thunderbird account to use the current email address and mail server settings.
  - IMAP and SMTP ports, security, and authentication settings remain unchanged.

- **Bug Fixes**
  - Improved stale scheduled-workflow monitoring to account for GitHub’s typical four-hour scheduling delay.
  - Added coverage for hourly, daily, weekly, and monthly schedules to reduce false alerts while still detecting genuinely missed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->