### PR TITLE
chore(flake/nixpkgs-stable): `02e08985` -> `0dd31db7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1786711500,
-        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
+        "lastModified": 1786943417,
+        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
+        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`fccdbb1a`](https://github.com/NixOS/nixpkgs/commit/fccdbb1a43f59b407159fbea11c401fc299b99e9) | `` kas: 5.3 -> 5.4 ``                                                                             |
| [`3b91c7b6`](https://github.com/NixOS/nixpkgs/commit/3b91c7b6017052b060696d877d297b2a76a7f0a8) | `` kas: 5.2 -> 5.3 ``                                                                             |
| [`ce7487ce`](https://github.com/NixOS/nixpkgs/commit/ce7487ce6f815e52c5e561e141a6c54679be0823) | `` drawio: 30.2.6 -> 31.1.8 ``                                                                    |
| [`eabc4f2a`](https://github.com/NixOS/nixpkgs/commit/eabc4f2aa5a2e5e9bfe0fc2923d40ac08e6793b2) | `` node-core-utils: 7.0.0 -> 7.1.0 ``                                                             |
| [`76ec27b0`](https://github.com/NixOS/nixpkgs/commit/76ec27b021ec39935e3b81dbe70d99e4f702a345) | `` ghgrab: 2.0.1 -> 2.0.2 ``                                                                      |
| [`bf79e0de`](https://github.com/NixOS/nixpkgs/commit/bf79e0de04f6c3be297c5540834be7151e2b5b58) | `` grafana-loki: 3.7.4 -> 3.7.6 ``                                                                |
| [`df6a682f`](https://github.com/NixOS/nixpkgs/commit/df6a682fd789fff9161f6c3e238ce2a888ade005) | `` mount-zip: 1.12 -> 1.16 ``                                                                     |
| [`93192ab4`](https://github.com/NixOS/nixpkgs/commit/93192ab47b108a009aa4ac16709d76387fa2bd06) | `` cel-go: 0.30.0 -> 0.31.0 ``                                                                    |
| [`da3b73c1`](https://github.com/NixOS/nixpkgs/commit/da3b73c10fe7c6a8a9b3528657bdb53740195bee) | `` nextcloud*.packages: update ``                                                                 |
| [`f1b20bce`](https://github.com/NixOS/nixpkgs/commit/f1b20bce68a07ff7725b94a35c86d0dcc090ef4b) | `` nextcloud34: 34.0.2 -> 34.0.3 ``                                                               |
| [`f5de3a82`](https://github.com/NixOS/nixpkgs/commit/f5de3a82994704006b974427c0f7277659ee3c56) | `` nextcloud33: 33.0.7 -> 33.0.8 ``                                                               |
| [`a9186cd3`](https://github.com/NixOS/nixpkgs/commit/a9186cd31fa47529cabf7be4c4ca20630d385e02) | `` nextcloud32: 32.0.13 -> 32.0.14 ``                                                             |
| [`b83411c4`](https://github.com/NixOS/nixpkgs/commit/b83411c4b8241fd0dc9abb4a7aef387c59dc8a3e) | `` roundcube: 1.7.2 -> 1.7.3 ``                                                                   |
| [`005426b8`](https://github.com/NixOS/nixpkgs/commit/005426b897a021869ccd508179aaee2aed5c1c70) | `` modrinth-app-unwrapped: 0.17.3 -> 0.17.5 ``                                                    |
| [`fbd253fc`](https://github.com/NixOS/nixpkgs/commit/fbd253fc832c742b3448fbfb189b2a5100672d4f) | `` porxie: 0.3.3 -> 0.3.4 ``                                                                      |
| [`671880aa`](https://github.com/NixOS/nixpkgs/commit/671880aa1c1b5e73cffac67a9d46c8709cc64243) | `` electrum: 4.8.0 -> 4.8.1 ``                                                                    |
| [`6653219f`](https://github.com/NixOS/nixpkgs/commit/6653219f3940526848fbd8ca95cb9dedf547e61c) | `` electrum: move trezor into default dependencies ``                                             |
| [`cd8b7116`](https://github.com/NixOS/nixpkgs/commit/cd8b7116a1c2c90020a55047c8a94db134dda363) | `` python3Packages.trezor: 0.20.0 -> 0.20.2 ``                                                    |
| [`c8ab23b4`](https://github.com/NixOS/nixpkgs/commit/c8ab23b48706d359b039bc412ae5802b1fe3657a) | `` feedparser-sgmllib: init at 2.1.0 ``                                                           |
| [`23a9453e`](https://github.com/NixOS/nixpkgs/commit/23a9453e9e997ad6fccace8d73a611487b08942b) | `` maintainers: add ar4m1s ``                                                                     |
| [`7a70f119`](https://github.com/NixOS/nixpkgs/commit/7a70f11920fac103252f666ec08916438448a8d1) | `` nixos/gitlab: increase postgres  max locks per transaction ``                                  |
| [`f363f9ae`](https://github.com/NixOS/nixpkgs/commit/f363f9aed5f25151018797c6a5c388dcaab40abf) | `` checkstyle: 13.9.0 -> 13.10.0 ``                                                               |
| [`a43feb11`](https://github.com/NixOS/nixpkgs/commit/a43feb110fdc05145f026a5ce3fd78a55470f15c) | `` calibre: 9.11.0 -> 9.13.0 ``                                                                   |
| [`74a46296`](https://github.com/NixOS/nixpkgs/commit/74a46296de75a212f087ccf01d306a06033d9029) | `` exo: add CVE-2026-14738 to meta.knownVulnerabilities ``                                        |
| [`6a7accce`](https://github.com/NixOS/nixpkgs/commit/6a7accceeafd145a9dbebedcdc7e99631ce93071) | `` vivaldi: 8.1.4087.61 -> 8.1.4087.66 ``                                                         |
| [`2ca96c19`](https://github.com/NixOS/nixpkgs/commit/2ca96c19efbf7a2c1bff65e5ab1dcf02d9841c1a) | `` rlottie: 0.2-unstable-2026-07-03 -> 0.2-unstable-2026-08-11 ``                                 |
| [`0f377af7`](https://github.com/NixOS/nixpkgs/commit/0f377af786076383b9752f7bf6365fb1eb50ce46) | `` python3Packages.trafilatura: 2.0.0 -> 2.1.0 ``                                                 |
| [`e37da567`](https://github.com/NixOS/nixpkgs/commit/e37da56733ab1e7e16478aea39b80f5c8f0d142e) | `` gpac: 26.02.0 -> 26.07.0 ``                                                                    |
| [`6e972501`](https://github.com/NixOS/nixpkgs/commit/6e972501f141a08e42cd23ff42cf0c7fc7f1a005) | `` fulcio: 1.8.5 -> 1.8.6 ``                                                                      |
| [`fad5e1dc`](https://github.com/NixOS/nixpkgs/commit/fad5e1dcc63212c73dde29ed6b087cafc75b15b7) | `` rekor-cli: 1.5.1 -> 1.5.2 ``                                                                   |
| [`588fcfa2`](https://github.com/NixOS/nixpkgs/commit/588fcfa25d8c57e248a77e9db6c0f9f593324068) | `` acli: 1.3.22-stable -> 1.3.23-stable ``                                                        |
| [`3e1dee93`](https://github.com/NixOS/nixpkgs/commit/3e1dee931a7845272a4444ca0280fcbee9cb31f5) | `` ghostfolio: 3.43.0 -> 3.50.0 ``                                                                |
| [`e453a86f`](https://github.com/NixOS/nixpkgs/commit/e453a86f7c4d84dca80aa5377c900446b1d473bf) | `` openlist: 4.2.4 -> 4.2.5 ``                                                                    |
| [`214c4062`](https://github.com/NixOS/nixpkgs/commit/214c4062fc0ec2464ca6b408518ed6d65724b2d5) | `` garnet: 2.1.1 -> 2.1.4 ``                                                                      |
| [`7268f933`](https://github.com/NixOS/nixpkgs/commit/7268f9331c34d0d036775af4d1267077eed45a3e) | `` navidromePlugins.listenbrainz-daily-playlist: 5.0.2 -> 6.0.0 ``                                |
| [`56852004`](https://github.com/NixOS/nixpkgs/commit/568520045881e19a1c86b0300d5afa8f76fdef15) | `` msedgedriver: derive maintainers from related package ``                                       |
| [`01708fbe`](https://github.com/NixOS/nixpkgs/commit/01708fbeb431459f8df09fec854078707bbe83b4) | `` librewolf-unwrapped: 153.0.3-1 -> 153.0.4-1 ``                                                 |
| [`9734c9d0`](https://github.com/NixOS/nixpkgs/commit/9734c9d082a92c94e3af05928baebbbb71e2edcc) | `` mailpit: 1.30.6 -> 1.30.7 ``                                                                   |
| [`474c9c3f`](https://github.com/NixOS/nixpkgs/commit/474c9c3f47a2be12241ad052e1fbb72fb80472fb) | `` python3Packages.dlinfo: unbreak darwin ``                                                      |
| [`354e36e9`](https://github.com/NixOS/nixpkgs/commit/354e36e9fdf65f08e060cdd83ae6159bd57f7c47) | `` postgresql_18: 18.4 -> 18.6 ``                                                                 |
| [`5cf5dcbd`](https://github.com/NixOS/nixpkgs/commit/5cf5dcbdffa082a7f75d0315e21a9fb8f2e3ad97) | `` postgresql_17: 17.10 -> 17.11 ``                                                               |
| [`7d3271b8`](https://github.com/NixOS/nixpkgs/commit/7d3271b8b4929ef7cab705f6f5f79f03cfc37af1) | `` postgresql_16: 16.14 -> 16.15 ``                                                               |
| [`e1f5a6dc`](https://github.com/NixOS/nixpkgs/commit/e1f5a6dcfdc84b8cc27c80bad7820e711a47be35) | `` postgresql_15: 15.18 -> 15.19 ``                                                               |
| [`a1ffa676`](https://github.com/NixOS/nixpkgs/commit/a1ffa676ec027f5d14505986e3e78a0d9c9ccb88) | `` postgresql_14: 14.23 -> 14.24 ``                                                               |
| [`8f75bfd6`](https://github.com/NixOS/nixpkgs/commit/8f75bfd6975e310b9e2e5f75a2bcedd772e919fc) | `` radicle-desktop: 0.14.0 -> 0.15.0 ``                                                           |
| [`3c53d70b`](https://github.com/NixOS/nixpkgs/commit/3c53d70bdba2dd22f12c190ea16e366feb038af2) | `` firefox-devedition-unwrapped: 154.0b9 -> 154.0b10 ``                                           |
| [`a7b7e5fa`](https://github.com/NixOS/nixpkgs/commit/a7b7e5faa3653fc17e9107caad4976930409e2c5) | `` firefox-beta-unwrapped: 154.0b9 -> 154.0b10 ``                                                 |
| [`770fe309`](https://github.com/NixOS/nixpkgs/commit/770fe309d99935d999cfe0418d9953e2a6c50e5d) | `` equibop: 3.2.1 -> 3.2.2 ``                                                                     |
| [`2d6708a1`](https://github.com/NixOS/nixpkgs/commit/2d6708a1fb66613e3da2ee2a9519125c06635396) | `` python3Packages.whenever: 0.10.4 -> 0.10.5 ``                                                  |
| [`f1c2c284`](https://github.com/NixOS/nixpkgs/commit/f1c2c2848ef9458692cb53bae55e23b76edf1c9b) | `` python3Packages.courlan: 1.3.2 -> 1.4.0 ``                                                     |
| [`8191a538`](https://github.com/NixOS/nixpkgs/commit/8191a53815af4e26429df7bcfab71ae9708c6285) | `` mastodon: 4.6.5 -> 4.6.6 ``                                                                    |
| [`cdbe9e57`](https://github.com/NixOS/nixpkgs/commit/cdbe9e571fe5214a624200c915447d50e026aecc) | `` codex: 0.145.0 -> 0.146.0 ``                                                                   |
| [`b769b19f`](https://github.com/NixOS/nixpkgs/commit/b769b19f323999906f74e4a27f7c0bec8052d2de) | `` codex: 0.144.4 -> 0.145.0 ``                                                                   |
| [`b32e9fd3`](https://github.com/NixOS/nixpkgs/commit/b32e9fd3518446df905b25a5d4b3a43501c81097) | `` codex: 0.144.1 -> 0.144.4 ``                                                                   |
| [`4dcce686`](https://github.com/NixOS/nixpkgs/commit/4dcce686d72f201934df96ae8e531eab652f825f) | `` codex: 0.142.5 -> 0.144.1 ``                                                                   |
| [`d11221ae`](https://github.com/NixOS/nixpkgs/commit/d11221ae890e0a135513ec317ccb85cce31f3f6c) | `` codex: 0.142.3 -> 0.142.5 ``                                                                   |
| [`eebecaba`](https://github.com/NixOS/nixpkgs/commit/eebecaba6fbee7a42a549a3f07198713bc7f10db) | `` codex: 0.142.2 -> 0.142.3 ``                                                                   |
| [`fe6ce90b`](https://github.com/NixOS/nixpkgs/commit/fe6ce90b8642b92f12fb4fd9c4d96ae24f676b86) | `` codex: 0.142.0 -> 0.142.2 ``                                                                   |
| [`fedb29c1`](https://github.com/NixOS/nixpkgs/commit/fedb29c13cf635ae491d78c089e029cd944c0e01) | `` codex: 0.141.0 -> 0.142.0 ``                                                                   |
| [`295ca5b8`](https://github.com/NixOS/nixpkgs/commit/295ca5b879b946fe5b14d6283820ab6c52e4d0f7) | `` codex: 0.139.0 -> 0.141.0 ``                                                                   |
| [`16938938`](https://github.com/NixOS/nixpkgs/commit/16938938edf9d52906ba6f429ff43c0d60ea9a4b) | `` codex: 0.137.0 -> 0.139.0 ``                                                                   |
| [`3b9c4bb7`](https://github.com/NixOS/nixpkgs/commit/3b9c4bb71ebc9b70ccdeed25b5fb03fb17f17d20) | `` codex: 0.136.0 -> 0.137.0 ``                                                                   |
| [`15971f58`](https://github.com/NixOS/nixpkgs/commit/15971f588eeae9837d83ae40eb5b16039cd14359) | `` codex: 0.135.0 -> 0.136.0 ``                                                                   |
| [`9bc31aac`](https://github.com/NixOS/nixpkgs/commit/9bc31aac0a9dd26d4a1bf956d779913f37ebce9f) | `` codex: 0.134.0 -> 0.135.0 ``                                                                   |
| [`ee66d2aa`](https://github.com/NixOS/nixpkgs/commit/ee66d2aa7d2277c54a0bd6fbc3a9cb753d96cc17) | `` codex: 0.133.0 -> 0.134.0 ``                                                                   |
| [`7836af42`](https://github.com/NixOS/nixpkgs/commit/7836af420e2dd5184af56a244a2dbc72ffdab854) | `` nezha-agent: 2.3.1 -> 2.3.3 ``                                                                 |
| [`394aa214`](https://github.com/NixOS/nixpkgs/commit/394aa214ce7514f9f79729054cdc572bbe790f32) | `` pnpm: 11.20.0 -> 11.21.0 ``                                                                    |
| [`7c3b7ae1`](https://github.com/NixOS/nixpkgs/commit/7c3b7ae19c2d1af381c73dde766367aa8632aac5) | `` nixosTests.miniflux: Revert "remove apparmor" ``                                               |
| [`8920474c`](https://github.com/NixOS/nixpkgs/commit/8920474c9e3a765b7ffebc842881f7d392f45c71) | `` nixos/miniflux: fix AppArmor profile ``                                                        |
| [`70fadfc1`](https://github.com/NixOS/nixpkgs/commit/70fadfc15d0710c4427d5ddd2d76234767d41b1e) | `` dracut: fix CVE-2026-15816 ``                                                                  |
| [`785367fa`](https://github.com/NixOS/nixpkgs/commit/785367fa91c3af61ce492033f553eb6d45b40328) | `` n8n: 2.32.6 -> 2.33.7 ``                                                                       |
| [`e7557380`](https://github.com/NixOS/nixpkgs/commit/e7557380bd8c262283e6b4600a7060e9b552f612) | `` nixosTests.opencloud: fix LDAPS and aarch64 WebDriver setup ``                                 |
| [`38535a20`](https://github.com/NixOS/nixpkgs/commit/38535a20d91aa873adcac83f5c39dc780377b4e3) | `` nixos/tests/matrix/mautrix-meta: fix tests for newer mautrix versions ``                       |
| [`d9e24e7d`](https://github.com/NixOS/nixpkgs/commit/d9e24e7d7daad04178e3c3a10c6e7c0ad8162f37) | `` nixos/mautrix-meta: update settings description example generation method ``                   |
| [`c32c500f`](https://github.com/NixOS/nixpkgs/commit/c32c500f42ee0322371901b643e90fe5944ce174) | `` nixos/mautrix-meta: automatically select the right binary based on mode instagram or others `` |
| [`fe3267a1`](https://github.com/NixOS/nixpkgs/commit/fe3267a102c06c5aa295dc42cdcf0d2cf7507af8) | `` mautrix-meta: add mautrix-instagram binary build ``                                            |
| [`f2238834`](https://github.com/NixOS/nixpkgs/commit/f223883455f2d2b0d3a84766e35f44685214b9f5) | `` jetbrains.pycharm: 2026.2 -> 2026.2.0.1 ``                                                     |
| [`40e39de3`](https://github.com/NixOS/nixpkgs/commit/40e39de3df72f7e68d7ec236bd36b07e664d8bd3) | `` udisks: 2.11.1 -> 2.11.2 ``                                                                    |
| [`cea6672d`](https://github.com/NixOS/nixpkgs/commit/cea6672d6b179ba39046cf2aec3a29b717e9ae8d) | `` opencloud.web: 7.1.2 -> 7.2.0 ``                                                               |
| [`05a341d7`](https://github.com/NixOS/nixpkgs/commit/05a341d715d6e6f088cae509ec57012fd1a08a47) | `` opencloud.web: 7.1.0 -> 7.1.2 ``                                                               |
| [`fb51130d`](https://github.com/NixOS/nixpkgs/commit/fb51130d6d215da0e28981bed1ef75a481c0fe8f) | `` opencloud: 7.1.0 -> 7.2.0 ``                                                                   |
| [`ecd4a3a2`](https://github.com/NixOS/nixpkgs/commit/ecd4a3a2718c34201b86d8618a0248d12cd22bb3) | `` opencloud{,-web}: 7.0.0 -> 7.1.0 ``                                                            |
| [`ccc95106`](https://github.com/NixOS/nixpkgs/commit/ccc951062d8f7fdabc3659dd90908053a000def9) | `` opencloud.idp-web: fix after #487046 ``                                                        |
| [`43b3561b`](https://github.com/NixOS/nixpkgs/commit/43b3561bb133568ccb239c86e91109ef7764b254) | `` opencloud.idp-web: Migrate to pnpmBuildHook ``                                                 |
| [`16377983`](https://github.com/NixOS/nixpkgs/commit/163779839a377679b3d3b1d65d05f75221faecdb) | `` xwayland-satellite: 0.8.1 -> 0.8.2 ``                                                          |
| [`26e47f38`](https://github.com/NixOS/nixpkgs/commit/26e47f38b1672f3971f3dc827d900b1ff8b4268c) | `` gokrazy: 0-unstable-2026-01-09 -> 0-unstable-2026-07-23 ``                                     |