### PR TITLE
chore(flake/nixvim): `738351a7` -> `8704f5ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -960,11 +960,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1786348146,
-        "narHash": "sha256-we5zDEFfn8TgzeWKjKDMIjeQZ59omEPl23NIF+13/ys=",
+        "lastModified": 1786858016,
+        "narHash": "sha256-Vczr2zxD0orq6N2QQe5uqOGF7TRDcQJRRuAcsdHr4kg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d482ef84049d9b7276b83a06e4e4d76983830097",
+        "rev": "54ba4bcec4043e72a4006d825e0d7aff5562008f",
         "type": "github"
       },
       "original": {
@@ -1141,11 +1141,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1786577888,
-        "narHash": "sha256-EVSCHLGozO2S4d14WianQ9JiU9tpPgdFv9uD74/xqeQ=",
+        "lastModified": 1786971673,
+        "narHash": "sha256-YoR5OFSUk5F/K1xWikfPcd27bSAt8x5ZVAqBZ/khEys=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "738351a7813be094fb00fce1a149bcc25e936c36",
+        "rev": "8704f5ec5b2c500720fc65197e4edd49414b31a4",
         "type": "github"
       },
       "original": {
@@ -1594,6 +1594,7 @@
       }
     },
     "systems_9": {
+      "flake": false,
       "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`8704f5ec`](https://github.com/nix-community/nixvim/commit/8704f5ec5b2c500720fc65197e4edd49414b31a4) | `` flake: Update ``                                        |
| [`94fa51d8`](https://github.com/nix-community/nixvim/commit/94fa51d8b7d734feef1b8db5bb2a8c67ddc5cd12) | `` modules/lsp: updated `inlayHints` option description `` |
| [`73a1c2ef`](https://github.com/nix-community/nixvim/commit/73a1c2ef73613fd0c75abca9d49193de3cfa8979) | `` modules/lsp: added codelens option ``                   |
| [`b5d9e7d2`](https://github.com/nix-community/nixvim/commit/b5d9e7d2cf02e322ff6ef780862951c2d8f22f1b) | `` flake: mark `systems` as `flake=false` ``               |
| [`f1311e1d`](https://github.com/nix-community/nixvim/commit/f1311e1d8c101bf3fbce6804de144ca1546d0901) | `` tests: disable veridian (build failure) ``              |
| [`e20511b7`](https://github.com/nix-community/nixvim/commit/e20511b72320ab72e1f6ab6c8e149bc8a2264801) | `` flake: Update ``                                        |