### PR TITLE
fix(monitoring): ship maranello's journal to Loki

### DIFF
--- a/hosts/linux/maranello/configuration.nix
+++ b/hosts/linux/maranello/configuration.nix
@@ -15,6 +15,21 @@ in
   imports = [
     ./hardware-configuration.nix
     ../../../profiles/desktop.nix
+
+    # Log shipping to Loki. Imported per-host rather than from the desktop
+    # profile because the two desktops need different shippers: Daytona is a
+    # roaming laptop converted to push-based monitoring (f8081793), so it
+    # carries its own inline alloy config that ALSO does prometheus
+    # remote_write, and pulling this module in there would define
+    # services.alloy twice. maranello is stationary and is scraped normally at
+    # maranello.local:9100, so it needs only the journal half -- which is all
+    # this module is, by design ("deliberately a dumb shipper").
+    #
+    # Without this, maranello was the only host in the fleet whose logs existed
+    # nowhere but its own journal, and that journal is size-bound: measured at
+    # 8 days of retention against a 30-day policy, because SystemMaxUse=1G
+    # binds long before MaxRetentionSec=30day.
+    ../../../modules/monitoring/agent/alloy.nix
   ];
 
   # Hardware profile settings

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -13,10 +13,16 @@
     ../modules/secrets/sops.nix
     ../modules/data/nas-mounts.nix
     ../modules/data/wifi-networks.nix
-    # Monitoring: node_exporter only. cadvisor (Docker container metrics)
-    # and alloy (log shipping) are deliberately not pulled in — desktops
-    # don't run the same container fleet and log shipping is out of scope
-    # for this profile.
+    # Monitoring: node_exporter only. cadvisor (Docker container metrics) is
+    # deliberately not pulled in -- desktops don't run the same container
+    # fleet.
+    #
+    # Log shipping is NOT excluded on purpose, it is just per-host: the two
+    # desktops need different shippers. Daytona is a roaming laptop on
+    # push-based monitoring with its own inline alloy config that also does
+    # prometheus remote_write; maranello is stationary, is scraped normally,
+    # and imports modules/monitoring/agent/alloy.nix for the journal half
+    # only. Defining alloy here would collide with Daytona's.
     ../modules/monitoring/agent/node_exporter.nix
   ];
 


### PR DESCRIPTION
maranello was the **only host in the fleet whose logs existed nowhere but its
own journal** — and that journal turns out to be size-bound, not time-bound.

Measured on the host:

```text
policy   : MaxRetentionSec=30day, SystemMaxUse=1G
actual   : 966.2M used, oldest entry 8 days 3 hours old
```

`SystemMaxUse` binds long before `MaxRetentionSec`, so effective retention is
~8 days against a 30-day policy. A month-old incident on maranello was already
unrecoverable, and nothing reported that.

## Why maranello was the gap

Every other host ships, including Daytona — but Daytona got it as a *side
effect*, not by intent. Daytona is a roaming laptop converted to push-based
monitoring in `f8081793` because the master cannot reliably scrape a machine
that changes networks, and its inline alloy config does `prometheus.remote_write`
as well as journal shipping. maranello is stationary and **is** scraped normally
at `maranello.local:9100`, so it only ever needed the journal half.

## Why a host-level import and not the desktop profile

Two concrete reasons, either of which alone rules the alternatives out:

- Adding the module to `profiles/desktop.nix` would define `services.alloy`
  **twice on Daytona**, which already has its own inline config.
- Copying Daytona's config into maranello would make maranello's node metrics
  arrive **twice** — once by the master's existing pull, once by `remote_write`.

`modules/monitoring/agent/alloy.nix` is the right shape: it describes itself as
"deliberately a dumb shipper", extracts no metrics, and exposes nothing to
scrape. Its nginx access-log source is already gated on `services.nginx.enable`,
so maranello (nginx off) renders without it automatically.

## Verified from the built config, not assumed

```text
labels           : hostname = "maranello", host = "maranello"
sources          : journal only
prometheus blocks: 0        <- no double-ingestion
nginx references : 0        <- correctly gated off
endpoint         : http://192.168.31.20:5678/loki/api/v1/push
```

Daytona's config is byte-unchanged. maranello, Daytona and sdrhub all evaluate
clean with no `evaluation warning:`; maranello's home-manager activation
evaluates too. All 10 Linux hosts now ship to Loki, which has
`retention_period = "30d"`.

Also corrects the comment in `profiles/desktop.nix`, which claimed log shipping
was "out of scope for this profile". It was never out of scope — it is per-host
because the two desktops need different shippers, and leaving that comment would
have made the next reader think excluding maranello was deliberate.

## Note

This does not change maranello's *local* journal retention, which stays at ~8
days. It means that shortfall no longer costs anything, because Loki now holds
30 days centrally — the same arrangement every other host already had. The
local-retention metric discussed for audit item 6.11 is still worth adding to
make that shortfall visible rather than measured by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled host-specific journal log shipping to Loki for improved monitoring visibility.
  * Added monitoring support without enabling container metrics collection on the desktop profile.
* **Documentation**
  * Clarified monitoring behavior across supported systems, including which hosts use log shipping and push-based metrics.
  * Documented that Prometheus remote-write configuration remains limited to the designated monitoring setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->