### PR TITLE
chore(flake/nixpkgs): `0e251e24` -> `e5bdc4a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`1613d78a`](https://github.com/NixOS/nixpkgs/commit/1613d78aaaff70499a2cf11b549872293b07b8e9) | `` shelfmark: 1.3.7 -> 1.3.9 ``                                                                  |
| [`b5dfa59b`](https://github.com/NixOS/nixpkgs/commit/b5dfa59b2d1c349a1a224fe4e5a79e11919923ad) | `` zwave-js-ui: 11.22.2 -> 11.22.3 ``                                                            |
| [`4aae1f63`](https://github.com/NixOS/nixpkgs/commit/4aae1f63343e60dc5a44e52c0c702be69d846c16) | `` gotenberg: 8.35.0 -> 8.36.0 ``                                                                |
| [`4f638b9c`](https://github.com/NixOS/nixpkgs/commit/4f638b9ca8daa2494ee41a7e56dfa31850ea0c40) | `` diskwatch: 0.1.6 -> 0.3.2 ``                                                                  |
| [`98a564e5`](https://github.com/NixOS/nixpkgs/commit/98a564e5e33c7c74e788c2a9655f2032e2033789) | `` warp-terminal: 0.2026.07.29.09.05.stable_02 -> 0.2026.08.12.21.54.stable_00 ``                |
| [`9ee63c53`](https://github.com/NixOS/nixpkgs/commit/9ee63c536ce2a05164575201dc5175eb73f5b0ef) | `` zashboard: 3.17.0 -> 3.19.0 ``                                                                |
| [`c376646c`](https://github.com/NixOS/nixpkgs/commit/c376646c79d59cf1dd652c538d40f036adb7dbf1) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.355 -> 0.13.356 `` |
| [`64662bcb`](https://github.com/NixOS/nixpkgs/commit/64662bcb61d860d8fe79157eb2b71861dbee652c) | `` lessc: 4.8.1 -> 4.9.0 ``                                                                      |
| [`0556ae30`](https://github.com/NixOS/nixpkgs/commit/0556ae305568234d64504c97f4f9d07e99502f77) | `` linuxPackages.tt-kmd: 2.10.0 -> 2.11.0 ``                                                     |
| [`11f4edc2`](https://github.com/NixOS/nixpkgs/commit/11f4edc2cb3765de0516c7f69bb8b3772e72a79f) | `` cm-rgb: drop ``                                                                               |
| [`b7bcaf88`](https://github.com/NixOS/nixpkgs/commit/b7bcaf8818a24d7ba1ddf826a44eeef4ccc3e862) | `` terraform-providers.oracle_oci: 8.26.0 -> 8.27.0 ``                                           |
| [`7dbc9d3a`](https://github.com/NixOS/nixpkgs/commit/7dbc9d3a71f3e5b4cd13b965af95070af5d4faf0) | `` systemd: fix libfido2 buildInput not tracking withFido2 ``                                    |
| [`50ae7d30`](https://github.com/NixOS/nixpkgs/commit/50ae7d3089bbef841c3fe2f694ff8bf88a8eec08) | `` {python3Packages.,}gistyc: drop ``                                                            |
| [`3b7413d4`](https://github.com/NixOS/nixpkgs/commit/3b7413d417e926e68694ecbf0e8cecfe86cad3bf) | `` animdl: drop ``                                                                               |
| [`56efa0b3`](https://github.com/NixOS/nixpkgs/commit/56efa0b31b3ae8be593dcab4d7561235e2ca91b5) | `` lightdm: Fix switching users ``                                                               |
| [`f770561f`](https://github.com/NixOS/nixpkgs/commit/f770561f95ec7f56c41cc313aba5c490537cec27) | `` diylc: 5.11.0 -> 6.2.0 ``                                                                     |
| [`a6c273d1`](https://github.com/NixOS/nixpkgs/commit/a6c273d1d22a9fd964113f813666b9b8eb3ecf35) | `` adl: drop ``                                                                                  |
| [`84acd383`](https://github.com/NixOS/nixpkgs/commit/84acd3831c099086d8df96ee8556720f797be696) | `` rtags: 2.41-unstable-2025-12-29 -> 2.46 ``                                                    |
| [`1e7fa18c`](https://github.com/NixOS/nixpkgs/commit/1e7fa18cae28112eba75ad774b2e9d99abbdcc3c) | `` freqtweak: fix version, modernize ``                                                          |
| [`e949f190`](https://github.com/NixOS/nixpkgs/commit/e949f19015a9981dfcffa1961a34a32d7b4475e4) | `` cypress: 14.5.4 -> 15.19.0 ``                                                                 |
| [`eb5f2b31`](https://github.com/NixOS/nixpkgs/commit/eb5f2b31d54196b4cc6f5813a78a16aaaf74e033) | `` footswitch: fix version, modernize ``                                                         |
| [`0a05dba2`](https://github.com/NixOS/nixpkgs/commit/0a05dba2840846d618e4b2b9001c748b8d78f6ed) | `` python3Packages.google-cloud-dns: migrate to finalAttrs ``                                    |
| [`81aa12dc`](https://github.com/NixOS/nixpkgs/commit/81aa12dc6752091fe8b1a01951ce72a512619703) | `` python3Packages.google-cloud-dns: 0.36.1 -> 0.37.0 ``                                         |
| [`fe12886b`](https://github.com/NixOS/nixpkgs/commit/fe12886b9845cd525be98c14973110a07f07c390) | `` jailer: 16.11 -> 17.2.1 ``                                                                    |
| [`7baa6adb`](https://github.com/NixOS/nixpkgs/commit/7baa6adbbf2c735a485994f1c02418b9e885ac58) | `` betterleaks: 1.7.3 -> 1.7.4 ``                                                                |
| [`2b74aa5f`](https://github.com/NixOS/nixpkgs/commit/2b74aa5ffdd9e43a2659eb0e8ece39d3e08b0708) | `` fasd: drop ``                                                                                 |
| [`43d9cc83`](https://github.com/NixOS/nixpkgs/commit/43d9cc835da7d13de92faf1c1d60881a09dc4e1a) | `` python3Packages.pysyncobj: 0.3.15 -> 0.3.16 ``                                                |
| [`592fdd0a`](https://github.com/NixOS/nixpkgs/commit/592fdd0add2599d694f8e40f30d0077f1d6e78b9) | `` python3Packages.ttls: 1.10.0 -> 1.11.1 ``                                                     |
| [`b7fa7036`](https://github.com/NixOS/nixpkgs/commit/b7fa7036f579543bf1fc3c8bd9d79c020721687f) | `` python3Packages.ttp-templates: 0.5.8 -> 0.5.9 ``                                              |
| [`344c01d8`](https://github.com/NixOS/nixpkgs/commit/344c01d8fa2cf811cf557fca5748c2f1a36c8b04) | `` fcitx5-lotus: 3.4.1 -> 3.5.2 ``                                                               |
| [`48d6fd63`](https://github.com/NixOS/nixpkgs/commit/48d6fd6302e227b8a938e8c41eb8d8d6a1deeda3) | `` python3Packages.twilio: 9.10.9 -> 9.11.0 ``                                                   |
| [`6a62de4d`](https://github.com/NixOS/nixpkgs/commit/6a62de4dbefb9480e7e9644ef7f52c95153d7ecf) | `` python3Packages.pymisp: 2.5.34.1 -> 2.5.34.2 ``                                               |
| [`89ced657`](https://github.com/NixOS/nixpkgs/commit/89ced6577accfa36036a176deb8cef5424cc3508) | `` python3Packages.lacuscore: 1.25.1 -> 1.25.2 ``                                                |
| [`dd8669fd`](https://github.com/NixOS/nixpkgs/commit/dd8669fd30d5be3e7bde5e5ce1a70f76947deaa6) | `` python3Packages.playwrightcapture: 1.40.5 -> 1.40.8 ``                                        |
| [`4282f634`](https://github.com/NixOS/nixpkgs/commit/4282f6342b358bb9b53805a2e6f9c202459f3d08) | `` python3Packages.lookyloo-models: 0.3.0 -> 0.3.1 ``                                            |
| [`530775e9`](https://github.com/NixOS/nixpkgs/commit/530775e9212cce46b2f4417c3092668e81c87b1c) | `` python3Packages.sqlite-utils: 4.1.1 -> 4.2.1 ``                                               |
| [`7fc4785f`](https://github.com/NixOS/nixpkgs/commit/7fc4785fac07f070ccd10fce9147bf3a13515af1) | `` python3Packages.xarray: enable local networking on darwin to fix tests ``                     |
| [`8d6d9d04`](https://github.com/NixOS/nixpkgs/commit/8d6d9d045177c3692569a0a5ea8746407d49a4d6) | `` flexget: 3.19.31 -> 3.20.5 ``                                                                 |
| [`f4a72008`](https://github.com/NixOS/nixpkgs/commit/f4a7200876ae6ba40885fca3b54abd1460a3c1ef) | `` pgsrip: relax trakit ``                                                                       |
| [`5703c1ec`](https://github.com/NixOS/nixpkgs/commit/5703c1ec0ab9e8ce6acd78ee56a0e5c76c93b18d) | `` python3Packages.knowit: 0.5.11 -> 0.6.1 ``                                                    |
| [`c0b3b15e`](https://github.com/NixOS/nixpkgs/commit/c0b3b15e78f1d0eb6cd61eb55c28f8613cf2841b) | `` python3Packages.trakit: 0.2.5 -> 0.3.0 ``                                                     |
| [`12bd8032`](https://github.com/NixOS/nixpkgs/commit/12bd8032925c83dc8e1fab4c23bfc13c793781fc) | `` upsies: 2026.06.12 -> 2026.08.09 ``                                                           |
| [`9118867e`](https://github.com/NixOS/nixpkgs/commit/9118867e1fe8cbf1da939f1ab13b60fad790bfea) | `` python3Packages.aiobtclientapi: 1.1.4 -> 2.0.1 ``                                             |
| [`9c709308`](https://github.com/NixOS/nixpkgs/commit/9c7093081eb2ea98ff6f7c5024ab4176294f2404) | `` python3Packages.aiobtclientrpc: 5.0.1 -> 6.0.1 ``                                             |
| [`f59c4807`](https://github.com/NixOS/nixpkgs/commit/f59c48079697ec6438800065567b804d381b61c0) | `` rust-parallel: 1.23.0 -> 1.24.0 ``                                                            |
| [`ed7acc02`](https://github.com/NixOS/nixpkgs/commit/ed7acc0213b9e701e78876e2f595a98902239f23) | `` ocamlPackages.charon: 2026.08.06 -> 2026.08.15 ``                                             |
| [`8f3ebf4b`](https://github.com/NixOS/nixpkgs/commit/8f3ebf4b53b1d15f4fee56569abc8bfd65bbb4b1) | `` python3Packages.alibabacloud-gateway-oss: 0.0.28 -> 0.0.29 ``                                 |
| [`b85c02d3`](https://github.com/NixOS/nixpkgs/commit/b85c02d31c47c0e3f704bdee04572b022978bb3a) | `` python3Packages.alibabacloud-vpc20160428: 7.1.5 -> 7.1.6 ``                                   |
| [`12f20a14`](https://github.com/NixOS/nixpkgs/commit/12f20a141edf6d6287edf69da7446b3135a7dbfc) | `` python3Packages.cyclopts: 4.22.0 -> 4.22.5 ``                                                 |
| [`4b30651e`](https://github.com/NixOS/nixpkgs/commit/4b30651eb224d2bde85194af87de2aba62bc2dd1) | `` nasctui: 1.0.4 -> 1.0.5 ``                                                                    |
| [`dd5b6da2`](https://github.com/NixOS/nixpkgs/commit/dd5b6da26288d35dd0d3bf1d2c8b4f1ab0b0946d) | `` nnn: 5.2 -> 5.3 ``                                                                            |
| [`24c9e502`](https://github.com/NixOS/nixpkgs/commit/24c9e502952989542c14af6c79956802ff587776) | `` bomly: 0.18.0 -> 0.23.0 ``                                                                    |
| [`fec234a6`](https://github.com/NixOS/nixpkgs/commit/fec234a601a496adae23327af607b8b819ed3f74) | `` cosmic-protocols: 0-unstable-2026-07-10 -> 0-unstable-2026-08-14 ``                           |
| [`26a09706`](https://github.com/NixOS/nixpkgs/commit/26a097066464a9c33a0918d02c6c4c88c7dd27f3) | `` gotip: 0.9.0 -> 0.10.1 ``                                                                     |
| [`b9a7d2c6`](https://github.com/NixOS/nixpkgs/commit/b9a7d2c6df851cfd93cddda7779654a788aee2da) | `` aws-vault: 7.13.3 -> 7.13.4 ``                                                                |
| [`527dbd94`](https://github.com/NixOS/nixpkgs/commit/527dbd94d8b1c2cdb4b1ac490f1ba5f60eab51b5) | `` syft: 1.50.0 -> 1.51.0 ``                                                                     |
| [`c42e8166`](https://github.com/NixOS/nixpkgs/commit/c42e81665698a6b12ae3235594fd31c42a568d6f) | `` sqlmap: 1.10.6 -> 1.10.8 ``                                                                   |
| [`06f96705`](https://github.com/NixOS/nixpkgs/commit/06f967053e009f347babcc71f6400145aab11110) | `` cider-2: 4.0.9.1 -> 4.0.17 ``                                                                 |
| [`3944d592`](https://github.com/NixOS/nixpkgs/commit/3944d5927958e0ec942bb00d72b2afb0105f7031) | `` ceph.tests: Move RGW/dashbaord test from deprecated-filestore to bluestore ``                 |
| [`d829a133`](https://github.com/NixOS/nixpkgs/commit/d829a1338d53658d8752590dfdc0d1f48e771564) | `` ceph.tests.ceph-single-node-deprecated-filestore: Fix dashboard test timing out ``            |
| [`da989226`](https://github.com/NixOS/nixpkgs/commit/da989226431d27c7bd24ed3006c8a3234c071149) | `` openhack: 0.2.1 -> 0.2.3 ``                                                                   |
| [`24bd2e84`](https://github.com/NixOS/nixpkgs/commit/24bd2e844ca3303831c3e64d06d30c46c64a7e3a) | `` multica-cli: 0.4.20 -> 0.4.26 ``                                                              |
| [`ba079935`](https://github.com/NixOS/nixpkgs/commit/ba0799352da2d2f209207a5233a0a140996c7c49) | `` linkding: 1.45.0 -> 1.46.1 ``                                                                 |
| [`5e94ab96`](https://github.com/NixOS/nixpkgs/commit/5e94ab9620403eb36bec56ad955616bf842874a9) | `` itgmaniaPackages.itg3encore: 0-unstable-2026-07-26 -> 0-unstable-2026-08-10 ``                |
| [`bc266b5f`](https://github.com/NixOS/nixpkgs/commit/bc266b5ff575358acb9aaee739bdaf1172dbcb4f) | `` python3Packages.xknx: 3.18.0 -> 3.19.0 ``                                                     |
| [`7a49beca`](https://github.com/NixOS/nixpkgs/commit/7a49beca50353287822319ac29eb90097d64e8f5) | `` vimPlugins.codediff-nvim: 2.66.0 -> 2.67.0 ``                                                 |
| [`e40b2301`](https://github.com/NixOS/nixpkgs/commit/e40b23012b77c336ef42ca6dbd4f1f4617ef153f) | `` terraform-providers.vmware_avi: 32.1.1 -> 32.1.2 ``                                           |
| [`a46d92cd`](https://github.com/NixOS/nixpkgs/commit/a46d92cdbb94975e96dc505e0076ce14e0c38690) | `` kubectl-rabbitmq: 2.22.3 -> 2.22.4 ``                                                         |
| [`25c789a6`](https://github.com/NixOS/nixpkgs/commit/25c789a639ea7b09cb1eacd5764d7e5e6a368c51) | `` sbt-extras: 2025-08-25 -> 2026-05-04 ``                                                       |
| [`3fc21448`](https://github.com/NixOS/nixpkgs/commit/3fc214489d62a07f8212f316e3cedd32f6cf4721) | `` zoneminder: enable nix-update-script ``                                                       |
| [`6dfc26ff`](https://github.com/NixOS/nixpkgs/commit/6dfc26ff11fca130885641efb1f910172561cabf) | `` zoneminder: 1.38.3 -> 1.38.4 ``                                                               |
| [`0d011799`](https://github.com/NixOS/nixpkgs/commit/0d011799c0320aa59ac68b483d40809a08d3bf70) | `` flyctl: 0.4.79 -> 0.4.83 ``                                                                   |
| [`0fde879b`](https://github.com/NixOS/nixpkgs/commit/0fde879b5ec99e3aed045c7010abbe68f4fa86f3) | `` python3Packages.consese-json: add dwt as maintainer ``                                        |
| [`5b4b3f5a`](https://github.com/NixOS/nixpkgs/commit/5b4b3f5a07cc0c1d1963501d101cf857ddbf291f) | `` prometheus-chrony-exporter: 0.13.3 -> 0.14.0 ``                                               |
| [`bca1439e`](https://github.com/NixOS/nixpkgs/commit/bca1439ea2619aeead4e02301a350f58ec38882b) | `` vermouth: 2.0.1 -> 2.0.2 ``                                                                   |
| [`2061dac9`](https://github.com/NixOS/nixpkgs/commit/2061dac94520651e5be2498d8b00e54c65b3e7ed) | `` stakk: 1.19.0 -> 2.1.3 ``                                                                     |
| [`f86b4536`](https://github.com/NixOS/nixpkgs/commit/f86b4536bfc4a29d57430d540548993a7216d1e8) | `` metabase: 0.59.2 -> 0.63.5 ``                                                                 |
| [`917ec3b1`](https://github.com/NixOS/nixpkgs/commit/917ec3b1c2817cbb949e16edda7ed0da0e2bacc6) | `` nixos/gitlab: increase postgres  max locks per transaction ``                                 |
| [`d1e9a8d6`](https://github.com/NixOS/nixpkgs/commit/d1e9a8d66c58491f23c17862b2eb2d376e2ce4e0) | `` python3Packages.pyreqwest: 0.12.2 -> 0.12.4 ``                                                |
| [`946719e1`](https://github.com/NixOS/nixpkgs/commit/946719e1e62764abfdcd79e4fde4672635db74bd) | `` mprisence: 1.8.0 -> 1.8.2 ``                                                                  |
| [`7d1ac295`](https://github.com/NixOS/nixpkgs/commit/7d1ac2955441b6ac02bae58c468f0527ded04993) | `` ijhttp: 252.23892.409 -> 261.25134.95 ``                                                      |
| [`97c9f3cf`](https://github.com/NixOS/nixpkgs/commit/97c9f3cf1adb9242f9aa8316b9920c8e2b553841) | `` python3Packages.nvchecker: 2.21 -> 2.22 ``                                                    |
| [`ca193e28`](https://github.com/NixOS/nixpkgs/commit/ca193e28e3a130c2ab006d3b702e2cb655b394e5) | `` publii: remove broken changelog link ``                                                       |
| [`dcea481f`](https://github.com/NixOS/nixpkgs/commit/dcea481fb14d3910a4a1b6fd4cbf9c59dbb1fe55) | `` lsp-plugins: 1.2.33 -> 1.2.34 ``                                                              |
| [`d43aee30`](https://github.com/NixOS/nixpkgs/commit/d43aee30f8f3f95bfe92f1537c1099dee893cbea) | `` python3Packages.roma: 1.5.7 -> 1.6.0 ``                                                       |
| [`d4e5556f`](https://github.com/NixOS/nixpkgs/commit/d4e5556f9b4d2b06622f857346455bce3ae40561) | `` pythonPackages.skytemple-files: Disable nixpkgs-update auto-update ``                         |
| [`03d0e6ce`](https://github.com/NixOS/nixpkgs/commit/03d0e6ced1aeb85c86f37672985878ff3d4c0fbc) | `` python3Packages.guessit: 3.8.0 -> 4.4.0 ``                                                    |
| [`91bc4f76`](https://github.com/NixOS/nixpkgs/commit/91bc4f76403302fcb78beee101feb934704b7aa0) | `` python3Packages.rebulk: 3.2.0 -> 6.0.1 ``                                                     |
| [`17eabb05`](https://github.com/NixOS/nixpkgs/commit/17eabb054e4b9cd388f30ed0590116236705d58c) | `` python3Packages.georss-wa-dfes-client: 0.4 -> 2026.6.0 ``                                     |
| [`69e57f56`](https://github.com/NixOS/nixpkgs/commit/69e57f56b4d5cc76f755fcf97c19d58350ac24b6) | `` python3Packages.georss-nrcan-earthquakes-client: 0.4 -> 2026.6.0 ``                           |
| [`a4111f48`](https://github.com/NixOS/nixpkgs/commit/a4111f483a95b4067917f8b803136f7163796e69) | `` python3Packages.model-checker: migrate to finalAttrs ``                                       |
| [`43144be8`](https://github.com/NixOS/nixpkgs/commit/43144be8ac9a5db4c009e989e664ba3626afb2ec) | `` worktrunk: 0.71.0 -> 0.74.0 ``                                                                |
| [`415d26c9`](https://github.com/NixOS/nixpkgs/commit/415d26c9a476f1ef8226179ccdea7025ca4af32f) | `` xplr: 1.1.0 -> 1.1.1 ``                                                                       |
| [`13ad4051`](https://github.com/NixOS/nixpkgs/commit/13ad4051b9518fa927aa7406bbe68d117e6b8e55) | `` soundsource: 6.1.0 -> 6.1.1 ``                                                                |
| [`d65c01d4`](https://github.com/NixOS/nixpkgs/commit/d65c01d41b02b807d60064da5d0b427ad39aec86) | `` raycast-beta: 0.68.0.0 -> 0.71.5.0 ``                                                         |
| [`b4955aef`](https://github.com/NixOS/nixpkgs/commit/b4955aefefab0664a8747399c3c005383ce04952) | `` raycast: 1.104.17 -> 1.104.24 ``                                                              |
| [`20644add`](https://github.com/NixOS/nixpkgs/commit/20644add7b02bda109194423f2f29e11c837dd71) | `` python3Packages.ntc-templates: 8.1.0 -> 9.2.0 ``                                              |
| [`0dd57041`](https://github.com/NixOS/nixpkgs/commit/0dd570416c02ac0f5f23c72903433b69af1093fe) | `` python3Packages.deezer-python: 7.3.0 -> 7.4.0 ``                                              |
| [`39d9140c`](https://github.com/NixOS/nixpkgs/commit/39d9140c0f3a48ef9217edc192d85d52a3967588) | `` cypress: make updateScript update all sources ``                                              |
| [`ae2ad0df`](https://github.com/NixOS/nixpkgs/commit/ae2ad0df3d696ee54ef022cc6ab7984a2a4f6ad6) | `` nixos/sd-image: use lsblk -npo PARTN to identify partition for sd-card expansion ``           |
| [`5a7539f0`](https://github.com/NixOS/nixpkgs/commit/5a7539f0520b29c891c1bf4d9a4aeed845229420) | `` vial: add tallesCoelho as maintainer ``                                                       |
| [`80b2aa41`](https://github.com/NixOS/nixpkgs/commit/80b2aa4165584463e0a8ed2e56f809103fa5040d) | `` flycast: add tallesCoelho as maintainer ``                                                    |
| [`0b79a4df`](https://github.com/NixOS/nixpkgs/commit/0b79a4dfc146b8f251ebe024939b385cfc671a84) | `` distrobox: add tallesCoelho as maintainer ``                                                  |
| [`99d950e4`](https://github.com/NixOS/nixpkgs/commit/99d950e4fd686dde01046a2ffd28c79bf8e2f0c5) | `` maintainers: update gepbird ``                                                                |
| [`33a23679`](https://github.com/NixOS/nixpkgs/commit/33a23679bf6be6323faaf757531804d3fb153a28) | `` python3Packages.python-technove: migrate to finalAttrs ``                                     |
| [`b15059ab`](https://github.com/NixOS/nixpkgs/commit/b15059ab63449482d8e4434c0ec7301e774a4f34) | `` python3Packages.python-technove: 2.1.1 -> 2.1.2 ``                                            |
| [`944bf4a8`](https://github.com/NixOS/nixpkgs/commit/944bf4a8b14f4801d01a8f63bb4422d6e77e17c9) | `` python3Packages.pycfmodel: 2.1.1 -> 2.1.2 ``                                                  |
| [`d315d237`](https://github.com/NixOS/nixpkgs/commit/d315d2372f98d5230ebc2060186ab2323af7febe) | `` python3Packages.nicegui: 3.15.0 -> 3.16.0 ``                                                  |
| [`41e5720b`](https://github.com/NixOS/nixpkgs/commit/41e5720ba50f40472551c54cf332ea38627eae3a) | `` python3Packages.itkwasm-downsample-wasi: 2.0.0 -> 2.0.2 ``                                    |
| [`f7ade4bc`](https://github.com/NixOS/nixpkgs/commit/f7ade4bcfd79330314ff8889378b29cc4674c82e) | `` python3Packages.itkwasm-downsample-emscripten: 2.0.0 -> 2.0.2 ``                              |
| [`7bdf687b`](https://github.com/NixOS/nixpkgs/commit/7bdf687b09c53f91229e98db61169dc443cf7a83) | `` python3Packages.itkwasm-downsample: 2.0.0 -> 2.0.2 ``                                         |
| [`61b68d4b`](https://github.com/NixOS/nixpkgs/commit/61b68d4b3c2f7e6d2f8057571634a6d38e909552) | `` zenoh-cpp: fix CMake export + clean ``                                                        |
| [`d51ab424`](https://github.com/NixOS/nixpkgs/commit/d51ab4246b8f7a2526c0605722fc889a0eea8fa8) | `` chameleon-cli: 2.2.0-unstable-2026-07-04 -> 2.2.0-unstable-2026-08-10 ``                      |
| [`c5876657`](https://github.com/NixOS/nixpkgs/commit/c58766579d10ac20315da7deb142e17f40140846) | `` zenoh-c: fix CMake export + more features + clean ``                                          |
| [`49f619cc`](https://github.com/NixOS/nixpkgs/commit/49f619cc029bce514e7073a8d7d83d80fd7d1364) | `` equicord: 2026-05-26 -> 2026-08-15 ``                                                         |
| [`05f70998`](https://github.com/NixOS/nixpkgs/commit/05f709987948de62b0b4a569ebfd3cd14faa2008) | `` python3Packages.model-checker: 1.2.12 -> 1.3.3 ``                                             |
| [`5566de77`](https://github.com/NixOS/nixpkgs/commit/5566de771b8e7824f31b7e1922af97031d0edf2c) | `` python3Packages.georss-ingv-centro-nazionale-terremoti-client: 0.7 -> 2026.6.0 ``             |
| [`0e317315`](https://github.com/NixOS/nixpkgs/commit/0e3173152eef7d5679e2e249bb65ab71dcc382b1) | `` python3Packages.georss-generic-client: 0.8 -> 2026.6.0 ``                                     |
| [`2ecf02d5`](https://github.com/NixOS/nixpkgs/commit/2ecf02d5840ded6811b74014fad5f8542bee2be8) | `` nwjs-ffmpeg-prebuilt: 0.107.0 -> 0.114.2 ``                                                   |
| [`b5ee6d5b`](https://github.com/NixOS/nixpkgs/commit/b5ee6d5b91c2fc1005217c207c8a477589703617) | `` python3Packages.claude-agent-sdk: 0.2.138 -> 0.2.139 ``                                       |
| [`ac05c37a`](https://github.com/NixOS/nixpkgs/commit/ac05c37a4709c987d3d255c68c8300a1f82305ea) | `` python3Packages.cdcs: 0.2.6 -> 0.2.7 ``                                                       |
| [`bb3723ff`](https://github.com/NixOS/nixpkgs/commit/bb3723ffabcbe169f41c6550bd6eaa1274fff32c) | `` python3Packages.aioruckus: migrate to finalAttrs ``                                           |
| [`67f58528`](https://github.com/NixOS/nixpkgs/commit/67f58528c00943756f9d4d31fb26b18070489459) | `` faust-physicalmodeling: 2.85.5 -> 2.85.9 ``                                                   |
| [`20831760`](https://github.com/NixOS/nixpkgs/commit/20831760fadb98e2b710fb2ab1361e1dac3e87d6) | `` python3Packages.aioruckus: 0.46.3 -> 0.47.0 ``                                                |
| [`79376f03`](https://github.com/NixOS/nixpkgs/commit/79376f03e65cf4578e62e6e8944f89c2de5df72b) | `` python3Packages.aioautomower: 2.7.6 -> 2.8.0 ``                                               |
| [`5bf2285d`](https://github.com/NixOS/nixpkgs/commit/5bf2285dd8bb60cf415947456b71dca8c3521597) | `` emscripten: 6.0.5 -> 6.0.6 ``                                                                 |
| [`7c01cd72`](https://github.com/NixOS/nixpkgs/commit/7c01cd72dcc091dc807e4a6aa5ad60becafe5401) | `` yazi{-unwrapped}: 26.5.6 -> 26.8.15 ``                                                        |
| [`d47a77dc`](https://github.com/NixOS/nixpkgs/commit/d47a77dc53850d44506c2758f5669a542f7bc08d) | `` python3Packages.boto3-stubs: 1.43.71 -> 1.43.72 ``                                            |
| [`1a83bd3b`](https://github.com/NixOS/nixpkgs/commit/1a83bd3bd6e41ba0eea79a1622d588a99bf6750e) | `` python3Packages.mypy-boto3-sagemaker: 1.43.68 -> 1.43.72 ``                                   |
| [`2785ba0e`](https://github.com/NixOS/nixpkgs/commit/2785ba0ee3d554810b751b2f78d6f7170574b879) | `` python3Packages.mypy-boto3-redshift-serverless: 1.43.47 -> 1.43.72 ``                         |
| [`12b267a2`](https://github.com/NixOS/nixpkgs/commit/12b267a28c23a2b6b9863cd7de99260bff987de3) | `` python3Packages.mypy-boto3-redshift: 1.43.53 -> 1.43.72 ``                                    |
| [`d4e12103`](https://github.com/NixOS/nixpkgs/commit/d4e1210346ea9c6fd3c7773fdc367cf43e39d8ae) | `` python3Packages.mypy-boto3-glue: 1.43.70 -> 1.43.72 ``                                        |
| [`3b387c49`](https://github.com/NixOS/nixpkgs/commit/3b387c49d3959be81eefc2ce652eeecf20889581) | `` python3Packages.publicsuffixlist: 1.0.2.20260726 -> 1.0.2.20260815 ``                         |
| [`b7b272bb`](https://github.com/NixOS/nixpkgs/commit/b7b272bb4d220fb60c5f6ed88446d5383fd26350) | `` python3Packages.iamdata: 0.1.202608141 -> 0.1.202608151 ``                                    |
| [`e902d40b`](https://github.com/NixOS/nixpkgs/commit/e902d40b8b3986cffcffcccff777259db87929d1) | `` python3Packages.onvif-parsers: sync changelog with tag ``                                     |
| [`9f6997fd`](https://github.com/NixOS/nixpkgs/commit/9f6997fd985ac2ef5a1d319cf2987bac4d0e20d4) | `` toppra: init at 0.6.9 ``                                                                      |
| [`18c5a9b4`](https://github.com/NixOS/nixpkgs/commit/18c5a9b4a8fe80c550276b5bb72bd40f33f18a8f) | `` ghostfolio: 3.43.0 -> 3.50.0 ``                                                               |
| [`8504e5e5`](https://github.com/NixOS/nixpkgs/commit/8504e5e5946ed6bd7870025070cdf86fdddfbed9) | `` imapdedup: set strictDeps & __structuredAttrs ``                                              |
| [`5c0df67f`](https://github.com/NixOS/nixpkgs/commit/5c0df67f180cba2287a092afc74cce0849ab5eab) | `` imapdedup: add meta.changelog ``                                                              |
| [`e37b7e7c`](https://github.com/NixOS/nixpkgs/commit/e37b7e7c14e6a65ce2005808f9cd026979aefa30) | `` osgqt: drop ``                                                                                |
| [`27c6d601`](https://github.com/NixOS/nixpkgs/commit/27c6d60102708a5c7c14f6f059b7f224e0507fa8) | `` dart-source: 3.12.2 -> 3.13.0 ``                                                              |
| [`9c6333cc`](https://github.com/NixOS/nixpkgs/commit/9c6333ccf1c8150f89486ec8d3f97abd1a9c1ddd) | `` dart-bin: 3.12.2 -> 3.13.0 ``                                                                 |
| [`58ee84ee`](https://github.com/NixOS/nixpkgs/commit/58ee84eefab2b6d8b777c90ed5be5a2d838d42f5) | `` gepetto-viewer: drop ``                                                                       |
| [`c8dd8a3c`](https://github.com/NixOS/nixpkgs/commit/c8dd8a3cbca55f26df853c311a85dd0e39793362) | `` gepetto-viewer-corba: drop ``                                                                 |
| [`a076c7fa`](https://github.com/NixOS/nixpkgs/commit/a076c7fa84a47b94defac1eced8d4acf8aa09271) | `` python3Packages.gepetto-gui: drop ``                                                          |
| [`85bc4572`](https://github.com/NixOS/nixpkgs/commit/85bc45723afba22dd1dbc4fa4df107f020fe114b) | `` python3Packages.llama-cloud: 2.13.0 -> 2.14.0 ``                                              |
| [`6e58ef3c`](https://github.com/NixOS/nixpkgs/commit/6e58ef3cff0859d4dd4ff40af0978bef60e5160d) | `` kiro-cli-unwrapped: 2.16.1 -> 2.18.1 ``                                                       |
| [`7df76950`](https://github.com/NixOS/nixpkgs/commit/7df76950cf17a109736c0824a810c3f93e9a4275) | `` github-mcp-server: 1.8.0 -> 1.9.0 ``                                                          |
| [`c7893b88`](https://github.com/NixOS/nixpkgs/commit/c7893b88002a20d6da0184845fa514d14db7066f) | `` kdePackages: Frameworks 6.28 -> 6.29 ``                                                       |
| [`6673b099`](https://github.com/NixOS/nixpkgs/commit/6673b099be4d0c2a8b80397cd000987553bd0343) | `` sauce-connect: 5.3.0 -> 5.5.3 ``                                                              |
| [`21406cf8`](https://github.com/NixOS/nixpkgs/commit/21406cf87453a18982a28708d7c53af8b6de4c42) | `` wezterm: 0-unstable-2026-08-05 -> 0-unstable-2026-08-12 ``                                    |
| [`5a3c9ec7`](https://github.com/NixOS/nixpkgs/commit/5a3c9ec7bbe78d094ef2e4cea06987f1f1f3d208) | `` emmylua-ls: 0.24.0 -> 0.25.1 ``                                                               |
| [`8dec8c06`](https://github.com/NixOS/nixpkgs/commit/8dec8c06a908d8186dcad0afc719b1eb0c50be93) | `` msedgedriver: derive maintainers from related package ``                                      |
| [`2dd9b87f`](https://github.com/NixOS/nixpkgs/commit/2dd9b87f17a61f79b48a905a559175f6ae29aef5) | `` openlist: 4.2.4 -> 4.2.5 ``                                                                   |
| [`ea37d530`](https://github.com/NixOS/nixpkgs/commit/ea37d530604a500df5dbf1b6748cfdb86c54fb47) | `` imapdedup: 1.2 -> 1.3 ``                                                                      |
| [`0cd5ed21`](https://github.com/NixOS/nixpkgs/commit/0cd5ed212abe2e6ac7a6c3a8ff76bc1506699b86) | `` mailpit: 1.30.6 -> 1.30.7 ``                                                                  |
| [`9fd9aa0e`](https://github.com/NixOS/nixpkgs/commit/9fd9aa0ee1717bee1800c00556ef7ef28b5167c3) | `` python3Packages.py-opendisplay: 7.15.0 -> 7.16.0 ``                                           |
| [`2d01f046`](https://github.com/NixOS/nixpkgs/commit/2d01f0463b6a2ccc3021a4868e13a4383a80923a) | `` python3Packages.onvif-parsers: 2.3.0 -> 2.3.1 ``                                              |
| [`6bcd43ac`](https://github.com/NixOS/nixpkgs/commit/6bcd43ac1b2afb573e8264c9fef46d04db1fb8cc) | `` python3Packages.qtile-extras: 0.36.0 -> 0.37.0 ``                                             |
| [`aa8b053c`](https://github.com/NixOS/nixpkgs/commit/aa8b053c31642fe5c0d05f52008dfddbc5cafe48) | `` python3Packages.httpx-socks: 0.11.0 -> 0.13.1 ``                                              |
| [`f351630e`](https://github.com/NixOS/nixpkgs/commit/f351630eb99d565cf0c95c1d9499d57d649de54c) | `` terraform-providers.newrelic_newrelic: 3.96.0 -> 3.96.2 ``                                    |
| [`66e7af9f`](https://github.com/NixOS/nixpkgs/commit/66e7af9ff6f55030f14298c8dc9f776f28ce0155) | `` squeezelite: 2.0.0.1584 -> 2.0.0.1586 ``                                                      |
| [`d70d93db`](https://github.com/NixOS/nixpkgs/commit/d70d93db30b579e570b28eefdd71e7c1d497a6c5) | `` incus-ui-canonical: 0.21.5 -> 0.21.6 ``                                                       |
| [`75686aa6`](https://github.com/NixOS/nixpkgs/commit/75686aa6f4a315e29983ccbf955f6bd5e4f8d98f) | `` home-assistant-custom-lovelace-modules.multiple-entity-row: 4.9.0 -> 4.10.1 ``                |
| [`83d74a54`](https://github.com/NixOS/nixpkgs/commit/83d74a54123a55390fbbbd90350048693ed7c0ae) | `` home-assistant-custom-lovelace-modules.custom-brand-icons: 2026.08.0 -> 2026.08.2 ``          |
| [`1ed61040`](https://github.com/NixOS/nixpkgs/commit/1ed61040b0990f5296ff458486a450ee0ac9fc62) | `` home-assistant-custom-components.versatile_thermostat: 10.0.2 -> 10.1.0 ``                    |
| [`d99b247c`](https://github.com/NixOS/nixpkgs/commit/d99b247c180372aeb90ae3d9db6f5be9fe86245c) | `` home-assistant-custom-components.valetudo: 2026.01.1 -> 2026.08.0 ``                          |
| [`87cfc38f`](https://github.com/NixOS/nixpkgs/commit/87cfc38f3699a97a9328483bef89cb29eabdd020) | `` home-assistant-custom-components.sensi: 2.1.5 -> 2.1.6 ``                                     |
| [`9f7f9427`](https://github.com/NixOS/nixpkgs/commit/9f7f942751541bf433b3ae9781f9a54d263299f4) | `` home-assistant-custom-components.localthings: 0.20.0 -> 0.22.0 ``                             |
| [`d0eca70a`](https://github.com/NixOS/nixpkgs/commit/d0eca70a14c60cb91226060a3ab68ccd27bdf57a) | `` python3Packages.smartthings-local: 0.1.3 -> 0.1.6 ``                                          |
| [`64bb4c1d`](https://github.com/NixOS/nixpkgs/commit/64bb4c1ddeabc2079615eaf9e0327d7107e9a3fb) | `` python3Packages.langchain-google-genai: 4.3.2 -> 4.3.4 ``                                     |
| [`be42808c`](https://github.com/NixOS/nixpkgs/commit/be42808c213d94d7e97867ee8af7ba4335f4bd42) | `` chiaki-ng: pin ffmpeg_8 ``                                                                    |
| [`b83e6393`](https://github.com/NixOS/nixpkgs/commit/b83e6393c9045d4972cc480366a74cbe492783d5) | `` harmonist: add meta.changelog ``                                                              |
| [`2683f5a1`](https://github.com/NixOS/nixpkgs/commit/2683f5a1ee79cab7706ad476a81ad5a3ae85cc20) | `` home-assistant-custom-components.ingress: 1.3.0 -> 1.3.2 ``                                   |
| [`960375e0`](https://github.com/NixOS/nixpkgs/commit/960375e01e80e7dcda542ed507733e55de8f33da) | `` home-assistant-custom-components.garmin_connect: 3.0.14 -> 3.0.15 ``                          |
| [`25997787`](https://github.com/NixOS/nixpkgs/commit/25997787624ea0524a3541c1348397a998a063c3) | `` home-assistant-custom-components.frigidaire: 0.1.37 -> 0.1.38 ``                              |
| [`2d21ad83`](https://github.com/NixOS/nixpkgs/commit/2d21ad836e6e7ebe13ab94ccf4611b2b5acad38f) | `` home-assistant-custom-components.ecoflow_ble: 1.0.3 -> 1.0.4 ``                               |
| [`b6992586`](https://github.com/NixOS/nixpkgs/commit/b69925866b3c40a8cf31b3d67c0179a71b9ddb88) | `` home-assistant-custom-components.dreo: 1.11.1 -> 1.11.2 ``                                    |
| [`5dcc1416`](https://github.com/NixOS/nixpkgs/commit/5dcc1416f7f0fc3cfc4040d3a1979832e8a07db3) | `` home-assistant-custom-components.daikin_onecta: 4.6.13 -> 4.6.15 ``                           |
| [`55bd39c8`](https://github.com/NixOS/nixpkgs/commit/55bd39c8cc4a67380b2d3bcfd205859eadd6681f) | `` home-assistant-custom-components.browser-mod: 3.2.0 -> 3.2.1 ``                               |
| [`3c59a976`](https://github.com/NixOS/nixpkgs/commit/3c59a9761fb9291f2b9421004d74e634427f0db1) | `` home-assistant-custom-components.bodymiscale: 2026.7.0 -> 2026.8.0 ``                         |
| [`16deab2c`](https://github.com/NixOS/nixpkgs/commit/16deab2c5716cf519f57054c41bc3c67457f0583) | `` home-assistant-custom-components.blueprints-updater: 2.11.1 -> 2.12.2 ``                      |
| [`f3236fe0`](https://github.com/NixOS/nixpkgs/commit/f3236fe0e46ad946ff5f1d2225e6b06b7f42075e) | `` python3Packages.homeassistant-stubs: 2026.8.1 -> 2026.8.2 ``                                  |
| [`d54ad52d`](https://github.com/NixOS/nixpkgs/commit/d54ad52da1cf0b71139875b4f84f2c86f8c1eab0) | `` home-assistant-custom-components.blueprints-updater: 2.11.1 -> 2.12.2 ``                      |
| [`fbabf422`](https://github.com/NixOS/nixpkgs/commit/fbabf422cb53692678f32187953cdeaaed422dde) | `` usacloud: modernize slightly ``                                                               |
| [`d2f57d0f`](https://github.com/NixOS/nixpkgs/commit/d2f57d0f023580a495f89c155c2b71136e27aef9) | `` home-assistant-custom-components.browser-mod: 3.2.0 -> 3.2.1 ``                               |
| [`108f9aa7`](https://github.com/NixOS/nixpkgs/commit/108f9aa7fc0635be0ac08e6dc987aaa764e17694) | `` python3Packages.deebot-client: unpin cryptography ``                                          |
| [`f81416e7`](https://github.com/NixOS/nixpkgs/commit/f81416e7ec3ce9024a59b5c0fa4d338c0a5e1c57) | `` pana: 0.23.16 -> 0.23.18 ``                                                                   |
| [`041bce7c`](https://github.com/NixOS/nixpkgs/commit/041bce7c99ce5fe2cf1a1c429a8869a929738ab1) | `` readeck: 0.22.3 -> 0.23.0 ``                                                                  |
| [`b6d690b9`](https://github.com/NixOS/nixpkgs/commit/b6d690b9341edf39515f8c51983dacab68f9755f) | `` kicad-testing: 10.0-2026-07-21 -> 10.0-2026-08-14 ``                                          |
| [`48d0ec21`](https://github.com/NixOS/nixpkgs/commit/48d0ec2104fa76bf08d7e03576c2178ee38ab007) | `` dblab: 0.47.3 -> 0.48.0 ``                                                                    |
| [`7d4f14e6`](https://github.com/NixOS/nixpkgs/commit/7d4f14e6b69b52154dcc044b30667f1c0a60592d) | `` goa: 3.23.4 -> 3.29.1 ``                                                                      |
| [`a59af309`](https://github.com/NixOS/nixpkgs/commit/a59af30953a78ae4c3669e1410267e4823ef869c) | `` python3Packages.clingo: 5.8.1 -> 5.8.2 ``                                                     |
| [`4055e99d`](https://github.com/NixOS/nixpkgs/commit/4055e99dd4df572a1b90ca2aa843c209aaf281c5) | `` ollama-cpu: 0.32.11 -> 0.32.13 ``                                                             |
| [`2b8b7fa8`](https://github.com/NixOS/nixpkgs/commit/2b8b7fa8129069b8d47515c0551e3a987a3d13e9) | `` fishPlugins.pure: 4.15.0 -> 4.18.0 ``                                                         |
| [`e6648f75`](https://github.com/NixOS/nixpkgs/commit/e6648f75d6e3e5b53ed409146d4597a8ceb17801) | `` waveterm: 0.13.1 -> 0.14.5 ``                                                                 |
| [`111778ad`](https://github.com/NixOS/nixpkgs/commit/111778ad6e417b901268cf440590d8bbf1c60037) | `` fail2ban: add changelog ``                                                                    |
| [`9df8d1d1`](https://github.com/NixOS/nixpkgs/commit/9df8d1d16b2887cbca67484f70731fe3eb489ea1) | `` libdeltachat: 2.58.0 -> 2.59.0 ``                                                             |
| [`d8018824`](https://github.com/NixOS/nixpkgs/commit/d8018824e7910b4e09e22e91e9bbb117a11dcbe1) | `` incus-compose: 1.1.0 -> 1.2.0 ``                                                              |
| [`c2120e94`](https://github.com/NixOS/nixpkgs/commit/c2120e9434e1466599e9bc095ea283705880acee) | `` parla: 0.7.8 -> 0.8.0 ``                                                                      |
| [`2c0c5ec6`](https://github.com/NixOS/nixpkgs/commit/2c0c5ec62db9e0d5446c8f6349f0ccbedb533e89) | `` shelfmark: 1.3.5 -> 1.3.7 ``                                                                  |
| [`1c3dae95`](https://github.com/NixOS/nixpkgs/commit/1c3dae95727acb512959ecd634fe2be17dfcc5cc) | `` fail2ban: set __structuredAttrs & strictDeps ``                                               |
| [`8a6f91bf`](https://github.com/NixOS/nixpkgs/commit/8a6f91bf9adddc09c3d8720a3e34cb1565769d43) | `` nushellPlugins.highlight: 1.4.15+0.113.1 -> 1.4.16+0.114.1 ``                                 |
| [`7828be24`](https://github.com/NixOS/nixpkgs/commit/7828be245b60f199267169fe0c4f3ecb5a97d0ef) | `` jetty: 12.1.11 -> 12.1.12 ``                                                                  |
| [`d9dd09b3`](https://github.com/NixOS/nixpkgs/commit/d9dd09b3142a15e648e2013f11a677d11386e710) | `` python3Packages.plotnine: 0.15.7 -> 0.15.8 ``                                                 |
| [`f6acec25`](https://github.com/NixOS/nixpkgs/commit/f6acec258c779880fd7e6cbe32aa7df13183cc78) | `` qrc: init at 0.9.0 ``                                                                         |
| [`a4e888b2`](https://github.com/NixOS/nixpkgs/commit/a4e888b221bf2c8ba1e6784c5ab45ce4e6afaccb) | `` python3Packages.hist: skip crashing test on darwin ``                                         |
| [`a3f6add1`](https://github.com/NixOS/nixpkgs/commit/a3f6add18880d715c70c3b620d6e5b47ff6e2caf) | `` python3Packages.hist: cleanup ``                                                              |
| [`a9a08554`](https://github.com/NixOS/nixpkgs/commit/a9a0855451b694f865fd275957136e5f83f2fe37) | `` fail2ban: switch to pyproject ``                                                              |
| [`e8a242d0`](https://github.com/NixOS/nixpkgs/commit/e8a242d0ba47580769f277097ea68bb9682c9dd1) | `` gtkmm2: drop ``                                                                               |
| [`778678f8`](https://github.com/NixOS/nixpkgs/commit/778678f8d5af06d4fa02d0c81e3781565783cc37) | `` rPackages.HilbertVisGUI: mark as broken due to gtk2 dependency ``                             |
| [`15c59ef5`](https://github.com/NixOS/nixpkgs/commit/15c59ef558c4c7744842ab79e071d77a6352aa88) | `` utsushi: drop ``                                                                              |
| [`2a59da8e`](https://github.com/NixOS/nixpkgs/commit/2a59da8e348b1cdff8dbc134a1521a260fce0168) | `` pcb2gcode: drop ``                                                                            |
| [`8ee2cc9d`](https://github.com/NixOS/nixpkgs/commit/8ee2cc9d58c4f6383262e8a84b7c2278a3020190) | `` nitrogen: drop ``                                                                             |
| [`fb10c389`](https://github.com/NixOS/nixpkgs/commit/fb10c389d2552066223305b9847290ed95791a29) | `` lvtk: drop gtkmm2 dependency ``                                                               |
| [`6c60d01d`](https://github.com/NixOS/nixpkgs/commit/6c60d01d68bf24cb6ede72ab275d6414c4d0a8be) | `` lv2-cpp-tools: drop ``                                                                        |
| [`8b83d21a`](https://github.com/NixOS/nixpkgs/commit/8b83d21ab7bf3834392cd016172cd9f0074d34fa) | `` vocproc: drop ``                                                                              |
| [`3828117f`](https://github.com/NixOS/nixpkgs/commit/3828117f53d82c09dd7c06e9838c9a4ee70d327d) | `` gigedit: drop gtkmm2 dependency, use gtkmm3 ``                                                |
| [`8c320c06`](https://github.com/NixOS/nixpkgs/commit/8c320c06ec6a22c44f253c0aa759f17c87dea8b3) | `` ganv: drop ``                                                                                 |
| [`be4be392`](https://github.com/NixOS/nixpkgs/commit/be4be392138fda8053f046b2dbc91519074fd0d1) | `` ingen: disable gui to drop ganv and gtkmm2 dependencies ``                                    |
| [`d5f7f060`](https://github.com/NixOS/nixpkgs/commit/d5f7f060c6a1b2cfc2f11e38c0a6c3ccb83e262a) | `` patchage: drop ``                                                                             |
| [`45f16894`](https://github.com/NixOS/nixpkgs/commit/45f16894c42fc867be4aabfb8b23f17f1c0e5abf) | `` eq10q: drop ``                                                                                |
| [`233fa5ec`](https://github.com/NixOS/nixpkgs/commit/233fa5ec76fca2e3c99cfa251c09a748cc5f1edc) | `` ahoviewer: drop ``                                                                            |
| [`baf2dbb3`](https://github.com/NixOS/nixpkgs/commit/baf2dbb373bec9be961d6861dd18626ac4fad057) | `` python3Packages.asdf-astropy: unbreak, ignore CacheMissingWarning ``                          |
| [`2c18410a`](https://github.com/NixOS/nixpkgs/commit/2c18410aa51228d030b2e1ef717a1b1989aa1f71) | `` postfix-tlspol: 1.12.1 -> 1.12.2 ``                                                           |
| [`022da8ed`](https://github.com/NixOS/nixpkgs/commit/022da8ed2bb90cdce389f4c8628cdf13ce3aba22) | `` python3Packages.qcodes: ignore PendingDeprecationWarning ``                                   |
| [`c5811ac1`](https://github.com/NixOS/nixpkgs/commit/c5811ac1d4bc5361b9e00032e80da5245cdba7d6) | `` mistral-rs: 0.9.0 -> 0.9.1 ``                                                                 |
| [`6324df0c`](https://github.com/NixOS/nixpkgs/commit/6324df0cfcd698020ff5f9edc18147c0b0b6a54e) | `` bit-logo: 0.3.0 -> 0.4.0 ``                                                                   |
| [`8eb553ff`](https://github.com/NixOS/nixpkgs/commit/8eb553ff80351a2fe24a0490986fdd098837acb5) | `` python3Packages.awkward: 2.12.0 -> 2.13.0 ``                                                  |
| [`1f11c4ac`](https://github.com/NixOS/nixpkgs/commit/1f11c4ac3cd978f3c5186ec5aa3d0af42fb41d61) | `` snyk: 1.1306.1 -> 1.1306.4 ``                                                                 |
| [`ad073dd7`](https://github.com/NixOS/nixpkgs/commit/ad073dd713ab7022b6689444e04df0547fcae77d) | `` prowler: 5.36.0 -> 5.39.0 ``                                                                  |
| [`70f14cf9`](https://github.com/NixOS/nixpkgs/commit/70f14cf94e582d2ec7608881f0c55008d80dc4ed) | `` cdktn-cli: 0.23.3 -> 0.24.0 ``                                                                |
| [`03a1b0dd`](https://github.com/NixOS/nixpkgs/commit/03a1b0ddc4a94368e309b12b8006d6bd25a3c5ff) | `` python3Packages.columnize: disable bulk updates ``                                            |
| [`9ef5ee81`](https://github.com/NixOS/nixpkgs/commit/9ef5ee81e440148b9f89c6f6cb74496819ead442) | `` Revert "python3Packages.columnize: 0.3.11 -> 3.11" ``                                         |
| [`607f57b6`](https://github.com/NixOS/nixpkgs/commit/607f57b6649539d613ed80d1872d1d95485cd8d6) | `` python3Packages.huaweicloudsdk*: init at 3.1.210 ``                                           |
| [`219d2fcd`](https://github.com/NixOS/nixpkgs/commit/219d2fcdba399d68a2a528974324c5b84bed1d66) | `` postgresql_19: 19beta2 -> 19beta3 ``                                                          |
| [`8404bf48`](https://github.com/NixOS/nixpkgs/commit/8404bf489572c1afb116b757ff1d396b2dcd2439) | `` postgresql_18: 18.4 -> 18.6 ``                                                                |
| [`a248c2dd`](https://github.com/NixOS/nixpkgs/commit/a248c2dd552c1259761f7efb14adc10c9302fea1) | `` postgresql_17: 17.10 -> 17.11 ``                                                              |
| [`78007d9c`](https://github.com/NixOS/nixpkgs/commit/78007d9caa9202be84d21e1a69a18e76e9f88fe3) | `` postgresql_16: 16.14 -> 16.15 ``                                                              |
| [`bc408022`](https://github.com/NixOS/nixpkgs/commit/bc408022552ecc06f346c590c05c39193dc5324e) | `` postgresql_15: 15.18 -> 15.19 ``                                                              |
| [`25c7c0b6`](https://github.com/NixOS/nixpkgs/commit/25c7c0b6da27a6ba08db89a35d464f1ae2112f85) | `` postgresql_14: 14.23 -> 14.24 ``                                                              |
| [`72997994`](https://github.com/NixOS/nixpkgs/commit/72997994635d49bf6239e56d95697849f84422c2) | `` diffoscope: 327 -> 328 ``                                                                     |
| [`e49bc368`](https://github.com/NixOS/nixpkgs/commit/e49bc3682c4d66d065b84699c1aac3fe23c781d2) | `` netwatch: change changelog ``                                                                 |
| [`1ccefe20`](https://github.com/NixOS/nixpkgs/commit/1ccefe20d3e67a8a3ead9f57b4d42a826ede50a5) | `` netwatch: change homepage ``                                                                  |
| [`5b391d17`](https://github.com/NixOS/nixpkgs/commit/5b391d178a28b705d82de7726c506b93f7d7a0f3) | `` diskwatch: add optional dependency smartmontools ``                                           |
| [`66ff4d5a`](https://github.com/NixOS/nixpkgs/commit/66ff4d5a1269555a2030834a1fe65718ecafeb6b) | `` diskwatch: change homepage ``                                                                 |
| [`ac323b9e`](https://github.com/NixOS/nixpkgs/commit/ac323b9eb266c72d32d220ecfa12435406412aae) | `` diskwatch: remove versionCheckProgramArg ``                                                   |
| [`aec83bd5`](https://github.com/NixOS/nixpkgs/commit/aec83bd535bdb7c849d9711be22a4f3ce2840cc8) | `` diskwatch: add tomasrivera as maintainer ``                                                   |
| [`9bc5ab1c`](https://github.com/NixOS/nixpkgs/commit/9bc5ab1c1b878833164eed7b349fb6b9b98bb099) | `` syswatch: change homepage ``                                                                  |
| [`afea4ae2`](https://github.com/NixOS/nixpkgs/commit/afea4ae202bf400b6b22f950c38870a5c33fb7ae) | `` ta-lib: cleanup ``                                                                            |
| [`a41a0f61`](https://github.com/NixOS/nixpkgs/commit/a41a0f617d10517d6c0849d9ebb97829c007abf6) | `` deadlock-mod-manager: 1.0.0 -> 1.1.0 ``                                                       |
| [`e39ee820`](https://github.com/NixOS/nixpkgs/commit/e39ee820f99e22b44db03862272c945bd9383bd9) | `` home-assistant: 2026.8.1 -> 2026.8.2 ``                                                       |
| [`cc0ad2ca`](https://github.com/NixOS/nixpkgs/commit/cc0ad2ca1bda28865e5a91cf14b8e9263e6ae755) | `` home-assistant.frontend: 20260729.6 -> 20260729.7 ``                                          |
| [`df655b24`](https://github.com/NixOS/nixpkgs/commit/df655b2456e02cfef5aaaa66f2020b31d5d73305) | `` python3Packages.xknx: 3.18.0 -> 3.19.0 ``                                                     |
| [`7f7b6b74`](https://github.com/NixOS/nixpkgs/commit/7f7b6b74da28609d416edd238d4493594c1c7a68) | `` python3Packages.py-nymta: 0.4.0 -> 0.4.1 ``                                                   |
| [`a0e67770`](https://github.com/NixOS/nixpkgs/commit/a0e67770139a8239d54e17b986526a06158a509c) | `` python3Packages.midea-local: 6.11.1 -> 7.0.0 ``                                               |
| [`2b75259d`](https://github.com/NixOS/nixpkgs/commit/2b75259d500daf40426a5942d5c58489cbbe5eb3) | `` python3Packages.incomfort-client: 0.7.0 -> 0.7.1 ``                                           |
| [`4382b3ae`](https://github.com/NixOS/nixpkgs/commit/4382b3aeb957f31ed8494472184d863be81361a2) | `` python3Packages.homematicip: 2.14.0 -> 2.15.0 ``                                              |
| [`d2468ca2`](https://github.com/NixOS/nixpkgs/commit/d2468ca2a90d6d062f7214d93daa4acab963cf2e) | `` python3Packages.blebox-uniapi: 2.5.5 -> 2.5.7 ``                                              |
| [`605c7ab6`](https://github.com/NixOS/nixpkgs/commit/605c7ab6065a5392787c8053e5b8daef83bb6601) | `` python3Packages.aiopvapi: 3.4.0 -> 3.4.1 ``                                                   |
| [`00dc49b1`](https://github.com/NixOS/nixpkgs/commit/00dc49b1fcc7d396df8302c71b2bc1c8d2590cc1) | `` python3Packages.aiolyric: 2.1.1 -> 2.1.2 ``                                                   |
| [`41ffc01d`](https://github.com/NixOS/nixpkgs/commit/41ffc01d3fe6016fa82c2fc4bf7cf7022c0d2f94) | `` zennotes-desktop: 2.27.0 -> 2.28.2 ``                                                         |
| [`d445abed`](https://github.com/NixOS/nixpkgs/commit/d445abed4775c8b4a5314d7151b013aa6c45baa4) | `` flutter347: init at 3.47.0 ``                                                                 |
| [`849faa1a`](https://github.com/NixOS/nixpkgs/commit/849faa1aab24b85244e82d5683098ecf28eef469) | `` versatiles: 4.6.1 -> 4.7.0 ``                                                                 |
| [`e8f6f95d`](https://github.com/NixOS/nixpkgs/commit/e8f6f95dd9693ad155b4ab2591786ee424d31e73) | `` trufflehog: 3.96.0 -> 3.97.0 ``                                                               |
| [`89f1120b`](https://github.com/NixOS/nixpkgs/commit/89f1120bc1c4465f8603b708eda35a423c25201d) | `` libretro.snes9x2010: 0-unstable-2026-07-23 -> 0-unstable-2026-08-11 ``                        |
| [`fcf2b449`](https://github.com/NixOS/nixpkgs/commit/fcf2b44994420e88b2ac6684e75d50da339bd186) | `` terraform-providers.goharbor_harbor: 3.12.3 -> 3.12.4 ``                                      |
| [`3f59e885`](https://github.com/NixOS/nixpkgs/commit/3f59e8858f88d7074769b936e7bf93b36c05b3e9) | `` python3Packages.formulas: init at 1.3.4 ``                                                    |
| [`b6f18483`](https://github.com/NixOS/nixpkgs/commit/b6f1848340197645f3df2d5ab4ec25eb03a4948b) | `` maintainers: remove drew-dirac ``                                                             |
| [`6fe033b6`](https://github.com/NixOS/nixpkgs/commit/6fe033b6281f2039689ac7f7a78532e9aa2cd6ba) | `` python3Packages.scipp: 26.7.0 -> 26.8.0 ``                                                    |
| [`88667bcc`](https://github.com/NixOS/nixpkgs/commit/88667bcc2e0e9b4c5a8421190593c3eb6b2a446c) | `` resticprofile: 0.31.0 -> 0.33.1 ``                                                            |
| [`b3e43855`](https://github.com/NixOS/nixpkgs/commit/b3e43855f26600521c4b2f5d7af1c23b32a76da3) | `` radicle-desktop: 0.14.0 -> 0.15.0 ``                                                          |
| [`024ee860`](https://github.com/NixOS/nixpkgs/commit/024ee86097bd135afc9584c111b8423fe74a473b) | `` dotenvx: 2.19.2 -> 2.21.0 ``                                                                  |
| [`4aee89ca`](https://github.com/NixOS/nixpkgs/commit/4aee89cae4121aef3b72d3754dc8bb62272fe201) | `` devilutionx: fmt -> fmt_11, unbreak ``                                                        |
| [`84762776`](https://github.com/NixOS/nixpkgs/commit/847627764b7228d48079c898973da622c8d8d173) | `` python3Packages.jupyterlab: fix application assets path ``                                    |
| [`9bdc1c94`](https://github.com/NixOS/nixpkgs/commit/9bdc1c94550f102a67dbfe9959e0f60db062a16f) | `` python3Packages.jupyterlab: 4.5.8 -> 4.5.10 ``                                                |
| [`3c86c957`](https://github.com/NixOS/nixpkgs/commit/3c86c957b946fe01328c455883ba95e14aca4691) | `` roam-research: drop ``                                                                        |
| [`a9edf093`](https://github.com/NixOS/nixpkgs/commit/a9edf093d74059718d65f526e840ddcc7e7d0b26) | `` python3Packages.qtile: 0.36.0 -> 0.37.0 ``                                                    |
| [`d1645f33`](https://github.com/NixOS/nixpkgs/commit/d1645f33cfa1cb939336bff42f866078ac7668ac) | `` ollama: 0.32.7 -> 0.32.11 ``                                                                  |
| [`6d9be5f0`](https://github.com/NixOS/nixpkgs/commit/6d9be5f06ff471c83dc849cfb9e64874ef172538) | `` ollama: check that llama-cpp is matching ``                                                   |
| [`1e3b4d12`](https://github.com/NixOS/nixpkgs/commit/1e3b4d12bc37358417b74f6c957541340b240131) | `` ollama: add updateScript to passthru ``                                                       |
| [`01fd2446`](https://github.com/NixOS/nixpkgs/commit/01fd24467495944b2f189e6772bcb5e20a5e7acf) | `` spec-kit: 0.16.1 -> 0.16.3 ``                                                                 |
| [`2abacdbe`](https://github.com/NixOS/nixpkgs/commit/2abacdbe50994821cb276704c80ba0c99fec1dcc) | `` terraform-providers.vpsfreecz_vpsadmin: 1.2.0 -> 1.3.0 ``                                     |
| [`6435307a`](https://github.com/NixOS/nixpkgs/commit/6435307ab70d54c282b6efafb614cdb154056fec) | `` python3Packages.sphinxcontrib-restbuilder: init at 0.3 ``                                     |
| [`367e542a`](https://github.com/NixOS/nixpkgs/commit/367e542a5e507996800c7ce9d1c1637a738b9733) | `` python3Packages.bahttext: init at 1.0.2-unstable-2020-05-31 ``                                |
| [`aaa76b74`](https://github.com/NixOS/nixpkgs/commit/aaa76b744ac08259706ee1444fe3254f9e3dcb08) | `` openmvs: move to by-name, cleanup ``                                                          |
| [`dab1a3b7`](https://github.com/NixOS/nixpkgs/commit/dab1a3b726fb70ef272ea21809145a2f9039354d) | `` cyclonedx-gomod: 1.10.0 -> 1.11.0 ``                                                          |
| [`7490ec4e`](https://github.com/NixOS/nixpkgs/commit/7490ec4ea4e297c5b739117e57914907533d7946) | `` ratspeak: init at 1.0.25 ``                                                                   |
| [`062912fb`](https://github.com/NixOS/nixpkgs/commit/062912fbab57f7d23e959c449a31f45c34304ba1) | `` terraform-providers.auth0_auth0: 1.54.0 -> 1.54.1 ``                                          |
| [`520e54c2`](https://github.com/NixOS/nixpkgs/commit/520e54c24c32fdc2f8879541b64d7903db249654) | `` remnote: 1.27.19 -> 1.27.32 ``                                                                |
| [`67a6b232`](https://github.com/NixOS/nixpkgs/commit/67a6b232f01b928704c1ecdf923792254ef27c66) | `` git-pkgs: 0.18.2 -> 0.19.0 ``                                                                 |
| [`3c09a27a`](https://github.com/NixOS/nixpkgs/commit/3c09a27af5982fcceec08d8403a00a910c3904aa) | `` sketchybar-app-font: 2.0.71 -> 2.0.75 ``                                                      |
| [`31c887a2`](https://github.com/NixOS/nixpkgs/commit/31c887a2adc6b7c55102cd3e46a17a0e19b76d5e) | `` stable-diffusion-cpp: add jk as maintainer ``                                                 |
| [`322e7f81`](https://github.com/NixOS/nixpkgs/commit/322e7f814877841d0bb6b2d8048f91f83b58b7d6) | `` stable-diffusion-cpp: master-797-5ef4a75 -> master-820-de298c2 ``                             |
| [`7ed77256`](https://github.com/NixOS/nixpkgs/commit/7ed772560b134f155ca5c8dc52aa0977131f16b7) | `` bashd: init at v0.2.3 ``                                                                      |
| [`aae1a195`](https://github.com/NixOS/nixpkgs/commit/aae1a1953f02732ec36fd613969947f46375abab) | `` mdbook-mermaid: 0.17.0 -> 0.17.1 ``                                                           |
| [`65cb7dee`](https://github.com/NixOS/nixpkgs/commit/65cb7dee886c23b45a4a10d93609b05ba283038e) | `` linux: raise minimum version for loongarch64 ``                                               |
| [`df1aeab4`](https://github.com/NixOS/nixpkgs/commit/df1aeab455d91475db667d7f707678c633fff3fb) | `` vimPlugins.herdr-splits-nvim: init at 0.5.2 ``                                                |
| [`4d022825`](https://github.com/NixOS/nixpkgs/commit/4d0228251ea853104aa985cee86e56a7823c8b8e) | `` phpExtensions.zstd: 0.15.2 -> 0.18.0 ``                                                       |
| [`bc981ff0`](https://github.com/NixOS/nixpkgs/commit/bc981ff07708dccfe960c0142836b871890ef3e0) | `` pyldapsearch: init at 0.2.0 ``                                                                |
| [`74268c87`](https://github.com/NixOS/nixpkgs/commit/74268c878d98db3f6dadc97774c7f66986217240) | `` protolint: 0.56.4 -> 0.57.0 ``                                                                |
| [`422c44de`](https://github.com/NixOS/nixpkgs/commit/422c44debc2c517cc24960490f68f07a286778a8) | `` trivy: 0.73.0 -> 0.74.0 ``                                                                    |
| [`f2e8b647`](https://github.com/NixOS/nixpkgs/commit/f2e8b647dba03e3d20656e9f6ac3fa4363b6f295) | `` cbom: init at 0.1.1 ``                                                                        |
| [`3cc8546c`](https://github.com/NixOS/nixpkgs/commit/3cc8546cb539d60b3f1cfce331a8bf5cb3a8c040) | `` xmake: 3.0.9 -> 3.1.0 ``                                                                      |
| [`9c24b967`](https://github.com/NixOS/nixpkgs/commit/9c24b9676250c1e3216f40c9f9212ab743b23d19) | `` acdi: init at 0.5.2 ``                                                                        |
| [`04e423be`](https://github.com/NixOS/nixpkgs/commit/04e423be3799179e7c3b212799b90660512913bb) | `` comfyui: 0.32.0 -> 0.33.1 ``                                                                  |
| [`b9c2c5c1`](https://github.com/NixOS/nixpkgs/commit/b9c2c5c1da32c8c32fb119f6431ca1ab8bc9e9b9) | `` python3Packages.comfy-kitchen: 0.2.30 -> 0.2.31 ``                                            |
| [`0d664db3`](https://github.com/NixOS/nixpkgs/commit/0d664db3394a1c3e8b408641994b55829ffa7142) | `` python3Packages.types-awscrt: 0.34.1 -> 0.36.2 ``                                             |
| [`681803ba`](https://github.com/NixOS/nixpkgs/commit/681803bac877fc48a264cceb60caaa8762475186) | `` glitchtip: 6.2.0 -> 6.2.6 ``                                                                  |
| [`1f0fd931`](https://github.com/NixOS/nixpkgs/commit/1f0fd9312778ddec66bb64403d6430e844aa5b71) | `` glitchtip.glitchtip-rust: 0.3.0 -> 0.9.0 ``                                                   |
| [`e8880862`](https://github.com/NixOS/nixpkgs/commit/e88808626deb51ef4bbb52fbe793e16d5521524a) | `` glitchtip.frontend: 6.2.0 -> 6.2.6 ``                                                         |
| [`5ed7a0d4`](https://github.com/NixOS/nixpkgs/commit/5ed7a0d4d83ccab5866ac2315b89172569abca1b) | `` glitchtip.django-allauth-async: init at 65.16.1.7 ``                                          |
| [`8387929b`](https://github.com/NixOS/nixpkgs/commit/8387929bc869831c16f8f1e730c0de6a5b81e553) | `` python3Packages.django-vtasks: 2.1.2 -> 3.1.0 ``                                              |
| [`4310d6ac`](https://github.com/NixOS/nixpkgs/commit/4310d6ac325e07296f5810c82a88b1a49c23bc6b) | `` python3Packages.django-vpg: init at 0.4.0 ``                                                  |
| [`5190a5ac`](https://github.com/NixOS/nixpkgs/commit/5190a5acb04ef13a46489ec58bd1e5c217b3b4f3) | `` vector-blf: init at 2.4.2 ``                                                                  |
| [`5fd8b23a`](https://github.com/NixOS/nixpkgs/commit/5fd8b23a4365bd7db0830272ec250451a739a4b4) | `` python3Packages.pycep-parser: 0.7.0 -> 0.7.1 ``                                               |
| [`c97e516b`](https://github.com/NixOS/nixpkgs/commit/c97e516b7f31d9bf186645ec8eb48b7fcc7a5dbe) | `` python3Packages.comfyui-workflow-templates-media-assets-01: 0.1.26 -> 0.1.28 ``               |
| [`378b5cee`](https://github.com/NixOS/nixpkgs/commit/378b5cee55bcee3bcf8cd63627f4c0ad59751bac) | `` python3Packages.comfyui-workflow-templates-json: 0.1.42 -> 0.1.47 ``                          |
| [`41b9e9a2`](https://github.com/NixOS/nixpkgs/commit/41b9e9a26c2757ab587016d34bb070913ef45929) | `` python3Packages.comfyui-workflow-templates-core: 0.3.307 -> 0.3.312 ``                        |
| [`402e09a8`](https://github.com/NixOS/nixpkgs/commit/402e09a876168a26b9eceb1795f00dcaa85d7d27) | `` python3Packages.comfyui-workflow-templates: 0.11.39 -> 0.11.41 ``                             |
| [`82e94f1e`](https://github.com/NixOS/nixpkgs/commit/82e94f1ef5f4d98cd2e498bb44601edb91b60429) | `` chainsaw: 2.16.2 -> 2.16.3 ``                                                                 |
| [`bd7038ab`](https://github.com/NixOS/nixpkgs/commit/bd7038ab7b9bfb6fdf26ba66bf02a2deca21f8a5) | `` lua-language-server: 3.19.0 -> 3.19.1 ``                                                      |
| [`10216402`](https://github.com/NixOS/nixpkgs/commit/1021640215c4b92785babd31cd1ee9abfec63634) | `` aver: 0.27.1 -> 0.28.1 ``                                                                     |
| [`5aca65b4`](https://github.com/NixOS/nixpkgs/commit/5aca65b486b8269052c761c4455a77c463f590d6) | `` python3Packages.tmodbus: 0.5.0 -> 0.5.1 ``                                                    |
| [`c7bf12c3`](https://github.com/NixOS/nixpkgs/commit/c7bf12c36602f81f606d7a6d4cef726c2b6de729) | `` python3Packages.oslo-config: 10.6.0 -> 10.7.0 ``                                              |
| [`bf3a8dec`](https://github.com/NixOS/nixpkgs/commit/bf3a8dec2f0ab0e8b7be839df2d6bf2d789fdb0e) | `` proto: 0.60.0 -> 0.60.2 ``                                                                    |
| [`3ef7a3f1`](https://github.com/NixOS/nixpkgs/commit/3ef7a3f1bebdd551cfa039cac14011a7fe027dbb) | `` mastodon: 4.6.5 -> 4.6.6 ``                                                                   |
| [`43fd8af8`](https://github.com/NixOS/nixpkgs/commit/43fd8af87547b0fa6ee4c2f8bc4ce060cbae0383) | `` treewide: finalAttrs.doCheck -> finalAttrs.finalPackage.doCheck ``                            |

*... and 659 more commits (truncated)*