### PR TITLE
nvrhub: replace DB1 doorbell with Reolink D340W, and fix the stale frameN shm gap

### DIFF
--- a/hosts/linux/nvrhub/frigate.nix
+++ b/hosts/linux/nvrhub/frigate.nix
@@ -1,4 +1,4 @@
-# Frigate NVR — 8 Hikvision cameras.
+# Frigate NVR — 8 cameras: 7 Hikvision + 1 Reolink doorbell.
 #
 # WHY FRIGATE AND NOT SHINOBI
 #
@@ -38,21 +38,36 @@
 let
   # ── Camera inventory ──────────────────────────────────────────────────────
   #
-  # All eight are Hikvision on the LAN, verified 2026-08-10 by querying
-  # /ISAPI/System/deviceInfo and /ISAPI/Streaming/channels on each, and by
-  # ffprobing both RTSP channels of each over TCP.
+  # Seven Hikvision, verified 2026-08-10 by querying /ISAPI/System/deviceInfo
+  # and /ISAPI/Streaming/channels on each, and by ffprobing both RTSP channels
+  # of each over TCP.
   #
   #   7x DS-2CD2342WD-I (firmware V5.5.0)
   #     channel 101: 2688x1520 H.264 @20fps  (record)
   #     channel 102:  640x360  H.264 @15fps  (detect)
   #
-  #   1x DB1 doorbell, 192.168.31.122 (firmware V1.4.62)
-  #     channel 101: 1920x1080 H.264 @12fps  (record)
-  #     channel 102:  640x480  H.264 @~3fps  (detect)
+  # One Reolink doorbell, which REPLACED the Hikvision DB1 that used to sit at
+  # 192.168.31.122. Verified 2026-08-17 against the device itself via its
+  # /cgi-bin/api.cgi GetDevInfo + GetEnc endpoints and by ffprobing both RTSP
+  # paths over TCP:
   #
-  # The DB1 substream really does deliver ~3fps (24 frames in 8s, measured),
-  # and reports maxFrameRate=0 over ISAPI rather than a real value. It gets its
-  # own detect block below instead of the shared 640x360/5fps one.
+  #   1x Reolink D340W "Video Doorbell WiFi", 192.168.31.27
+  #     hardVer DB_566128M5MP_W, firmware v3.0.0.4662_2508071282
+  #     h264Preview_01_main: 2560x1920 H.264 High @20fps + AAC LC 16 kHz mono
+  #     h264Preview_01_sub:   640x480  H.264 High @10fps + AAC LC 16 kHz mono
+  #
+  # Strictly better than the DB1 it replaced on every axis that matters here:
+  # 4.9 MP vs 2.1 MP recorded, 20fps vs 12fps recorded, and a substream that
+  # delivers a real 10fps (101 frames in 10.1s, measured) against the DB1's
+  # ~3fps. It is the only 4:3 substream in the fleet, so like the DB1 it keeps
+  # its own detect block rather than sharing the 640x360 one.
+  #
+  # NOTE FOR THE NEXT REOLINK: this camera was unreachable on first contact
+  # because current Reolink firmware ships with HTTP, HTTPS, RTSP, RTMP and
+  # ONVIF all DISABLED — only the proprietary port 9000 answers, and it resets
+  # non-Reolink clients. RTSP must be switched on by hand in the Reolink app
+  # (Device Settings -> Network -> Advanced -> Port Settings) before Frigate can
+  # see anything. There is no way to do that declaratively from here.
   #
   # Names are the Frigate camera keys and appear in the UI, in MQTT topics and
   # in alert labels, so they are the snake_case form of the physical location
