### PR TITLE
chore(flake/home-manager-stable): `d4fd2466` -> `09ae1b85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -674,11 +674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119570,
-        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
+        "lastModified": 1786924861,
+        "narHash": "sha256-hftabkb+73OcGzvwFAjCiQorAhprs9TnU1+FkGO5CIw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
+        "rev": "09ae1b85a6db412d841d60f924b23f881f0d0a38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`09ae1b85`](https://github.com/nix-community/home-manager/commit/09ae1b85a6db412d841d60f924b23f881f0d0a38) | `` aerospace: add regression test for reload guard ``             |
| [`ed6fc5d8`](https://github.com/nix-community/home-manager/commit/ed6fc5d825fee77895a5ae7c25c7f889c4868a8c) | `` aerospace: skip config reload when AeroSpace is not running `` |