### PR TITLE
feat: self-hosted clipboard sync with server-side history

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -80,6 +80,15 @@
       automerge: true,
     },
     {
+      // Owned by update-syncclipboard.yaml, which bumps this image and the
+      // client AppImage in overlays/syncclipboard.nix together. Both ship from
+      // one upstream tag, and Renovate cannot see the overlay, so letting it
+      // automerge the image alone would silently split the pair. The parity
+      // check in lint.yaml is the backstop if this rule is ever removed.
+      matchPackageNames: ["jericx/syncclipboard-server"],
+      enabled: false,
+    },
+    {
       matchDatasources: ["docker"],
       versioning: "regex:^(telegraf|v\\d+-latest|latest)-build-(?<major>\\d+)$",
       matchPackageNames: ["/^ghcr\\.io/sdr-enthusiasts/.+$/"],

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,6 +81,40 @@ jobs:
         # occurred when acarsdec-3 was replaced by xng on acarshub.
         run: nix build --no-link --print-build-logs .#checks.x86_64-linux.decoder-units-sync
 
+      - name: Check SyncClipboard server/client version parity
+        # The server image and the Linux client AppImage ship from a single
+        # upstream tag but are pinned in two files, and only the image is
+        # visible to Renovate. update-syncclipboard.yaml moves both together;
+        # this is the backstop that catches any path which moves only one --
+        # including a hand edit, or Renovate if its exclusion is ever removed.
+        #
+        # Deliberately stricter than upstream's contract, which is
+        # `server >= client` rather than equality. Equality costs nothing since
+        # both come from the same tag, and it means nobody has to read
+        # Changes.md to decide whether a given bump is safe.
+        run: |
+          set -euo pipefail
+
+          overlay_version=$(sed -n 's/^\s*version = "\(.*\)";/\1/p' overlays/syncclipboard.nix | head -1)
+          image_tag=$(sed -n 's|.*image = "jericx/syncclipboard-server:\([^"@]*\).*|\1|p' hosts/linux/sdrhub/configuration.nix | head -1)
+
+          if [ -z "$overlay_version" ] || [ -z "$image_tag" ]; then
+            echo "could not read one of the pins (overlay='$overlay_version' image='$image_tag')" >&2
+            exit 1
+          fi
+
+          # The overlay stores a bare version, the image tag carries a leading v.
+          if [ "$overlay_version" != "${image_tag#v}" ]; then
+            echo "SyncClipboard pins disagree:" >&2
+            echo "  overlays/syncclipboard.nix        version = $overlay_version" >&2
+            echo "  hosts/linux/sdrhub/configuration  image   = $image_tag" >&2
+            echo "Both ship from one upstream tag and must move together." >&2
+            echo "Run ./scripts/sync-syncclipboard.sh to reconcile them." >&2
+            exit 1
+          fi
+
+          echo "SyncClipboard pins agree: $overlay_version"
+
   # =====================================================================
   # Required Check Summary
   # =====================================================================

--- a/.github/workflows/update-syncclipboard.yaml
+++ b/.github/workflows/update-syncclipboard.yaml
@@ -1,0 +1,124 @@
+---
+name: update-syncclipboard
+
+# Keeps the SyncClipboard server image and the Linux client AppImage pinned to
+# the same upstream release.
+#
+# Both artifacts ship from a single upstream tag, but they live in two places
+# here, and only one of them is visible to Renovate:
+#
+#   hosts/linux/sdrhub/configuration.nix   server image  -- Renovate DOES match
+#   overlays/syncclipboard.nix             client AppImage -- nothing watches it
+#
+# Renovate's docker updates automerge, so left alone it would walk the server
+# forward on its own. That is usually the safe direction (upstream states
+# compatibility as `server >= client`), but v3.1.1 was a hard break in both
+# directions and such breaks are announced only in prose. This workflow owns
+# both pins so they move together; renovate.json5 disables the image so the two
+# cannot race. scripts/sync-syncclipboard.sh carries the full reasoning.
+#
+# Runs at :40 rather than on the hour. GitHub documents the top of the hour as
+# its highest-contention slot for scheduled workflows and drops queued jobs
+# under load.
+
+on:
+  schedule:
+    - cron: "40 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-syncclipboard:
+    name: Update SyncClipboard pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # PAT (not GITHUB_TOKEN) so the pushed branch triggers CI on the
+          # resulting PR -- see the same note in renovate-relock.yaml.
+          token: ${{ secrets.PAT }}
+          persist-credentials: true
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: accept-flake-config = true
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "github[bot]"
+
+      - name: Sync both pins to the latest upstream release
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          nix shell nixpkgs#skopeo nixpkgs#jq -c ./scripts/sync-syncclipboard.sh
+          rc=$?
+
+          # 0 = already correct, 2 = pins were updated, anything else = error.
+          case "$rc" in
+            0) echo "changed=false" >> "$GITHUB_OUTPUT" ;;
+            2) echo "changed=true"  >> "$GITHUB_OUTPUT" ;;
+            *) echo "sync failed with exit $rc" >&2; exit "$rc" ;;
+          esac
+
+          version=$(sed -n 's/^\s*version = "\(.*\)";/\1/p' overlays/syncclipboard.nix | head -1)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the client package builds
+        if: steps.sync.outputs.changed == 'true'
+        # The image digest came straight from the registry and needs no
+        # verification, but the AppImage hash is only proven correct by a build
+        # that actually fetches and checks it.
+        run: nix build '.#nixosConfigurations.Daytona.pkgs.syncclipboard' --no-link
+
+      - name: Verify sdrhub still evaluates
+        if: steps.sync.outputs.changed == 'true'
+        run: nix eval '.#nixosConfigurations.sdrhub.config.system.build.toplevel.drvPath'
+
+      - name: Commit, push, and open a PR
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          NEW_VERSION: ${{ steps.sync.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          branch="update-syncclipboard-${NEW_VERSION}"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "branch $branch already exists upstream; nothing to do"
+            exit 0
+          fi
+
+          git checkout -b "$branch"
+          git add overlays/syncclipboard.nix hosts/linux/sdrhub/configuration.nix
+          git commit -m "chore(syncclipboard): update server and client to v${NEW_VERSION}"
+          git push -u origin "$branch"
+
+          gh pr create \
+            --title "chore(syncclipboard): update server and client to v${NEW_VERSION}" \
+            --body "$(cat <<BODY
+          Automated bump of both SyncClipboard pins to upstream v${NEW_VERSION}.
+
+          Server image (\`hosts/linux/sdrhub/configuration.nix\`) and Linux
+          client AppImage (\`overlays/syncclipboard.nix\`) move together, because
+          both ship from the same upstream tag and nothing machine-readable
+          distinguishes an additive server release from a wire-protocol change.
+
+          The image digest came from the registry. The AppImage hash was proven
+          by \`nix build .#nixosConfigurations.Daytona.pkgs.syncclipboard\`, and
+          sdrhub still evaluates.
+
+          Check upstream's Changes.md for an "upgrade notice" section before
+          merging: v3.1.1 required wiping client-local data, and a future break
+          could do the same.
+          BODY
+          )" \
+            --label dependencies \
+            --label automated

--- a/features/desktop/clipboard/default.nix
+++ b/features/desktop/clipboard/default.nix
@@ -1,0 +1,106 @@
+# SyncClipboard desktop client, pointed at the sdrhub clipboard server.
+#
+# The client keeps its own state in ~/.config/SyncClipboard/SyncClipboard.json
+# and rewrites that file whenever a setting changes in the UI, so the file
+# cannot be a read-only symlink into the store. Instead a pre-start step merges
+# the connection settings into whatever is already there, which keeps the
+# server details declarative while leaving every other key under the app's
+# control.
+#
+# The password necessarily ends up in that JSON in plaintext, because that is
+# where the client reads it from. It arrives from sops rather than the Nix
+# store (which is world-readable), and the file is left mode 0600.
+{
+  lib,
+  pkgs,
+  config,
+  user,
+  ...
+}:
+let
+  cfg = config.desktop.clipboard;
+
+  # Same secret the server container consumes, referenced rather than copied so
+  # the two cannot drift apart. It is an env-format file:
+  #   SYNCCLIPBOARD_USERNAME=...
+  #   SYNCCLIPBOARD_PASSWORD=...
+  secretKey = "docker/sdrhub/syncclipboard.env";
+
+  configure = pkgs.writeShellApplication {
+    name = "syncclipboard-configure";
+    runtimeInputs = [ pkgs.jq ];
+    text = ''
+      secret="${config.sops.secrets.${secretKey}.path}"
+      target="$HOME/.config/SyncClipboard/SyncClipboard.json"
+
+      mkdir -p "$(dirname "$target")"
+      [ -f "$target" ] || echo '{}' > "$target"
+
+      username="$(sed -n 's/^SYNCCLIPBOARD_USERNAME=//p' "$secret")"
+      password="$(sed -n 's/^SYNCCLIPBOARD_PASSWORD=//p' "$secret")"
+
+      if [ -z "$username" ] || [ -z "$password" ]; then
+        echo "syncclipboard: credentials missing from $secret" >&2
+        exit 1
+      fi
+
+      # A stable account id rather than the GUID the UI would generate, so that
+      # re-running this updates the same account instead of accumulating one
+      # per activation. The id is only ever a dictionary key.
+      tmp="$(mktemp)"
+      jq \
+        --arg url ${lib.escapeShellArg cfg.serverUrl} \
+        --arg user "$username" \
+        --arg pass "$password" \
+        '.SavedAccounts.SyncClipboard.sdrhub = {
+            RemoteURL: $url,
+            UserName: $user,
+            Password: $pass,
+            DeletePreviousFilesOnPush: true,
+            CustomName: "sdrhub"
+          }
+          | .Account = { AccountId: "sdrhub", AccountType: "SyncClipboard" }
+          | .SyncService.SyncSwitchOn = true' \
+        "$target" > "$tmp"
+
+      mv "$tmp" "$target"
+      chmod 600 "$target"
+    '';
+  };
+in
+{
+  options.desktop.clipboard = {
+    enable = lib.mkEnableOption "SyncClipboard client";
+
+    serverUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "http://clipboard.sdrhub.lan";
+      description = "Base URL of the SyncClipboard server.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${user}.packages = [ pkgs.syncclipboard ];
+
+    sops.secrets.${secretKey} = {
+      owner = user;
+      mode = "0400";
+    };
+
+    # Tray-only application, so it needs a running graphical session with an
+    # SNI host (wayle provides the StatusNotifierWatcher on this fleet).
+    systemd.user.services.syncclipboard = {
+      description = "SyncClipboard client";
+      partOf = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStartPre = lib.getExe configure;
+        ExecStart = lib.getExe pkgs.syncclipboard;
+        Restart = "always";
+        RestartSec = "5s";
+      };
+    };
+  };
+}

--- a/features/desktop/clipboard/default.nix
+++ b/features/desktop/clipboard/default.nix
@@ -60,7 +60,28 @@ let
             CustomName: "sdrhub"
           }
           | .Account = { AccountId: "sdrhub", AccountType: "SyncClipboard" }
-          | .SyncService.SyncSwitchOn = true' \
+          | .SyncService.SyncSwitchOn = true
+
+          # Force the client onto wl-clipboard by forbidding the other two
+          # sources. This is half of a two-part fix and is useless on its own:
+          # the overlay has to supply the wl-clipboard binary as well, or
+          # prohibiting the alternatives leaves the client with nothing.
+          #
+          # Left to itself the client prefers Avalonia its own in-process X11
+          # path, which only sees the Wayland selection via XWayland. That
+          # returns content for some copies and nothing for others, and an
+          # empty read is classified as `Unkown` and dropped without an error.
+          # Symptom is intermittent syncing, not an obvious failure.
+          | .ClipboardFactory.ProhibitSources = ["xclip", "Avalonia"]
+
+          # Server-side history is the reason this service exists at all, and
+          # it is off by default -- local history alone would leave the panel
+          # disagreeing with what the server holds.
+          | .History.EnableHistory = true
+          | .History.EnableSyncHistory = true
+
+          | .Program.Language = "en-US"
+          | .Program.HideWindowOnStartup = true' \
         "$target" > "$tmp"
 
       mv "$tmp" "$target"

--- a/features/desktop/default.nix
+++ b/features/desktop/default.nix
@@ -28,6 +28,7 @@ in
     ./appimage
     ./audio
     ./brave
+    ./clipboard
     ./discord
     ./firefox
     ./flatpak
@@ -66,6 +67,7 @@ in
       appimage.enable = cfg.enable_extra;
       audio.enable = true;
       brave.enable = true;
+      clipboard.enable = true;
       discord.enable = cfg.enable_extra;
       environments.enable = true;
       firefox.enable = true;

--- a/features/desktop/environments/hyprland/default.nix
+++ b/features/desktop/environments/hyprland/default.nix
@@ -237,6 +237,7 @@ in
             hl.exec_cmd("gsettings set org.gnome.desktop.interface gtk-theme '${gtkThemeName}'")
             hl.exec_cmd("systemctl restart --user wayle")
             hl.exec_cmd("systemctl restart --user sway-audio-idle-inhibit")
+            hl.exec_cmd("systemctl restart --user syncclipboard")
             hl.exec_cmd("systemctl restart --user hypridle")
             hl.exec_cmd("systemctl restart --user network-manager-applet")
             hl.exec_cmd("systemctl restart --user udiskie-agent")

--- a/features/desktop/environments/niri/default.nix
+++ b/features/desktop/environments/niri/default.nix
@@ -89,6 +89,14 @@ in
                 "systemctl"
                 "--user"
                 "restart"
+                "syncclipboard"
+              ];
+            }
+            {
+              command = [
+                "systemctl"
+                "--user"
+                "restart"
                 "hypridle"
               ];
             }

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -26,6 +26,7 @@ let
     "dump978.sdrhub" = "192.168.31.20";
     "piaware.sdrhub" = "192.168.31.20";
     "jellyfin.sdrhub" = "192.168.31.20";
+    "clipboard.sdrhub" = "192.168.31.20";
     "acarshub" = "192.168.31.24";
     "fredhub" = "192.168.31.14";
     "fredvps" = "5.161.253.151";
@@ -686,6 +687,35 @@ in
       }
 
       ###############################################################
+      # SYNCCLIPBOARD (clipboard sync + server-side history)
+      ###############################################################
+      {
+        name = "syncclipboard";
+        image = "jericx/syncclipboard-server:v3.2.0@sha256:3f2d9c6ce4fbefca769e40d79ed2cac2ad8fc3adf962c0599ba9176b502a3b6d";
+
+        restart = "always";
+
+        # Credentials only; the image's own appsettings.json supplies the
+        # rest, including MaxSavedHistoryCount. The env vars take priority
+        # over that file when both are non-empty, which is why the password
+        # never has to appear in the Nix store.
+        environmentFiles = [
+          config.sops.secrets."docker/sdrhub/syncclipboard.env".path
+        ];
+
+        # Loopback-only. The server speaks plain HTTP and carries a password,
+        # so it is reached exclusively through the nginx vhost below rather
+        # than being published to the LAN. Same reasoning as karma/blackbox.
+        ports = [
+          "127.0.0.1:5033:5033"
+        ];
+
+        volumes = [
+          "/opt/adsb/syncclipboard:/app/data"
+        ];
+      }
+
+      ###############################################################
       # ACARS ROUTER (ACARS + VDLM2 + HFDL consolidation)
       ###############################################################
       {
@@ -824,6 +854,20 @@ in
           locations."/".proxyPass = "http://192.168.31.20:8083";
         };
 
+        # Clipboard payloads are whatever happened to be on a clipboard, so
+        # the default 1m body limit is far too small once images are in play.
+        # The upstream is loopback-only, so this vhost is the only way in.
+        "clipboard.sdrhub.lan" = {
+          serverAliases = [ "clipboard.sdrhub.local" ];
+          locations."/" = {
+            proxyPass = "http://127.0.0.1:5033";
+            extraConfig = ''
+              client_max_body_size 512m;
+              proxy_read_timeout 300s;
+            '';
+          };
+        };
+
         "piaware.sdrhub.lan" = {
           serverAliases = [ "piaware.sdrhub.local" ];
           locations."/".proxyPass = "http://192.168.31.20:8084";
@@ -877,12 +921,14 @@ in
       # Ensure directory exists (does not touch contents if already there)
       install -d -m0755 -o fred -g users /opt/adsb
       install -d -m0755 -o fred -g users /opt/adsb/degoog
+      install -d -m0755 -o fred -g users /opt/adsb/syncclipboard
     '';
     deps = [ ];
   };
 
   sops.secrets = {
     "docker/sdrhub/dozzle.env" = mkContainerSecret "dozzle";
+    "docker/sdrhub/syncclipboard.env" = mkContainerSecret "syncclipboard";
 
     # Deliberately NOT mkContainerSecret. Both are declared but unconsumed:
     # the dozzle-agent container takes no environmentFiles (its secret is

--- a/hosts/linux/sdrhub/configuration.nix
+++ b/hosts/linux/sdrhub/configuration.nix
@@ -863,6 +863,15 @@ in
             proxyPass = "http://127.0.0.1:5033";
             extraConfig = ''
               client_max_body_size 512m;
+
+              # Stream to the upstream instead of buffering. Auth happens in
+              # SyncClipboard, not nginx, so with the default
+              # proxy_request_buffering on any LAN client could push 512m of
+              # body to disk before ever being told 401. Streaming lets the
+              # upstream reject it immediately, and client_body_timeout bounds
+              # a slow trickle (proxy_read_timeout only covers the response).
+              proxy_request_buffering off;
+              client_body_timeout 60s;
               proxy_read_timeout 300s;
             '';
           };
@@ -921,7 +930,12 @@ in
       # Ensure directory exists (does not touch contents if already there)
       install -d -m0755 -o fred -g users /opt/adsb
       install -d -m0755 -o fred -g users /opt/adsb/degoog
-      install -d -m0755 -o fred -g users /opt/adsb/syncclipboard
+      # 0700, unlike its siblings: this one holds clipboard history, which
+      # is whatever happened to be copied, passwords included. The image sets
+      # no USER so the container runs as root and writes root-owned,
+      # world-readable files; 0755 left them traversable by any local user.
+      # Root ignores DAC, so tightening the directory does not affect it.
+      install -d -m0700 -o fred -g users /opt/adsb/syncclipboard
     '';
     deps = [ ];
   };

--- a/modules/monitoring/master/blackbox.nix
+++ b/modules/monitoring/master/blackbox.nix
@@ -129,6 +129,14 @@ let
   # Each was verified 200 from sdrhub itself (dump978 after following its
   # single redirect to /skyaware978/, which is why the internal module follows
   # redirects and the public ones do not).
+  # Endpoints that legitimately answer 401 unauthenticated. Probing these with
+  # http_2xx would fire permanently; the point of the probe is to prove nginx
+  # still reaches a live upstream, and a 401 proves exactly that without
+  # putting a credential in the exporter.
+  internalAuthedEndpoints = [
+    "http://clipboard.sdrhub.local/" # -> 127.0.0.1:5033 (syncclipboard)
+  ];
+
   internalEndpoints = [
     "http://sdrhub.local/" # landing page
     "http://tar1090.sdrhub.local/" # -> 192.168.31.20:8080
@@ -201,6 +209,20 @@ let
       # so following redirects on acarshub.com would silently report
       # acarshub.app's expiry, and sdr-e.org would report github.com's. The
       # cert-expiry alerts would then be watching the wrong certificates.
+      # Accepts only 401. A 2xx here would mean the server stopped requiring
+      # authentication, which is itself worth catching.
+      http_401 = {
+        prober = "http";
+        timeout = "10s";
+        http = {
+          method = "GET";
+          valid_status_codes = [ 401 ];
+          follow_redirects = true;
+          fail_if_not_ssl = false;
+          preferred_ip_protocol = "ip4";
+        };
+      };
+
       https_2xx = {
         prober = "http";
         timeout = "10s";
@@ -286,6 +308,7 @@ in
       (mkProbeJob "blackbox-https-redirect-secondary" "https_redirect" publicRedirectSecondaryEndpoints)
 
       (mkProbeJob "blackbox-http-internal" "http_2xx" internalEndpoints)
+      (mkProbeJob "blackbox-http-internal-authed" "http_401" internalAuthedEndpoints)
 
       # The exporter's own operational metrics -- not a probe, a normal scrape.
       # Without this, a dead exporter yields no probe_success series at all,

--- a/modules/monitoring/master/blackbox.nix
+++ b/modules/monitoring/master/blackbox.nix
@@ -218,7 +218,10 @@ let
           method = "GET";
           valid_status_codes = [ 401 ];
           follow_redirects = true;
-          fail_if_not_ssl = false;
+          # Matches http_2xx: these vhosts are plain HTTP by design, so TLS
+          # appearing here means something was reconfigured and the probe
+          # should say so rather than quietly passing.
+          fail_if_ssl = true;
           preferred_ip_protocol = "ip4";
         };
       };

--- a/modules/secrets/secrets.yaml
+++ b/modules/secrets/secrets.yaml
@@ -51,6 +51,7 @@ docker:
         acarshub.env: ENC[AES256_GCM,data:+22/GsZR9wQtbPuyXe2UUlpNDnda89X/N7IhSMWx+n8n4NFDrgQJy2hbGn0wDRLdNeIChgcDBwsb5kIilQTaXoG9dSTWTXjsfXi1NeTWSEGgKbwJsvHzKZs4+2c5jcmbOJ/6v4EvLzgzdD3TB4+PDq+5QdPMeGezitEwpgwdMtAn9opHtNW1iq3vKDV4x5/izr/XT1Xn6CHiAn2bYBwfvomuA3KswZ/1AQSU0rc22uXnGDyQxqece9AFi51MLBb57NVsGXPseZp/bnOi3iQrI2uYqXaJ/8fg54GIr1g//B0J+AQcoLoraIo+rr+xiEPSpW0wTMWR0FqdMdac48gaUlQoB9aH+J5MXIF1nmOtga2xCqA92ED/C0Vetoxx6bDpIuJcZ3DNiGSrhIjgXv2c4jOP2nw8Wmz5gGyhDUBTiSzDuc3hz5sxnTuiMsp2WdtvHKNUeacXJTiADaaTMrgzzNz3Bkc2k/YYnzLOW6mmPUl4shEHhjGOKGGtS457Bbqye6h/euuoVjDEZ9HaOI/7OZ+EK396QiZ4LbyJc5CdZCv61sqdW79wI5x8D6uAFn5Aaf7dlIW5eHMtjtx7SrMYHOpFpqHboC0jPEJYeU0hdxVAcY10dQj1QeSGVW5kXmxFxdbdSybwWGov8u+X8OLf+1jfEI/SLNCCDZ2iG15WMYhoMmxdwq2q32+mUiNHO205NmpCoktrXP8Un4aMiQa6ZqQ=,iv:AsL5fS6JJZd/aOhFRhA0aMAFa2zbWAOACuGz5Ijm1+o=,tag:5JX1j3GkphH1dFtz7SZ+MA==,type:str]
         acars2pos.env: ENC[AES256_GCM,data:C3W6DrUPvUeUtWCRgMKaRoTiprbEtRKHQpCAdYavU+K1YHv7Roco5bz4+ae05jb42UMjIj+tVAcLM8PmDAK8QoY=,iv:NxrG5Lz8WoF5RDRzctP6eNC4/oahcM0vn4vAFiL7mNo=,tag:dOVXOND6/6WUihvcEwWlbg==,type:str]
         acars_router.env: ENC[AES256_GCM,data:DJRJNKk27IJjWvPLy4ha4h1eHhQl7f23GCZFFjDzXDC816R1fEintt2GHUADUT4iHPghyDBcVJmtBjiu5/B4idmk15mBEk9870zpaahymhYMcmIwdbc1KBCLt5aX0tdyCasl5GeGW8svKGXlvL+dUGnkAAj6UoMj+OkT/1umPUECJSBsoq1ZMCaJ5qcWS9oHQ/ufFUqmRvjRiWWzGE4wxlzoKAuCTaIvSJ7p5vcAyxBP4FKCzhfOTDhDRr9vdqBt6yOQGy+SJgJ91xBFgVM6IcLggksVxBpShw+g2JRqEEDp+CuePlL9o9vG+mHVsThjGWlgYJ1LfiACzjqE/IJVjUmJ3Q41FqSOoaNo3gXY1MWmpAhFVJRbVmQ7DFEcPAUvYJRBsm5J6JT8hDYA3+WnGVB/aBlWDqSZ0lZAu8AcFc2fnLtaGkTszrkj/lVWkX6WJY1BJbfwuyzawE8Xac7YJ/ORXYk6Bmj588MaUfPTHWqC92jF,iv:oEWqe3t5+LDuFwqawE36VVar1DK5hTWik6CraVZxJdE=,tag:k1V5HjMoQkczaToW/6ynvQ==,type:str]
+        syncclipboard.env: ENC[AES256_GCM,data:is8yuHVwx8uSKujskYh2NWmncg4cDMJxwaGSiw1DwitJKU2JS9MFxAE6OdnBKF1mYrWyIKWw7X9RxHXSnfQKJr9Fo4Pv1iPqWM1PKqYpokVsG5/qyYRgp1TjplU=,iv:bKJ/5GSgEfu1XZWqU+xxFqbnAyfYA1Aacb8U2Lyy5aE=,tag:V0JOOoQJZlynyh6Yj+OMcA==,type:str]
 github-token: ENC[AES256_GCM,data:Kq5JwiSTFoWytsfgvKMCX5SUkr4RC9wSKsSpHuZ/Fr3veXdUQF0pHg==,iv:SxNmsoLbqwzsrMYVdWiZpJDoDvGjCKX0hwZG1Y567kQ=,tag:RVOwQEJ9oTZb2v+YrLvL/Q==,type:str]
 email:
     phone: ENC[AES256_GCM,data:g2QUYsrB/76IoDH5CH8=,iv:6u+OHGb+ZOii3Xau3DFyAg4O9ZWYtUHeTtPjDKTI/gs=,tag:5QfeUanATem8qZ2mArgxMw==,type:str]
@@ -193,7 +194,7 @@ sops:
             DQ4Uj3tQP2arw+SMlfSzRpTkOER5Ng8CUJSS711gdmk+y47vNS8fxg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1dnvtnuwfhew8hpfrxjdfqkajtxvgkzgthm8m6l3j2cu6xgmn3u4sh0a3ts
-    lastmodified: "2026-08-11T18:23:33Z"
-    mac: ENC[AES256_GCM,data:ia01OCQe2udNQgMsVbW8u1+aSbREAVvhYiYrqL098ZV2Gsdt+8WB6FahQE2qBwSh/XJzm+XfdyIDPR8dA8puT3IRnQgGvL41c5yb1xBKzjmmQqPaxOKhkDLh7ZvCoe5kRUdfr0sGF9SqlHvD07srouY7gBZswz3eqazp4S1iPyM=,iv:ERg7QHIYG427zzIM2FERnIMlRlAX4GUb3hAO7ymsIac=,tag:90dWF44IedS0Dq7FQL/5Jg==,type:str]
+    lastmodified: "2026-08-17T00:14:35Z"
+    mac: ENC[AES256_GCM,data:h5z9hNGPzKIq+Q4CE7oaN+DT7aLpzNt2jH0FKlGGV4LTs4UHOyKOD+BJl7/TxGArHSZmVCqUcgIbE+Z/0wkn2CcPlV6qItBO1XHPWnKITifzjprj3ykjtQtHZM4TM89yptz3Mfelxshq07WiX/Fl7UDvXmm+yV8PvkYQkDHq5yA=,iv:RSz1Hd6+tcEoJ7Z/96qPI6t6WGJp7bPi9MH7jQf8M1s=,tag:Cr18kHlO+kB+73CxvhuuWA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -30,6 +30,10 @@ final: prev: {
 
   cider3 = final.callPackage ./cider.nix { };
 
+  # SyncClipboard desktop client. Upstream ships an AppImage only and it is
+  # not in nixpkgs; see overlays/syncclipboard.nix for the ICU caveat.
+  syncclipboard = final.callPackage ./syncclipboard.nix { };
+
   # Pin opencode to the latest upstream release rather than nixpkgs'
   # (frequently stale) pin. See overlays/opencode.nix for the bump
   # procedure.

--- a/overlays/syncclipboard.nix
+++ b/overlays/syncclipboard.nix
@@ -17,6 +17,8 @@
   appimageTools,
   fetchurl,
   icu,
+  wl-clipboard,
+  xclip,
   ...
 }:
 let
@@ -33,16 +35,34 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
-  # .NET aborts at startup without ICU:
+  # icu: .NET aborts at startup without it, printing
   #
   #   Couldn't find a valid ICU package installed on the system. Please
   #   install libicu ... Alternatively you can set the configuration flag
   #   System.Globalization.Invariant to true
   #
-  # Confirmed by running the bare AppImage through appimage-run. Providing
-  # the real library is preferable to switching on invariant globalization,
+  # Providing the real library is preferable to invariant globalization,
   # which would silently change string comparison and formatting behaviour.
-  extraPkgs = _: [ icu ];
+  #
+  # wl-clipboard and xclip are how the client actually reads the clipboard --
+  # it shells out to them rather than doing it in-process. Upstream's own AUR
+  # package lists both as runtime `depends`, but an AppImage declares nothing,
+  # so inside this FHS sandbox they were simply absent.
+  #
+  # That absence did not fail loudly. The client silently fell back to
+  # Avalonia's in-process X11 path, which reaches the Wayland selection only
+  # through XWayland: it caught some copies and returned empty for others,
+  # which then classified as `Unkown` and skipped the upload with no error.
+  # The result looked like flaky syncing rather than a missing dependency.
+  #
+  # Installing these is necessary but not sufficient -- the client still has
+  # to be told to prefer them over the X11 path. See the ProhibitSources
+  # setting in features/desktop/clipboard.
+  extraPkgs = _: [
+    icu
+    wl-clipboard
+    xclip
+  ];
 
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/xyz.jericx.desktop.syncclipboard.desktop \

--- a/overlays/syncclipboard.nix
+++ b/overlays/syncclipboard.nix
@@ -1,0 +1,57 @@
+# SyncClipboard desktop client — distributed as an AppImage.
+#
+# Added as an overlay so pkgs.syncclipboard is available everywhere
+# (systemPackages, home-manager, devShells) without any manual imports.
+#
+# Upstream ships AppImage/deb/rpm only and is not in nixpkgs, so this wraps
+# the AppImage rather than building from source. It is an Avalonia (.NET) app
+# and shows its UI through a StatusNotifierItem tray icon; wayle provides the
+# SNI watcher on this fleet, so the tray works without extra plumbing.
+#
+# Usage in overlays/default.nix:
+#
+#   final: prev: {
+#     syncclipboard = final.callPackage ./syncclipboard.nix { };
+#   }
+{
+  appimageTools,
+  fetchurl,
+  icu,
+  ...
+}:
+let
+  pname = "syncclipboard";
+  version = "3.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/Jeric-X/SyncClipboard/releases/download/v${version}/SyncClipboard_linux_x64.AppImage";
+    hash = "sha256-dqdxO094da47A5S3ZNZhbimBY8MO3sqsgE0/42LC1H0=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  # .NET aborts at startup without ICU:
+  #
+  #   Couldn't find a valid ICU package installed on the system. Please
+  #   install libicu ... Alternatively you can set the configuration flag
+  #   System.Globalization.Invariant to true
+  #
+  # Confirmed by running the bare AppImage through appimage-run. Providing
+  # the real library is preferable to switching on invariant globalization,
+  # which would silently change string comparison and formatting behaviour.
+  extraPkgs = _: [ icu ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/xyz.jericx.desktop.syncclipboard.desktop \
+      $out/share/applications/${pname}.desktop
+
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-warn 'Exec=/usr/bin/SyncClipboard.Desktop.Default' "Exec=$out/bin/${pname}" \
+      --replace-warn 'TryExec=/usr/bin/SyncClipboard.Desktop.Default' "TryExec=$out/bin/${pname}"
+
+    cp -r ${appimageContents}/usr/share/icons $out/share/icons
+  '';
+}

--- a/scripts/sync-syncclipboard.sh
+++ b/scripts/sync-syncclipboard.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# sync-syncclipboard.sh -- keep the SyncClipboard server and client pinned to
+# the same upstream release.
+#
+# WHY THIS EXISTS
+#
+# SyncClipboard ships the server and every desktop client from a single
+# upstream tag, but they land in two different places in this repo:
+#
+#     hosts/linux/sdrhub/configuration.nix   the server, as a Docker image
+#     overlays/syncclipboard.nix             the Linux client, as an AppImage
+#
+# Only the first is visible to Renovate (its custom regex manager matches
+# `image = "..."` under hosts/linux/*/configuration.nix, and docker updates
+# automerge). Nothing watches the overlay. Left alone, Renovate would walk the
+# server forward on its own while the client stayed put.
+#
+# HOW BADLY THAT WOULD ACTUALLY BREAK THINGS
+#
+# Usually not at all, and it is worth being precise about why rather than
+# cargo-culting a lockstep rule. Upstream states compatibility as a *minimum*
+# server version, not an exact one:
+#
+#     v3.1.1-beta3  "requires server version v3.1.1-beta3 or above"
+#     v3.1.1-beta4  "server version must be v3.1.1-beta4 or above"
+#
+# So the contract is `server >= client`, and Renovate moving the server ahead
+# is the safe direction. The failure mode that matters is a client newer than
+# its server, which no automation here can cause.
+#
+# The exception is real but rare: v3.1.1 was a hard break in both directions
+# ("all clients and independently-deployed servers in the sync network must be
+# upgraded together") because it reworked the account system and the wire
+# protocol. One such break in the 3.x series so far, and it was announced only
+# in prose in Changes.md -- nothing machine-readable separates "additive server
+# release" from "protocol changed".
+#
+# Holding the two equal is therefore a deliberate over-constraint. It costs
+# nothing, because both artifacts come from the same tag and there is no
+# version the server could usefully be on that the client could not, and it
+# replaces "read the changelog and reason about it" with "CI already checked".
+#
+# EXIT CODES
+#
+#   0  already in sync, nothing written
+#   2  files were updated
+#   1  error
+#
+# Deliberately mirrors sync-opencode-hash.sh so workflows can treat both the
+# same way.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+overlay="${repo_root}/overlays/syncclipboard.nix"
+host_config="${repo_root}/hosts/linux/sdrhub/configuration.nix"
+
+image_name="jericx/syncclipboard-server"
+appimage_url_base="https://github.com/Jeric-X/SyncClipboard/releases/download"
+
+die() {
+  echo "sync-syncclipboard: $*" >&2
+  exit 1
+}
+
+target_version="${1:-}"
+if [ -z "$target_version" ]; then
+  target_version="$(gh api repos/Jeric-X/SyncClipboard/releases/latest --jq .tag_name)" ||
+    die "could not resolve the latest upstream release"
+fi
+# Accept either "v3.2.0" or "3.2.0" from the caller; the overlay stores the
+# bare version and the image tag carries the v.
+version="${target_version#v}"
+tag="v${version}"
+
+current_version="$(sed -n 's/^\s*version = "\(.*\)";/\1/p' "$overlay" | head -1)"
+current_image="$(sed -n 's|.*image = "'"${image_name}"':\([^"]*\)".*|\1|p' "$host_config" | head -1)"
+
+[ -n "$current_version" ] || die "could not read the pinned version from $overlay"
+[ -n "$current_image" ] || die "could not read the pinned image from $host_config"
+
+echo "overlay version: $current_version"
+echo "image pin:       $current_image"
+echo "target:          $tag"
+
+# The AppImage hash and the image digest are both content addresses, so they
+# are re-resolved even when the version has not moved. An upstream re-tag or a
+# rebuilt image would otherwise leave a pin that no longer matches reality.
+appimage_url="${appimage_url_base}/${tag}/SyncClipboard_linux_x64.AppImage"
+echo "fetching AppImage hash..."
+appimage_hash="$(nix store prefetch-file --json --hash-type sha256 "$appimage_url" | jq -r .hash)" ||
+  die "could not prefetch $appimage_url"
+
+echo "fetching image digest..."
+digest="$(skopeo inspect --no-tags "docker://docker.io/${image_name}:${tag}" --format '{{.Digest}}')" ||
+  die "could not inspect docker://docker.io/${image_name}:${tag}"
+
+case "$digest" in
+  sha256:*) ;;
+  *) die "unexpected digest format: $digest" ;;
+esac
+
+new_image="${tag}@${digest}"
+echo "resolved image:  $new_image"
+echo "resolved hash:   $appimage_hash"
+
+changed=0
+
+# Overlay: version and hash.
+if [ "$current_version" != "$version" ] || ! grep -qF "$appimage_hash" "$overlay"; then
+  sed -i \
+    -e "s|^\(\s*version = \"\).*\(\";\)$|\1${version}\2|" \
+    -e "s|^\(\s*hash = \"\).*\(\";\)$|\1${appimage_hash}\2|" \
+    "$overlay"
+  changed=1
+fi
+
+# Host config: image tag and digest.
+if [ "$current_image" != "$new_image" ]; then
+  sed -i "s|image = \"${image_name}:[^\"]*\";|image = \"${image_name}:${new_image}\";|" "$host_config"
+  changed=1
+fi
+
+if [ "$changed" -eq 0 ]; then
+  echo "already in sync"
+  exit 0
+fi
+
+# Re-read rather than trusting the sed, so a silently non-matching pattern is
+# caught here instead of at eval time in CI.
+after_version="$(sed -n 's/^\s*version = "\(.*\)";/\1/p' "$overlay" | head -1)"
+after_image="$(sed -n 's|.*image = "'"${image_name}"':\([^"]*\)".*|\1|p' "$host_config" | head -1)"
+[ "$after_version" = "$version" ] || die "overlay version did not update (got '$after_version')"
+[ "$after_image" = "$new_image" ] || die "image pin did not update (got '$after_image')"
+grep -qF "$appimage_hash" "$overlay" || die "overlay hash did not update"
+
+echo "updated to $tag"
+exit 2


### PR DESCRIPTION
Self-hosted SyncClipboard: server on sdrhub at `clipboard.sdrhub.lan`, client packaged and configured declaratively on both desktops, with history kept server-side.

## Why this rather than building our own

Evaluated against: two Wayland desktops, self-hosted server, server-side history, macOS, iOS, nixpkgs packaging, E2EE. SyncClipboard meets every hard requirement and two of three nice-to-haves.

**iOS background sync is impossible for anyone.** Apple restricts pasteboard reads to foreground apps as policy — iOS 9 blocked background reads, 14 added a visible banner, 16 added a confirmation prompt. Commercial clipboard managers work around it with a Picture-in-Picture player to stay technically foregrounded. No self-hosted tool, ours or anyone's, changes that; Shortcuts is the ceiling. Building our own would have bought E2EE we don't need on our own LAN and Nix packaging we get for free, at the cost of owning three client platforms forever, and would have hit the identical iOS wall.

## Server

- Container pinned `v3.2.0@sha256:3f2d9c6c…`, following the existing `services.adsb.containers` pattern.
- **Loopback-published** (`127.0.0.1:5033`) rather than LAN-published — it speaks plain HTTP and carries a password, so nginx is the only way in. Same reasoning already applied to karma and blackbox.
- Credentials from sops, not `appsettings.json`. The server prefers `SYNCCLIPBOARD_USERNAME`/`PASSWORD` over the config file when both are non-empty, so the password never reaches the world-readable Nix store. `MaxSavedHistoryCount` and friends live in the `appsettings.json` the server writes into its persisted volume on first run, so they're tunable in place without a rebuild.
- State directory is `0700`. It holds clipboard history — whatever was copied, passwords included — and the image sets no `USER`, so the container runs as root and writes world-readable files. Deliberately stricter than its siblings under `/opt/adsb`, which hold no secrets.
- nginx streams request bodies rather than buffering. Auth happens in SyncClipboard, not nginx, so with buffering on a LAN client could push 512m to disk before being told 401.

## Client

Upstream ships an AppImage only and isn't in nixpkgs, so it's wrapped via `appimageTools` following the existing `overlays/cider.nix` precedent.

**The interesting bug.** Syncing was intermittent — some copies reached the server, most didn't, nothing logged an error. Two causes, and each fix is useless without the other:

1. The client *shells out* to `wl-clipboard`/`xclip` rather than reading the clipboard in-process. Upstream's AUR package lists both as runtime `depends`; an AppImage declares nothing, so inside the FHS sandbox neither existed. Rather than failing, the client fell back to Avalonia's in-process X11 path, which reaches a Wayland selection only through XWayland — content for some copies, empty for others, and an empty read classifies as `Unkown` and is dropped silently.
2. Even with the binaries present, it still preferred the X11 path. `ProhibitSources` now forbids `xclip` and `Avalonia`, leaving it with `wl-clipboard`.

Testing these separately is what made it hard to find: prohibiting the alternatives *before* installing `wl-clipboard` leaves the client with no source at all, so that setting looked inert.

Config is merged rather than symlinked — the client rewrites its own file whenever a setting changes in the UI, so a read-only store path would break it. A pre-start step sets only the keys we manage and leaves `MaxItemCount`, retention, log settings and theme alone. Verified idempotent against the live config. `EnableSyncHistory` was defaulting to `false`, which left history local and the panel disagreeing with the server — the whole point of the service.

Autostart is a `graphical-session.target` unit plus an explicit restart from both the niri and hyprland session hooks, matching how `wayle`, `polkit-gnome` and `sway-audio-idle-inhibit` are already handled.

## Keeping it current

The server image and the client AppImage ship from one upstream tag but are pinned in two files, and only the image is visible to Renovate — whose docker updates automerge. Nothing watched the overlay.

Upstream states compatibility as a *minimum* server version (`server >= client`), so Renovate moving the server ahead is normally the safe direction. But v3.1.1 was a hard break in both directions, announced only in prose in `Changes.md`, and nothing machine-readable separates an additive release from a protocol change. Holding the two equal is a deliberate over-constraint that costs nothing, since both come from the same tag.

- `scripts/sync-syncclipboard.sh` resolves a tag to an image digest and an AppImage hash and rewrites both pins, exiting `2` on change like `sync-opencode-hash.sh`. Verified by downgrading to v3.1.9 and back — byte-identical tree.
- `update-syncclipboard.yaml` runs it daily, proves the AppImage hash with a real build, opens one PR. Scheduled at `:40` because GitHub documents the top of the hour as its most contended slot.
- `renovate.json5` disables the image so the two can't race; `lint.yaml` gains a parity check as the backstop.

## Verified on the live host

```text
unauthenticated       loopback:401   via-nginx:401
authenticated PUT     200
authenticated GET     200, stored text with matching SHA256
history               records written, starred/pinned metadata present
blackbox probe        probe_success{blackbox-http-internal-authed} = 1
end-to-end            wl-copy on maranello -> server, confirmed by content
```

## Open question for review

`clipboard.sdrhub.lan` is plain HTTP, matching every other vhost on sdrhub. Unlike the others it carries **HTTP Basic credentials on every request**, and the payload is clipboard content. On a trusted LAN that may be acceptable; if not, it needs an internal CA (mkcert or similar) distributed to clients, since public ACME can't issue for `.lan`. Flagging rather than deciding — it's a host-wide convention change, not a one-vhost tweak.

## Not included

macOS clients (manual `.dmg`, same URL and credential) and a `buildDotnetModule` package to replace the AppImage — worth doing on its own merits, but it builds the same `Desktop.Default` project the AppImage runs, so it would not have fixed anything here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a LAN-accessible clipboard synchronization service with persistent storage and protected credentials.
  * Added a desktop clipboard client with automatic synchronization, secure setup, and startup support in supported desktop environments.
  * Added a dedicated web endpoint supporting large uploads and longer-running requests.

* **Monitoring**
  * Added health monitoring for authenticated clipboard service responses.

* **Maintenance**
  * Added automated checks and updates to keep client and server versions aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->