@@ -60,6 +75,7 @@ let
   # previous NVR left on the disk.
   cameras = {
     front_door = {
+      brand = "hikvision";
       host = "192.168.31.237";
       detect = {
         width = 640;
@@ -68,35 +84,58 @@ let
       };
     };
     doorbell = {
-      host = "192.168.31.122";
-      # DB1, not a DS-2CD2342WD-I: 4:3 substream and a much lower frame rate.
+      brand = "reolink";
+      host = "192.168.31.27";
+
+      # 4:3 substream, so not the shared 640x360 block.
+      #
+      # width/height MUST equal the substream's real resolution -- Frigate uses
+      # them as frame_shape to slice the raw yuv420p byte stream, so a mismatch
+      # yields sheared garbage rather than an error. 640x480 is ffprobe-verified
+      # against h264Preview_01_sub. Omitting them entirely would also work
+      # (Frigate probes the stream at config.py:534-555) and would arrive at the
+      # same numbers; they are stated so the inventory above is checkable.
+      #
+      # Not adjustable in any case: GetEnc reports the substream `size` as a
+      # bare "640*480" string, unlike `bitRate`/`frameRate` which come back as
+      # lists of options. Detecting on more pixels would mean pointing the
+      # detect role at the 2560x1920 mainstream, which is the exact cost the
+      # substream split exists to avoid.
+      #
+      # fps is 5 rather than the 10 the substream actually delivers: the other
+      # seven cameras detect at 5, the detector is a single shared CPU
+      # detector, and Frigate downsamples the decode to detect.fps anyway.
+      # Frigate itself warns above 10 and recommends 5 (config.py:559). The
+      # DB1's 3 was a hardware ceiling; this 5 is a choice, so it can be raised
+      # to 10 if doorbell detection latency ever matters more than CPU.
       detect = {
         width = 640;
         height = 480;
-        fps = 3;
+        fps = 5;
       };
 
-      # The only camera with an audio stream, and it needs transcoding.
+      # Still the only camera with audio, but it no longer needs transcoding.
       #
-      # The DB1 publishes h264 video + pcm_mulaw (G.711 µ-law) audio; the seven
-      # DS-2CD2342WD-I units publish video only. MP4 has no tag for pcm_mulaw,
-      # so copying it made ffmpeg fail the container header outright:
+      # The DB1 published pcm_mulaw (G.711 µ-law), which MP4 has no tag for, so
+      # copying it failed the container header outright:
       #
       #   Could not find tag for codec pcm_mulaw in stream #1
       #   [out#0/segment] Could not write header (incorrect codec parameters ?)
       #
       # Every doorbell segment was then discarded ("Invalid or missing video
-      # stream in segment ... Discarding") while the other seven recorded fine.
-      # Observed on first deploy: 54 errors, all of them this camera.
+      # stream in segment ... Discarding") while the other seven recorded fine
+      # — 54 errors on first deploy, all of them that camera. Hence the old
+      # `preset-record-generic-audio-aac`, which re-encoded to AAC.
       #
-      # Transcoding to AAC rather than dropping audio with
-      # `preset-record-generic` (-an): a doorbell is the one camera where audio
-      # is actually worth having, and re-encoding 8 kHz mono G.711 to AAC is
-      # negligible. Video is still stream-copied, so the expensive path is
-      # untouched.
-      recordPreset = "preset-record-generic-audio-aac";
+      # The D340W publishes AAC LC directly, so the transcode is pure waste.
+      # `-audio-copy` is `-c copy` with no `-an`, i.e. BOTH streams are
+      # stream-copied and this camera now costs the same CPU to record as the
+      # other seven. Verified rather than assumed: 20s of the mainstream muxed
+      # with `ffmpeg -c copy -f mp4` produced avc1 + mp4a with no header error.
+      recordPreset = "preset-record-generic-audio-copy";
     };
     garage_door = {
+      brand = "hikvision";
       host = "192.168.31.35";
       detect = {
         width = 640;
@@ -105,6 +144,7 @@ let
       };
     };
     inside_garage = {
+      brand = "hikvision";
       host = "192.168.31.180";
       detect = {
         width = 640;
@@ -113,6 +153,7 @@ let
       };
     };
     kitchen = {
+      brand = "hikvision";
       host = "192.168.31.87";
       detect = {
         width = 640;
@@ -121,6 +162,7 @@ let
       };
     };
     living_room = {
+      brand = "hikvision";
       host = "192.168.31.18";
       detect = {
         width = 640;
@@ -129,6 +171,7 @@ let
       };
     };
     office = {
+      brand = "hikvision";
       host = "192.168.31.15";
       detect = {
         width = 640;
@@ -137,6 +180,7 @@ let
       };
     };
     upstairs_hall = {
+      brand = "hikvision";
       host = "192.168.31.10";
       detect = {
         width = 640;
@@ -146,29 +190,57 @@ let
     };
   };
 
-  # Hikvision RTSP URL. Channel 101 is the main stream, 102 the substream.
+  # RTSP paths per brand, keyed by the Frigate role that consumes them.
   #
+  # This used to be a single hardcoded Hikvision path with the channel number
+  # interpolated (101 main / 102 sub). Reolink does not expose channels that
+  # way at all — it names the streams — so the path is now a per-brand lookup
+  # instead of a per-camera number.
+  #
+  # `cameras.<name>.brand` is indexed into this attrset with NO default, which
+  # is the point: a missing or misspelled brand is an evaluation error at build
+  # time. Defaulting to hikvision would let the next Reolink silently inherit
+  # /Streaming/Channels/10x paths and fail only once deployed, as a stream that
+  # never connects.
+  streamPaths = {
+    hikvision = {
+      detect = "Streaming/Channels/102";
+      record = "Streaming/Channels/101";
+    };
+    reolink = {
+      detect = "h264Preview_01_sub";
+      record = "h264Preview_01_main";
+    };
+  };
+
   # rtsp:// with credentials inlined is how Frigate consumes these; the
   # placeholders below are substituted at runtime from the sops-provided
   # credential files, so no secret is rendered into the store.
+  #
+  # All eight cameras share one credential pair, including the Reolink — its
+  # admin account was set to the same username/password as the Hikvisions
+  # rather than adding a second sops secret and a second LoadCredential entry.
   mkStream =
-    host: channel:
-    "rtsp://{FRIGATE_CAMERA_USER}:{FRIGATE_CAMERA_PASSWORD}@${host}:554/Streaming/Channels/${toString channel}";
+    cam: role:
+    "rtsp://{FRIGATE_CAMERA_USER}:{FRIGATE_CAMERA_PASSWORD}@${cam.host}:554/${
+      streamPaths.${cam.brand}.${role}
+    }";
 
   mkCamera = _name: cam: {
     ffmpeg = {
       inputs = [
         # Substream drives detection. Decoding a 4MP stream 5x a second for
         # every camera is the single largest avoidable CPU cost in an NVR, and
-        # these cameras already publish a 640x360 substream for exactly this.
+        # every one of these cameras already publishes a low-resolution
+        # substream for exactly this.
         {
-          path = mkStream cam.host 102;
+          path = mkStream cam "detect";
           roles = [ "detect" ];
         }
         # Mainstream is recorded as-is: the bytes arrive already H.264 and are
         # stream-copied straight to disk, so recording costs almost no CPU.
         {
-          path = mkStream cam.host 101;
+          path = mkStream cam "record";
           roles = [ "record" ];
         }
       ];
@@ -291,6 +363,11 @@ in
       # Sized from a MEASURED bitrate, not a guess: 20s of the front-door
       # mainstream averaged 7.9 Mbps (VBR, 16 Mbps ceiling). That is ~85 GB per
       # camera per day, ~683 GB/day for all eight, against 3.5 TB usable.
+      #
+      # The Reolink doorbell does not disturb this despite recording 4.9 MP:
+      # Reolink caps its mainstream at 4096 kbps and 20s of it measured
+      # 4.39 Mbps, well under the 7.9 Mbps the estimate assumes per camera. So
+      # the figures below stay conservative.
       #
       # So continuous recording of everything is ~5.1 days and nothing else
       # fits. Hence the tiered policy:

--- a/hosts/linux/nvrhub/frigate.nix
+++ b/hosts/linux/nvrhub/frigate.nix
@@ -359,32 +359,50 @@ in
         "FRIGATE_CAMERA_PASSWORD:${config.sops.secrets."cameras/password".path}"
       ];
 
-      # Drop stale detect shared-memory segments before starting.
+      # Drop stale per-camera shared-memory segments before starting.
       #
-      # Frigate sizes one /dev/shm segment per camera as
-      # model.width * model.height * 3 and creates it under
-      # `except FileExistsError: pass`. Nothing ever resizes or removes an
-      # existing segment, and /dev/shm survives a service restart
-      # (PrivateTmp= does not cover it, and Frigate uses "untracked" shared
-      # memory deliberately so segments outlive a crash).
+      # Frigate creates every one of its /dev/shm segments under
+      # `except FileExistsError: pass` (util/image.py:842-850) and never
+      # resizes or removes one. /dev/shm also survives a service restart:
+      # PrivateTmp= does not cover it, and Frigate uses "untracked" shared
+      # memory deliberately so segments outlive a crash.
       #
-      # So ANY change to the model geometry leaves every camera pointing at a
-      # wrongly-sized buffer, and each camera processor dies with
+      # So any segment whose SIZE is derived from config outlives the config
+      # change that sized it, and the next start silently attaches to the old
+      # one. There are two independent families, both affected:
+      #
+      #   /dev/shm/<camera>          detector input, sized
+      #                              model.width * model.height * 3
+      #   /dev/shm/out-<camera>      detection output, fixed 20 * 6 * 4
+      #   /dev/shm/<camera>_frameN   frame ring buffers, sized
+      #                              detect.height * 3/2 * detect.width
+      #                              (camera/maintainer.py:156-157)
+      #
+      # The failure is the same either way: a camera process dies with
       #
       #   TypeError: buffer is too small for requested array
       #
       # while the service still reports active and keeps recording. Observed
-      # here switching 320x320 -> 416x416: all eight segments stayed 307200
-      # bytes from the previous generation and every camera process crashed on
-      # startup. It cost a live debugging session to find, and it recurs on
-      # every future model change (including the 416 -> 320 change that came
-      # with the cpu-detector fallback above) unless handled automatically.
+      # here on the MODEL family switching 320x320 -> 416x416: all eight
+      # segments stayed 307200 bytes from the previous generation and every
+      # camera process crashed on startup. It cost a live debugging session.
       #
-      # Only the per-camera detect segments and their `out-` counterparts are
-      # removed. The `<camera>_frameN` segments are the frame ring buffers,
-      # sized from the camera's own detect resolution rather than the model's;
-      # they are left alone so this does not become a blunt "wipe /dev/shm"
-      # that fights Frigate for ownership of its own IPC.
+      # The frameN family used to be left alone here, on the reasoning that it
+      # is sized from the camera's own detect resolution rather than the
+      # model's and so is not disturbed by model changes. That is true and also
+      # beside the point -- it just moves the trigger from "change the detector
+      # model" to "change any camera's detect width/height", which is an
+      # equally ordinary edit to this file. Leaving it out made the detect
+      # geometry in the inventory above quietly load-bearing: correct only for
+      # as long as nobody touched it. Both families are cleared now, so detect
+      # resolution is a freely editable number again.
+      #
+      # Still not a blunt "wipe /dev/shm": every path is derived from a known
+      # camera name, so this cannot touch Frigate's other IPC. In particular
+      # the `birdseye` segment (output/birdseye.py:801, created only when
+      # birdseye.restream is on) is not per-camera and is not matched -- and
+      # `<cam>_frame*` cannot cross-match a camera whose name is a prefix of
+      # another, since the `_frame` infix has to match too.
       #
       # This APPENDS to the three ExecStartPre entries the upstream module
       # already defines (clear-cache, create-writable-config,
@@ -393,10 +411,20 @@ in
       #
       # Safe to run unconditionally: the segments are pure IPC scratch space,
       # recreated on start, and the service is stopped when this executes.
+      #
+      # The trailing glob is unquoted on purpose, and it relies on BASH's
+      # unmatched-glob behaviour: with no match, bash passes the literal
+      # `<cam>_frame*` through and `rm -f` ignores it, so this exits 0 on a
+      # fresh boot where no segment exists yet. That matters because a failing
+      # ExecStartPre aborts the unit start entirely. pkgs.writeShellScript uses
+      # runtimeShell, which is bash here -- do NOT port this loop to a shell
+      # with zsh's nullglob-off semantics, where an unmatched glob is a fatal
+      # error that would abort the command BEFORE the two quoted rm targets are
+      # processed, silently reintroducing the stale-segment bug it fixes.
       ExecStartPre = [
-        (pkgs.writeShellScript "frigate-clear-stale-detect-shm" ''
+        (pkgs.writeShellScript "frigate-clear-stale-shm" ''
           for cam in ${lib.escapeShellArgs (builtins.attrNames cameras)}; do
-            rm -f "/dev/shm/$cam" "/dev/shm/out-$cam"
+            rm -f "/dev/shm/$cam" "/dev/shm/out-$cam" "/dev/shm/$cam"_frame*
           done
         '')
       ];


### PR DESCRIPTION
Replaces the Hikvision DB1 doorbell (192.168.31.122) with a Reolink D340W
"Video Doorbell WiFi" (192.168.31.27), and fixes a latent `/dev/shm` bug found
while doing it.

Two commits, intentionally ordered so the fix lands first — that way the camera
swap never has to carry a "don't change this number" caveat.

## `3f52140b` — fix: clear stale `<camera>_frameN` shm segments

The `ExecStartPre` cleanup removed the model-sized `/dev/shm/<camera>` and
`out-<camera>` segments but deliberately left the `<camera>_frameN` frame ring
buffers alone, reasoning that they are sized from the camera's *detect*
resolution rather than the detector *model's*, so a model change can't disturb
them.

That reasoning is correct and beside the point. It doesn't remove the bug, it
moves the trigger from "change the detector model" to "change any camera's
detect width/height" — an equally ordinary edit to this file.

Frigate sizes those buffers as `detect.height * 3/2 * detect.width`
(`camera/maintainer.py:156-157`) via a `create()` that swallows
`FileExistsError` (`util/image.py:842-850`), and never resizes or unlinks them.
`/dev/shm` survives a restart, so a changed detect resolution leaves that
camera attached to a wrongly-sized buffer and its process dies with
`TypeError: buffer is too small for requested array` while the unit still
reports active and keeps recording — the same silent failure already documented
here for the model segments, which cost a live debugging session.

Not a blunt `/dev/shm` wipe: every path derives from a known camera name, so the
non-per-camera `birdseye` segment is untouched, and the `_frame` infix prevents
cross-matching a camera whose name prefixes another (`garage` vs `garage_door`).

## `1fe43e67` — feat: Reolink D340W doorbell

Values read off the device via `/cgi-bin/api.cgi` `GetDevInfo` + `GetEnc` and
ffprobed over RTSP, per this file's existing convention:

| | DB1 (old) | D340W (new) |
| ------ | ------------------- | ----------------------------------- |
| record | 1920x1080 @12fps | 2560x1920 @20fps, 4.39 Mbps measured |
| detect | 640x480 @~3fps | 640x480 @10fps |
| audio | pcm_mulaw (G.711) | AAC LC 16 kHz mono |

- **Per-brand RTSP paths.** `mkStream` hardcoded Hikvision's
  `/Streaming/Channels/<channel>`; Reolink names streams instead of numbering
  channels, so paths are now a `streamPaths.<brand>.<role>` lookup. Indexed with
  **no default** on purpose — a missing or misspelled brand is an eval error,
  whereas defaulting to hikvision would let the next Reolink silently inherit
  channel paths and fail only once deployed. All seven Hikvisions gain an
  explicit `brand` and are otherwise untouched (verified byte-identical in the
  generated YAML).
- **Dropped the AAC transcode.** The old `audio-aac` preset existed because MP4
  has no tag for `pcm_mulaw`. The D340W publishes AAC LC directly, so
  `preset-record-generic-audio-copy` stream-copies both tracks and the doorbell
  now costs the same recording CPU as the other seven.
- **detect fps 3 -> 5.** The DB1's 3 was a hardware ceiling; the D340W delivers a
  real 10fps, so 5 is a deliberate downsample matching the other seven and
  Frigate's own recommendation (`config.py:559`). Geometry stays 640x480 — both
  what ffprobe reports and the only substream size the D340W offers.
- **Retention unaffected.** Despite 4.9 MP, Reolink caps the mainstream at
  4096 kbps and it measured 4.39 Mbps, under the 7.9 Mbps/camera the sizing
  assumes.

Also documented that current Reolink firmware ships with HTTP, HTTPS, RTSP, RTMP
and ONVIF **all disabled** — only proprietary port 9000 answers, and it resets
non-Reolink clients. RTSP must be enabled by hand in the Reolink app before
Frigate can see anything; that can't be done declaratively from here.

The camera's admin account was set to the existing shared `cameras/*` sops
credential rather than adding a second secret and `LoadCredential` entry.

## Verification

Per commit, not just at the tip:

- `nixfmt` / `statix` / `deadnix` clean
- nvrhub toplevel builds; no `evaluation warning:`
- Frigate's sandbox validator ran on the exact final YAML — traced the tree's
  unit -> `create-writable-config` -> `54vv7y70…-frigate-config`, the derivation
  that printed `*** Your config file is valid. ***`
- All four `ExecStartPre` entries present in order, upstream's three intact
- Generated YAML: seven Hikvisions byte-identical, only `doorbell` changed
- No credential in the store-rendered config or the repo
- Audio copy proven, not assumed: 20s of mainstream muxed with
  `ffmpeg -c copy -f mp4` -> `avc1` + `mp4a`, no header error
- Glob verified under bash against present / absent / prefix-colliding fixtures

## Reviewer note on the glob

`"/dev/shm/$cam"_frame*` is unquoted on purpose and depends on **bash's**
unmatched-glob behaviour: with no match bash passes the literal through and
`rm -f` ignores it, so the script exits 0 on a fresh boot. That matters because
a failing `ExecStartPre` aborts the unit start. `pkgs.writeShellScript` uses
`runtimeShell` (bash 5.3 here) — under zsh semantics an unmatched glob is fatal
and would abort *before* the two quoted `rm` targets are processed, silently
reintroducing the bug. There's a comment saying exactly this.

## Follow-ups, not in scope

- ONVIF (8000) still disabled on the camera — only needed for Home Assistant's
  doorbell-press `Visitor` sensor.
- Wi-Fi latency to the doorbell measured 143-335ms. Frigate defaults to
  `-rtsp_transport tcp` with a 10s timeout so it should hold, but if that camera
  starts logging `Unable to read frames from ffmpeg process`, the fix is a go2rtc
  `http-flv` restream rather than anything in this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for seven Hikvision cameras and a Reolink D340W doorbell.
  * Added brand-aware RTSP stream selection and camera metadata.
  * Configured Reolink detection at 640×480 resolution and 5 FPS.
  * Improved recording with AAC stream copying.

* **Bug Fixes**
  * Startup cleanup now safely removes stale camera and detector shared-memory segments.
  * Invalid camera brands are rejected during configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->