### PR TITLE
Audit remediation: batches 1-4

### DIFF
--- a/.github/workflows/cache-flake-inputs.yaml
+++ b/.github/workflows/cache-flake-inputs.yaml
@@ -49,6 +49,14 @@ on:
 
   workflow_dispatch:
 
+# Static group name: push-to-main, the daily schedule, and a manual
+# dispatch all archive the same input set to the same cache.
+# cancel-in-progress must stay false -- this pushes NARs to Attic, and a
+# cancelled push should not be interrupted mid-upload.
+concurrency:
+  group: cache-flake-inputs
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci-darwin.yaml
+++ b/.github/workflows/ci-darwin.yaml
@@ -7,6 +7,20 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+# Keyed on the ref so unrelated PRs (and merge-queue entries) never cancel
+# each other. cancel-in-progress is true: a superseded push to the same PR
+# ref should not keep occupying the scarce self-hosted macOS runners while
+# a newer commit is waiting to build.
+concurrency:
+  group: ci-darwin-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # `gh pr view` in the merge-queue-ci-skipper composite action (used by
+  # skip-if-clean below) reads the PR for the current ref.
+  pull-requests: read
+
 jobs:
   # =====================================================================
   # Fast-path: Detect whether merge_queue introduces zero diff

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -7,6 +7,20 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+# Keyed on the ref so unrelated PRs (and merge-queue entries) never cancel
+# each other. cancel-in-progress is true: a superseded push to the same PR
+# ref should not keep occupying the scarce self-hosted Linux runners while
+# a newer commit is waiting to build.
+concurrency:
+  group: ci-linux-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # `gh pr view` in the merge-queue-ci-skipper composite action (used by
+  # skip-if-clean below) reads the PR for the current ref.
+  pull-requests: read
+
 jobs:
   # =====================================================================
   # Fast-path: MUST ALWAYS RUN or downstream jobs will skip
@@ -681,12 +695,55 @@ jobs:
           fi
 
   # =====================================================================
+  # Colmena / nixosConfigurations parity
+  #
+  # flake/deployment/colmena.nix and nixosConfigurations are two
+  # independent evaluation paths through the same host modules, and they
+  # have actually diverged before: colmena's plain `pkgs.lib` versus the
+  # flake-extended `lib` nixosSystem uses produced different
+  # `versionSuffix` values, which made the entire server fleet report
+  # `unmanaged`. See the comment in flake/deployment/colmena.nix.
+  #
+  # scripts/gen-fleet-manifest.sh already runs this exact check before
+  # every fleet-manifest publish, but that workflow only triggers on push
+  # to main and a 6-hour schedule -- a regression can merge with this PR
+  # check green and not surface for hours. Running it here closes that
+  # gap at review time instead.
+  #
+  # This is a pure Nix eval: colmenaHive is colmena.lib.makeHive, a Nix
+  # library function, and .outPath needs no realisation. It runs on
+  # ubuntu-latest rather than the self-hosted build runners for the same
+  # reason find-systems and find-devshell do. No fork guard is needed --
+  # this repo's fork guards exist to keep fork PR code off the
+  # self-hosted runners specifically; a GitHub-hosted runner evaluating a
+  # fork's flake has nothing sensitive to protect.
+  colmena-parity:
+    name: Colmena / nixosConfigurations parity
+    runs-on: ubuntu-latest
+    needs: [skip-if-clean]
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
+
+      - name: Check colmena/nixosConfigurations parity
+        shell: bash
+        run: ./scripts/check-colmena-parity.sh
+
+  # =====================================================================
   # Required summary check
   # =====================================================================
   build-linux-summary:
     name: Build Linux Summary
     runs-on: ubuntu-latest
-    needs: [skip-if-clean, build-servers, build-desktops, dev-shell]
+    needs:
+      [skip-if-clean, build-servers, build-desktops, dev-shell, colmena-parity]
     if: ${{ always() }}
 
     steps:
@@ -701,19 +758,25 @@ jobs:
           SERVERS="${{ needs.build-servers.result }}"
           DESKTOPS="${{ needs.build-desktops.result }}"
           DEVSHELL="${{ needs.dev-shell.result }}"
+          PARITY="${{ needs.colmena-parity.result }}"
 
-          echo "Servers result:   $SERVERS"
-          echo "Desktops result:  $DESKTOPS"
-          echo "Dev shell result: $DEVSHELL"
+          echo "Servers result:        $SERVERS"
+          echo "Desktops result:       $DESKTOPS"
+          echo "Dev shell result:      $DEVSHELL"
+          echo "Colmena parity result: $PARITY"
 
           # A result of "skipped" means the matrix was empty (no systems in
           # scope for this PR) — that is a valid outcome, not a failure.
-          if [ "$SERVERS" = "failure" ] || [ "$DESKTOPS" = "failure" ] || [ "$DEVSHELL" = "failure" ]; then
+          # colmena-parity is never skipped for a non-empty skip flag (it
+          # has no system-count gate of its own), so "skipped" there only
+          # happens via the same skip-if-clean fast-path already handled
+          # above.
+          if [ "$SERVERS" = "failure" ] || [ "$DESKTOPS" = "failure" ] || [ "$DEVSHELL" = "failure" ] || [ "$PARITY" = "failure" ]; then
             echo "❌ One or more Linux builds failed."
             exit 1
           fi
 
