### PR TITLE
chore(flake/home-manager): `c8058ecc` -> `35374258`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -654,11 +654,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786826571,
-        "narHash": "sha256-nNqmXIFmESRnU91KARtiekSox0+o+E3AS0d1TuUQ/9o=",
+        "lastModified": 1786999651,
+        "narHash": "sha256-MTGMFlLDTklsXhCp4r5GXB4VAVadPdalXLvUjd/K7h0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c8058ecc1329a71a3c99c4d0353dba4009a66152",
+        "rev": "353742587cbaf079b3caee743115d037bc51fea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`35374258`](https://github.com/nix-community/home-manager/commit/353742587cbaf079b3caee743115d037bc51fea6) | `` concord: add module ``                                                      |
| [`ec161155`](https://github.com/nix-community/home-manager/commit/ec161155d76f7ec25404c0da2fa9f5f133f6ae4c) | `` hyprland: add XDPH settings ``                                              |
| [`aac4965d`](https://github.com/nix-community/home-manager/commit/aac4965ddb7ea2ff0f3cadd9502c7042b7aa07ba) | `` antigravity-cli: use lib.hm.mcp.resolveEnabled for MCP server resolution `` |
| [`c507a06b`](https://github.com/nix-community/home-manager/commit/c507a06bd1caba17e96b7f36725864d248859817) | `` antigravity-cli: emit disabled for disabled MCP servers ``                  |
| [`313aabfb`](https://github.com/nix-community/home-manager/commit/313aabfb207cacdf30e6c0508b401893466889e4) | `` ollama: allow `acceleration = "vulkan";` ``                                 |
| [`85a5c1f6`](https://github.com/nix-community/home-manager/commit/85a5c1f69c27faeb7efc0dfe1185bf0fbce1f541) | `` crush: avoid IFD for skill paths ``                                         |
| [`dca466f1`](https://github.com/nix-community/home-manager/commit/dca466f13221367ebb9b13194af0d2b4450d4fde) | `` github-copilot-cli: avoid IFD for path inputs ``                            |
| [`2e5052fc`](https://github.com/nix-community/home-manager/commit/2e5052fc725be2b63855883098185b2b4fcc1446) | `` antigravity-cli: avoid IFD for skill paths ``                               |
| [`7ccdf17f`](https://github.com/nix-community/home-manager/commit/7ccdf17fddce6828f88409d2659d19149083733b) | `` opencode: avoid IFD for skill paths ``                                      |
| [`d330408f`](https://github.com/nix-community/home-manager/commit/d330408f8146ed20b06b42248f52da345c38fa64) | `` codex: avoid IFD for derived paths ``                                       |
| [`fa4717d1`](https://github.com/nix-community/home-manager/commit/fa4717d13d8aaf3311db066a984862c4a7fc902e) | `` claude-code: avoid IFD for skill paths ``                                   |
| [`5bd50596`](https://github.com/nix-community/home-manager/commit/5bd505963717a894b02a57cdbcc00db28d9b029f) | `` hyprtoolkit: add module ``                                                  |