-          if [ "$SERVERS" = "cancelled" ] || [ "$DESKTOPS" = "cancelled" ] || [ "$DEVSHELL" = "cancelled" ]; then
+          if [ "$SERVERS" = "cancelled" ] || [ "$DESKTOPS" = "cancelled" ] || [ "$DEVSHELL" = "cancelled" ] || [ "$PARITY" = "cancelled" ]; then
             echo "❌ Build job was cancelled — treating as failure."
             exit 1
           fi

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -735,7 +735,12 @@ jobs:
     runs-on: [self-hosted, Linux]
     needs: [skip-if-clean]
     if: ${{ needs.skip-if-clean.outputs.skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # Matches build-servers/build-desktops. id-token is not used by this job,
+    # but nix-installer-action warns on every run without it ("FlakeHub is
+    # disabled because the workflow is misconfigured"), and this repo treats a
+    # noisy CI log as a defect.
     permissions:
+      id-token: "write"
       contents: "read"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -748,12 +753,19 @@ jobs:
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
 
+      # jq comes from `nix shell`, not the runner: the self-hosted NixOS
+      # runners have no jq on PATH (ubuntu-latest does, which is why this only
+      # surfaced after moving off it). Same invocation fleet-manifest.yaml uses
+      # for gen-fleet-manifest.sh.
+      #
       # No --emit-paths: the paths JSON exists only so gen-fleet-manifest.sh
-      # can reuse this eval. Emitting it here dumped 10 store paths as one
-      # unreadable line into the log.
+      # can reuse this eval. Emitting it here dumped 10 store paths into the
+      # log as one unreadable line.
       - name: Check colmena/nixosConfigurations parity
         shell: bash
-        run: ./scripts/check-colmena-parity.sh
+        run: |
+          nix shell --inputs-from . nixpkgs#jq --command \
+            ./scripts/check-colmena-parity.sh
 
   # =====================================================================
   # Required summary check

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -710,28 +710,47 @@ jobs:
   # check green and not surface for hours. Running it here closes that
   # gap at review time instead.
   #
-  # This is a pure Nix eval: colmenaHive is colmena.lib.makeHive, a Nix
-  # library function, and .outPath needs no realisation. It runs on
-  # ubuntu-latest rather than the self-hosted build runners for the same
-  # reason find-systems and find-devshell do. No fork guard is needed --
-  # this repo's fork guards exist to keep fork PR code off the
-  # self-hosted runners specifically; a GitHub-hosted runner evaluating a
-  # fork's flake has nothing sensitive to protect.
+  # This needs no BUILD -- colmenaHive is colmena.lib.makeHive, a Nix library
+  # function, and .outPath needs no realisation -- but it is not a cheap eval
+  # either: it evaluates system.build.toplevel for all 10 hosts plus all 8
+  # colmena nodes, i.e. 18 full system closures.
+  #
+  # It therefore runs on the self-hosted runners, NOT ubuntu-latest. Measured
+  # on this PR: 578s on ubuntu-latest, versus 103s for fleet-manifest doing
+  # strictly more work (the same two evals plus the manifest history merge and
+  # a git push) on self-hosted. The difference is entirely cold flake-input
+  # fetch and a cold eval cache; Nix itself installs in 9s. Note that
+  # find-systems is NOT a counter-example: it evaluates only
+  # `nixosConfigurations --apply builtins.attrNames`, which never forces a
+  # single system derivation, and finishes in ~36s.
+  #
+  # Because it is now on self-hosted, it carries the same fork guard as
+  # build-servers/build-desktops/dev-shell: fork PR code must not execute
+  # there. Consequence, deliberately accepted -- parity is not checked for
+  # fork PRs. That matches the build jobs, which already skip on forks, and a
+  # fork PR cannot deploy the fleet. build-linux-summary treats `skipped` as a
+  # valid outcome, so this does not break the required check.
   colmena-parity:
     name: Colmena / nixosConfigurations parity
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     needs: [skip-if-clean]
-    if: ${{ needs.skip-if-clean.outputs.skip != 'true' }}
+    if: ${{ needs.skip-if-clean.outputs.skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    permissions:
+      contents: "read"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
+          trust-runner-user: true
           extra-conf: |
             access-tokens = github.com=${{ github.token }}
             accept-flake-config = true
 
+      # No --emit-paths: the paths JSON exists only so gen-fleet-manifest.sh
+      # can reuse this eval. Emitting it here dumped 10 store paths as one
+      # unreadable line into the log.
       - name: Check colmena/nixosConfigurations parity
         shell: bash
         run: ./scripts/check-colmena-parity.sh
@@ -767,10 +786,10 @@ jobs:
 
           # A result of "skipped" means the matrix was empty (no systems in
           # scope for this PR) — that is a valid outcome, not a failure.
-          # colmena-parity is never skipped for a non-empty skip flag (it
-          # has no system-count gate of its own), so "skipped" there only
-          # happens via the same skip-if-clean fast-path already handled
-          # above.
+          # colmena-parity has no system-count gate, but it does carry a fork
+          # guard (it runs on self-hosted), so "skipped" there means either
+          # the skip-if-clean fast-path already handled above, or a fork PR.
+          # Both are valid; only failure/cancelled are treated as fatal.
           if [ "$SERVERS" = "failure" ] || [ "$DESKTOPS" = "failure" ] || [ "$DEVSHELL" = "failure" ] || [ "$PARITY" = "failure" ]; then
             echo "❌ One or more Linux builds failed."
             exit 1

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -77,6 +77,18 @@ on:
     - cron: "0 7 * * 1"
   workflow_dispatch:
 
+# A static group name (not keyed on ref, unlike the PR-triggered CI
+# workflows): the Monday cron and a manual workflow_dispatch both target
+# the default branch, and the point of this group is to serialise them
+# against EACH OTHER, closing the TOCTOU window where a manual dispatch
+# races the cron. cancel-in-progress must stay false: the aggregate job
+# mutates GitHub issue #1717 via `gh issue create`/`edit`/`close`, and
+# cancelling mid-mutation risks a duplicate issue rather than a clean
+# update.
+concurrency:
+  group: cve-scan
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write
@@ -118,7 +130,10 @@ jobs:
     name: Scan nixos/${{ matrix.system }}
     runs-on: [self-hosted, Linux]
     needs: [find-systems]
-    if: ${{ needs.find-systems.outputs.nixos != '[]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # No fork guard needed here: this workflow only triggers on `schedule`
+    # and `workflow_dispatch` (see header), never `pull_request`, so
+    # fork-PR code never reaches this job.
+    if: ${{ needs.find-systems.outputs.nixos != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -277,6 +292,40 @@ jobs:
             exit 1
           fi
 
+          # Grype vulnerability-DB liveness gate.
+          #
+          # The two assertions above catch a collapsed SBOM. They say
+          # nothing about grype's own vulnerability database: a stale or
+          # empty DB scans a perfectly healthy SBOM, finds nothing to
+          # match against, and reports zero vulnerabilities -- a result
+          # indistinguishable, to every check above, from a genuinely
+          # clean system. Fed into the aggregate job, that produces a
+          # false all-clear: TOTAL stays 0, MISSING stays 0, and the
+          # rolling tracking issue (#1717) auto-closes with "found zero
+          # vulnerability matches" on a scan that never actually checked
+          # anything against a current database.
+          #
+          # `grype db status` sets `valid: false` (with a reason in
+          # `.error`) once the local DB is absent or exceeds its max
+          # allowed age, so gate on that instead of trusting a silent
+          # zero-match result. The result is written to db-status.txt and
+          # uploaded alongside the SBOM (see the always()-gated upload
+          # step below) so the aggregate job can see it per-system, the
+          # same way it already sees per-system coverage via the SBOM
+          # artifact itself.
+          echo "Checking grype vulnerability DB liveness..."
+          db_status_json=$(nix shell --inputs-from . nixpkgs#grype --command grype db status -o json || true)
+          db_valid=$(nix shell --inputs-from . nixpkgs#jq --command jq -r '.valid // false' <<< "$db_status_json" 2>/dev/null || echo false)
+          echo "$db_status_json"
+
+          if [ "$db_valid" != "true" ]; then
+            db_reason=$(nix shell --inputs-from . nixpkgs#jq --command jq -r '.error // "grype db status produced no usable output"' <<< "$db_status_json" 2>/dev/null || echo "grype db status produced no usable output")
+            echo "stale: ${db_reason}" > db-status.txt
+            echo "::error::grype vulnerability DB is not live (${db_reason}) -- refusing to report a scan that cannot be verified against a current database" >&2
+            exit 1
+          fi
+          echo "live" > db-status.txt
+
           echo "Step 2/2: scanning SBOM with grype..."
           # grype reads sbom.cdx.json, writes a new CycloneDX file with
           # vulnerabilities to a temp path, then we atomically replace.
@@ -323,6 +372,18 @@ jobs:
           echo "vuln_count=$vuln_count" >> "$GITHUB_OUTPUT"
 
       - name: Upload SBOM
+        # always() so db-status.txt still reaches the aggregate job when
+        # the step above failed the DB-liveness gate before ever calling
+        # grype -- otherwise the aggregate can only see this system as
+        # "missing" and cannot distinguish a dead vulnerability DB from
+        # any other kind of scan failure.  sbom.cdx.json/csv/spdx.json
+        # already exist by that point (sbomnix and the coverage
+        # assertions run before the DB gate), so this uploads a partial
+        # but genuine SBOM alongside the "stale" marker.  For failures
+        # further upstream (sbomnix itself, coverage, scannable-count)
+        # none of these files exist yet; if-no-files-found defaults to
+        # "warn", so that does not itself fail this step.
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-nixos-${{ matrix.system }}
@@ -330,6 +391,7 @@ jobs:
             sbom.cdx.json
             sbom.csv
             sbom.spdx.json
+            db-status.txt
           retention-days: 30
 
   # =====================================================================
@@ -385,10 +447,12 @@ jobs:
 
           # =================================================================
           # Per-system pass: count CVEs in each SBOM, build the set of
-          # systems that produced an artefact.
+          # systems that produced an artefact, and track whether each
+          # system's grype vulnerability DB was confirmed live.
           # =================================================================
           shopt -s nullglob
           declare -A scanned
+          db_not_live=()
           for dir in reports/sbom-*/; do
             artifact=$(basename "$dir")
             # artifact name is "sbom-<kind>-<name>"
@@ -408,6 +472,17 @@ jobs:
 
             if [ "$count" -gt 0 ]; then
               systems_with_cves+=("${kind}/${name}:${count}")
+            fi
+
+            # db-status.txt is written by scan-linux right before the
+            # grype invocation (see the DB-liveness gate in cve-scan.yaml's
+            # scan job) and contains exactly "live" or "stale: <reason>".
+            # Its absence is treated the same as "stale": an artefact that
+            # predates this check, or a step that failed before writing
+            # it, must not silently count as a verified-live DB.
+            db_status="${dir}db-status.txt"
+            if [ ! -f "$db_status" ] || ! grep -qx "live" "$db_status"; then
+              db_not_live+=("${kind}/${name}")
             fi
           done
 
@@ -532,6 +607,19 @@ jobs:
               echo
             fi
 
+            if [ "${#db_not_live[@]}" -gt 0 ]; then
+              echo "## ⚠ Vulnerability DB not verified live"
+              echo
+              echo "${#db_not_live[@]} system(s) produced an SBOM but grype's vulnerability DB could not be confirmed current on that runner, so a zero-match result there does NOT mean clean:"
+              echo
+              for sys in "${db_not_live[@]}"; do
+                echo "- \`$sys\`"
+              done
+              echo
+              echo "See [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the grype db status error. The rolling issue will not auto-close while this is non-empty."
+              echo
+            fi
+
             if [ "$total" -eq 0 ]; then
               echo "## No vulnerabilities found"
               echo
@@ -627,8 +715,11 @@ jobs:
             fi
           fi
 
-          echo "total=$total" >> "$GITHUB_OUTPUT"
-          echo "missing=${#missing[@]}" >> "$GITHUB_OUTPUT"
+          {
+            echo "total=$total"
+            echo "missing=${#missing[@]}"
+            echo "db_not_live=${#db_not_live[@]}"
+          } >> "$GITHUB_OUTPUT"
 
           echo "--- report body (size=$(wc -c < body.md) bytes) ---"
           cat body.md
@@ -638,6 +729,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TOTAL: ${{ steps.report.outputs.total }}
           MISSING: ${{ steps.report.outputs.missing }}
+          DB_NOT_LIVE: ${{ steps.report.outputs.db_not_live }}
         shell: bash
         run: |
           set -euo pipefail
@@ -695,16 +787,26 @@ jobs:
 
           if [ "$TOTAL" -eq 0 ]; then
             # Update body so the issue still reflects the latest scan,
-            # but only auto-close when we have COMPLETE coverage.  If
-            # any system failed to scan we don't actually know whether
-            # it's clean — closing the issue would hide that fact.
+            # but only auto-close when we have COMPLETE coverage AND every
+            # scanned system's grype vulnerability DB was confirmed live.
+            #
+            # The DB-liveness leg exists because zero matches is not, by
+            # itself, evidence of a clean fleet: a stale or empty grype DB
+            # also reports zero matches against a perfectly healthy SBOM,
+            # and that failure mode passes both the coverage and
+            # scannable-component assertions in the scan job. Without this
+            # check the issue would auto-close on a scan that never
+            # actually checked anything against a current database — see
+            # the DB-liveness gate comment in the scan-linux job.
             gh issue edit "$number" --body-file body.md
-            if [ "$state" = "OPEN" ] && [ "$MISSING" -eq 0 ]; then
-              echo "Closing issue (zero CVEs, complete coverage)..."
+            if [ "$state" = "OPEN" ] && [ "$MISSING" -eq 0 ] && [ "$DB_NOT_LIVE" -eq 0 ]; then
+              echo "Closing issue (zero CVEs, complete coverage, DB verified live on every system)..."
               gh issue close "$number" \
                 --comment "Latest scan found zero vulnerability matches across all systems. Closing."
-            elif [ "$state" = "OPEN" ]; then
+            elif [ "$state" = "OPEN" ] && [ "$MISSING" -gt 0 ]; then
               echo "Zero CVEs in scanned systems but ${MISSING} system(s) missing — leaving issue open."
+            elif [ "$state" = "OPEN" ]; then
+              echo "Zero CVEs reported but ${DB_NOT_LIVE} system(s) could not confirm a live vulnerability DB — leaving issue open, since a zero-match result there is not trustworthy."
             fi
           else
             gh issue edit "$number" --body-file body.md

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -313,6 +313,25 @@ jobs:
           # step below) so the aggregate job can see it per-system, the
           # same way it already sees per-system coverage via the SBOM
           # artifact itself.
+          # `grype db status` only REPORTS local state -- it never fetches.
+          # grype's own auto-update happens as part of a scan invocation, so
+          # gating on `status` alone would fail the job on any runner whose
+          # cache is absent or past its max allowed age (5 days by default)
+          # EVEN THOUGH the scan below would have downloaded a current DB and
+          # worked. That turns a guard against false all-clears into a source
+          # of false failures on fresh runners. Raised by review on PR #2241.
+          #
+          # So update first and treat a failed update as the real signal: it
+          # means the DB source is unreachable, which is exactly the condition
+          # under which a zero-match result must not be trusted.
+          echo "Updating grype vulnerability DB..."
+          if ! nix shell --inputs-from . nixpkgs#grype --command grype db update 2>db-update.err; then
+            db_reason="grype db update failed: $(tr '\n' ' ' <db-update.err | head -c 300)"
+            echo "stale: ${db_reason}" > db-status.txt
+            echo "::error::${db_reason} -- refusing to report a scan that cannot be verified against a current database" >&2
+            exit 1
+          fi
+
           echo "Checking grype vulnerability DB liveness..."
           db_status_json=$(nix shell --inputs-from . nixpkgs#grype --command grype db status -o json || true)
           db_valid=$(nix shell --inputs-from . nixpkgs#jq --command jq -r '.valid // false' <<< "$db_status_json" 2>/dev/null || echo false)
@@ -620,10 +639,24 @@ jobs:
               echo
             fi
 
-            if [ "$total" -eq 0 ]; then
+            # "clean" is only honest when the fleet was FULLY scanned against a
+            # verified-live DB. Zero matches with systems missing, or with a DB
+            # that could not be confirmed current, means "we do not know" --
+            # which is the whole point of the two blocks above, and printing
+            # "All scanned systems are clean" underneath them would contradict
+            # them in the same comment. The auto-close logic already gates on
+            # all three; the report body has to agree with it. Note the
+            # `missing` half of this was a pre-existing bug, not new to the DB
+            # work. Raised by review on PR #2241.
+            if [ "$total" -eq 0 ] && [ "${#missing[@]}" -eq 0 ] && [ "${#db_not_live[@]}" -eq 0 ]; then
               echo "## No vulnerabilities found"
               echo
               echo "All scanned systems are clean."
+              echo
+            elif [ "$total" -eq 0 ]; then
+              echo "## No verified vulnerability matches"
+              echo
+              echo "Zero matches were returned, but this run does not establish that the fleet is clean -- see the warnings above. Treat this as \"unknown\", not \"clean\"."
               echo
             else
               echo "## ${total} vulnerability matches across ${#systems_with_cves[@]} system(s)"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,12 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  # `gh pr view` in the merge-queue-ci-skipper composite action (used by
+  # skip-if-clean below) reads the PR for the current ref.
+  pull-requests: read
+
 jobs:
   # =====================================================================
   # Fast-path job — now always runs, but only sets skip=true on merge_group

--- a/.github/workflows/opencode-hash-guard.yaml
+++ b/.github/workflows/opencode-hash-guard.yaml
@@ -33,6 +33,15 @@ on:
       - "flake.lock"
       - "overlays/opencode.nix"
 
+# Keyed on the ref so unrelated PRs never cancel each other.
+# cancel-in-progress is true: this pushes a fixup commit onto the PR
+# branch, and on rapid repushes only the newest head's hash matters -- a
+# superseded run racing to push a correction for a commit that no longer
+# exists is pure waste.
+concurrency:
+  group: opencode-hash-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 # Only what checkout needs. The push authenticates with a PAT supplied inline
 # at push time, so the job token never needs write access, and nothing here
 # touches the pull-requests API.

--- a/.github/workflows/renovate-relock.yaml
+++ b/.github/workflows/renovate-relock.yaml
@@ -39,7 +39,12 @@ jobs:
   relock:
     # Only act on Renovate's PRs.  Skip everything else (incl. our own
     # follow-up push, which is authored by github[bot]) to avoid loops.
-    if: github.event.pull_request.user.login == 'renovate[bot]'
+    # The same-repo check matters because this checks out the PR head,
+    # runs `nix flake lock --refresh` against it, and pushes the result
+    # with a write-scoped PAT (not GITHUB_TOKEN -- see below): a
+    # same-named fork PR would otherwise get its (attacker-controlled)
+    # flake.nix evaluated and re-locked with that PAT.
+    if: github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/update-apple-fonts.yaml
+++ b/.github/workflows/update-apple-fonts.yaml
@@ -33,6 +33,14 @@ on:
     - cron: "15 5 * * 1"
   workflow_dispatch:
 
+# Static group name: the weekly cron and a manual dispatch open/update the
+# same PR branch. cancel-in-progress must stay false -- a cancelled run
+# could leave the branch mid-update (hash rewritten, PR body not yet
+# refreshed), which is worse than letting a redundant run finish.
+concurrency:
+  group: update-apple-fonts
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/update-syncclipboard.yaml
+++ b/.github/workflows/update-syncclipboard.yaml
@@ -26,6 +26,14 @@ on:
     - cron: "40 4 * * *"
   workflow_dispatch:
 
+# Static group name: the daily cron and a manual dispatch open/update the
+# same PR branch. cancel-in-progress must stay false -- a cancelled run
+# could leave the branch mid-update (one pin moved, the other not yet),
+# which is exactly the divergence this workflow exists to prevent.
+concurrency:
+  group: update-syncclipboard
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/AUDIT-2026-08-04.md
+++ b/AUDIT-2026-08-04.md
@@ -1,15 +1,90 @@
 # Repository audit -- 2026-08-04
 
-Scratch review document. **Not for commit.** Delete or gitignore when done.
+Tracked remediation document. Originally a scratch review; kept in-tree
+deliberately as the remediation record. **Do not delete.** Update the status
+markers as work lands, and add a new re-verification section rather than
+silently editing findings, so the dated evidence trail survives.
 
 Method: four parallel subagent audits (Nix style, service config, CI health,
 CI gaps), followed by independent re-verification of every claim marked
 critical below. Nothing in the "Verified" rows is agent hearsay -- each was
 re-checked directly with `grep`, `nix eval`, `gh`, or an NVD lookup.
 
+## Reading this document
+
+The numbered parts below are a **snapshot dated 2026-08-04**. A full
+re-verification was run on **2026-08-17** (four parallel read-only agents plus
+direct spot checks). Every part now carries a status line reflecting the
+2026-08-17 state. Where the original text was factually wrong, the correction
+is inline and labelled; the original claim is preserved so the error is
+traceable.
+
+Status vocabulary used throughout:
+
+| Marker            | Meaning                                                            |
+| ----------------- | ------------------------------------------------------------------ |
+| DONE              | Fixed and verified in the tree. No further action.                  |
+| PARTIAL           | Some sub-items fixed, others live. Read the per-item detail.        |
+| LIVE              | Still present, unchanged, actionable.                               |
+| REJECTED          | Deliberately not doing this. Rationale recorded.                    |
+| DEFERRED          | Real, but scheduled for a separate planning session.                |
+| UNVERIFIABLE      | Cannot be confirmed from a checkout. Needs an out-of-band check.    |
+
+The actionable work is consolidated in **Part 9 -- Remediation batches** at
+the end. That section, not the per-part text, is the execution plan. The parts
+exist to supply the evidence and rationale so a future agent does not redo the
+analysis.
+
+### Fleet facts a future agent needs
+
+The fleet grew after the audit was written. Anything in the parts below that
+counts hosts is stale by one.
+
+- **12 hosts total**: 10 Linux (8 servers + 2 desktops) + 2 Darwin.
+- `nvrhub` was added 2026-08-10 (commit `c6390294`), _after_ this audit. It is
+  a Frigate NVR host with 8 cameras writing to a dedicated XFS volume. It does
+  not appear in the audit's original per-host tables.
+- `nvrhub` was wired in correctly everywhere structural: `flake/hosts/servers.nix`,
+  `colmenaHive.nodes`, `nixosConfigurations`, `modules/secrets/.sops.yaml`, and
+  correctly excluded from `desktop_names`. No CI classification drift.
+- `nvrhub` nonetheless **reproduced two already-audited defects on day one**
+  (missing `restartUnits` on its sops secrets; a new large unbacked-up dataset).
+  See Part 3 and Part 9 Batch 2. Treat this as evidence that these gaps
+  propagate to new hosts unless the shared module enforces the pattern.
+- `.sops.yaml` moved to `modules/secrets/.sops.yaml` and now lists 12
+  recipients, matching the 12 hosts.
+
 ---
 
 ## Part 0 -- Live secret exposures
+
+**Status 2026-08-17: DONE**, with one UNVERIFIABLE item and one stale doc.
+
+- S1 fixed by commit `e7e44a84` ("take the fleet off a root token and out of
+  tracked files"). No `eyJ` token anywhere in the tree. Workflows now use
+  `secrets.ATTIC_TOKEN` at `ci-linux.yaml:406,413,476,483,643,651` and
+  `ci-darwin.yaml:323,330,471,479`. `gh secret list` confirms `ATTIC_TOKEN`
+  exists. `modules/services/attic/attic_client.nix` now defaults
+  `tokenFile = null`; only pushing hosts render a token, from a 0600 sops file,
+  never a world-readable Nix store path.
+- S2 fixed. `modules/monitoring/master/grafana.nix:163` is now
+  `$__file{/run/secrets/monitoring/grafana_secret_key}`, with the sops
+  declaration at `:56-59` including `restartUnits = [ "grafana.service" ]`.
+  The value behind the secret was **regenerated, not relocated** -- the comment
+  block at `:26-55` states this explicitly, which is the correct response given
+  the old value is unchangeably public in history.
+- **UNVERIFIABLE:** git history was _not_ rewritten and the repo is still
+  `PUBLIC`, so both old values remain recoverable via `git log -p`. That is
+  acceptable **only** because both were rotated. For S1 specifically, Attic has
+  no per-token revocation, so `e7e44a84` claims the server signing key was
+  replaced (which invalidates all tokens at once). That claim cannot be checked
+  from a checkout. Confirm it once using the "Proving an old token is dead"
+  procedure in `agent-docs/ATTIC_OPERATIONS.md`, then record the result here.
+- **Stale doc:** `agent-docs/MONITORING.md:308,315` still lists
+  `grafana.nix:74 | secret_key hardcoded in plaintext` as an open defect with an
+  unchecked `- [ ] Move the Grafana secret_key into sops`. The code fix has
+  landed; the doc has not caught up. Drift in the unusual direction -- doc says
+  not done, code says done. See Part 9 Batch 1.
 
 These changed the recommended priority order, so they lead.
 
@@ -71,6 +146,19 @@ copy of the `admin_password` pattern six lines above (`sops.secrets` plus
 
 ## Part 1 -- opencode.jsonc
 
+**Status 2026-08-17: DONE** for the file itself. The follow-on guard (Part 7
+item 2) is still LIVE.
+
+`opencode.jsonc` is 22 lines, `agent` is top-level, and there is no `command`
+block at all -- so nothing is missing a required `template`. `git status` clean.
+
+Still missing: nothing validates the file against its own `$schema`. The
+rendered `.pre-commit-config.yaml` has exactly two `check-jsonschema` hooks,
+both `--builtin-schema github-{actions,workflows}`, and the generic `check-json`
+hook matches `\.json$` so it would not even see a `.jsonc` file. The newer
+`opencode-hash-guard.yaml` workflow validates the pinned `node_modules` FOD
+hash, which is a different concern and does not close this. See Part 9 Batch 4.
+
 Resolved. The problem was not formatting; the file was schema-invalid, which
 is why it silently failed to load.
 
@@ -110,8 +198,48 @@ Non-issues ruled out along the way:
 
 ## Part 2 -- Nix and house-style audit
 
-Baseline: `statix check .` and `deadnix --fail .` are both clean on the
-current tree, so nothing below is lint-catchable noise.
+**Status 2026-08-17: LIVE**, except the `assertions` gap which is PARTIAL.
+Every critical and style finding below was re-confirmed present. Line numbers
+have drifted; corrected numbers are given per item. Two new instances of
+already-listed anti-patterns were found in files the audit never opened.
+
+Baseline still holds: `statix check .` and `deadnix --fail .` both exit 0 clean
+on the current tree (re-run 2026-08-17). Repo is now **207 `.nix` files**.
+
+Re-verification deltas, in the order the findings appear below:
+
+| Finding                        | 2026-08-17 state                                                                                   |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `allowUnfree = true`           | LIVE at `features/common/system/default.nix:75`. **New:** same anti-pattern at `profiles/darwin.nix:61`. |
+| `permittedInsecurePackages`    | LIVE at `features/common/system/default.nix:71-73`. Still absent from `tracked-upstream-fixes.json`. |
+| `stateVersion` defaults        | LIVE. `mk-system.nix:70`, `flake/hosts/nixos.nix:69`, plus `mk-darwin-system.nix:30`. Now 9 implicit of 12. |
+| `with lib;` module scope       | LIVE, both sites, exact line match.                                                                 |
+| `with pkgs;` over a `let`      | LIVE at `libreoffice/default.nix:7`. **New:** same shape at `features/common/git/default.nix:20`.   |
+| `deadnix: skip` in firmware.nix | LIVE. Still imported by nothing -- only self-reference is a commented-out import at `firmware.nix:3`. |
+| Bare `mkForce`                 | LIVE at `environments/common.nix:256`. Still the only unexplained one of 8.                          |
+| Duplicated `allowUnfreePredicate` | LIVE, drifted to `fredhub/configuration.nix:12-16` and `:27-31`.                                 |
+| Duplicated `.gitconfig`        | LIVE, line ranges unchanged (`home.nix:76-111`, `nik-home.nix:30-65`).                              |
+| `homeDir` reinvented 4x        | LIVE, all four sites confirmed.                                                                     |
+| SDR container boilerplate      | LIVE, no `mkSdrContainer` exists. **One audit count was wrong** -- see correction below.             |
+| `mk-simple-package-module`     | LIVE at `:66-69`. Usage grew 12 -> 13 modules.                                                       |
+| Zero `assertions` / `warnings` | PARTIAL. `assertions` now in 3 files. `warnings` still zero. See below.                             |
+
+**Correction to the original text.** The `"/run:exec,size=64M"` count below
+says 25 occurrences across 5 hosts including `hfdlhub2`. The real count is **22
+across 4 hosts**, and `hfdlhub2` has **zero** -- it is an HFDL-observer-only
+host with no local SDR device, and no commit ever gave it that pattern. This
+was a miscount in the original audit, not a change. The other two counts in
+that table (13 `deviceCgroupRules`, 4 `usbfs.enable`) are exact.
+
+**Progress on the `assertions` gap.** Three `assertions = [` blocks now exist,
+all added after this audit, which is a real partial close of the "zero
+assertions in 192 files" finding:
+
+- `modules/base/deployment-meta.nix:109` -- `internetFacing -> tailscaleAddress != null`, plus a stale-address guard (2026-08-09).
+- `modules/monitoring/master/unbound-exporter.nix:52` -- asserts `extended-statistics` is on (2026-08-16).
+- `hosts/linux/sdrhub/configuration.nix:1454` -- asserts Grafana `root_url` matches the nginx vhost (2026-08-17).
+
+`warnings = [` is still at **zero occurrences** repo-wide.
 
 ### Critical Nix findings
 
@@ -121,12 +249,14 @@ current tree, so nothing below is lint-catchable noise.
 | `permittedInsecurePackages = [ "openssl-1.1.1w" ]`, fleet-wide, uncommented, untracked | `features/common/system/default.nix:60-62` | No record of what still needs it. This is exactly a `tracked-upstream-fixes.json` case, and the fwupd polkit workaround 200 lines down in the same file is properly registered. This one is not. |
 | Seven of eleven hosts inherit `stateVersion` from a function default | `flake/lib/mk-system.nix:70`, `flake/hosts/nixos.nix:72` | fredhub `25.11`, fredvps `25.05`, all others implicitly `24.11`. Bumping that default for a new host retroactively changes `stateVersion` on seven existing hosts -- the exact opposite of the option's purpose. |
 
-Per-host `stateVersion` as it stands:
+Per-host `stateVersion` as it stands (`nvrhub` row added 2026-08-17; all other
+rows re-confirmed unchanged):
 
 | Host | stateVersion | Source |
 | --- | --- | --- |
 | fredhub | 25.11 | explicit, `flake/hosts/servers.nix:27` |
 | fredvps | 25.05 | explicit, `flake/hosts/servers.nix:33` |
+| nvrhub | 26.05 | explicit, `flake/hosts/servers.nix:70` |
 | sdrhub | 24.11 | implicit default |
 | acarshub | 24.11 | implicit default |
 | vdlmhub | 24.11 | implicit default |
@@ -134,8 +264,8 @@ Per-host `stateVersion` as it stands:
 | hfdlhub2 | 24.11 | implicit default |
 | Daytona | 24.11 | implicit default |
 | maranello | 24.11 | implicit default |
-| Freds-MacBook-Pro | 25.05 | implicit default |
-| Freds-Mac-Studio | 25.05 | implicit default |
+| Freds-MacBook-Pro | 25.05 | implicit default, `flake/lib/mk-darwin-system.nix:30` |
+| Freds-Mac-Studio | 25.05 | implicit default, `flake/lib/mk-darwin-system.nix:30` |
 
 ### Style and duplication findings
 
@@ -191,7 +321,7 @@ system-level path purely because the shared helper defaults to it.
 - **The no-git-rev-in-closure rule is fully honored.**
   `flake/lib/mk-system.nix:140-157` documents why it was removed, and the
   only revision reference in the repo (`flake/deployment/colmena.nix:121-125`)
-  tracks the pinned *nixpkgs* input revision, not the flake revision, which
+  tracks the pinned _nixpkgs_ input revision, not the flake revision, which
   is closure-neutral.
 - Overlay `final`/`prev` naming consistent across all live overlays; every
   `overrideAttrs` carries an explanatory comment, several cross-referencing
@@ -214,7 +344,92 @@ surface.
 
 ## Part 3 -- Service configuration and tooling gaps
 
+**Status 2026-08-17: PARTIAL.** One finding fully fixed, one substantially
+fixed, the rest LIVE. Backups and disko/nixos-anywhere are DEFERRED to their
+own planning session by explicit decision -- do not fold them into the batches
+in Part 9.
+
+| Finding                                | 2026-08-17 state                                                                                          |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| No backups                             | DEFERRED. Still zero `restic`/`borgbackup`/`postgresqlBackup`. Made **worse** by nvrhub -- see below.       |
+| `discord-backup.nix` is a same-disk `cp` | DONE. Now uses SQLite's online `.backup` API. See below.                                                  |
+| No `restartUnits` on sops secrets      | PARTIAL, ~33 of ~69 now wired. The docker-container cohort is solved. See below.                            |
+| No Docker log rotation                 | LIVE. Zero `log-opts` / `virtualisation.docker.daemon.settings` repo-wide.                                  |
+| No `configurationLimit`                | LIVE. `features/common/boot/default.nix:3-5`, systemd-boot fleet-wide, no cap. Every host has VFAT `/boot`, nvrhub included (`nvrhub/hardware-configuration.nix:39-46`). No host uses grub. |
+| Prometheus `--web.enable-admin-api`    | LIVE at `prometheus.nix:175` (line unchanged). Binds `0.0.0.0:9090` (`:169-170`), port opened at `:156-159`. sdrhub still advertises `192.168.31.0/24` (`sdrhub/configuration.nix:506`), so still tailnet-reachable. Pushgateway being loopback-bound at `:754` does not mitigate this. |
+| `github_api` at `mode = "0444"`        | LIVE, drifted to `hosts/linux/fredvps/configuration.nix:812-814`. Confirmed the **only** world-readable sops secret; other `0444` hits are Grafana dashboard JSON in `environment.etc`, and `sops.nix:74`'s `0644` is an `allowed_signers` public-key file. |
+| No `min-free` / `max-free`             | LIVE. `modules/base/system.nix:84-88` still weekly-only `--delete-older-than 7d` plus `optimise.automatic`. |
+| `discord-db-backup` unhardened, no jitter | LIVE. `discord-backup.nix:26-93` has zero hardening directives and no `RandomizedDelaySec`. The pattern exists in 5 other places (`imageapi-metrics.nix:101`, `lammacpp/default.nix:99`, `github-runners.nix:446`, `tailscale/default.nix:192`, `node_exporter.nix:517`), so this is now the outlier. |
+| `docker-<name>.service` unhardened     | LIVE. `adsb-docker-units.nix:69-93` `mkUnit` sets only `Restart`, `TimeoutStartSec`, `ExecStart*`. Contrast `python-venv-app.nix:157-191`, a full sandbox. Applies to ~26 containers. |
+| disko / nixos-anywhere / etc. unused   | DEFERRED (structural tools). Still zero references.                                                        |
+| `eza` and `lsd` both installed         | LIVE and, on reflection, fine -- both are actively used. `zsh/default.nix:42` aliases `ls` to `lsd`; `yazi/default.nix:45,115` shells out to `eza`. Reclassify as REJECTED, not a defect. |
+| All images digest-pinned               | Still clean. 35 `image =` declarations, all `@sha256:`. nvrhub uses the native `services.frigate` module and contributes zero container images. |
+| fail2ban scoping                       | Still good, but **the audit's number is stale** -- see correction below.                                    |
+| `trusted-users` narrow                 | Still `["root" "@wheel" "fred"]` at `modules/base/system.nix:72-75`.                                        |
+
+**Correction to the original text.** The audit says fail2ban has
+`maxretry = 3`. The sshd jail on port 2269 is now `maxretry = 2`
+(`fredvps/configuration.nix:980`), a deliberate tightening in commit `da0e9b82`
+alongside `mode = "aggressive"`. Decoy jails run `maxretry = 1`; `recidive` and
+`nginx-probe` are 3; `nginx-limit-req` / `nginx-bad-request` are 10; the global
+default is 5. `bantime-increment` was hardened further (`:901-905`,
+`multipliers` out to 256, `maxtime = "168h"`) and a new
+`dbpurgeage = "30d"` keeps escalation history longer. Do not "restore"
+`maxretry = 3`.
+
+### What was fixed, and what the fix teaches
+
+**`discord-backup.nix` is no longer a `cp`.** It now uses `sqlite3 ".backup"`
+(the online backup API) into a `.part` path, then atomically `mv`s into place,
+with stale `.part` cleanup and 14-day retention (`:63-84`). Its own header
+documents why: the DB runs in WAL mode, so `cp` was silently dropping
+uncommitted WAL data and could produce torn files. The header also states an
+out-of-repo NAS pulls `/mnt/discord-storage` nightly via `rsync --delete`. That
+is **not verifiable from this repo** -- no `fileSystems` entry mounts
+`/mnt/discord` or `/mnt/discord-storage` separately, so on-disk independence
+cannot be confirmed either way here. Fold that verification into the deferred
+backups session.
+
+**`restartUnits` is now solved for the cohort that mattered.** A new helper,
+`modules/services/mk-container-secret.nix` (`mkContainerSecret` /
+`mkContainerSecrets`), automatically wires
+`restartUnits = [ "docker-<name>.service" ]`, and is used on every
+docker-container `.env` secret across fredvps, sdrhub, hfdlhub1, hfdlhub2,
+vdlmhub, and acarshub. ~33 of ~69 declarations now carry restart wiring
+(sdrhub alone has 16), plus `attic_server.nix:55-57`, both grafana secrets, and
+`github-ci-exporter.nix:60-61`.
+
+This was not theoretical. `attic_server.nix:36-40` records a real incident dated
+2026-08-17: a rotated key with no restart produced a 403 `AccessError`
+indistinguishable from a bad token. That is exactly the silent-stale-credential
+failure the audit predicted.
+
+Still lacking `restartUnits`, roughly 36 declarations:
+
+- The fleet-wide SSH block, 11 keys -- `modules/secrets/sops.nix:65-122`.
+- `github-token` / `github_pat` -- `profiles/adsb-hub.nix:22`, `modules/base/system.nix:94`.
+- `tailscale/authkey`, fleet-wide -- `modules/services/tailscale/default.nix:29-31`.
+- Seven desktop email / wifi / attic-token keys -- `profiles/desktop.nix:47-82`.
+- Alertmanager's healthchecks endpoint and both Pushover keys -- `modules/monitoring/master/prometheus.nix:46-50`. These use `LoadCredential=`, which has the identical stale-path problem.
+- `cloudflare_acme_token` on two hosts -- `sdrhub/acme.nix:49`, `fredhub/nginx.nix:46`.
+- `github_api` on fredvps -- see the 0444 item above.
+- **`cameras/username` / `cameras/password` on nvrhub** -- `hosts/linux/nvrhub/frigate.nix:406-409`. This is the day-one regression: `mkContainerSecret` already existed and was in use on six hosts. Rotating the shared camera credential and redeploying leaves Frigate on the stale password.
+
+Two sdrhub secrets are deliberately excluded with a recorded reason
+(`sdrhub/configuration.nix:1506-1519`): `dozzle-agent.env` and
+`airspy_adsb.env` feed a commented-out container, so `restartUnits` would name
+a unit that never reads them. Leave those alone.
+
 ### The largest structural gap: no backups exist
+
+**Status: DEFERRED to a dedicated planning session.** Recorded here for
+completeness only. The one update since the audit is that the at-risk inventory
+**grew**: `nvrhub` adds ~2.05 TB of continuous 8-camera H.264 Frigate
+recordings on a dedicated XFS volume (`/var/lib/frigate` on
+`/dev/disk/by-label/nvr-media`, 30-day alert / 14-day detection retention,
+`nvrhub/frigate.nix:255-275`) with no backup or replication anywhere in the
+repo. `scripts/acarshub-db-repair.sh:280-282` still deletes the stale 5.6 GB
+backup with no replacement.
 
 Verified directly -- zero `services.restic`, zero `services.borgbackup`, zero
 `services.postgresqlBackup` in the tree.
@@ -294,7 +509,77 @@ would break under rootless Podman. The one cosmetic overlap is having both
 
 ## Part 4 -- CVE scan root cause
 
+**Status 2026-08-17: PARTIAL. The workflow is green, but this part's root-cause
+diagnosis below was WRONG. Read this status block before trusting the analysis
+that follows it.**
+
+The workflow has been green since 2026-08-11 03:18 UTC, six consecutive
+successes including the 2026-08-17 scheduled run. Issue #1717 is still open and
+was updated by that run. The two failures on 2026-08-10 and 2026-08-11 carry the
+identical pre-fix signature and predate the fix commits by hours -- they are the
+tail of this incident, not a new regression.
+
+### The actual root cause, which is not what this part says
+
+This part hypothesizes a grype vulnerability-DB problem (stale/corrupt cache on
+the long-lived runners, or an NVD provider gap) and calls it "the one item not
+verifiable from outside the runner." **That hypothesis was wrong.** Per commits
+`6f337be6` and `7df2995e`, there were three real defects, none of them DB
+related:
+
+1. **Coverage collapse via a `.drv` path.** The scan passed sbomnix a `.drv`
+   path believing it avoided deriver lookups. It does not -- sbomnix runs
+   `nix path-info --recursive` on the realised output closure however the
+   target is named. Passing the `.drv` bought nothing and **cost the nixpkgs
+   metadata that is the sole source of exact CPEs.** Scannable coverage sat at
+   **3%** while component coverage read a healthy 87%. That, not a dead DB, is
+   why matches went to zero uniformly across seven closures. Fixed by switching
+   to the flakeref.
+2. **The guard was inverted.** grype omits `.vulnerabilities` entirely on an
+   empty match set rather than emitting `[]`, and the guard read the missing key
+   as "grype produced garbage." A real grype failure is already caught earlier
+   -- it exits non-zero and writes a 0-byte file, so `set -e` aborts at the
+   grype call and never reaches the check. Missing key now means zero.
+3. **Fabricated CPEs.** sbomnix synthesises heuristic
+   `cpe:2.3:a:<pname>:<pname>:<version>` entries for anything nixpkgs metadata
+   does not cover, reproducing exactly the false-positive class that killed
+   vulnix -- `fish` matched FiSH (an IRC plugin) at CVSS 10 and led the report;
+   `ada` matched Ada.cx. Those accounted for 192 of 317 matches on one desktop
+   closure. Now dropped via `--exclude-cpe-matching`.
+
+Lesson for future agents: this part reasoned from run metadata (identical grype
+store path, no workflow change, no nixpkgs bump) to an external cause, and
+never questioned whether the SBOM itself was intact. **When a scanner reports
+zero, check what it was given before checking what it knows.**
+
+### Recommendation status
+
+| Rec | Status | Detail |
+| --- | ------ | ------ |
+| 1. Canary / DB liveness | PARTIAL | Two liveness assertions landed and are **stronger than the proposed canary** for the failure that actually occurred: SBOM coverage floor of 60% of the runtime closure (`cve-scan.yaml:229-249`, healthy is 85-90%) and an absolute floor of 50 components carrying a CPE (`:251-277`, baseline ~97 servers / ~112 desktops). The second exists precisely because component coverage stayed at 87% while scannable coverage was 3%, so a ratio could not catch it. **Still missing: any check on grype's own vulnerability DB.** No `grype db status` / `grype db check` anywhere. See the live risk below. |
+| 2. Ignore list with reason + review date | PARTIAL | `.github/grype-ignore.yaml` exists (note: **not** `.grype.yaml` as proposed), referenced at `cve-scan.yaml:294` via `-c`. Per-entry `vulnerability` + `package.name` scoping, prose reason per entry, and a header rule set requiring a concrete verifiable reason rather than "old" or "probably fine." Missing: a structured per-entry review/expiry date field. Triage discipline is demonstrably real -- `f792b8ae` reverted its own over-broad 74-entry kernel suppression one commit after adding it. |
+| 3. Publication-date floor | REJECTED | Deliberate, by the same person who implemented 1 and 2, days after this audit. The ignore file's header states: "We deliberately do NOT filter by CVSS score, EPSS probability, or age... Triage belongs in the report, not in a silent filter." Do not re-propose this. |
+| 4. `osv-scanner` parallel trial | LIVE | Zero references repo-wide outside this document. |
+
+**The one live risk in this part.** `cve-scan.yaml:696-708` auto-closes the
+tracking issue #1717 when `TOTAL -eq 0 && MISSING -eq 0`, and `MISSING` counts
+systems that failed to _produce a report_, not DB health. A dead or empty grype
+DB against a perfectly healthy 97-CPE SBOM still yields zero matches, passes
+both coverage assertions, and **closes the tracking issue with a false
+all-clear.** This is the residual of rec 1 and is the only Part 4 item in the
+Batch 1 work below.
+
+Note that the kernel suppressions in `7df2995e` are not a blanket exclusion.
+All 74 were individually checked against the NVD API for unbounded
+`cpe:2.3:o:linux:linux_kernel` ranges, and the same scan deliberately still
+reports 93 genuine 2025/2026 kernel CVEs whose ranges really do contain the
+running version. Net effect per host: vdlmhub 45 -> 182 findings (it had been
+_hiding_ real ones), Daytona 121 -> 93 (it had been reporting phantoms).
+
 ### Why it is failing now
+
+**Historical. Superseded by the status block above -- the conclusion in this
+subsection is incorrect.**
 
 Identical signature on both recent failures (`gh run view 30806645765
 --log-failed` and `30968134758`):
@@ -374,7 +659,17 @@ Two important consequences:
 Currently no mitigation is applied at all: no `--whitelist`, no CVSS floor,
 no publication-date filter, and `meta.knownVulnerabilities` is not consulted.
 
+**Update 2026-08-17.** This subsection's analysis was **correct**, and the
+unbounded-CPE mechanism it identified is now the documented basis for the 74
+kernel suppressions in `7df2995e`. The "no mitigation applied" sentence above is
+stale: `.github/grype-ignore.yaml` is now the mitigation. The CVSS floor and
+publication-date filter remain deliberately absent (see rec 3, REJECTED), and
+`meta.knownVulnerabilities` is still not consulted.
+
 ### Recommended CVE remediation, in order
+
+**Historical. See the "Recommendation status" table above for what actually
+landed and what was rejected.**
 
 1. **Add a canary component to the zero-match guard.** This is an
    independent correctness bug: today the workflow cannot distinguish "DB is
@@ -407,6 +702,58 @@ correct -- it scans `system.build.toplevel`, not just flake packages.
 ---
 
 ## Part 5 -- Other CI findings
+
+**Status 2026-08-17: PARTIAL.** The three input-category findings are all DONE
+and mechanically enforced. The workflow-level findings are all LIVE, and the
+`concurrency:` gap has since propagated into four new workflows.
+
+| Finding                              | 2026-08-17 state                                                                    |
+| ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `nixpkgs-kernel` category drift      | DONE. See below.                                                                     |
+| `ci-darwin.yaml` missing four inputs | DONE. All 25 lock inputs present at `ci-darwin.yaml:151-176`.                          |
+| Circular `agents.md` <-> skill ref   | DONE. See below.                                                                     |
+| No `concurrency:` on CI workflows    | LIVE, and now worse. See below.                                                      |
+| No `permissions:` block on three     | LIVE. Confirmed absent from `ci-linux.yaml`, `ci-darwin.yaml`, `lint.yaml`. The other 13 workflows all declare one. |
+| `cve-scan.yaml` no `concurrency:`    | LIVE. Zero `concurrency:` in all 716 lines. Triggers are still `schedule` + `workflow_dispatch`, so the TOCTOU window on the `gh issue list` / `gh issue create` logic stays open. |
+| `cve-scan.yaml` dead fork guard      | LIVE, drifted to `cve-scan.yaml:121`. No `pull_request` trigger exists, so `github.event_name != 'pull_request'` is always true.  |
+| `renovate-relock.yaml:42` gate       | LIVE, exact same line number.                                                        |
+
+**The input-category invariant is now machine-enforced -- this is the model to
+copy for the other sync problems in this document.** A checker,
+`.opencode/skills/projects/nixos-input-category-sync/scripts/check-input-category-sync.py`
+(174 lines), is wired into **both** enforcement points:
+
+- pre-commit hook `input-category-sync` (`.pre-commit-config.yaml:399-419`),
+  whose `files:` regex covers `flake.nix`, `flake.lock`, both CI workflows, the
+  impacted-hosts script, and the checker itself.
+- flake check `input-category-sync` (`flake/dev/checks.nix:255-263`).
+
+Run live on 2026-08-17 it reports
+`flake-input category sync OK (25 inputs, 4 locations agree)`. A manual
+cross-check of all 25 inputs against all four locations found zero mismatches.
+`nixpkgs-kernel` is now at `ci-linux.yaml:162` (`server`),
+`ci-darwin.yaml:163` (`skip`), and `impacted-hosts.sh:221` (`server`).
+
+**The circular reference is resolved.** The mapping table now lives in
+`nixos-input-category-sync/SKILL.md:38-68`, and the skill carries an explicit
+instruction not to move it back: "Do not put the mapping table in `agents.md`.
+It used to be cited there, and `agents.md` now explicitly delegates it here --
+for a while both documents pointed at each other."
+
+**The `concurrency:` gap spread.** `fleet-manifest.yaml:52` is still the only
+workflow in the repo with a `concurrency:` block. Four workflows added since the
+audit also lack one: `cache-flake-inputs.yaml`, `opencode-hash-guard.yaml`,
+`update-apple-fonts.yaml`, `update-syncclipboard.yaml`. The first two matter
+most -- `cache-flake-inputs` runs on self-hosted with overlapping
+`push`/`schedule` triggers, and `opencode-hash-guard` pushes commits back to a
+PR branch, so rapid repushes could run it concurrently against itself. Fix all
+seven in one pass, not just the two the audit named.
+
+**Two doc-path corrections for future greps.** The lint workflow is
+`.github/workflows/lint.yaml`, not `ci-lint.yaml` -- `agents.md:86` still has
+the wrong name in its directory diagram. Renovate config is
+`.github/renovate.json5`, not repo-root `renovate.json5`; the audit's line
+number 32 is correct but its implied path is not.
 
 ### Input-category sync drift
 
@@ -479,7 +826,55 @@ The skill text needs fixing.
   use careful `set -euo pipefail`, validate JSON shape rather than mere
   validity, and self-heal on corrupt state.
 
+### CI verified clean -- re-checked 2026-08-17, no regressions
+
+All five spot checks in the subsection above still pass:
+
+- Fork guards intact and correctly formed on every `pull_request`-reachable
+  self-hosted job. Now **three** in `ci-linux.yaml` (`:376,451,622`) rather than
+  two -- a new `dev-shell` self-hosted job was added at `:620-622` and was
+  correctly guarded. `ci-darwin.yaml:294,450`.
+- `build-linux-summary` (`ci-linux.yaml:686-720`) still inspects
+  `needs.*.result` and now also treats `cancelled` as failure. Darwin and lint
+  summaries follow the same shape.
+- `grep -n "uses:.*@" .github/workflows/*.yaml | grep -vE "@[0-9a-f]{40}"`
+  returns zero matches, including across the four new workflows.
+- `devshell_inputs` byte-identical at `ci-linux.yaml:576` and
+  `ci-darwin.yaml:416`.
+- `fail-fast: false` present at `ci-linux.yaml:381,456` and `ci-darwin.yaml:299`.
+
+One note on a different-but-correct idiom: `cache-flake-inputs.yaml:60` guards
+with `github.repository == 'fredsystems/nixos'` rather than the
+`head.repo.full_name` pattern. That is correct for its trigger set (`push`,
+`schedule`, `workflow_dispatch` -- no `pull_request`). If it is ever given a
+`pull_request` trigger, that guard becomes insufficient.
+
 ### Workflow health
+
+**Status 2026-08-17: everything green.** `cve-scan.yaml`, the only unhealthy
+workflow at audit time, recovered on 2026-08-11 (see Part 4). Current state:
+
+| Workflow                 | Last run   | Last success |
+| ------------------------ | ---------- | ------------ |
+| CI (Linux)               | success    | 2026-08-17   |
+| CI (Darwin)              | success    | 2026-08-17   |
+| Lint                     | success    | 2026-08-17   |
+| CVE scan (sbomnix)       | success    | 2026-08-17   |
+| Fleet Manifest           | success    | 2026-08-17   |
+| Check Alert Metrics      | success    | 2026-08-17   |
+| track-upstream-fixes     | success    | 2026-08-16   |
+| update-flakes            | success    | 2026-08-16   |
+| renovate-relock          | skipped    | n/a          |
+| update-opencode          | success    | 2026-08-17   |
+| Cache Flake Inputs       | success    | 2026-08-17   |
+| opencode-hash-guard      | success    | 2026-08-16   |
+| update-apple-fonts       | success    | 2026-08-17   |
+| update-syncclipboard     | success    | 2026-08-17   |
+
+The last four are new since the audit. `renovate-relock` skipping is correct --
+no renovate PR was in flight.
+
+The original audit's table, for the record:
 
 | Workflow | Last status | Last success | Notes |
 | --- | --- | --- | --- |
@@ -499,6 +894,29 @@ Nothing except `cve-scan.yaml` is unhealthy.
 ---
 
 ## Part 6 -- Missing CI capability
+
+**Status 2026-08-17: LIVE. Not one item in this part has been implemented.**
+Re-verified individually:
+
+| Item                              | 2026-08-17 state                                                                              |
+| --------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1. Colmena parity on PRs          | LIVE. `grep -rn "colmenaHive" .github/workflows/` returns nothing. `fleet-manifest.yaml:19-21` still `push: [main]` + 6h schedule, no `pull_request`. Parity currently _holds_ (`nix eval .#colmenaHive.nodes` returns all 8 servers including nvrhub), but nothing would catch a regression pre-merge. |
+| 2. Dead-module reachability       | LIVE. `firmware.nix` still imported by nothing; `ci-linux.yaml:103-104` still has `flake.nix\|firmware.nix) global=true`. No reachability check exists. |
+| 3. sops recipient consistency     | LIVE as a _check_. The **data** happens to be in sync: `modules/secrets/.sops.yaml:4-15` lists 12 recipients, all 12 wired into the single `secrets.yaml` rule at `:18-32`, and nvrhub was added correctly. But `grep -rn "updatekeys" .github .opencode scripts` returns nothing -- the runbook step at `sops.nix:135-144` is still manual and unenforced. In sync by diligence, not by machine. |
+| 4. `diff-closures` PR comment     | LIVE. No reference anywhere in workflows or `checks.nix`.                                       |
+| 5. Two scoped `nixosTest`s        | LIVE. `grep -rn "nixosTest\|pkgs.testers\|runNixOSTest"` returns **zero hits repo-wide**, including `flake/dev/checks.nix`. The KVM prerequisite is still unconfirmed. |
+| 6. Doc-drift check                | LIVE. Still in sync by luck: `nix eval .#nixosModules --apply builtins.attrNames` returns exactly the 14 modules `MODULES.md` documents, but `MODULES.md` was last touched 2026-02-11 while `modules/` has commits from today. `desktop_names=("Daytona" "maranello")` at `ci-linux.yaml:255` still matches reality. |
+| Tier 2: Renovate for `.opencode`  | LIVE. `.github/renovate.json5:32` still `enabledManagers: ["custom.regex", "github-actions"]`. `.opencode/package-lock.json` still exists, mtime 2026-06-03, tracked by nothing. |
+| Tier 2: option schema lint        | LIVE, numbers refined. Of 82 `mkOption` blocks: **1 has no `type` at all** -- `modules/secrets/sops.nix:21` (`sops_secrets.enable_secrets.enable`), the exact one the audit named -- and **17 of 82 (~21%) have no `description`**, concentrated in `modules/terminal/common.nix` (6), `modules/services/nas-mount-type.nix` (5), `nas-home.nix`, `sync-compose.nix`, `nas-system.nix`. |
+
+The full `nixosModules` attribute list, so a future doc-drift check has a
+baseline to assert against:
+
+```text
+adsb-hub, default, desktop-common, github-runners, hardware-fingerprint,
+hardware-graphics, hardware-i2c, hardware-logitech, hardware-profiles,
+hardware-rtl-sdr, hardware-u2f, nas-mounts, sync-hosts, wifi-networks
+```
 
 ### Tier 1, worth doing
 
@@ -576,6 +994,32 @@ Nothing except `cve-scan.yaml` is unhealthy.
 
 ## Part 7 -- Additional observations
 
+**Status 2026-08-17: PARTIAL.**
+
+| Item                              | 2026-08-17 state                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------------------------- |
+| 1. Stale `flake.nix:69-74` comment | LIVE. Byte-identical, same line range, 13 days on. Line 78 is still already `nixos-26.05-small`. The comment still instructs the next human not to hand-bump a ref that was already bumped. |
+| 2. No opencode.jsonc schema check  | LIVE. See Part 1 status.                                                                       |
+| 3. No secret-rotation story        | PARTIAL. Attic now has a real runbook; Grafana and sops do not. See below.                      |
+| 4. Backup without tested restore   | DEFERRED with the backups session.                                                             |
+| 5. Detection-vs-survivability      | Still the correct headline. The secret half is now closed (Part 0 DONE); the backup half is not. |
+| 6. On the CVE instinct             | Confirmed correct, and now the documented basis for the kernel suppressions. See Part 4.        |
+
+**On item 3.** `agent-docs/ATTIC_OPERATIONS.md` (335 lines, new since the audit)
+is a genuine rotation runbook: Procedure A renews tokens, Procedure B rotates
+the signing key (the actual leaked-token response), Procedure C rebuilds from
+nothing, plus a "Proving an old token is dead" verification section using
+`POST /_api/v1/get-missing-paths`. That closes the S1 half of this finding
+properly.
+
+Grafana does not have an equivalent. `grafana.nix:26-55` has substantial inline
+commentary on rotation safety, but commentary in a Nix file is not a runbook --
+there is no generate-value / where-to-put-it / deploy-order / how-to-verify
+procedure comparable to Attic's Procedure B. Neither is there any runbook for
+**sops age-key rotation**, which is arguably the more important one: it is still
+just the inline `sops updatekeys` comment at `sops.nix:135-144`, and Part 6
+item 3 confirms nothing checks that it was done.
+
 These are not from the subagent reports.
 
 1. **`flake.nix:69-74` is now factually wrong.** The comment says "The ref
@@ -616,7 +1060,10 @@ These are not from the subagent reports.
 
 ---
 
-## Suggested sequencing
+## Part 8 -- Suggested sequencing (original, superseded)
+
+Kept for the record. Superseded by Part 9. Items 1 and 3 have since landed
+(1 fully, 3 partially); item 4 is deferred.
 
 | Order | Work | Rationale |
 | --- | --- | --- |
@@ -626,3 +1073,166 @@ These are not from the subagent reports.
 | 4 | Backups plus restore test | Largest structural gap |
 | 5 | Quick-wins batch | `configurationLimit`, Docker log rotation, drop admin API, key mode 0400, `nixpkgs-kernel` categories, stale comment, concurrency groups, opencode schema hook |
 | 6 | Everything else | Genuine improvement, not load-bearing |
+
+---
+
+## Part 9 -- Remediation batches
+
+**This is the execution plan.** Written 2026-08-17 from the re-verification.
+The parts above supply evidence and rationale; work from this section.
+
+### Scope exclusions, by explicit decision
+
+Two items are **out of scope for remediation** and get their own planning
+session. Do not fold them into any batch, do not "partially start" them, and do
+not let a batch grow to touch them.
+
+- **Backups and restore verification.** Part 3, Part 7 item 4.
+- **disko / nixos-anywhere for fredvps.** Part 3 "Structural tools not in use".
+
+Both are genuinely the largest structural gaps in the fleet. They are excluded
+because they need a design conversation (what gets backed up, to where, with
+what retention, verified how) rather than an implementation pass. Note for that
+session: `nvrhub`'s ~2 TB of Frigate footage makes it more urgent than the
+original audit implies, and `discord-backup.nix`'s claim of an out-of-repo NAS
+rsync needs verifying.
+
+### Batch ordering rationale
+
+The batches are ordered by **how bad it is if the item stays broken**, not by
+effort. Batch 1 leads because every item in it is a case where the repo
+currently reports _good_ while being _bad_ -- a false signal is worse than a
+known gap, because a known gap does not stop you looking.
+
+### Batch 1 -- false-signal fixes
+
+Small, mechanical, high value. Each of these makes the repo tell the truth.
+
+| # | Work | Files | Notes |
+| - | ---- | ----- | ----- |
+| 1.1 | grype vulnerability-DB liveness gate | `.github/workflows/cve-scan.yaml` | The only live Part 4 item. Add `grype db status` / `grype db check` as a step before the match count, or inject a known-vulnerable canary CPE _after_ the existing coverage assertions. Then gate the `TOTAL -eq 0` auto-close at `:696-708` on DB liveness, not just `MISSING`. Do not touch the two coverage assertions at `:229-277` -- they are correct and were hard-won. |
+| 1.2 | Delete the stale channel-ref comment | `flake.nix:69-74` | Actively harmful: it exists to stop a human hand-bumping, and now instructs the wrong action. Line 78 is already `nixos-26.05-small`. |
+| 1.3 | Mark Grafana `secret_key` done | `agent-docs/MONITORING.md:308,315` | Doc says open, code says fixed. Check the box, drop the `grafana.nix:74` reference. |
+| 1.4 | Fix the lint workflow filename | `agents.md:86` | `ci-lint.yaml` -> `lint.yaml`. The file has never been called `ci-lint.yaml`. |
+| 1.5 | Drop `--web.enable-admin-api` | `modules/monitoring/master/prometheus.nix:175` | Unauthenticated `POST /api/v1/admin/tsdb/delete_series` on a `0.0.0.0:9090` bind, tailnet-reachable via sdrhub's advertised `192.168.31.0/24`. Nothing in the repo calls it. |
+| 1.6 | `github_api` to `mode = "0400"` | `hosts/linux/fredvps/configuration.nix:812-814` | World-readable private key on the host running four Actions runners plus a second human user. Confirmed the only world-readable sops secret. |
+| 1.7 | Confirm the old Attic token is dead | none (out-of-band) | Run the "Proving an old token is dead" procedure in `agent-docs/ATTIC_OPERATIONS.md`. Record the result in Part 0. This is the last UNVERIFIABLE item from the secret exposures. |
+
+Verification for 1.2, 1.5, 1.6: `nix eval` the impacted hosts per
+`nixos-eval-impacted-hosts`. 1.5 and 1.6 are single-host changes (monitoring
+master, fredvps). 1.2 touches `flake.nix`, which CI classifies `global=true`.
+1.3, 1.4 are docs only. 1.1 is a workflow change -- verify with `actionlint` via
+pre-commit plus a `workflow_dispatch` run.
+
+### Batch 2 -- nvrhub gap closure
+
+`nvrhub` is the newest host and shipped reproducing two already-audited
+defects. Close them before the pattern reaches host 13.
+
+| # | Work | Files | Notes |
+| - | ---- | ----- | ----- |
+| 2.1 | `restartUnits` on the camera secrets | `hosts/linux/nvrhub/frigate.nix:406-409` | Use the existing `mkContainerSecret` helper (`modules/services/mk-container-secret.nix`), or `restartUnits = [ "frigate.service" ]` directly since Frigate is a native module rather than a docker unit. Today, rotating the shared camera credential and redeploying leaves Frigate on the stale password with no error. |
+| 2.2 | Review the `0.0.0.0:9634` metrics bind | `hosts/linux/nvrhub/frigate.nix:469-478` | New LAN-wide listener with an nginx `allow 192.168.31.0/24; deny all;` ACL as its only gate, unlike the rest of the fleet's exporters which are Tailscale-scoped. **Read the comments first** -- three alternatives were tried and failed, and are recorded there. This may well be correct as-is; the deliverable is a decision, not necessarily a change. |
+
+Do **not** try to fix nvrhub's lack of backups here. That is the deferred
+session.
+
+### Batch 3 -- fleet-wide operational guardrails
+
+Each item is a few lines in a shared module and each prevents a class of
+outage. These are the "boring reliability" fixes.
+
+| # | Work | Files | Notes |
+| - | ---- | ----- | ----- |
+| 3.1 | `configurationLimit` on systemd-boot | `features/common/boot/default.nix:3-5` | Small VFAT `/boot` on all 10 Linux hosts with no generation cap is the single most common "NixOS will not boot" failure. No host uses grub, so one option in one file covers the fleet. |
+| 3.2 | Docker log rotation | new or existing shared docker module | Set `virtualisation.docker.daemon.settings.log-opts` with `max-size`/`max-file`. 15-25 chatty decoders per box, all `restart = "always"`, currently on the uncapped default `json-file` driver. |
+| 3.3 | `min-free` / `max-free` | `modules/base/system.nix:84-88` | Currently weekly-only `--delete-older-than 7d`. Nothing collects under mid-week disk pressure, which matters most on the small-disk VPS. |
+| 3.4 | `RandomizedDelaySec` on the discord backup timer | `hosts/linux/fredvps/discord-backup.nix:26-93` | Also add the hardening directives it lacks. It is now the fleet's only unjittered timer -- the pattern exists in five other places. |
+| 3.5 | Harden the docker wrapper units | `modules/services/adsb-docker-units.nix:69-93` | `mkUnit` only shells out to `docker run`, so `NoNewPrivileges` and `ProtectSystem=strict` cost nothing. Mirror `modules/services/python-venv-app.nix:157-191`, which already applies exactly this reasoning. Covers ~26 containers in one edit. |
+
+3.2 and 3.5 are the two that change every container host, so eval all of
+acarshub, hfdlhub1, hfdlhub2, sdrhub, vdlmhub, fredvps. 3.1 and 3.3 are
+`global=true` by CI classification.
+
+### Batch 4 -- CI structural guards
+
+Ordered cheapest-first within the batch. Item 4.1 is, per the original audit,
+the best value-to-effort ratio in the whole document, and the divergence it
+guards against **has actually happened** (see `flake/deployment/colmena.nix:98-115`).
+
+| # | Work | Files | Notes |
+| - | ---- | ----- | ----- |
+| 4.1 | Colmena parity check on PRs | `.github/workflows/ci-linux.yaml` (or a new job) | `scripts/gen-fleet-manifest.sh:130-211` already has the whole comparison -- it evaluates `colmenaHive.nodes`, diffs each node's toplevel against `nixosConfigurations`, treats warnings as fatal, and refuses to publish on mismatch. It only runs on `push: [main]`, so a regression merges green and surfaces hours later as `NixOSFleetManifestStale`. ~20 lines, pure eval, no build time. |
+| 4.2 | `concurrency:` groups | all 7 workflows lacking one | `ci-linux.yaml`, `ci-darwin.yaml`, `cve-scan.yaml`, `cache-flake-inputs.yaml`, `opencode-hash-guard.yaml`, `update-apple-fonts.yaml`, `update-syncclipboard.yaml`. Copy the shape from `fleet-manifest.yaml:52-54`, but **choose `cancel-in-progress` per workflow** -- `fleet-manifest` deliberately uses `false` because cancelling a manifest publish mid-push misattributes closures. The CI workflows want `true`; `cve-scan` wants `false` (it mutates issue #1717). |
+| 4.3 | `permissions:` blocks | `ci-linux.yaml`, `ci-darwin.yaml`, `lint.yaml` | The only three of 14 workflows without one. Not currently exploitable; breaks the repo's own convention. |
+| 4.4 | `renovate-relock.yaml:42` repo guard | `.github/workflows/renovate-relock.yaml` | Add `&& github.event.pull_request.head.repo.full_name == github.repository`. It checks out PR head code and runs `nix flake lock --refresh` with a write-scoped PAT behind a single `user.login` condition. Not exploitable today (`renovate[bot]` is App-reserved) but it is the one place that skips the repo's own pattern. |
+| 4.5 | opencode.jsonc schema validation | `.pre-commit-config.yaml` source (`fredsystems/precommit-base`) or `flake/dev/checks.nix` | `check-jsonschema` is already in the stack for workflows. Point it at `opencode.jsonc` with `--schemafile https://opencode.ai/config.json`. Note the pre-commit config is **generated** -- it is a symlink to `/nix/store/...` and marked DO NOT MODIFY, so this may need a change in `precommit-base` upstream or a local flake check instead. |
+| 4.6 | Delete the dead fork guard | `.github/workflows/cve-scan.yaml:121` | The workflow has no `pull_request` trigger, so `github.event_name != 'pull_request'` is always true. Vestigial copy-paste. Harmless but misleading. |
+| 4.7 | sops recipient-consistency check | new flake check or pre-commit hook | Diff the recipient list embedded in `secrets.yaml`'s own sops metadata against the anchors in `modules/secrets/.sops.yaml`. **Requires no plaintext access.** Currently in sync by diligence only; missing `sops updatekeys` after a key rotation fails at deploy time on real hardware. |
+| 4.8 | Doc-drift check | new flake check | Assert `nix eval .#nixosModules --apply builtins.attrNames` equals the set documented in `MODULES.md`, and that `nixosConfigurations` minus `desktop_names` equals the server set. Baseline attribute list is recorded in Part 6 above. Currently in sync by luck -- `MODULES.md` last touched 2026-02-11, `modules/` touched today. |
+| 4.9 | Dead-module reachability check | new flake check | `firmware.nix` is a live instance: imported by nothing, yet `ci-linux.yaml:103-104` rebuilds all 10 hosts when it is touched. Decide 5.1 below first -- if `firmware.nix` is deleted, this check has no current subject and becomes purely preventative. |
+
+**Copy the enforcement model from Part 5.** The input-category invariant went
+from "documented in four places and drifting" to "machine-checked in a
+pre-commit hook _and_ a flake check" via
+`check-input-category-sync.py`. Items 4.7, 4.8, 4.9 are the same shape of
+problem and should get the same shape of solution: a script in the repo, wired
+into both `.pre-commit-config.yaml` and `flake/dev/checks.nix`.
+
+### Batch 5 -- Nix hygiene and de-duplication
+
+**5.1 needs a decision from you before implementation.** Everything else in
+this batch is mechanical.
+
+| # | Work | Files | Notes |
+| - | ---- | ----- | ----- |
+| 5.1 | `allowUnfree` policy | `features/common/system/default.nix:75`, `profiles/darwin.nix:61`, `hosts/linux/fredhub/configuration.nix:12-16,27-31`, `features/desktop/fonts/default.nix:25-33` | **DECISION REQUIRED.** nixpkgs gates on `allowUnfreePredicate or (pkg: allowUnfree)`, so the blanket `true` silently defeats both narrow predicates. Two coherent outcomes: (a) tighten to predicates everywhere and delete the blanket `true` from both files, or (b) accept blanket unfree and delete the two misleading predicates. What must not persist is the current state, where the predicates look like enforcement and are not. Note `profiles/darwin.nix:61` is a second instance the original audit missed. |
+| 5.2 | `openssl-1.1.1w` tracking | `features/common/system/default.nix:71-73`, `.github/tracked-upstream-fixes.json` | Either register it in the manifest with a check type per `nixos-track-upstream-fix`, or determine nothing needs it and remove it. The ladybird entry at manifest line 277 already explicitly contrasts itself with "the openssl-1.1.1w entry already in that list" -- which does not exist. Fix the reference either way. |
+| 5.3 | Decide `firmware.nix`'s fate | `firmware.nix` | Imported by nothing; its only self-reference is a commented-out import with a FIXME at `:3`. It also carries a `# deadnix: skip` pragma at `:7` violating the no-bypass rule, and a `with lib;` at `:37`. Either delete the file or import it and drop the pragma. Deleting also removes it from `ci-linux.yaml:103`'s `global=true` trigger. |
+| 5.4 | Explicit `stateVersion` per host | `flake/lib/mk-system.nix:70`, `flake/hosts/nixos.nix:69`, `flake/lib/mk-darwin-system.nix:30`, `flake/hosts/servers.nix` | 9 of 12 hosts inherit from a literal default. Bumping that default for a new host retroactively changes `stateVersion` on nine existing hosts -- the exact opposite of the option's purpose. Set each host explicitly to its **current effective value** (table in Part 2 -- do not "upgrade" anyone), then either remove the default or make it an error. Pair with an assertion, since `assertions` now has precedent in three files. |
+| 5.5 | Collapse SDR container boilerplate | `modules/services/adsb-docker-units.nix` | A `mkSdrContainer` default collapses 13 `deviceCgroupRules` and 22 `/run:exec,size=64M` repetitions. The module already has a freeform container type with `c.deviceCgroupRules or [ ]` (`:42`) and `c.tmpfs or [ ]` (`:37`), so no structural change is needed. Note the corrected counts in Part 2 -- hfdlhub2 has none of the tmpfs pattern and is not in scope. |
+| 5.6 | De-duplicate `homeDir` | `modules/base/home-linux.nix:8`, `modules/secrets/sops.nix:17`, `hosts/linux/fredvps/nik-home.nix:12`, `features/common/git/default.nix:38` | Four implementations, two character-identical modulo variable name. One `lib` helper. |
+| 5.7 | De-duplicate the `.gitconfig` template | `modules/base/home.nix:76-111`, `hosts/linux/fredvps/nik-home.nix:30-65` | 36 lines byte-identical apart from two interpolated names. Parameterise. |
+| 5.8 | Justify or remove the bare `mkForce` | `features/desktop/environments/common.nix:256` | `services.upower.enable` is only ever set here, so the `mkForce` may be unnecessary. Every other `mkForce` in the repo (8 total) carries a comment tied to a real conflict. |
+| 5.9 | `with pkgs;` over `let` blocks | `features/desktop/libreoffice/default.nix:7`, `features/common/git/default.nix:20` | Both mix implicit and explicit resolution in one expression. The git one is a second instance the original audit did not name. |
+| 5.10 | `with lib;` at module scope | `modules/secrets/sops.nix:11`, `modules/services/github-runners.nix:9` | **Also fix the skill.** statix 0.5.8 does not flag this, contrary to what `nix-best-practices` asserts. That stated-versus-enforced gap in the skill text is worth fixing alongside the code. |
+
+Every item here needs `nix eval` on impacted hosts before push. 5.1, 5.2, 5.4
+are `global=true`; 5.5 covers four container hosts.
+
+### Batch 6 -- deferred and lower value
+
+Real improvements, not load-bearing. Do not start these while anything in
+Batches 1-4 is open.
+
+| # | Work | Notes |
+| - | ---- | ----- |
+| 6.1 | Two scoped `nixosTest`s | `adsb-docker-units.nix` (hand-rolled systemd generator wrapping raw `docker run`, drives 4 hosts) and `modules/secrets/sops.nix` provisioning. **Blocked on a prerequisite:** confirm the nix build user can open `/dev/kvm` on fredhub. `kvm-amd` being loaded on bare metal is a hardware fact, not a permission. Zero `nixosTest` exists in the repo today, so this is greenfield. |
+| 6.2 | `nix store diff-closures` PR comment | Reuse the existing `find-systems` matrix output (`ci-linux.yaml:364-376`). Diffs already-built store paths, so near-zero incremental cost. Catches accidental world-rebuilds. |
+| 6.3 | `osv-scanner` month-long parallel trial | Explicitly a trial, not a swap. OSV encodes per-ecosystem version ranges instead of CPE match strings, eliminating the unbounded-CPE class outright. Honest cost: sbomnix emits structural CPEs and much of every SBOM is Nix plumbing with no OSV identity, so the trade is fewer false positives against possible silent coverage loss. Run both, diff for a month, then decide. |
+| 6.4 | Per-entry review dates in the grype ignore list | `.github/grype-ignore.yaml` has reasons but not dates. Note the file's header **deliberately rejects** CVSS/EPSS/age filtering -- add dates for review scheduling, not as a filter. |
+| 6.5 | Option schema lint | 1 `mkOption` with no `type` (`modules/secrets/sops.nix:21`), 17 of 82 with no `description`. Fix the missing `type` in Batch 5 if convenient; the lint itself is Batch 6. |
+| 6.6 | Renovate for `.opencode/package-lock.json` | `.github/renovate.json5:32` sets `enabledManagers: ["custom.regex", "github-actions"]`, so npm is off and `@opencode-ai/plugin` is tracked by nothing. |
+| 6.7 | Grafana and sops rotation runbooks | `agent-docs/ATTIC_OPERATIONS.md` is the template -- Procedure A/B/C plus a verification section. sops age-key rotation is the more important of the two, since Part 6 item 3 confirms nothing checks that `updatekeys` was run. |
+| 6.8 | `mk-simple-package-module` install path | `modules/lib/mk-simple-package-module.nix:66-69` uses `users.users.<name>.packages` while the rest of the repo uses home-manager. 13 modules take the system path purely because the helper defaults to it. Behaviour-preserving but wide; low priority. |
+| 6.9 | `warnings` as a guardrail surface | Still zero repo-wide. `assertions` now has three precedents; `warnings` is the softer half of the same cheap-guardrail idea (node table, hostname allowlists). |
+| 6.10 | Post-deploy smoke test | `scripts/colmena-apply-drifted.sh` does zero post-apply verification. Marginal, since `NixOSDeployDrift` catches anything outside the 30-second apply window. |
+
+### Items to not re-propose
+
+Recorded so a future agent does not resurrect a settled decision.
+
+| Candidate | Why not |
+| --------- | ------- |
+| CVE publication-date floor | REJECTED deliberately post-audit. `.github/grype-ignore.yaml`'s header: "Triage belongs in the report, not in a silent filter." |
+| UDP `rmem`/`wmem` kernel tuning | Every feed protocol in use is TCP (readsb beast 30002/30003/30005, SBS, ultrafeeder). The only UDP in the fleet is DNS. Cargo cult. |
+| A CVSS severity floor | Both worked examples of the false-positive class are CVSS 8.8. The intuitive fix does not work here. |
+| `impermanence` | Wrong fit given the stateful databases. |
+| Removing `eza` or `lsd` | Both are actively used: `zsh/default.nix:42` aliases `ls` to `lsd`, `yazi/default.nix:45,115` shells out to `eza`. Not a defect. |
+| Restoring fail2ban `maxretry = 3` | The sshd jail is deliberately 2 as of `da0e9b82`. The audit's blanket "maxretry=3" was stale. |
+| Bare `nix flake check` in CI | Redundant; `lint.yaml` already builds the same derivations. |
+| gitleaks / trufflehog | The repo commits sops ciphertext by design, so it is all noise. Batch 4.7 is the useful version of this idea. |
+| Swapping colmena, sops-nix, or Docker | None clears the "materially better" bar. The Docker dependence in `adsb-docker-units.nix` is device-passthrough-specific and would break under rootless Podman. |
+| `nix-fast-build` / `nix-eval-jobs` | No eval bottleneck at 10 hosts by two targets; the Actions matrix already parallelises. |
+| Scheduled fleet-drift issue | `NixOSDeployDrift`, `NixOSUnmanagedSystem`, `NixOSFleetManifestStale` already do this, faster. |
+| Putting the input-category table back in `agents.md` | The skill now explicitly forbids it. Both documents used to point at each other. |

--- a/AUDIT-2026-08-04.md
+++ b/AUDIT-2026-08-04.md
@@ -73,18 +73,20 @@ counts hosts is stale by one.
   The value behind the secret was **regenerated, not relocated** -- the comment
   block at `:26-55` states this explicitly, which is the correct response given
   the old value is unchangeably public in history.
-- **UNVERIFIABLE:** git history was _not_ rewritten and the repo is still
-  `PUBLIC`, so both old values remain recoverable via `git log -p`. That is
-  acceptable **only** because both were rotated. For S1 specifically, Attic has
-  no per-token revocation, so `e7e44a84` claims the server signing key was
-  replaced (which invalidates all tokens at once). That claim cannot be checked
-  from a checkout. Confirm it once using the "Proving an old token is dead"
-  procedure in `agent-docs/ATTIC_OPERATIONS.md`, then record the result here.
-- **Stale doc:** `agent-docs/MONITORING.md:308,315` still lists
+- **CONFIRMED 2026-08-17 (was UNVERIFIABLE):** the old Attic token is **dead**
+  and the replacement token is good, verified out-of-band by fred against the
+  running server. Batch 1 item 1.7 is therefore DONE. Recorded here because it
+  is not checkable from a checkout and would otherwise be re-flagged forever.
+- git history was _not_ rewritten and the repo is still `PUBLIC`, so both old
+  values remain recoverable via `git log -p`. That is acceptable **because both
+  were rotated** -- S1's server signing key was replaced (Attic has no
+  per-token revocation, so replacing the key invalidates all tokens at once)
+  and S2's value was regenerated. No further action.
+- **Stale doc: FIXED.** `agent-docs/MONITORING.md` listed
   `grafana.nix:74 | secret_key hardcoded in plaintext` as an open defect with an
-  unchecked `- [ ] Move the Grafana secret_key into sops`. The code fix has
-  landed; the doc has not caught up. Drift in the unusual direction -- doc says
-  not done, code says done. See Part 9 Batch 1.
+  unchecked `- [ ] Move the Grafana secret_key into sops` long after the code
+  fix landed. Both corrected; the checklist entry now also records that the
+  value was regenerated rather than relocated.
 
 These changed the recommended priority order, so they lead.
 
@@ -354,13 +356,75 @@ in Part 9.
 | No backups                             | DEFERRED. Still zero `restic`/`borgbackup`/`postgresqlBackup`. Made **worse** by nvrhub -- see below.       |
 | `discord-backup.nix` is a same-disk `cp` | DONE. Now uses SQLite's online `.backup` API. See below.                                                  |
 | No `restartUnits` on sops secrets      | PARTIAL, ~33 of ~69 now wired. The docker-container cohort is solved. See below.                            |
-| No Docker log rotation                 | LIVE. Zero `log-opts` / `virtualisation.docker.daemon.settings` repo-wide.                                  |
-| No `configurationLimit`                | LIVE. `features/common/boot/default.nix:3-5`, systemd-boot fleet-wide, no cap. Every host has VFAT `/boot`, nvrhub included (`nvrhub/hardware-configuration.nix:39-46`). No host uses grub. |
-| Prometheus `--web.enable-admin-api`    | LIVE at `prometheus.nix:175` (line unchanged). Binds `0.0.0.0:9090` (`:169-170`), port opened at `:156-159`. sdrhub still advertises `192.168.31.0/24` (`sdrhub/configuration.nix:506`), so still tailnet-reachable. Pushgateway being loopback-bound at `:754` does not mitigate this. |
-| `github_api` at `mode = "0444"`        | LIVE, drifted to `hosts/linux/fredvps/configuration.nix:812-814`. Confirmed the **only** world-readable sops secret; other `0444` hits are Grafana dashboard JSON in `environment.etc`, and `sops.nix:74`'s `0644` is an `allowed_signers` public-key file. |
-| No `min-free` / `max-free`             | LIVE. `modules/base/system.nix:84-88` still weekly-only `--delete-older-than 7d` plus `optimise.automatic`. |
-| `discord-db-backup` unhardened, no jitter | LIVE. `discord-backup.nix:26-93` has zero hardening directives and no `RandomizedDelaySec`. The pattern exists in 5 other places (`imageapi-metrics.nix:101`, `lammacpp/default.nix:99`, `github-runners.nix:446`, `tailscale/default.nix:192`, `node_exporter.nix:517`), so this is now the outlier. |
-| `docker-<name>.service` unhardened     | LIVE. `adsb-docker-units.nix:69-93` `mkUnit` sets only `Restart`, `TimeoutStartSec`, `ExecStart*`. Contrast `python-venv-app.nix:157-191`, a full sandbox. Applies to ~26 containers. |
+| No Docker log rotation                 | **REJECTED 2026-08-17 -- premise was wrong twice over.** See the correction below. |
+| No `configurationLimit`                | DONE 2026-08-17. `configurationLimit = 10` in `features/common/boot/default.nix`. |
+| Prometheus `--web.enable-admin-api`    | **DEFERRED to the backups session -- premise was wrong.** See the correction below. |
+| `github_api` at `mode = "0444"`        | DONE 2026-08-17. Now `0400` with the numeric `uid`/`gid` the consuming container needs, plus `restartUnits`. Residual recorded in the code: host uid 1000 is in practice `fred`, so this is not isolation from the admins -- the container's uid forces 1000 absent userns-remap. |
+| No `min-free` / `max-free`             | DONE 2026-08-17. Added to `nix.settings` in `modules/base/system.nix`. |
+| `discord-db-backup` unhardened, no jitter | DONE 2026-08-17. `RandomizedDelaySec` plus conservative sandboxing. `ProtectSystem`/`ProtectHome` deliberately omitted -- the `.backup` API opens the live WAL-mode DB and may need write access to the DB's own directory for `-wal`/`-shm` siblings, and a broken nightly backup is worse than an unhardened one. |
+| `docker-<name>.service` unhardened     | DONE 2026-08-17. `ProtectSystem=strict`, `ReadWritePaths=[/run/docker.sock]`, `NoNewPrivileges`, `PrivateTmp` on `mkUnit`. The `docker run` construction is byte-identical before and after, verified by diffing the evaluated `ExecStart`. |
+
+### Correction: the Prometheus admin-API finding had a false premise
+
+The row above originally read "Nothing in the repo calls that endpoint."
+**That is wrong.** `modules/monitoring/master/prometheus.nix:118-129` defines a
+daily `createPrometheusSnapshot` service that does
+`curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot`, supported by
+`setPrometheusACL` (grants `fred` read access to the snapshot directory) and
+`prunePrometheusSnapshots` (daily, 30-day retention). It is a real TSDB
+snapshot subsystem, not dead code.
+
+Two consequences:
+
+1. Removing the flag breaks it **silently**. The `curl` has no `-f`, so a 403
+   from a disabled admin API still exits 0. The job would report success and do
+   nothing -- exactly the false-signal class Batch 1 exists to eliminate.
+2. The snapshots live in `/var/lib/prometheus2/data/snapshots`, i.e. **the same
+   disk as the TSDB they snapshot**. That is corruption insurance, not loss
+   insurance -- the identical criticism this audit levelled at the old
+   same-disk `cp` in `discord-backup.nix`.
+
+**Decision: item 1.5 is reverted in full and handed to the deferred backups
+session.** The admin API and the snapshot timer are both left exactly as they
+were. The security concern is real and unchanged, but it cannot be resolved by
+deleting a flag: it needs a decision about how the Prometheus TSDB is actually
+backed up, which is that session's subject. Options noted for it: restrict
+reachability rather than the flag (complicated by
+`--web.enable-remote-write-receiver` needing a non-local bind, and Prometheus
+having no way to bind different endpoints to different addresses), or replace
+the same-disk snapshot with a real off-host backup and then drop the flag.
+
+### Correction: the Docker log-rotation finding had a false premise
+
+The row above originally read "no `log-opts` anywhere ... default uncapped
+`json-file` driver. Classic disk filler." **Both halves are wrong:**
+
+- This fleet's Docker log driver is **journald**, not `json-file`. NixOS'
+  `virtualisation.docker` module defaults `logDriver` to `"journald"`, and this
+  repo never overrides it. Verified:
+  `nix eval .#nixosConfigurations.sdrhub.config.virtualisation.docker.logDriver`
+  returns `"journald"`. It is also deliberate, not accidental --
+  `modules/monitoring/agent/alloy.nix` ships container logs to Loki _via the
+  journal_, relabelling `__journal__container_name` / `__journal__container_id`.
+- journald is **already capped**. `modules/base/system.nix:132-153` sets
+  `SystemMaxUse=1G` and `MaxRetentionSec=30day`, with a comment documenting the
+  real incident that prompted it (all seven servers sitting at ~4G on
+  journald's 10%-of-disk default).
+
+`max-size` / `max-file` are only honoured by the `json-file` and `local`
+drivers, so the recommended fix would have been **inert on every host**. An
+inert setting that looks like a fix is worse than a recorded rejection, so it
+was not landed.
+
+**Decision: item 3.2 is REJECTED.** Do not re-propose `log-opts` while the
+driver is journald.
+
+There is a real residual, which is a different problem and is tracked
+separately as Batch 6 item 6.11: journald's 1G is a **shared** budget across
+all services, so a single very chatty container can crowd out other services'
+log retention even though total disk usage stays bounded. Per-container caps
+would require moving off journald, which breaks alloy's ingestion path -- a
+genuine tradeoff, not a quick fix.
 | disko / nixos-anywhere / etc. unused   | DEFERRED (structural tools). Still zero references.                                                        |
 | `eza` and `lsd` both installed         | LIVE and, on reflection, fine -- both are actively used. `zsh/default.nix:42` aliases `ls` to `lsd`; `yazi/default.nix:45,115` shells out to `eza`. Reclassify as REJECTED, not a defect. |
 | All images digest-pinned               | Still clean. 35 `image =` declarations, all `@sha256:`. nvrhub uses the native `services.frigate` module and contributes zero container images. |
@@ -1081,6 +1145,69 @@ Kept for the record. Superseded by Part 9. Items 1 and 3 have since landed
 **This is the execution plan.** Written 2026-08-17 from the re-verification.
 The parts above supply evidence and rationale; work from this section.
 
+### Execution status as of 2026-08-17
+
+**Batches 1-4 are complete**, on branch `audit-remediation-b1-b4`, executed as
+four parallel worktrees merged sequentially with verification after each merge.
+Batches 5 and 6 are untouched.
+
+| Item | Outcome |
+| ---- | ------- |
+| 1.1 grype DB liveness | DONE |
+| 1.2 stale channel comment | DONE |
+| 1.3 MONITORING.md grafana entry | DONE |
+| 1.4 `ci-lint.yaml` -> `lint.yaml` | DONE |
+| 1.5 Prometheus admin API | **REVERTED -- false premise, deferred to backups session** |
+| 1.6 `github_api` mode | DONE |
+| 1.7 prove old Attic token dead | DONE -- confirmed out-of-band, token dead, replacement good |
+| 2.1 nvrhub `restartUnits` | DONE |
+| 2.2 nvrhub metrics bind | REVIEWED, no change -- already stricter than the fleet baseline for a non-internet-facing host |
+| 3.1 `configurationLimit` | DONE |
+| 3.2 Docker log rotation | **REJECTED -- false premise, see Part 3 correction** |
+| 3.3 `min-free`/`max-free` | DONE |
+| 3.4 discord timer jitter + hardening | DONE |
+| 3.5 docker wrapper hardening | DONE |
+| 4.1 colmena parity on PRs | DONE |
+| 4.2 concurrency groups | DONE, all seven |
+| 4.3 `permissions:` blocks | DONE |
+| 4.4 renovate-relock repo guard | DONE |
+| 4.5 opencode.jsonc validation | DONE, offline/structural -- see note |
+| 4.6 dead fork guard | DONE |
+| 4.7 sops recipient check | DONE |
+| 4.8 doc-drift check | DONE |
+| 4.9 dead-module reachability | NOT STARTED -- blocked on 5.3 (`firmware.nix` fate) |
+
+**Three of this document's own findings turned out to have false premises.**
+1.5 and 3.2 are corrected in Part 3; Part 4's root cause is corrected in its
+own status block. That is a 3-in-~40 error rate on findings that were presented
+as verified, and all three failed the same way: a `grep` found no match, and
+the absence was read as "not configured" rather than "configured elsewhere, or
+defaulted by NixOS". Future auditors should treat "I grepped and found nothing"
+as a hypothesis, not a finding -- confirm against the **evaluated** config
+(`nix eval`), not the source text.
+
+Notes on two DONE items that landed differently than specified:
+
+- **4.5** is enforced as an offline structural check (top-level keys against a
+  snapshot of opencode's key list, plus the required `template` field on every
+  `command` entry). A live fetch of `opencode.ai/config.json` is impossible in
+  the enforced path: `git-hooks.nix` runs the entire hook suite as one sandboxed
+  Nix build with no network, so a fetching hook hard-fails the whole suite
+  rather than degrading. A full-schema mode exists but is manual-only.
+  Vendoring the schema was rejected -- it would become a second `MODULES.md`.
+- **4.1** extracted the parity comparison into `scripts/check-colmena-parity.sh`,
+  called by both `gen-fleet-manifest.sh` and the new PR job, so there is exactly
+  one copy of the logic. The new job runs on a GitHub-hosted runner (the eval is
+  cheap -- `colmenaHive` is a pure lib function and `.outPath` needs no
+  realisation) and joins `build-linux-summary`'s `needs` so it counts toward the
+  required status check.
+
+One defect was found at integration and fixed: the three new check scripts had
+no tool-check preamble, and `check-opencode-jsonc.sh` reported a missing python
+`json5` module as `"opencode.jsonc is not valid JSONC"` -- inventing a config
+bug that did not exist. Same false-signal class the check was written to
+prevent.
+
 ### Scope exclusions, by explicit decision
 
 Two items are **out of scope for remediation** and get their own planning
@@ -1217,6 +1344,7 @@ Batches 1-4 is open.
 | 6.8 | `mk-simple-package-module` install path | `modules/lib/mk-simple-package-module.nix:66-69` uses `users.users.<name>.packages` while the rest of the repo uses home-manager. 13 modules take the system path purely because the helper defaults to it. Behaviour-preserving but wide; low priority. |
 | 6.9 | `warnings` as a guardrail surface | Still zero repo-wide. `assertions` now has three precedents; `warnings` is the softer half of the same cheap-guardrail idea (node table, hostname allowlists). |
 | 6.10 | Post-deploy smoke test | `scripts/colmena-apply-drifted.sh` does zero post-apply verification. Marginal, since `NixOSDeployDrift` catches anything outside the 30-second apply window. |
+| 6.11 | journald's shared log budget | Opened 2026-08-17 out of the rejected item 3.2. `modules/base/system.nix:132-153` caps journald at `SystemMaxUse=1G` / `MaxRetentionSec=30day`, which bounds total disk but is a **shared** budget: one very chatty container can crowd out other services' retention inside that envelope. Per-container caps would need `logDriver` moved off journald, which breaks `alloy.nix`'s journal-based ingestion into Loki. A real tradeoff -- scope it properly before touching it, and do not "fix" it by adding `log-opts`, which is inert under journald. |
 
 ### Items to not re-propose
 
@@ -1230,6 +1358,8 @@ Recorded so a future agent does not resurrect a settled decision.
 | `impermanence` | Wrong fit given the stateful databases. |
 | Removing `eza` or `lsd` | Both are actively used: `zsh/default.nix:42` aliases `ls` to `lsd`, `yazi/default.nix:45,115` shells out to `eza`. Not a defect. |
 | Restoring fail2ban `maxretry = 3` | The sshd jail is deliberately 2 as of `da0e9b82`. The audit's blanket "maxretry=3" was stale. |
+| Docker `log-opts` / `max-size` / `max-file` | REJECTED 2026-08-17. Inert under this fleet's journald log driver, which is deliberate and already capped. See the Part 3 correction. The real residual is item 6.11. |
+| Removing Prometheus `--web.enable-admin-api` on its own | A daily snapshot job genuinely calls that endpoint, and `curl` without `-f` means disabling the flag breaks it silently. Deferred to the backups session; see the Part 3 correction. |
 | Bare `nix flake check` in CI | Redundant; `lint.yaml` already builds the same derivations. |
 | gitleaks / trufflehog | The repo commits sops ciphertext by design, so it is all noise. Batch 4.7 is the useful version of this idea. |
 | Swapping colmena, sops-nix, or Docker | None clears the "materially better" bar. The Docker dependence in `adsb-docker-units.nix` is device-passthrough-specific and would break under rootless Podman. |

--- a/AUDIT-2026-08-04.md
+++ b/AUDIT-2026-08-04.md
@@ -346,10 +346,11 @@ surface.
 
 ## Part 3 -- Service configuration and tooling gaps
 
-**Status 2026-08-17: PARTIAL.** One finding fully fixed, one substantially
-fixed, the rest LIVE. Backups and disko/nixos-anywhere are DEFERRED to their
-own planning session by explicit decision -- do not fold them into the batches
-in Part 9.
+**Status 2026-08-17: PARTIAL.** Most of this part was remediated in Batch 3
+(PR #2241) -- see the per-row outcomes below. Two findings turned out to have
+false premises and are corrected further down. Backups and disko/nixos-anywhere
+are DEFERRED to their own planning session by explicit decision -- do not fold
+them into the batches in Part 9.
 
 | Finding                                | 2026-08-17 state                                                                                          |
 | -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
@@ -477,7 +478,24 @@ Still lacking `restartUnits`, roughly 36 declarations:
 - Alertmanager's healthchecks endpoint and both Pushover keys -- `modules/monitoring/master/prometheus.nix:46-50`. These use `LoadCredential=`, which has the identical stale-path problem.
 - `cloudflare_acme_token` on two hosts -- `sdrhub/acme.nix:49`, `fredhub/nginx.nix:46`.
 - `github_api` on fredvps -- see the 0444 item above.
-- **`cameras/username` / `cameras/password` on nvrhub** -- `hosts/linux/nvrhub/frigate.nix:406-409`. This is the day-one regression: `mkContainerSecret` already existed and was in use on six hosts. Rotating the shared camera credential and redeploying leaves Frigate on the stale password.
+- `fred-yubi` on Daytona (`hosts/linux/daytona/configuration.nix:181`) and
+  `fred-yubi-maranello` on maranello (`hosts/linux/maranello/configuration.nix:97`).
+  Both omitted from the original inventory -- caught by review on PR #2241.
+  Note these are `u2f_keys` files read by PAM at authentication time rather
+  than by a long-running daemon, so `restartUnits` may be genuinely
+  inapplicable here; assess before "fixing" them.
+
+**RESOLVED 2026-08-17:** `cameras/username` / `cameras/password` on nvrhub
+(`hosts/linux/nvrhub/frigate.nix`) were the day-one regression on this list.
+Now wired to `restartUnits = [ "frigate.service" ]` -- deliberately not via
+`mkContainerSecret`, which hardcodes `docker-<name>.service` and would have
+pointed at a unit that does not exist on that host.
+
+Treat the counts in this section as indicative rather than exact. The
+declaration total depends on whether a shared module applied to many hosts
+counts once or once per host, and review on PR #2241 arrived at 29 rather than
+36 for the enumerated bullets. The actionable content is the list, not the
+number.
 
 Two sdrhub secrets are deliberately excluded with a recorded reason
 (`sdrhub/configuration.nix:1506-1519`): `dozzle-agent.env` and
@@ -620,18 +638,35 @@ zero, check what it was given before checking what it knows.**
 
 | Rec | Status | Detail |
 | --- | ------ | ------ |
-| 1. Canary / DB liveness | PARTIAL | Two liveness assertions landed and are **stronger than the proposed canary** for the failure that actually occurred: SBOM coverage floor of 60% of the runtime closure (`cve-scan.yaml:229-249`, healthy is 85-90%) and an absolute floor of 50 components carrying a CPE (`:251-277`, baseline ~97 servers / ~112 desktops). The second exists precisely because component coverage stayed at 87% while scannable coverage was 3%, so a ratio could not catch it. **Still missing: any check on grype's own vulnerability DB.** No `grype db status` / `grype db check` anywhere. See the live risk below. |
+| 1. Canary / DB liveness | PARTIAL | Two liveness assertions landed and are **stronger than the proposed canary** for the failure that actually occurred: SBOM coverage floor of 60% of the runtime closure (`cve-scan.yaml:229-249`, healthy is 85-90%) and an absolute floor of 50 components carrying a CPE (`:251-277`, baseline ~97 servers / ~112 desktops). The second exists precisely because component coverage stayed at 87% while scannable coverage was 3%, so a ratio could not catch it. **Since CLOSED (Batch 1 item 1.1, PR #2241):** a `grype db update` followed by a `grype db status` liveness gate now runs before the scan, is propagated per-system to the aggregate job, and gates the auto-close. The update must come first -- `status` never fetches, and grype's auto-update only happens as part of a scan, so gating on `status` alone would have failed fresh runners. |
 | 2. Ignore list with reason + review date | PARTIAL | `.github/grype-ignore.yaml` exists (note: **not** `.grype.yaml` as proposed), referenced at `cve-scan.yaml:294` via `-c`. Per-entry `vulnerability` + `package.name` scoping, prose reason per entry, and a header rule set requiring a concrete verifiable reason rather than "old" or "probably fine." Missing: a structured per-entry review/expiry date field. Triage discipline is demonstrably real -- `f792b8ae` reverted its own over-broad 74-entry kernel suppression one commit after adding it. |
 | 3. Publication-date floor | REJECTED | Deliberate, by the same person who implemented 1 and 2, days after this audit. The ignore file's header states: "We deliberately do NOT filter by CVSS score, EPSS probability, or age... Triage belongs in the report, not in a silent filter." Do not re-propose this. |
 | 4. `osv-scanner` parallel trial | LIVE | Zero references repo-wide outside this document. |
 
-**The one live risk in this part.** `cve-scan.yaml:696-708` auto-closes the
-tracking issue #1717 when `TOTAL -eq 0 && MISSING -eq 0`, and `MISSING` counts
-systems that failed to _produce a report_, not DB health. A dead or empty grype
-DB against a perfectly healthy 97-CPE SBOM still yields zero matches, passes
-both coverage assertions, and **closes the tracking issue with a false
-all-clear.** This is the residual of rec 1 and is the only Part 4 item in the
-Batch 1 work below.
+**The one live risk in this part -- CLOSED 2026-08-17 by Batch 1 item 1.1.**
+As found, `cve-scan.yaml` auto-closed tracking issue #1717 when
+`TOTAL -eq 0 && MISSING -eq 0`, and `MISSING` counts systems that failed to
+_produce a report_, not DB health. A dead or empty grype DB against a perfectly
+healthy 97-CPE SBOM yielded zero matches, passed both coverage assertions, and
+**closed the tracking issue with a false all-clear.**
+
+Now fixed in three places, all of which were needed:
+
+1. `grype db update` runs before the liveness check, because `grype db status`
+   never fetches and grype's own auto-update only fires as part of a scan.
+   Gating on `status` alone would have failed any runner with an absent or
+   stale cache **even though the scan would have worked** -- trading a false
+   all-clear for a false failure. Caught by review on PR #2241.
+2. A failed update or a `valid: false` status writes the reason to
+   `db-status.txt`, which is uploaded per-system and read by the aggregate job.
+   Auto-close now requires zero matches, complete coverage, **and** a verified
+   DB.
+3. The report body agrees with the gate. It previously still printed "All
+   scanned systems are clean" whenever `total` was zero, contradicting the
+   warnings directly above it. It now prints that only when nothing is missing
+   and the DB was verified, and otherwise says the result is unknown rather
+   than clean. The `missing` half of that was a pre-existing bug, not new to
+   the DB work. Also caught by review on PR #2241.
 
 Note that the kernel suppressions in `7df2995e` are not a blanket exclusion.
 All 74 were individually checked against the NVD API for unbounded
@@ -767,20 +802,21 @@ correct -- it scans `system.build.toplevel`, not just flake packages.
 
 ## Part 5 -- Other CI findings
 
-**Status 2026-08-17: PARTIAL.** The three input-category findings are all DONE
-and mechanically enforced. The workflow-level findings are all LIVE, and the
-`concurrency:` gap has since propagated into four new workflows.
+**Status 2026-08-17: DONE.** The three input-category findings were already
+fixed and mechanically enforced. Every workflow-level finding below was
+remediated in Batch 4 (PR #2241). The `concurrency:` gap had propagated into
+four new workflows by re-verification time; all seven were fixed together.
 
 | Finding                              | 2026-08-17 state                                                                    |
 | ------------------------------------ | ----------------------------------------------------------------------------------- |
 | `nixpkgs-kernel` category drift      | DONE. See below.                                                                     |
 | `ci-darwin.yaml` missing four inputs | DONE. All 25 lock inputs present at `ci-darwin.yaml:151-176`.                          |
 | Circular `agents.md` <-> skill ref   | DONE. See below.                                                                     |
-| No `concurrency:` on CI workflows    | LIVE, and now worse. See below.                                                      |
-| No `permissions:` block on three     | LIVE. Confirmed absent from `ci-linux.yaml`, `ci-darwin.yaml`, `lint.yaml`. The other 13 workflows all declare one. |
-| `cve-scan.yaml` no `concurrency:`    | LIVE. Zero `concurrency:` in all 716 lines. Triggers are still `schedule` + `workflow_dispatch`, so the TOCTOU window on the `gh issue list` / `gh issue create` logic stays open. |
-| `cve-scan.yaml` dead fork guard      | LIVE, drifted to `cve-scan.yaml:121`. No `pull_request` trigger exists, so `github.event_name != 'pull_request'` is always true.  |
-| `renovate-relock.yaml:42` gate       | LIVE, exact same line number.                                                        |
+| No `concurrency:` on CI workflows    | DONE (4.2). All seven workflows, `cancel-in-progress` chosen per workflow. See below for the propagation history. |
+| No `permissions:` block on three     | DONE (4.3). Minimal blocks on `ci-linux.yaml`, `ci-darwin.yaml`, `lint.yaml`, traced to the `merge-queue-ci-skipper` action's `gh pr view` call. |
+| `cve-scan.yaml` no `concurrency:`    | DONE (4.2), with `cancel-in-progress: false` since the run mutates issue #1717. This also closes the TOCTOU window where a manual dispatch raced the Monday cron. |
+| `cve-scan.yaml` dead fork guard      | DONE (4.6). Removed; the workflow has no `pull_request` trigger.                      |
+| `renovate-relock.yaml:42` gate       | DONE (4.4). Now also requires `head.repo.full_name == github.repository`.             |
 
 **The input-category invariant is now machine-enforced -- this is the model to
 copy for the other sync problems in this document.** A checker,
@@ -959,17 +995,18 @@ Nothing except `cve-scan.yaml` is unhealthy.
 
 ## Part 6 -- Missing CI capability
 
-**Status 2026-08-17: LIVE. Not one item in this part has been implemented.**
-Re-verified individually:
+**Status 2026-08-17: PARTIAL.** At re-verification time not one item here had
+been implemented. Batch 4 (PR #2241) then landed items 1, 3 and 6. The rest
+remain LIVE. Re-verified individually:
 
 | Item                              | 2026-08-17 state                                                                              |
 | --------------------------------- | ---------------------------------------------------------------------------------------------- |
-| 1. Colmena parity on PRs          | LIVE. `grep -rn "colmenaHive" .github/workflows/` returns nothing. `fleet-manifest.yaml:19-21` still `push: [main]` + 6h schedule, no `pull_request`. Parity currently _holds_ (`nix eval .#colmenaHive.nodes` returns all 8 servers including nvrhub), but nothing would catch a regression pre-merge. |
+| 1. Colmena parity on PRs          | DONE (4.1). Extracted to `scripts/check-colmena-parity.sh`, called by both `gen-fleet-manifest.sh` and a new PR-time job on a GitHub-hosted runner, which joins `build-linux-summary`'s `needs`. Exactly one copy of the comparison logic now exists. |
 | 2. Dead-module reachability       | LIVE. `firmware.nix` still imported by nothing; `ci-linux.yaml:103-104` still has `flake.nix\|firmware.nix) global=true`. No reachability check exists. |
-| 3. sops recipient consistency     | LIVE as a _check_. The **data** happens to be in sync: `modules/secrets/.sops.yaml:4-15` lists 12 recipients, all 12 wired into the single `secrets.yaml` rule at `:18-32`, and nvrhub was added correctly. But `grep -rn "updatekeys" .github .opencode scripts` returns nothing -- the runbook step at `sops.nix:135-144` is still manual and unenforced. In sync by diligence, not by machine. |
+| 3. sops recipient consistency     | DONE (4.7) -- `scripts/check-sops-recipients.sh`, wired into both a pre-commit hook and a flake check. Original finding, for context: The **data** happens to be in sync: `modules/secrets/.sops.yaml:4-15` lists 12 recipients, all 12 wired into the single `secrets.yaml` rule at `:18-32`, and nvrhub was added correctly. But `grep -rn "updatekeys" .github .opencode scripts` returns nothing -- the runbook step at `sops.nix:135-144` is still manual and unenforced. In sync by diligence, not by machine. |
 | 4. `diff-closures` PR comment     | LIVE. No reference anywhere in workflows or `checks.nix`.                                       |
 | 5. Two scoped `nixosTest`s        | LIVE. `grep -rn "nixosTest\|pkgs.testers\|runNixOSTest"` returns **zero hits repo-wide**, including `flake/dev/checks.nix`. The KVM prerequisite is still unconfirmed. |
-| 6. Doc-drift check                | LIVE. Still in sync by luck: `nix eval .#nixosModules --apply builtins.attrNames` returns exactly the 14 modules `MODULES.md` documents, but `MODULES.md` was last touched 2026-02-11 while `modules/` has commits from today. `desktop_names=("Daytona" "maranello")` at `ci-linux.yaml:255` still matches reality. |
+| 6. Doc-drift check                | DONE (4.8) -- `scripts/check-doc-drift.sh`, wired into both a hook and a flake check. Original finding, for context: was in sync by luck: `nix eval .#nixosModules --apply builtins.attrNames` returns exactly the 14 modules `MODULES.md` documents, but `MODULES.md` was last touched 2026-02-11 while `modules/` has commits from today. `desktop_names=("Daytona" "maranello")` at `ci-linux.yaml:255` still matches reality. |
 | Tier 2: Renovate for `.opencode`  | LIVE. `.github/renovate.json5:32` still `enabledManagers: ["custom.regex", "github-actions"]`. `.opencode/package-lock.json` still exists, mtime 2026-06-03, tracked by nothing. |
 | Tier 2: option schema lint        | LIVE, numbers refined. Of 82 `mkOption` blocks: **1 has no `type` at all** -- `modules/secrets/sops.nix:21` (`sops_secrets.enable_secrets.enable`), the exact one the audit named -- and **17 of 82 (~21%) have no `description`**, concentrated in `modules/terminal/common.nix` (6), `modules/services/nas-mount-type.nix` (5), `nas-home.nix`, `sync-compose.nix`, `nas-system.nix`. |
 
@@ -1062,8 +1099,8 @@ hardware-rtl-sdr, hardware-u2f, nas-mounts, sync-hosts, wifi-networks
 
 | Item                              | 2026-08-17 state                                                                             |
 | --------------------------------- | --------------------------------------------------------------------------------------------- |
-| 1. Stale `flake.nix:69-74` comment | LIVE. Byte-identical, same line range, 13 days on. Line 78 is still already `nixos-26.05-small`. The comment still instructs the next human not to hand-bump a ref that was already bumped. |
-| 2. No opencode.jsonc schema check  | LIVE. See Part 1 status.                                                                       |
+| 1. Stale `flake.nix:69-74` comment | DONE (1.2). Deleted. It had been byte-identical for 13 days, telling the next human not to hand-bump a ref that line 78 had already bumped. |
+| 2. No opencode.jsonc schema check  | DONE (4.5), as an offline structural check -- a live schema fetch is impossible in the enforced path. See the Part 9 note. |
 | 3. No secret-rotation story        | PARTIAL. Attic now has a real runbook; Grafana and sops do not. See below.                      |
 | 4. Backup without tested restore   | DEFERRED with the backups session.                                                             |
 | 5. Detection-vs-survivability      | Still the correct headline. The secret half is now closed (Part 0 DONE); the backup half is not. |

--- a/agent-docs/MONITORING.md
+++ b/agent-docs/MONITORING.md
@@ -305,14 +305,16 @@ This is orthogonal to log shipping, which works correctly on every host includin
 | prometheus.nix:327          | Inhibit list references `SDRServiceFailure` and `FeederUpstreamFailure`, both being removed             |
 | adsb-docker-units.nix:31-82 | `mkUnit` silently ignores the `hostname`, `requires`, and `depends_on` keys set by several hosts        |
 | hardware/rtl-sdr.nix:17     | `lib.mkDefault` on a list option -- see [Kernel parameter merge hazard](#kernel-parameter-merge-hazard) |
-| grafana.nix:74              | `secret_key` hardcoded in plaintext; the admin password is correctly sops-managed                       |
+| ~~grafana.nix:74~~          | ~~`secret_key` hardcoded in plaintext~~ -- fixed; now sops-managed at `grafana.nix:56-59,163`            |
 
 - [x] Fix the `Daytona` regex case sensitivity
 - [x] Add `hostname` and `role` labels to the unlabelled scrape jobs
 - [x] Update the Alertmanager inhibit list when the dead rules are removed
 - [ ] Either honour or remove the ignored keys in `mkUnit`
 - [x] Remove `lib.mkDefault` from `boot.kernelParams` in `rtl-sdr.nix`
-- [ ] Move the Grafana `secret_key` into sops
+- [x] Move the Grafana `secret_key` into sops. The value was **regenerated**,
+      not relocated -- the old one is unchangeably public in git history, so
+      moving it as-is would have been theatre. See `grafana.nix:26-55`.
 - [ ] Decide on TLS and access control for the LAN monitoring endpoints.
       Prometheus (9090), Alertmanager (9093), Loki (5678) and Grafana (3333) are
       reachable on the LAN without auth or TLS, and Alertmanager in particular

--- a/agents.md
+++ b/agents.md
@@ -83,7 +83,7 @@ and HFDL decoders.
     ├── workflows/
     │   ├── ci-linux.yaml        # Linux CI
     │   ├── ci-darwin.yaml       # macOS CI
-    │   ├── ci-lint.yaml         # Pre-commit / linting
+    │   ├── lint.yaml            # Pre-commit / linting
     │   ├── fleet-manifest.yaml  # Publishes per-host expected closure paths
     │   └── update-flakes.yaml   # Per-input flake update (1 PR per input)
     ├── merge-queue-ci-skipper/  # Composite action: skip redundant merge-queue builds

--- a/features/common/boot/default.nix
+++ b/features/common/boot/default.nix
@@ -1,8 +1,21 @@
 {
   boot = {
     # ── Bootloader ─────────────────────────────────────────────────────────────
-    loader.systemd-boot.enable = true;
-    loader.efi.canTouchEfiVariables = true;
+    loader = {
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+
+      # Every host's /boot is a small VFAT ESP (confirmed on nvrhub), and
+      # none use grub. Left uncapped, systemd-boot keeps a kernel+initrd set
+      # for every generation ever built, and colmena deploys frequently
+      # enough (every push that touches an impacted host) that the ESP
+      # fills up and the NEXT deploy fails to write its boot entry -- the
+      # classic "cannot write to /boot: No space left on device" that
+      # leaves a host stuck one generation short of booting at all. 10 is
+      # enough rollback depth to survive a bad deploy discovered a few
+      # pushes later while keeping the ESP's worst case bounded.
+      systemd-boot.configurationLimit = 10;
+    };
 
     # ── Plymouth (graphical splash) ────────────────────────────────────────────
     plymouth = {

--- a/flake.nix
+++ b/flake.nix
@@ -66,13 +66,6 @@
     # that does not match is treated by Renovate as an unparseable
     # currentValue and silently never updated.
     #
-    # The ref below is knowingly stale -- nixos-25.11-small stopped
-    # receiving commits on 2026-06-30 when 25.11 went EOL.  It is left
-    # in place deliberately so the newly-added annotation has something
-    # to act on: the next Renovate run should open the grouped "nixos
-    # stable channel" PR moving this to nixos-26.05-small.  Do not bump
-    # it by hand before that PR lands, or the fix goes untested.
-    #
     # renovate: datasource=git-refs depName=nixpkgs-kernel packageName=https://github.com/NixOS/nixpkgs versioning=regex:^nixos-(?<major>\d+)\.(?<minor>\d+)-small$
     nixpkgs-kernel = {
       url = "github:nixos/nixpkgs/nixos-26.05-small";

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -82,6 +82,80 @@
           python3 "$script"
         '';
       };
+
+      # Verifies the sops age-recipient set is consistent across
+      # modules/secrets/.sops.yaml's `keys:` anchors, its creation_rules
+      # entry for secrets.yaml, and the recipients actually embedded in
+      # secrets.yaml's own (unencrypted) sops metadata.
+      #
+      # Adding a recipient (new host, key rotation) requires a manual
+      # follow-up step -- `sops updatekeys secrets.yaml` -- documented only
+      # as a comment in modules/secrets/sops.nix. Nothing enforced it. Miss
+      # it and the new/rotated host fails to decrypt at deploy time, on
+      # real hardware, instead of at review time. No decryption key is
+      # needed: sops embeds who it encrypted for in the clear, so this
+      # check runs anywhere, including CI runners with none of the 12
+      # private keys.
+      sopsRecipientsCheck = pkgs.writeShellApplication {
+        name = "check-sops-recipients";
+        runtimeInputs = [
+          pkgs.yq-go
+          pkgs.jq
+        ];
+        text = ''
+          bash scripts/check-sops-recipients.sh
+        '';
+      };
+
+      # Verifies two doc/config invariants that were previously in sync
+      # only by luck: MODULES.md documents exactly the modules exported by
+      # `nixosModules`, and the desktop/server host split (`desktop_names`
+      # in ci-linux.yaml vs. flake/hosts/servers.nix) is self-consistent.
+      #
+      # ACTUAL_MODULES_JSON / ALL_SYSTEMS_JSON / SERVERS_NIX_KEYS_JSON are
+      # baked in at build time from already-evaluated Nix values
+      # (`self.nixosModules`, `self.nixosConfigurations`,
+      # flake/hosts/servers.nix) rather than left for the script to fetch
+      # via `nix eval` at runtime. That matters here specifically because
+      # this SAME derivation is used both as the pre-commit hook entry
+      # below and as the standalone `checks.doc-drift` -- and git-hooks'
+      # own `run` derivation (what `nix build .#checks.pre-commit-check`
+      # and CI's lint job exercise) runs the WHOLE hook suite inside a
+      # sandboxed Nix build with the nix-command feature disabled and no
+      # daemon-socket access, so a runtime `nix eval` call from inside a
+      # hook fails there unconditionally, commit-time invocation or not.
+      # (See scripts/check-doc-drift.sh's header: the script itself still
+      # falls back to a live `nix eval` when these env vars are unset, for
+      # convenience when a human runs it directly.)
+      docDriftCheck = pkgs.writeShellApplication {
+        name = "check-doc-drift";
+        runtimeInputs = [ pkgs.jq ];
+        text = ''
+          export ACTUAL_MODULES_JSON=${lib.escapeShellArg (builtins.toJSON (lib.attrNames self.nixosModules))}
+          export ALL_SYSTEMS_JSON=${lib.escapeShellArg (builtins.toJSON (lib.attrNames self.nixosConfigurations))}
+          export SERVERS_NIX_KEYS_JSON=${lib.escapeShellArg (builtins.toJSON (lib.attrNames (import ../hosts/servers.nix)))}
+          bash scripts/check-doc-drift.sh
+        '';
+      };
+
+      # Validates opencode.jsonc: a structural check (offline, default --
+      # unknown top-level keys and command entries missing `template`,
+      # wired into both the hook and the standalone check below via
+      # `--offline`) plus, when run by hand with no flag, full validation
+      # against opencode's live JSON Schema over the network. See
+      # scripts/check-opencode-jsonc.sh's header for why the live-schema
+      # mode cannot be wired into either the hook or the flake check.
+      opencodeJsoncCheck = pkgs.writeShellApplication {
+        name = "check-opencode-jsonc";
+        runtimeInputs = [
+          (pkgs.python3.withPackages (ps: [ ps.json5 ]))
+          pkgs.jq
+          pkgs.check-jsonschema
+        ];
+        text = ''
+          bash scripts/check-opencode-jsonc.sh "$@"
+        '';
+      };
     in
     {
       # precommit-base exposes composable modules (`{ hooks, excludes,
@@ -133,6 +207,49 @@
                 # off because the checker always cross-references the full
                 # set; a single-file view cannot detect disagreement.
                 files = "^(flake\\.nix|flake\\.lock|\\.github/workflows/ci-(linux|darwin)\\.yaml|\\.opencode/skills/projects/nixos-(eval-impacted-hosts/scripts/impacted-hosts\\.sh|input-category-sync/scripts/check-input-category-sync\\.py))$";
+                pass_filenames = false;
+              };
+
+              sops-recipients = {
+                enable = true;
+                name = "sops age-recipient consistency (keys / creation_rules / secrets.yaml)";
+                entry = "${pkgs.lib.getExe sopsRecipientsCheck}";
+
+                # Fires when either the recipient/anchor declarations or the
+                # ciphertext's own embedded recipient metadata change --
+                # either side of the invariant can drift independently.
+                files = "^modules/secrets/(\\.sops\\.yaml|secrets\\.yaml)$";
+                pass_filenames = false;
+              };
+
+              doc-drift = {
+                enable = true;
+                name = "MODULES.md / desktop-server host-split drift";
+                entry = "${pkgs.lib.getExe docDriftCheck}";
+
+                # flake.nix is where the `nixosModules` attrset itself is
+                # declared (module add/rename/removal), so it is the actual
+                # trigger for MODULES.md drift, not modules/*.nix directly.
+                files = "^(MODULES\\.md|flake\\.nix|flake/hosts/servers\\.nix|\\.github/workflows/ci-linux\\.yaml)$";
+                pass_filenames = false;
+              };
+
+              opencode-jsonc-schema = {
+                enable = true;
+                name = "opencode.jsonc schema validation (structural, offline)";
+                entry = "${pkgs.lib.getExe opencodeJsoncCheck} --offline";
+
+                # `--offline`, not the default network mode: git-hooks'
+                # own `run` derivation (this is also what `nix build
+                # .#checks.pre-commit-check` and CI's lint job exercise)
+                # executes the WHOLE hook suite inside a sandboxed Nix
+                # build with no network, regardless of whether a human
+                # triggered it via `git commit` or via `nix flake check`.
+                # A hook that needs network here doesn't just skip
+                # gracefully -- it hard-fails the build for everyone. See
+                # scripts/check-opencode-jsonc.sh's header for the full
+                # reasoning and how to run the live-schema check manually.
+                files = "^opencode\\.jsonc$";
                 pass_filenames = false;
               };
             };
@@ -260,6 +377,49 @@
           ''
             cd ${self}
             check-input-category-sync
+            touch "$out"
+          '';
+
+      sops-recipients =
+        pkgs.runCommand "sops-recipients-check"
+          {
+            nativeBuildInputs = [ sopsRecipientsCheck ];
+          }
+          ''
+            cd ${self}
+            check-sops-recipients
+            touch "$out"
+          '';
+
+      # docDriftCheck already has ACTUAL_MODULES_JSON / ALL_SYSTEMS_JSON /
+      # SERVERS_NIX_KEYS_JSON baked in at build time (see its definition
+      # above), so this needs no extra wiring -- same derivation, same
+      # hermetic values, as the pre-commit hook entry.
+      doc-drift =
+        pkgs.runCommand "doc-drift-check"
+          {
+            nativeBuildInputs = [ docDriftCheck ];
+          }
+          ''
+            cd ${self}
+            check-doc-drift
+            touch "$out"
+          '';
+
+      # `--offline` skips the live-schema fetch: a sandboxed Nix build has
+      # no network, so only the structural check (unknown top-level keys,
+      # command entries missing `template`) runs here. Same reason the
+      # pre-commit hook above passes `--offline` too -- see its comment.
+      # Full schema validation is available by running
+      # `scripts/check-opencode-jsonc.sh` (no flag) directly, by hand.
+      opencode-jsonc-schema =
+        pkgs.runCommand "opencode-jsonc-schema-check"
+          {
+            nativeBuildInputs = [ opencodeJsoncCheck ];
+          }
+          ''
+            cd ${self}
+            check-opencode-jsonc --offline
             touch "$out"
           '';
 

--- a/hosts/linux/fredvps/configuration.nix
+++ b/hosts/linux/fredvps/configuration.nix
@@ -809,8 +809,34 @@ in
 
     "docker/fredvps/fredsite.env" = mkContainerSecret "fredsite";
 
-    "github_api" = {
-      mode = "0444";
+    # Consumed by the imageapi container (ghcr.io/sdr-enthusiasts/
+    # sdre-image-api), bind-mounted read-only at
+    # /opt/api/sdre-e-updater.2024-02-05.private-key.pem (see the
+    # `imageapi` entry in `services.adsb.containers` below). That image's
+    # Config.User is "node" -- confirmed via `docker inspect` -- which
+    # resolves to uid/gid 1000 inside the container, and this host does
+    # not enable Docker userns-remap, so the container sees the file's
+    # host-side uid/gid directly. uid/gid are set explicitly (rather than
+    # `owner`/`group`) because fred/nik get their uids assigned dynamically
+    # by NixOS (no static `uid =` in modules/base/user.nix), so there is no
+    # stable *username* to pin `owner` to -- sops-nix's numeric uid/gid
+    # apply regardless of whether a matching user exists.
+    # mkContainerSecret wires `restartUnits` to docker-imageapi.service so
+    # a rotated key is not silently left stale in a running container --
+    # this host runs it as a genuine Docker container (see
+    # adsb-docker-units.nix), unlike nvrhub's frigate.nix.
+    #
+    # Residual worth knowing: NixOS allocates normal users from 1000 up, so
+    # host uid 1000 is in practice the first-created human user (fred). This
+    # is 0400 rather than the previous world-readable 0444, but it is not
+    # isolation from the admins -- the container's uid is what forces 1000,
+    # and the collision is inherent to running it without userns-remap.
+    # Fixing that properly means userns-remap or a dedicated uid, not a mode
+    # change.
+    "github_api" = mkContainerSecret "imageapi" // {
+      mode = "0400";
+      uid = 1000;
+      gid = 1000;
     };
   };
 

--- a/hosts/linux/fredvps/discord-backup.nix
+++ b/hosts/linux/fredvps/discord-backup.nix
@@ -31,6 +31,39 @@
         Type = "oneshot";
         User = "nik";
         Group = "users";
+
+        # Hardening, kept deliberately conservative. This is the fleet's
+        # only backup of the live Discord bot DB, it runs as a normal user
+        # (not root), and it touches paths outside the Nix store and
+        # outside /home (/mnt/discord, /mnt/discord-storage) -- a broken
+        # nightly backup is worse than an unhardened one, so anything not
+        # clearly safe is left out rather than guessed at.
+        #
+        # These six are pure kernel/system-namespace restrictions with no
+        # dependency on which paths the script touches, so they cannot
+        # interact with the sqlite3 .backup / mv / find calls above:
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+
+        # Deliberately NOT set: ProtectSystem / ProtectHome.
+        #
+        # ProtectSystem=strict would make the filesystem read-only outside
+        # an explicit ReadWritePaths allowlist, and this script needs write
+        # access to *two* directories, not one: /mnt/discord-storage/backups
+        # (the obvious one -- .part files, the atomic rename, the retention
+        # sweep) AND, per the header comment above, potentially
+        # /mnt/discord itself. The .backup API opens the live WAL-mode
+        # database close to how a normal connection would, and this file's
+        # own comment on the test-site config notes a WAL reader can need
+        # directory write access to create -wal/-shm siblings. Getting that
+        # second path wrong silently breaks the backup (or the live bot) in
+        # a way that would not surface until the next restore is needed, so
+        # it's left out rather than guessed at.
       };
 
       # WHY sqlite3 .backup AND NOT cp
@@ -92,6 +125,13 @@
         # Equivalent to cron's "0 1 * * *"
         OnCalendar = "*-*-* 01:00:00";
         Persistent = true;
+
+        # Was the fleet's only unjittered timer. 15 minutes smooths out the
+        # exact-second alignment with other fixed-time daily jobs on this
+        # host (e.g. docker's autoPrune) without meaningfully delaying the
+        # backup relative to the NAS's nightly pull, which has hours of
+        # slack after 01:00 to work with.
+        RandomizedDelaySec = "15m";
       };
     };
   };

--- a/hosts/linux/nvrhub/frigate.nix
+++ b/hosts/linux/nvrhub/frigate.nix
@@ -403,9 +403,24 @@ in
     };
   };
 
+  # restartUnits is set directly (rather than reusing mkContainerSecret from
+  # modules/services/mk-container-secret.nix) because that helper hardcodes
+  # `restartUnits = [ "docker-${containerName}.service" ]`, and nvrhub runs no
+  # Docker containers -- Frigate is the native `services.frigate` module,
+  # started as `systemd.services.frigate` (see LoadCredential= above). Pointing
+  # restartUnits at a nonexistent docker-frigate.service would restart nothing
+  # while looking fixed. Without restartUnits here at all, rotating the shared
+  # camera credential and redeploying would leave Frigate's LoadCredential=
+  # holding the stale password with no error and no restart -- the same
+  # silent-stale-credential failure mode documented for the attic token at
+  # modules/services/attic/attic_server.nix:36-40.
   sops.secrets = {
-    "cameras/username" = { };
-    "cameras/password" = { };
+    "cameras/username" = {
+      restartUnits = [ "frigate.service" ];
+    };
+    "cameras/password" = {
+      restartUnits = [ "frigate.service" ];
+    };
   };
 
   # Expose Frigate's Prometheus metrics to the monitoring master.

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -79,6 +79,27 @@ in
         "nix-command"
         "flakes"
       ];
+
+      # min-free/max-free are checked by the Nix daemon around normal store
+      # operations (substitutions, builds), not just the scheduled `gc`
+      # below -- when free space on the store's filesystem drops under
+      # min-free, the daemon runs garbage collection there and then,
+      # deleting until max-free is reached (or nothing is left to collect).
+      # This is what actually reclaims space mid-week; `gc.automatic` above
+      # only ever fires once a week and does nothing about a Tuesday that
+      # fills the disk.
+      #
+      # Values are bytes and deliberately conservative given how wide this
+      # fleet's disk sizes are -- a small VPS up to bare-metal servers with
+      # multi-TB volumes all read this same setting. 1 GiB min-free is a
+      # floor that still leaves real headroom before "disk full" on the
+      # smallest host, without being so large it starts collecting
+      # constantly there. 5 GiB max-free is a small, fast reclaim on a big
+      # server and a meaningful chunk of breathing room on a small one;
+      # either way collection stops well before it turns into an unbounded
+      # sweep of the whole store.
+      min-free = 1073741824; # 1 GiB
+      max-free = 5368709120; # 5 GiB
     };
 
     gc = {

--- a/modules/services/adsb-docker-units.nix
+++ b/modules/services/adsb-docker-units.nix
@@ -70,6 +70,33 @@ let
         Restart = restartPolicy;
         TimeoutStartSec = 0;
 
+        # This hardens the WRAPPER unit, not the container it runs. The
+        # unit's own process only ever shells out to
+        # `docker run|pull|rm|stop` against the Docker socket -- the
+        # container's isolation is Docker's own job and is untouched by
+        # these settings. Because the wrapper does so little, it needs
+        # almost no privilege of its own, which is the same reasoning
+        # modules/services/python-venv-app.nix applies to its sandboxed
+        # services.
+        #
+        # ProtectSystem=strict makes the filesystem read-only outside an
+        # explicit allowlist. Connecting to an already-existing UNIX socket
+        # does not itself require a writable mount, but ReadWritePaths is
+        # listed anyway to be explicit and safe against any client-side
+        # bind/reconnect behaviour. Path confirmed against this repo's own
+        # rendered config (docker.socket's ListenStream), not assumed --
+        # the daemon config here sets no `-H` override.
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/run/docker.sock" ];
+
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+
+        # Deliberately NOT set: PrivateNetwork (these units manage
+        # networked containers) and User/Group (the wrapper needs whatever
+        # ambient permissions grant access to the Docker socket, which is
+        # root-only by default).
+
         ExecStartPre = [
           "-${pkgs.docker}/bin/docker rm -f ${c.name}"
           "${pkgs.docker}/bin/docker pull ${c.image}"

--- a/scripts/check-colmena-parity.sh
+++ b/scripts/check-colmena-parity.sh
@@ -37,10 +37,16 @@
 #   scripts/check-colmena-parity.sh
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Located via BASH_SOURCE rather than `git rev-parse`, for two reasons: it
+# does not require git merely to find the repo root (the tool check below
+# cannot fire if discovery itself dies on a missing git first), and it works
+# from inside a sandboxed Nix build, where there is no .git at all. Matches
+# check-sops-recipients.sh, check-doc-drift.sh and check-opencode-jsonc.sh.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-for tool in nix jq git; do
+# git is deliberately NOT in this list: nothing below shells out to it.
+for tool in nix jq; do
     command -v "$tool" >/dev/null 2>&1 || {
         echo "error: required tool not on PATH: $tool" >&2
         exit 1

--- a/scripts/check-colmena-parity.sh
+++ b/scripts/check-colmena-parity.sh
@@ -27,15 +27,31 @@
 #
 # OUTPUT CONTRACT
 #
-# All diagnostics go to stderr. On success, the nixosConfigurations ->
-# toplevel-outPath JSON object (the same shape gen-fleet-manifest.sh needs for
-# its own manifest work) is printed to stdout, and the script exits 0. On any
-# failure -- including a genuine parity mismatch -- nothing is printed to
-# stdout and the script exits non-zero.
+# All diagnostics go to stderr. Exit 0 means parity holds; any non-zero exit
+# -- including a genuine mismatch -- means it does not.
+#
+# stdout is EMPTY by default. With --emit-paths, the nixosConfigurations ->
+# toplevel-outPath JSON object is printed to stdout on success (and nothing on
+# failure). That exists solely so gen-fleet-manifest.sh can reuse this eval
+# instead of paying for a second one; it is opt-in because the standalone CI
+# job has no consumer for it, and defaulting to on dumped ten store paths as a
+# single unreadable line into every CI log.
 #
 # Usage:
-#   scripts/check-colmena-parity.sh
+#   scripts/check-colmena-parity.sh                # check only, quiet stdout
+#   scripts/check-colmena-parity.sh --emit-paths   # also print the paths JSON
 set -euo pipefail
+
+EMIT_PATHS=0
+case "${1:-}" in
+    --emit-paths) EMIT_PATHS=1 ;;
+    '') ;;
+    *)
+        echo "error: unknown argument: $1" >&2
+        echo "usage: $(basename "$0") [--emit-paths]" >&2
+        exit 2
+        ;;
+esac
 
 # Located via BASH_SOURCE rather than `git rev-parse`, for two reasons: it
 # does not require git merely to find the repo root (the tool check below
@@ -163,4 +179,6 @@ fi
 
 echo "colmena and nixosConfigurations agree for $(jq -r 'length' <<<"$COLMENA_JSON") server(s)." >&2
 
-printf '%s\n' "$PATHS_JSON"
+if [[ $EMIT_PATHS -eq 1 ]]; then
+    printf '%s\n' "$PATHS_JSON"
+fi

--- a/scripts/check-colmena-parity.sh
+++ b/scripts/check-colmena-parity.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# check-colmena-parity.sh -- assert that colmena would deploy the same
+# closures that `nixosConfigurations` describes.
+#
+# WHY THIS EXISTS
+#
+# `flake/deployment/colmena.nix` and `nixosConfigurations` are two independent
+# evaluation paths through the same host modules, and they can silently
+# diverge. It has actually happened: nixpkgs' `lib.nixosSystem` passes a
+# flake-extended `lib` into eval-config, colmena calls eval-config directly
+# with the plain `pkgs.lib`, and `system.nixos.versionSuffix` consequently came
+# out as `pre-git` instead of `.<date>.<shortRev>` -- which made colmena
+# produce a DIFFERENT store path than nixosConfigurations for every host at the
+# same commit. See the comment in flake/deployment/colmena.nix for the full
+# incident.
+#
+# scripts/gen-fleet-manifest.sh already runs this exact check before
+# publishing the fleet manifest, but that only happens on push to main and a
+# 6-hour schedule -- a regression can merge with CI green and not surface for
+# hours. This script is the standalone, PR-time version of the same check: it
+# is a pure Nix eval (colmenaHive is colmena.lib.makeHive; .outPath needs no
+# realisation), so it is cheap enough to run in CI on every pull request.
+#
+# gen-fleet-manifest.sh calls this script rather than duplicating the
+# comparison, so there is exactly one copy of the parity logic in the repo.
+#
+# OUTPUT CONTRACT
+#
+# All diagnostics go to stderr. On success, the nixosConfigurations ->
+# toplevel-outPath JSON object (the same shape gen-fleet-manifest.sh needs for
+# its own manifest work) is printed to stdout, and the script exits 0. On any
+# failure -- including a genuine parity mismatch -- nothing is printed to
+# stdout and the script exits non-zero.
+#
+# Usage:
+#   scripts/check-colmena-parity.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+for tool in nix jq git; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "error: required tool not on PATH: $tool" >&2
+        exit 1
+    }
+done
+
+# Evaluate every host's toplevel output path in a single eval.
+#
+# stderr is captured to a file rather than merged into stdout: nix prints
+# "Using saved setting for 'extra-substituters = ...'" notices for this flake's
+# nixConfig whenever the invoking user is not a trusted user, and folding those
+# into the JSON would corrupt it. This is the same trap the impacted-hosts
+# script documents.
+EVAL_STDERR="$(mktemp)"
+COLMENA_STDERR="$(mktemp)"
+trap 'rm -f "$EVAL_STDERR" "$COLMENA_STDERR"' EXIT
+
+echo "Evaluating system.build.toplevel for every host..." >&2
+
+if ! PATHS_JSON="$(
+    nix eval --json .#nixosConfigurations \
+        --apply 'cfgs: builtins.mapAttrs (_: c: c.config.system.build.toplevel.outPath) cfgs' \
+        2>"$EVAL_STDERR"
+)"; then
+    printf 'error: failed to evaluate host toplevels:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
+    exit 1
+fi
+
+# Mirror the CI policy that an evaluation warning is a failure. A warning
+# would otherwise never surface here, and it is exactly the kind of thing that
+# can precede a genuine eval-path divergence.
+if grep -q 'evaluation warning:' "$EVAL_STDERR"; then
+    printf 'error: evaluation produced warnings:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
+    exit 1
+fi
+
+# An empty or non-object result means the flake changed shape; comparing
+# against it would silently report parity for zero hosts.
+if [[ "$(jq -r 'type' <<<"$PATHS_JSON")" != "object" ]] ||
+    [[ "$(jq -r 'length' <<<"$PATHS_JSON")" -eq 0 ]]; then
+    echo "error: host evaluation produced no hosts -- refusing to check parity" >&2
+    exit 1
+fi
+
+echo "Evaluated $(jq -r 'length' <<<"$PATHS_JSON") host(s)." >&2
+
+# Assert that what colmena would deploy matches nixosConfigurations.
+#
+# This is the regression guard for the incident described in the header
+# comment above: colmena's plain `pkgs.lib` versus the flake-extended `lib`
+# producing different `versionSuffix` values, which made the entire fleet
+# report as `unmanaged`. Nothing else in CI evaluates colmenaHive, so without
+# this check the two paths can silently diverge again -- a nixpkgs change to
+# that lib overlay, or a colmena bump, would be enough.
+echo "Verifying colmena and nixosConfigurations agree..." >&2
+
+if ! COLMENA_JSON="$(
+    nix eval --json '.#colmenaHive.nodes' \
+        --apply 'ns: builtins.mapAttrs (_: n: n.config.system.build.toplevel.outPath) ns' \
+        2>"$COLMENA_STDERR"
+)"; then
+    printf 'error: failed to evaluate colmenaHive nodes:\n%s\n' "$(cat "$COLMENA_STDERR")" >&2
+    echo "       Cannot confirm colmena describes deployable paths; treating as a mismatch." >&2
+    exit 1
+fi
+
+# Same warnings-are-fatal policy the nixosConfigurations eval above applies.
+# This is the only place it can ever be enforced for the colmena evaluator:
+# nothing in CI evaluates colmenaHive, so a warning introduced by a nixpkgs or
+# colmena bump would otherwise never surface anywhere.
+if grep -q 'evaluation warning:' "$COLMENA_STDERR"; then
+    printf 'error: colmena evaluation produced warnings:\n%s\n' "$(cat "$COLMENA_STDERR")" >&2
+    exit 1
+fi
+
+# An empty or non-object node set would make the comparison below vacuous and
+# report "agree for 0 servers" as if parity held. Mirrors the identical guard
+# applied to PATHS_JSON above.
+if [[ "$(jq -r 'type' <<<"$COLMENA_JSON")" != "object" ]] ||
+    [[ "$(jq -r 'length' <<<"$COLMENA_JSON")" -eq 0 ]]; then
+    echo "error: colmena evaluation produced no nodes -- refusing to check parity" >&2
+    exit 1
+fi
+
+# A colmena node with no nixosConfigurations entry counts as a mismatch rather
+# than being skipped. Such a node should be unreachable -- mkNode dereferences
+# `self.nixosConfigurations.<name>._colmena`, so a missing entry throws during
+# evaluation and is caught above -- but suppressing the case would hide exactly
+# the failure this guard exists to report: a host colmena deploys that
+# nixosConfigurations has no path for.
+MISMATCHED="$(
+    jq -rn \
+        --argjson a "$PATHS_JSON" \
+        --argjson b "$COLMENA_JSON" \
+        '$b | to_entries
+         | map(select($a[.key] != .value)
+               | "  \(.key)\n    nixosConfigurations: \($a[.key] // "<missing>")\n    colmena:             \(.value)")
+         | join("\n")'
+)"
+
+if [[ -n "$MISMATCHED" ]]; then
+    cat >&2 <<EOF
+error: colmena would deploy different closures than nixosConfigurations describes.
+
+$MISMATCHED
+
+Every affected host would report deploy state 'unmanaged' forever, because its
+running closure is a path the fleet manifest can never contain.
+
+Fix the divergence (see flake/deployment/colmena.nix) rather than this check.
+EOF
+    exit 1
+fi
+
+echo "colmena and nixosConfigurations agree for $(jq -r 'length' <<<"$COLMENA_JSON") server(s)." >&2
+
+printf '%s\n' "$PATHS_JSON"

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# check-doc-drift.sh -- catch two "in sync by luck" invariants that used to
+# have no machine enforcement at all:
+#
+#   1. MODULES.md documents exactly the modules exported by
+#      `nixosModules` -- no more, no less.
+#   2. The desktop/server host split is consistent: `desktop_names` in
+#      ci-linux.yaml is a subset of `nixosConfigurations`, and every
+#      remaining ("server") host has a matching entry in
+#      flake/hosts/servers.nix.
+#
+# WHY THIS EXISTS
+#
+# MODULES.md was last hand-edited 2026-02-11; modules/ has had commits
+# since. Nothing re-derives the doc from the module set, so a module
+# add/rename/removal silently goes undocumented (or the doc silently goes
+# stale) until a human happens to notice. Same story for the host split:
+# `desktop_names=("Daytona" "maranello")` in ci-linux.yaml and the node
+# table in flake/hosts/servers.nix are two independent hand-maintained
+# lists that must describe the same fleet.
+#
+# PARSING STRATEGY
+#
+# MODULES.md's module list is derived from its own heading/bullet
+# structure rather than duplicated into a second hand-maintained list in
+# this script -- a second list would itself be a drift surface. Two
+# doc conventions carry a module name:
+#
+#   - a `#### `nixosModules.NAME`` heading (the fully-documented modules)
+#   - a `- **`nixosModules.NAME`**` bullet (the "individual hardware
+#     modules" quick-reference list)
+#
+# The desktop-host extraction mirrors, byte-for-byte, the grep/tr
+# pipeline `impacted-hosts.sh` already uses to read `desktop_names` out
+# of ci-linux.yaml, so there is exactly one parser for that array, not
+# two that can disagree.
+#
+# NIX-EVAL INJECTION
+#
+# Three of the sets this script compares (`nixosModules` attribute names,
+# `nixosConfigurations` attribute names, and flake/hosts/servers.nix's
+# attribute names) are, at heart, already-evaluated Nix values -- `self`
+# already has them in flake/dev/checks.nix. Shelling out to `nix eval`
+# for them here is the right thing to do when this script runs directly
+# (as a human, or as the pre-commit hook, both of which run outside the
+# Nix build sandbox with full daemon access) but would NOT work from
+# inside the standalone `checks.doc-drift` derivation: sandboxed builds
+# have no daemon-socket access, so a `nix eval` call from within one just
+# hangs or errors. So each of the three accepts an optional
+# pre-computed-JSON override via environment variable; the standalone
+# check sets all three from pure Nix (no IFD, no network) and this script
+# skips the `nix eval` call entirely when they're set.
+set -euo pipefail
+
+# Located by BASH_SOURCE, not `git rev-parse`, so this also works from
+# inside the standalone flake check's sandboxed build (no .git there).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODULES_MD="MODULES.md"
+CI_LINUX=".github/workflows/ci-linux.yaml"
+SERVERS_NIX="flake/hosts/servers.nix"
+
+for f in "$MODULES_MD" "$CI_LINUX" "$SERVERS_NIX"; do
+  if [[ ! -f $f ]]; then
+    echo "error: $f not found (run from the repository root)" >&2
+    exit 1
+  fi
+done
+
+errors=()
+
+# ---------------------------------------------------------------------------
+# 1. nixosModules vs MODULES.md
+# ---------------------------------------------------------------------------
+
+actual_modules_json="${ACTUAL_MODULES_JSON:-$(nix eval --json .#nixosModules --apply builtins.attrNames)}"
+mapfile -t actual_modules < <(jq -r '.[]' <<<"$actual_modules_json" | sort -u)
+
+mapfile -t documented_modules < <(
+  {
+    # shellcheck disable=SC2016 # single-quoted regex, not shell interpolation
+    grep -oP '^#{2,6}\s+`nixosModules\.\K[a-zA-Z0-9_-]+(?=`\s*$)' "$MODULES_MD" || true
+    # shellcheck disable=SC2016 # single-quoted regex, not shell interpolation
+    grep -oP '^-\s+\*\*`nixosModules\.\K[a-zA-Z0-9_-]+(?=`\*\*)' "$MODULES_MD" || true
+  } | sort -u
+)
+
+mapfile -t undocumented < <(comm -23 \
+  <(printf '%s\n' "${actual_modules[@]}") \
+  <(printf '%s\n' "${documented_modules[@]}"))
+
+mapfile -t stale_docs < <(comm -13 \
+  <(printf '%s\n' "${actual_modules[@]}") \
+  <(printf '%s\n' "${documented_modules[@]}"))
+
+for m in "${undocumented[@]}"; do
+  [[ -n $m ]] && errors+=(
+    "nixosModules.${m} exists but is not documented in ${MODULES_MD} (add a heading or bullet for it)"
+  )
+done
+
+for m in "${stale_docs[@]}"; do
+  [[ -n $m ]] && errors+=(
+    "${MODULES_MD} documents nixosModules.${m}, which no longer exists (remove it, or check for a rename)"
+  )
+done
+
+# ---------------------------------------------------------------------------
+# 2. desktop/server host split
+# ---------------------------------------------------------------------------
+
+all_systems_json="${ALL_SYSTEMS_JSON:-$(nix eval --json .#nixosConfigurations --apply builtins.attrNames)}"
+mapfile -t all_systems < <(jq -r '.[]' <<<"$all_systems_json" | sort -u)
+
+# Mirrors impacted-hosts.sh's own extraction of `desktop_names` verbatim, so
+# there is exactly one parser for this array.
+mapfile -t desktop_names < <(
+  grep -oE 'desktop_names=\("[^)]*"\)' "$CI_LINUX" \
+    | tr ' ' '\n' \
+    | grep -oE '"[A-Za-z0-9_-]+"' \
+    | tr -d '"' || true
+)
+
+if [[ ${#desktop_names[@]} -eq 0 ]]; then
+  errors+=("could not parse a \`desktop_names=(...)\` array out of ${CI_LINUX}")
+fi
+
+mapfile -t desktop_not_a_system < <(comm -23 \
+  <(printf '%s\n' "${desktop_names[@]}" | sort -u) \
+  <(printf '%s\n' "${all_systems[@]}"))
+
+for d in "${desktop_not_a_system[@]}"; do
+  [[ -n $d ]] && errors+=(
+    "${CI_LINUX}: desktop_names lists '${d}', which is not a nixosConfigurations host (typo, or a renamed/removed desktop)"
+  )
+done
+
+mapfile -t computed_servers < <(comm -23 \
+  <(printf '%s\n' "${all_systems[@]}") \
+  <(printf '%s\n' "${desktop_names[@]}" | sort -u))
+
+servers_nix_json="${SERVERS_NIX_KEYS_JSON:-$(nix eval --json --file "$SERVERS_NIX" --apply builtins.attrNames)}"
+mapfile -t servers_nix_keys < <(jq -r '.[]' <<<"$servers_nix_json" | sort -u)
+
+mapfile -t missing_from_servers_nix < <(comm -23 \
+  <(printf '%s\n' "${computed_servers[@]}") \
+  <(printf '%s\n' "${servers_nix_keys[@]}"))
+
+mapfile -t stale_in_servers_nix < <(comm -13 \
+  <(printf '%s\n' "${computed_servers[@]}") \
+  <(printf '%s\n' "${servers_nix_keys[@]}"))
+
+for s in "${missing_from_servers_nix[@]}"; do
+  [[ -n $s ]] && errors+=(
+    "'${s}' is a nixosConfigurations host, not in desktop_names, but has no entry in ${SERVERS_NIX} (add one)"
+  )
+done
+
+for s in "${stale_in_servers_nix[@]}"; do
+  [[ -n $s ]] && errors+=(
+    "${SERVERS_NIX} has an entry for '${s}', which is not a server host -- either it is not in nixosConfigurations at all, or it is listed in desktop_names in ${CI_LINUX} (remove the stale entry, or fix desktop_names)"
+  )
+done
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo "doc drift FAILED:" >&2
+  echo "" >&2
+  for e in "${errors[@]}"; do
+    echo "  - ${e}" >&2
+  done
+  exit 1
+fi
+
+echo "doc drift OK (${#actual_modules[@]} modules documented, ${#all_systems[@]} hosts split ${#desktop_names[@]} desktop / ${#computed_servers[@]} server, all in sync)"

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -62,6 +62,25 @@ MODULES_MD="MODULES.md"
 CI_LINUX=".github/workflows/ci-linux.yaml"
 SERVERS_NIX="flake/hosts/servers.nix"
 
+# Actionable message on a missing tool, matching gen-fleet-manifest.sh and
+# check-colmena-parity.sh. `nix` is only needed on the bare-invocation path;
+# the hook and flake check bake the expected values in at Nix eval time
+# (see ACTUAL_MODULES_JSON below) precisely because git-hooks.nix runs the
+# whole suite in a sandbox with nix-command disabled.
+for tool in jq grep; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: required tool not on PATH: $tool" >&2
+    echo "hint: run inside 'nix develop', or via 'nix build .#checks.\${system}.doc-drift'" >&2
+    exit 1
+  }
+done
+
+if [[ -z ${ACTUAL_MODULES_JSON:-} ]] && ! command -v nix >/dev/null 2>&1; then
+  echo "error: nix is not on PATH and ACTUAL_MODULES_JSON was not supplied" >&2
+  echo "hint: run inside 'nix develop', or via 'nix build .#checks.\${system}.doc-drift'" >&2
+  exit 1
+fi
+
 for f in "$MODULES_MD" "$CI_LINUX" "$SERVERS_NIX"; do
   if [[ ! -f $f ]]; then
     echo "error: $f not found (run from the repository root)" >&2

--- a/scripts/check-opencode-jsonc.sh
+++ b/scripts/check-opencode-jsonc.sh
@@ -163,15 +163,61 @@ done
 
 # --- structural check: every `command.*` entry requires `template` -------
 
-mapfile -t commands_missing_template < <(
-  jq -r '(.command // {}) | to_entries[] | select(.value.template == null) | .key' "$canonical_json"
-)
+# This must FAIL CLOSED, and getting that right takes more than the obvious
+# one-liner. Two traps:
+#
+#   1. `mapfile < <(jq ...)` does NOT propagate the process substitution's
+#      exit status, and `set -e` does not catch it either -- mapfile returns
+#      0 regardless. So a jq error yields an EMPTY array, which reads as
+#      "no commands are missing a template" and PASSES.
+#   2. If `command` or any entry under it is a scalar rather than an object,
+#      `.value.template` makes jq error ("Cannot index string with string")
+#      and exit 5 -- hitting trap 1 above.
+#
+# Combined, a config like {"command": {"foo": "bar"}} would have been
+# reported as valid by a check whose whole purpose is to reject it. So:
+# validate the shapes first, and capture jq's status explicitly rather than
+# through a pipeline that discards it.
 
-for c in "${commands_missing_template[@]}"; do
-  [[ -n $c ]] && errors+=(
-    "${CONFIG_FILE}: command '${c}' has no 'template' field, which opencode's schema requires for every command entry."
-  )
-done
+command_type="$(jq -r 'if has("command") then (.command | type) else "absent" end' "$canonical_json")"
+command_count=0
+
+case "$command_type" in
+  absent | 'null') ;; # no `command` block at all is fine
+  object)
+    command_count="$(jq -r '.command | length' "$canonical_json")"
+
+    # Reject non-object entries explicitly, before anything indexes into them.
+    mapfile -t non_object_commands < <(
+      jq -r '.command | to_entries[] | select((.value | type) != "object") | "\(.key) (\(.value | type))"' \
+        "$canonical_json"
+    )
+    for c in "${non_object_commands[@]}"; do
+      [[ -n $c ]] && errors+=(
+        "${CONFIG_FILE}: command '${c%% *}' is a ${c#* }, not an object -- opencode's schema requires each command entry to be an object with a 'template' field."
+      )
+    done
+
+    # Only now is it safe to read .template. Capture jq's status via a temp
+    # file rather than process substitution, so a failure is actually seen.
+    if ! jq -r '.command | to_entries[] | select((.value | type) == "object") | select(.value.template == null) | .key' \
+      "$canonical_json" >"${workdir}/missing-template.txt" 2>"${workdir}/missing-template.err"; then
+      echo "error: failed to inspect 'command' entries in $CONFIG_FILE" >&2
+      cat "${workdir}/missing-template.err" >&2
+      exit 1
+    fi
+    while IFS= read -r c; do
+      [[ -n $c ]] && errors+=(
+        "${CONFIG_FILE}: command '${c}' has no 'template' field, which opencode's schema requires for every command entry."
+      )
+    done <"${workdir}/missing-template.txt"
+    ;;
+  *)
+    errors+=(
+      "${CONFIG_FILE}: top-level 'command' is a ${command_type}, not an object -- opencode's schema expects a map of command name to command object."
+    )
+    ;;
+esac
 
 if [[ ${#errors[@]} -gt 0 ]]; then
   echo "opencode.jsonc structural check FAILED:" >&2
@@ -182,7 +228,7 @@ if [[ ${#errors[@]} -gt 0 ]]; then
   exit 1
 fi
 
-echo "opencode.jsonc structural check OK (${#actual_keys[@]} top-level keys, ${#commands_missing_template[@]} commands missing template)"
+echo "opencode.jsonc structural check OK (${#actual_keys[@]} top-level keys, ${command_count} command entr$([[ $command_count -eq 1 ]] && echo y || echo ies) validated)"
 
 if [[ $OFFLINE -eq 1 ]]; then
   exit 0

--- a/scripts/check-opencode-jsonc.sh
+++ b/scripts/check-opencode-jsonc.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# check-opencode-jsonc.sh -- validate opencode.jsonc against opencode's own
+# config JSON Schema, plus a hermetic structural check that stands in for
+# the schema when no network is available.
+#
+# WHY THIS EXISTS
+#
+# opencode.jsonc:1 declares `"$schema": "https://opencode.ai/config.json"`,
+# but nothing validated against it. opencode's `Config` schema sets
+# `additionalProperties: false`, so ANY unknown top-level key -- a typo, a
+# key from a newer opencode version this repo hasn't updated docs for, a
+# copy-paste mistake -- produces a hard `ConfigInvalidError` and NO config
+# loads at all: not "that one key is ignored", the whole file fails
+# closed and silently. That exact failure mode happened and is what opened
+# this audit. The pre-existing pre-commit stack runs `check-jsonschema`
+# twice already (`--builtin-schema github-actions` / `github-workflows`),
+# but its generic `check-json` hook only matches `\.json$`, so a `.jsonc`
+# file was never in scope for any of it.
+#
+# TWO VALIDATION MODES, ONE SCRIPT
+#
+# 1. Full schema validation (default; network required). Fetches opencode's
+#    live schema from https://opencode.ai/config.json and validates the
+#    (comment-stripped) config against it with check-jsonschema. This is
+#    the real, complete, always-current check. It is NOT wired into either
+#    the pre-commit hook or the standalone `checks.opencode-jsonc-schema`
+#    flake check, and this is a harder constraint than "sandboxed Nix
+#    builds have no network": this repo's repo-local hooks are wired
+#    through git-hooks.nix, and git-hooks' own `run` derivation -- what
+#    `nix build .#checks.pre-commit-check` and CI's lint job both exercise
+#    -- runs the ENTIRE hook suite (real `pre-commit run --all-files`)
+#    inside ONE sandboxed Nix build with no network and the nix-command
+#    feature disabled. That is true regardless of whether a human
+#    triggers it via `git commit` (which happens to reuse the exact same
+#    generated `.pre-commit-config.yaml`) or CI triggers it via `nix flake
+#    check`. So a hook needing network here does not fail gracefully in
+#    just the sandboxed path and succeed for real commits -- it hard-fails
+#    the whole hook suite for everyone, every time. Verified empirically:
+#    wiring this mode into the hook broke `nix build
+#    .#checks.pre-commit-check` with a DNS-resolution error.
+#    This mode is for manual/ad-hoc use: run it yourself when you touch
+#    opencode.jsonc and want the real, complete answer.
+#
+# 2. Structural check (`--offline`; hermetic, no network; the mode wired
+#    into both the hook and the standalone flake check). Re-derives, by
+#    hand, the two specific invariants that bit before, straight from a
+#    dated snapshot of opencode's schema, rather than vendoring the whole
+#    schema document (a multi-hundred-line file that would silently go
+#    stale exactly like MODULES.md did -- vendoring a schema to catch drift
+#    is itself a drift surface):
+#      - the top-level key set is `additionalProperties: false`, so every
+#        key in opencode.jsonc must be in the known-good list below
+#      - every entry under `command` requires a `template` field
+#    This is deliberately a small, human-reviewed allowlist rather than a
+#    full schema copy: it changes only when a human intentionally adds a
+#    new top-level key to opencode.jsonc, at which point extending a
+#    ~30-entry array in the same commit is a reasonable ask -- unlike
+#    keeping a nested multi-hundred-line JSON Schema document in sync with
+#    upstream on every opencode release.
+#
+# Usage:
+#   scripts/check-opencode-jsonc.sh            # full schema check (network, manual only)
+#   scripts/check-opencode-jsonc.sh --offline  # structural check (hook + flake check)
+set -euo pipefail
+
+# Located by BASH_SOURCE, not `git rev-parse`, so this also works from
+# inside the standalone flake check's sandboxed build (no .git there).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CONFIG_FILE="opencode.jsonc"
+SCHEMA_URL="https://opencode.ai/config.json"
+
+OFFLINE=0
+for arg in "$@"; do
+  case "$arg" in
+    --offline) OFFLINE=1 ;;
+    *)
+      echo "error: unknown argument '$arg'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f $CONFIG_FILE ]]; then
+  echo "error: $CONFIG_FILE not found (run from the repository root)" >&2
+  exit 1
+fi
+
+# Snapshot of opencode's `$defs.Config.properties` keys from
+# https://opencode.ai/config.json, taken 2026-08-17 against the opencode
+# version pinned in overlays/opencode.nix (1.18.18). Re-sync this list (and
+# bump the date) whenever overlays/opencode.nix's `version` is bumped AND
+# a legitimate new top-level key is intentionally added to opencode.jsonc.
+# shellcheck disable=SC2016 # '$schema' is a literal array element, not shell interpolation
+KNOWN_TOP_LEVEL_KEYS=(
+  '$schema' agent attachment autoshare autoupdate command compaction
+  default_agent disabled_providers enabled_providers enterprise experimental
+  formatter instructions layout logLevel lsp mcp mode model permission plugin
+  provider reference references server share shell skills small_model
+  snapshot subagent_depth tool_output tools username watcher
+)
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+canonical_json="${workdir}/opencode.json"
+
+# opencode.jsonc is JSONC (line comments, trailing commas), which no
+# strict JSON parser (jq, python's json, check-jsonschema's own loader)
+# accepts. json5 is a superset of JSONC and round-trips it to canonical
+# JSON losslessly for schema-checking purposes.
+if ! python3 -c '
+import json, sys
+import json5
+
+with open(sys.argv[1]) as f:
+    data = json5.load(f)
+
+with open(sys.argv[2], "w") as f:
+    json.dump(data, f)
+' "$CONFIG_FILE" "$canonical_json" 2>"${workdir}/parse-error.log"; then
+  echo "error: $CONFIG_FILE is not valid JSONC (failed to parse)" >&2
+  echo "" >&2
+  cat "${workdir}/parse-error.log" >&2
+  exit 1
+fi
+
+errors=()
+
+# --- structural check: additionalProperties: false emulation --------------
+
+mapfile -t actual_keys < <(jq -r 'keys[]' "$canonical_json" | sort -u)
+mapfile -t unknown_keys < <(comm -23 \
+  <(printf '%s\n' "${actual_keys[@]}") \
+  <(printf '%s\n' "${KNOWN_TOP_LEVEL_KEYS[@]}" | sort -u))
+
+for k in "${unknown_keys[@]}"; do
+  [[ -n $k ]] && errors+=(
+    "${CONFIG_FILE}: unknown top-level key '${k}' -- opencode's Config schema sets additionalProperties: false, so this key alone makes the ENTIRE config fail to load (ConfigInvalidError). Remove it, fix the typo, or add it to KNOWN_TOP_LEVEL_KEYS in $(basename "$0") if it is a legitimately new opencode option."
+  )
+done
+
+# --- structural check: every `command.*` entry requires `template` -------
+
+mapfile -t commands_missing_template < <(
+  jq -r '(.command // {}) | to_entries[] | select(.value.template == null) | .key' "$canonical_json"
+)
+
+for c in "${commands_missing_template[@]}"; do
+  [[ -n $c ]] && errors+=(
+    "${CONFIG_FILE}: command '${c}' has no 'template' field, which opencode's schema requires for every command entry."
+  )
+done
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo "opencode.jsonc structural check FAILED:" >&2
+  echo "" >&2
+  for e in "${errors[@]}"; do
+    echo "  - ${e}" >&2
+  done
+  exit 1
+fi
+
+echo "opencode.jsonc structural check OK (${#actual_keys[@]} top-level keys, ${#commands_missing_template[@]} commands missing template)"
+
+if [[ $OFFLINE -eq 1 ]]; then
+  exit 0
+fi
+
+# --- full schema validation (network) -------------------------------------
+
+echo "==> validating against live schema: ${SCHEMA_URL}"
+check-jsonschema --schemafile "$SCHEMA_URL" "$canonical_json"

--- a/scripts/check-opencode-jsonc.sh
+++ b/scripts/check-opencode-jsonc.sh
@@ -102,6 +102,25 @@ KNOWN_TOP_LEVEL_KEYS=(
   snapshot subagent_depth tool_output tools username watcher
 )
 
+# Fail on a missing dependency with an actionable message. This is separate
+# from the parse check below and MUST stay separate: conflating "the parser
+# is unavailable" with "the file is invalid" reports a config bug that does
+# not exist, which is the exact false-signal class this check was added to
+# prevent. The flake check and pre-commit hook supply these via
+# runtimeInputs; a human running this bare needs `nix develop`.
+command -v python3 >/dev/null 2>&1 || {
+  echo "error: required tool not on PATH: python3" >&2
+  echo "hint: run inside 'nix develop', or via 'nix build .#checks.\${system}.opencode-jsonc-schema'" >&2
+  exit 1
+}
+
+if ! python3 -c 'import json5' 2>/dev/null; then
+  echo "error: the python 'json5' module is not available" >&2
+  echo "note: this is a MISSING DEPENDENCY, not a problem with $CONFIG_FILE" >&2
+  echo "hint: run inside 'nix develop', or via 'nix build .#checks.\${system}.opencode-jsonc-schema'" >&2
+  exit 1
+fi
+
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 

--- a/scripts/check-sops-recipients.sh
+++ b/scripts/check-sops-recipients.sh
@@ -47,6 +47,19 @@ SOPS_YAML="modules/secrets/.sops.yaml"
 SECRETS_YAML="modules/secrets/secrets.yaml"
 RULE_PATH_REGEX="secrets.yaml\$"
 
+# Fail on a missing tool with an actionable message rather than letting the
+# first pipeline die on `yq: command not found`. Matches the preamble in
+# gen-fleet-manifest.sh and check-colmena-parity.sh. The flake check and the
+# pre-commit hook both supply these via runtimeInputs; a human running this
+# bare needs `nix develop`.
+for tool in yq jq; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: required tool not on PATH: $tool" >&2
+    echo "hint: run inside 'nix develop', or via 'nix build .#checks.\${system}.sops-recipients'" >&2
+    exit 1
+  }
+done
+
 for f in "$SOPS_YAML" "$SECRETS_YAML"; do
   if [[ ! -f $f ]]; then
     echo "error: $f not found (run from the repository root)" >&2

--- a/scripts/check-sops-recipients.sh
+++ b/scripts/check-sops-recipients.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# check-sops-recipients.sh -- verify sops age-recipient consistency for
+# modules/secrets/secrets.yaml across all three places that must agree.
+#
+# WHY THIS EXISTS
+#
+# modules/secrets/.sops.yaml declares 12 age recipients under `keys:` and
+# wires all of them into a single `creation_rules` entry for secrets.yaml,
+# so every one of the 12 machines can decrypt it. Adding a recipient (new
+# host, key rotation) requires a manual follow-up step -- `sops updatekeys
+# secrets.yaml` -- documented only as a comment in modules/secrets/sops.nix.
+# Nothing enforced it. Miss it and the new/rotated host fails to decrypt at
+# deploy time, on real hardware, instead of at review time.
+#
+# KEY INSIGHT
+#
+# sops embeds the recipient list it actually encrypted for in the ciphertext
+# file's own (unencrypted) metadata -- `sops.age[].recipient` in
+# secrets.yaml. No decryption key is needed to read it. That means this
+# check can run anywhere, including CI runners with no access to any of the
+# 12 private keys.
+#
+# THREE SETS THAT MUST BE EQUAL
+#
+#   1. anchors    -- the age keys declared under `keys:` in .sops.yaml
+#   2. rule       -- the age keys actually referenced by .sops.yaml's
+#                    creation_rules entry for `secrets.yaml$`
+#   3. embedded   -- the recipients sops actually encrypted secrets.yaml
+#                    for, per the file's own metadata
+#
+# (1 vs 2) catches .sops.yaml itself drifting internally: an anchor added
+# or removed from `keys:` without updating the creation_rules key_groups
+# that reference it.
+#
+# (2 vs 3) catches the missed-runbook-step case: creation_rules was
+# updated correctly, but `sops updatekeys` was never run, so the file on
+# disk still only decrypts for the old recipient set.
+set -euo pipefail
+
+# Located by BASH_SOURCE, not `git rev-parse`, so this also works from
+# inside the standalone flake check's sandboxed build (no .git there).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SOPS_YAML="modules/secrets/.sops.yaml"
+SECRETS_YAML="modules/secrets/secrets.yaml"
+RULE_PATH_REGEX="secrets.yaml\$"
+
+for f in "$SOPS_YAML" "$SECRETS_YAML"; do
+  if [[ ! -f $f ]]; then
+    echo "error: $f not found (run from the repository root)" >&2
+    exit 1
+  fi
+done
+
+# name -> age key, as declared under `keys:`. Falls back to the raw key as
+# its own "name" if an entry has no YAML anchor (shouldn't happen here, but
+# keeps error messages readable instead of crashing).
+anchors_json="$(
+  yq -o=json '[.keys[] | {"name": (anchor // .), "key": .}]' "$SOPS_YAML"
+)"
+
+# age keys wired into the secrets.yaml$ creation rule, across every
+# key_group (sops OR-groups for Shamir secret sharing; only one group
+# exists today, but a stray second group must be covered too).
+rule_keys_json="$(
+  yq -o=json '
+    [
+      .creation_rules[]
+      | select(.path_regex == "'"$RULE_PATH_REGEX"'")
+      | .key_groups[]?.age[]?
+    ] | unique
+  ' "$SOPS_YAML"
+)"
+
+if [[ "$(jq 'length' <<<"$rule_keys_json")" -eq 0 ]]; then
+  echo "error: no creation_rules entry for path_regex ${RULE_PATH_REGEX} in ${SOPS_YAML}" >&2
+  exit 1
+fi
+
+# recipients sops actually encrypted secrets.yaml for, read straight out of
+# the file's own (unencrypted) sops metadata. No decryption key needed.
+embedded_json="$(
+  yq -o=json '[.sops.age[]?.recipient] | unique' "$SECRETS_YAML"
+)"
+
+if [[ "$(jq 'length' <<<"$embedded_json")" -eq 0 ]]; then
+  echo "error: no sops.age[].recipient entries found in ${SECRETS_YAML}" >&2
+  exit 1
+fi
+
+messages_json="$(
+  jq -n \
+    --argjson anchors "$anchors_json" \
+    --argjson rule_keys "$rule_keys_json" \
+    --argjson embedded "$embedded_json" \
+    --arg sops_yaml "$SOPS_YAML" \
+    --arg secrets_yaml "$SECRETS_YAML" \
+    '
+    def name_for($key):
+      (($anchors[] | select(.key == $key) | .name) // $key);
+
+    ($anchors | map(.key)) as $anchor_keys
+    | ($anchor_keys - $rule_keys) as $missing_from_rule
+    | ($rule_keys - $anchor_keys) as $extra_in_rule
+    | ($rule_keys - $embedded) as $missing_from_secrets
+    | ($embedded - $rule_keys) as $extra_in_secrets
+    | (
+        ($missing_from_rule | map(
+          "\($sops_yaml): \(name_for(.)) has an age key under `keys:` but is not wired into the \($secrets_yaml | ltrimstr("modules/secrets/"))$ creation_rules key_groups -- add it to the age list."
+        ))
+        + ($extra_in_rule | map(
+          "\($sops_yaml): creation_rules for \($secrets_yaml | ltrimstr("modules/secrets/"))$ references \(name_for(.)), which has no matching anchor under `keys:` -- stale entry, remove it or restore the anchor."
+        ))
+        + ($missing_from_secrets | map(
+          "\($secrets_yaml) has not been re-encrypted for \(name_for(.)) yet -- creation_rules lists it but the file'"'"'s sops metadata does not. Run: sops updatekeys \($secrets_yaml)"
+        ))
+        + ($extra_in_secrets | map(
+          "\($secrets_yaml) is still encrypted for \(name_for(.)), which is no longer in creation_rules for \($secrets_yaml | ltrimstr("modules/secrets/"))$ -- remove the recipient and run sops updatekeys, or restore the creation_rules entry if this was accidental."
+        ))
+      )
+    '
+)"
+
+if [[ "$(jq 'length' <<<"$messages_json")" -gt 0 ]]; then
+  echo "sops recipient consistency FAILED:" >&2
+  echo "" >&2
+  jq -r '.[] | "  - " + .' <<<"$messages_json" >&2
+  echo "" >&2
+  echo "See the runbook comment in modules/secrets/sops.nix." >&2
+  exit 1
+fi
+
+count="$(jq 'length' <<<"$rule_keys_json")"
+echo "sops recipient consistency OK (${count} recipients, keys/creation_rules/secrets.yaml agree)"

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -88,127 +88,36 @@ done
 
 NOW="$(date +%s)"
 
-# Evaluate every host's toplevel output path in a single eval.
+# Evaluate every host's toplevel output path, and verify colmena would
+# deploy the same closures nixosConfigurations describes.
 #
-# stderr is captured to a file rather than merged into stdout: nix prints
-# "Using saved setting for 'extra-substituters = ...'" notices for this flake's
-# nixConfig whenever the invoking user is not a trusted user, and folding those
-# into the JSON would corrupt it. This is the same trap the impacted-hosts
-# script documents.
-EVAL_STDERR="$(mktemp)"
-trap 'rm -f "$EVAL_STDERR"' EXIT
+# This is a regression guard for a bug that made the entire server fleet
+# report `unmanaged`: nixpkgs' `lib.nixosSystem` passes a flake-extended
+# `lib` into eval-config, colmena calls eval-config directly with the
+# plain `pkgs.lib`, and `system.nixos.versionSuffix` consequently came out
+# as `pre-git` instead of `.<date>.<shortRev>` -- so colmena and
+# nixosConfigurations evaluated to DIFFERENT store paths for the same host
+# at the same commit, and the manifest described paths that no server
+# would ever be running. See the comment in flake/deployment/colmena.nix.
+#
+# The eval and the comparison both live in check-colmena-parity.sh so
+# there is exactly one copy of this logic in the repo; that script is also
+# run standalone in CI on every pull request (see ci-linux.yaml's
+# colmena-parity job) so a divergence is caught long before it would
+# otherwise surface here, hours later, as a stale-manifest alert.
+#
+# The script prints the nixosConfigurations toplevel-outPath JSON (what
+# this generator needs as PATHS_JSON) on stdout and exits non-zero on any
+# failure, including a genuine parity mismatch -- so under `set -e` a
+# mismatch aborts this script too, before anything is published.
+echo "Evaluating system.build.toplevel for every host and verifying colmena parity (rev ${REV})..." >&2
 
-echo "Evaluating system.build.toplevel for every host (rev ${REV})..." >&2
-
-if ! PATHS_JSON="$(
-    nix eval --json .#nixosConfigurations \
-        --apply 'cfgs: builtins.mapAttrs (_: c: c.config.system.build.toplevel.outPath) cfgs' \
-        2>"$EVAL_STDERR"
-)"; then
-    printf 'error: failed to evaluate host toplevels:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
-    exit 1
-fi
-
-# Mirror the CI policy that an evaluation warning is a failure. A warning does
-# not by itself change an output path, but publishing a manifest from a tree
-# that CI would have rejected would advertise paths for a commit that is not
-# actually deployable.
-if grep -q 'evaluation warning:' "$EVAL_STDERR"; then
-    printf 'error: evaluation produced warnings:\n%s\n' "$(cat "$EVAL_STDERR")" >&2
-    exit 1
-fi
-
-# An empty or non-object result means the flake changed shape; publishing it
-# would silently blank the manifest and disable drift detection fleet-wide.
-if [[ "$(jq -r 'type' <<<"$PATHS_JSON")" != "object" ]] ||
-    [[ "$(jq -r 'length' <<<"$PATHS_JSON")" -eq 0 ]]; then
-    echo "error: host evaluation produced no hosts -- refusing to publish" >&2
+if ! PATHS_JSON="$("$REPO_ROOT/scripts/check-colmena-parity.sh")"; then
+    echo "error: colmena/nixosConfigurations parity check failed (see above) -- refusing to publish" >&2
     exit 1
 fi
 
 echo "Evaluated $(jq -r 'length' <<<"$PATHS_JSON") host(s)." >&2
-
-# Assert that what colmena would deploy matches what this manifest publishes.
-#
-# This is a regression guard for a bug that made the entire server fleet report
-# `unmanaged`. The manifest is generated from `nixosConfigurations`, but servers
-# are deployed by colmena, and the two used to evaluate to DIFFERENT store paths
-# for the same host at the same commit: nixpkgs' `lib.nixosSystem` passes a
-# flake-extended `lib` into eval-config, colmena calls eval-config directly with
-# the plain `pkgs.lib`, and `system.nixos.versionSuffix` consequently came out as
-# `pre-git` instead of `.<date>.<shortRev>`. The manifest therefore described
-# paths that no server would ever be running. See the comment in
-# flake/deployment/colmena.nix.
-#
-# Nothing else in CI evaluates colmenaHive, so without this check the two paths
-# can silently diverge again -- a nixpkgs change to that lib overlay, or a
-# colmena bump, would be enough. Publishing a manifest that describes
-# undeployable paths is worse than not publishing: it marks every server
-# unmanaged. So divergence is fatal here rather than a warning.
-echo "Verifying colmena and nixosConfigurations agree..." >&2
-
-COLMENA_STDERR="$(mktemp)"
-trap 'rm -f "$EVAL_STDERR" "$COLMENA_STDERR"' EXIT
-
-if ! COLMENA_JSON="$(
-    nix eval --json '.#colmenaHive.nodes' \
-        --apply 'ns: builtins.mapAttrs (_: n: n.config.system.build.toplevel.outPath) ns' \
-        2>"$COLMENA_STDERR"
-)"; then
-    printf 'error: failed to evaluate colmenaHive nodes:\n%s\n' "$(cat "$COLMENA_STDERR")" >&2
-    echo "       Cannot confirm the manifest describes deployable paths; refusing to publish." >&2
-    exit 1
-fi
-
-# Same warnings-are-fatal policy the nixosConfigurations eval above applies.
-# This is the only place it can ever be enforced for the colmena evaluator:
-# nothing in CI evaluates colmenaHive, so a warning introduced by a nixpkgs or
-# colmena bump would otherwise never surface anywhere.
-if grep -q 'evaluation warning:' "$COLMENA_STDERR"; then
-    printf 'error: colmena evaluation produced warnings:\n%s\n' "$(cat "$COLMENA_STDERR")" >&2
-    exit 1
-fi
-
-# An empty or non-object node set would make the comparison below vacuous and
-# report "agree for 0 servers" on its way to publishing an unverified manifest.
-# Mirrors the identical guard applied to PATHS_JSON above.
-if [[ "$(jq -r 'type' <<<"$COLMENA_JSON")" != "object" ]] ||
-    [[ "$(jq -r 'length' <<<"$COLMENA_JSON")" -eq 0 ]]; then
-    echo "error: colmena evaluation produced no nodes -- refusing to publish" >&2
-    exit 1
-fi
-
-# A colmena node with no nixosConfigurations entry counts as a mismatch rather
-# than being skipped. Such a node should be unreachable -- mkNode dereferences
-# `self.nixosConfigurations.<name>._colmena`, so a missing entry throws during
-# evaluation and is caught above -- but suppressing the case would hide exactly
-# the failure this guard exists to report: a host colmena deploys that the
-# manifest has no path for, which reports `unmanaged` forever.
-MISMATCHED="$(
-    jq -rn \
-        --argjson a "$PATHS_JSON" \
-        --argjson b "$COLMENA_JSON" \
-        '$b | to_entries
-         | map(select($a[.key] != .value)
-               | "  \(.key)\n    nixosConfigurations: \($a[.key] // "<missing>")\n    colmena:             \(.value)")
-         | join("\n")'
-)"
-
-if [[ -n "$MISMATCHED" ]]; then
-    cat >&2 <<EOF
-error: colmena would deploy different closures than this manifest publishes.
-
-$MISMATCHED
-
-Every affected host would report deploy state 'unmanaged' forever, because its
-running closure is a path the manifest can never contain. Refusing to publish.
-
-Fix the divergence (see flake/deployment/colmena.nix) rather than this check.
-EOF
-    exit 1
-fi
-
-echo "colmena and nixosConfigurations agree for $(jq -r 'length' <<<"$COLMENA_JSON") server(s)." >&2
 
 # Previous manifest, if any. A malformed existing file is treated as absent
 # rather than fatal so a corrupted manifest self-heals on the next run.

--- a/scripts/gen-fleet-manifest.sh
+++ b/scripts/gen-fleet-manifest.sh
@@ -112,7 +112,7 @@ NOW="$(date +%s)"
 # mismatch aborts this script too, before anything is published.
 echo "Evaluating system.build.toplevel for every host and verifying colmena parity (rev ${REV})..." >&2
 
-if ! PATHS_JSON="$("$REPO_ROOT/scripts/check-colmena-parity.sh")"; then
+if ! PATHS_JSON="$("$REPO_ROOT/scripts/check-colmena-parity.sh" --emit-paths)"; then
     echo "error: colmena/nixosConfigurations parity check failed (see above) -- refusing to publish" >&2
     exit 1
 fi


### PR DESCRIPTION
Implements batches 1-4 of `AUDIT-2026-08-04.md` Part 9. **19 of 23 items landed**;
two were dropped because the audit's premise was wrong, one was confirmed
out-of-band, one is blocked on a Batch 5 decision.

Executed as four parallel git worktrees (`ws/ci`, `ws/checks`, `ws/hosts`,
`ws/guardrails`), merged sequentially with verification after each merge.

## Read this first: three of the audit's findings had false premises

Discovered only when someone tried to implement them. All three failed the same
way -- a `grep` found no match, and the absence was read as "not configured"
rather than "configured elsewhere, or defaulted by NixOS".

| Finding | Claim | Reality |
| ------- | ----- | ------- |
| 1.5 Prometheus admin API | "Nothing in the repo calls that endpoint" | `prometheus.nix:118-129` has a daily `createPrometheusSnapshot` that curls `POST /api/v1/admin/tsdb/snapshot`, plus ACL and 30-day-prune companions. `curl` has no `-f`, so removing the flag would have broken it **silently** -- a 403 still exits 0. |
| 3.2 Docker log rotation | "no `log-opts` anywhere, default uncapped `json-file` driver" | The driver is **journald** (verified by `nix eval`), deliberately, because `alloy.nix` ingests container logs from the journal. And journald is **already capped** at `SystemMaxUse=1G` / `MaxRetentionSec=30day`. `max-size`/`max-file` are journald no-ops, so the fix would have been **inert on every host**. |
| Part 4 CVE root cause | "stale/corrupt grype vulnerability DB" | A 3% SBOM coverage collapse from passing sbomnix a `.drv` path, which loses the nixpkgs metadata that is the only source of exact CPEs. Corrected in a prior commit. |

**1.5 is reverted in full** and handed to the deferred backups session -- the
snapshots sit on the same disk as the TSDB they snapshot, so they are corruption
insurance, not loss insurance, and that session has to decide the real answer
anyway. **3.2 is rejected**, with the genuine residual (journald's *shared* 1G
budget lets one chatty container crowd out other services' retention) opened as
new item 6.11. Both are in the audit's do-not-re-propose table.

## What landed

**Batch 1 -- false-signal fixes.** grype vuln-DB liveness gate, so auto-closing
issue #1717 now requires a verified-live DB and not just `MISSING == 0` (a dead
DB against a healthy SBOM previously produced a false all-clear). Removed the
`flake.nix` comment telling the reader not to hand-bump a channel ref that had
already been bumped. `github_api` 0444 -> 0400. Two doc fixes. Old Attic token
confirmed dead out-of-band.

**Batch 2 -- nvrhub.** `restartUnits` on the camera secrets. Deliberately *not*
via `mkContainerSecret`: that helper hardcodes `docker-<name>.service` and
Frigate is a native systemd unit, so the helper would have pointed at a
nonexistent unit -- worse than the bug, because it would look fixed. The
`0.0.0.0:9634` metrics vhost was reviewed and left alone; it is already stricter
than the fleet baseline for a non-internet-facing host.

**Batch 3 -- fleet guardrails.** `configurationLimit = 10` (every host has a
small VFAT ESP and no cap). `min-free`/`max-free`, since GC was weekly-only.
Jitter plus conservative sandboxing on `discord-db-backup`. Sandboxing on the
generated `docker-*.service` wrappers.

**Batch 4 -- CI structural guards.** Colmena parity now gates PRs. Concurrency
groups on all seven workflows that lacked them. `permissions:` on the three that
inherited the repo default. Same-repo guard on `renovate-relock`. Three new sync
checks, each wired into both a pre-commit hook and a flake check, following the
`input-category-sync` model.

## Reviewer attention

- **`build-linux-summary` gains a new dependency.** The `colmena-parity` job
  joins its `needs`, and `build-linux-summary` is the required status check.
  Intentional -- otherwise the required check could stay green while parity
  failed, defeating the point of catching it at PR time instead of hours later
  via `NixOSFleetManifestStale`. It runs on `ubuntu-latest`, not self-hosted:
  the eval is cheap (`colmenaHive` is a pure lib function, `.outPath` needs no
  realisation), so no fork guard is needed either.
- **The parity logic now has exactly one copy**, extracted to
  `scripts/check-colmena-parity.sh` and called by both `gen-fleet-manifest.sh`
  and the new job. `gen-fleet-manifest.sh` shrank by ~120 lines.
- **`github_api` residual, documented in-code.** 0400 with numeric `uid`/`gid`
  1000, which is what the consuming container needs absent userns-remap. NixOS
  allocates normal users from 1000 up, so host uid 1000 is in practice `fred` --
  this is not isolation from the admins, and the comment says so.
- **`ProtectSystem`/`ProtectHome` deliberately omitted** from `discord-db-backup`.
  The SQLite `.backup` API opens the live WAL-mode DB and may need write access
  to the DB's own directory for `-wal`/`-shm` siblings. A broken nightly backup
  is worse than an unhardened one.
- **4.5 is offline and structural, not full-schema.** `git-hooks.nix` runs the
  entire hook suite as one sandboxed Nix build with no network, so a fetching
  hook hard-fails the whole suite rather than degrading. A live-schema mode
  exists but is manual-only. Vendoring the schema was rejected -- it would
  become a second `MODULES.md`.
- **`ExecStart` is byte-identical** before and after the `mkUnit` hardening,
  verified by diffing the evaluated value. Only `serviceConfig` gained keys.

One defect was found at integration and fixed in `22d70022`: the three new check
scripts had no tool-check preamble, and `check-opencode-jsonc.sh` reported a
missing python `json5` module as `"opencode.jsonc is not valid JSONC"` --
inventing a config bug that did not exist. The same false-signal class the check
was written to prevent.

## Verification

- All 10 Linux hosts eval, **zero** `evaluation warning:` lines
- `statix check .` and `deadnix --fail .` clean
- All 5 flake checks build green, including the full pre-commit suite with the 3 new hooks
- `shellcheck` clean on all scripts; markdownlint and codespell clean
- `check-colmena-parity.sh` runs green against 10 hosts / 8 colmena nodes
- Each new check has a recorded negative test proving it can actually fail

## Not in this PR

- **1.7** was verified out-of-band rather than in code (old Attic token dead, replacement good) and is recorded in the audit doc so it is not re-flagged forever.
- **4.9** dead-module reachability is blocked on the `firmware.nix` delete-or-import decision, which is Batch 5 item 5.3.
- **Backups and disko/nixos-anywhere** remain explicitly out of scope pending their own planning session. Note nvrhub's ~2 TB of unbacked-up Frigate footage, and now the Prometheus TSDB question from 1.5, both land there.
- **Batch 5** is untouched. Its item 5.1 (`allowUnfree`) needs a decision before implementation: the fleet-wide blanket `true` defeats two narrow predicates, so either tighten to predicates everywhere or delete the misleading predicates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved secret protection, service isolation, backup hardening, and vulnerability-scan verification.
  - Services now restart automatically when relevant credentials rotate.
  - Restricted automated update operations to trusted repository-originated changes.

- **Reliability**
  - Added configuration parity, documentation consistency, secret-recipient, and configuration validation checks.
  - Improved CI concurrency, permissions, and validation coverage.

- **System Management**
  - Limited retained boot generations and enabled automatic storage cleanup.
  - Added randomized timing for nightly backups.

- **Documentation**
  - Updated audit records, monitoring notes, and workflow documentation to reflect current status and procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->