### PR TITLE
Audit remediation: batch 6 (CI capability + guardrails)

### DIFF
--- a/.github/grype-ignore.yaml
+++ b/.github/grype-ignore.yaml
@@ -27,6 +27,20 @@
 #      that instead.
 #   4. Re-check on major version bumps.  A reason tied to how a package
 #      is built today can stop holding tomorrow.
+#   5. Record when the reason was last checked with a `# Reviewed:
+#      YYYY-MM-DD` comment line directly above the entry's
+#      `- vulnerability:` line(s) (one date covers a whole comment block
+#      when it documents several entries, e.g. the gcc/gcc-wrapper pair
+#      below).  For a new entry this is the date you wrote the reason;
+#      when you re-check an existing entry per rule 4 and it still
+#      holds, bump the date to the day you checked it.
+#
+# The `Reviewed:` date is scheduling metadata for humans ONLY.  grype
+# does not read it, it has no effect on matching, and it must never be
+# used to make an entry start or stop suppressing based on how old it
+# is -- that would be exactly the age-based filtering this file rejects
+# below.  It exists so a stale reason is visible to a reviewer instead
+# of looking identical to one checked yesterday.
 #
 # We deliberately do NOT filter by CVSS score, EPSS probability, or age.
 # Those are ranking signals, not applicability signals: a low-EPSS bug in
@@ -82,6 +96,8 @@ ignore:
   # binary, not through an executable or a linked library.
   #
   # Re-evaluate if we ever add an aarch64-linux host.
+  #
+  # Reviewed: 2026-08-10
   - vulnerability: CVE-2023-4039
     package:
       name: gcc
@@ -97,6 +113,8 @@ ignore:
   # induce bit flips in specific memory, which is not a property OpenSSH
   # can fix and not one a package update resolves.  No upstream fix
   # exists to track.
+  #
+  # Reviewed: 2026-08-10
   - vulnerability: CVE-2023-51767
     package:
       name: openssh
@@ -109,6 +127,8 @@ ignore:
   # hosts/ for opie/OTP PAM configuration.
   #
   # Re-evaluate if OTP authentication is ever introduced.
+  #
+  # Reviewed: 2026-08-10
   - vulnerability: CVE-2007-2768
     package:
       name: openssh
@@ -121,6 +141,8 @@ ignore:
   # so it grants nothing an attacker in that position does not already
   # have.  Debian and Red Hat both classify this as not-a-vulnerability
   # for this reason, and no coreutils fix is planned.
+  #
+  # Reviewed: 2026-08-10
   - vulnerability: CVE-2016-2781
     package:
       name: coreutils
@@ -135,6 +157,8 @@ ignore:
   #
   # Re-evaluate if an FTP server or any service taking remote glob
   # patterns is ever deployed.
+  #
+  # Reviewed: 2026-08-10
   - vulnerability: CVE-2010-4756
     package:
       name: glibc

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -887,7 +887,10 @@ jobs:
 
           # shellcheck disable=SC2016 # $servers/$desktops are jq --argjson
           # bindings, not shell variables -- they must stay single-quoted.
-          hosts_json=$(nix shell --inputs-from . nixpkgs#jq --command jq -cn \
+          #
+          # --max-jobs 0: jq must only ever be substituted here, never
+          # built locally -- see the cost-model note on this job above.
+          hosts_json=$(nix shell --max-jobs 0 --inputs-from . nixpkgs#jq --command jq -cn \
             --argjson servers "$SERVERS" --argjson desktops "$DESKTOPS" \
             '($servers + $desktops) | unique')
 
@@ -912,7 +915,9 @@ jobs:
         run: |
           set -uo pipefail
 
-          status="$(nix shell --inputs-from . nixpkgs#jq --command ./scripts/diff-closures-comment.sh)"
+          # --max-jobs 0: jq must only ever be substituted here, never
+          # built locally -- see the cost-model note on this job above.
+          status="$(nix shell --max-jobs 0 --inputs-from . nixpkgs#jq --command ./scripts/diff-closures-comment.sh)"
           rc=$?
 
           if [ "$rc" -ne 0 ] || [ -z "$status" ]; then
@@ -951,7 +956,14 @@ jobs:
         run: |
           set -uo pipefail
 
-          bin_paths=$(nix build --no-link --print-out-paths --inputs-from . nixpkgs#gh nixpkgs#jq)
+          # --max-jobs 0: gh/jq must only ever be substituted here, never
+          # built locally -- see the cost-model note on this job above. A
+          # cache miss now fails this provisioning step cleanly instead
+          # of silently paying for a local build of either package.
+          if ! bin_paths=$(nix build --max-jobs 0 --no-link --print-out-paths --inputs-from . nixpkgs#gh nixpkgs#jq); then
+            echo "could not provision gh/jq (not in cache?) -- skipping PR comment" >&2
+            exit 0
+          fi
           while IFS= read -r p; do
             [ -n "$p" ] && PATH="$p/bin:$PATH"
           done <<<"$bin_paths"
@@ -959,9 +971,22 @@ jobs:
 
           marker='<!-- diff-closures-report -->'
 
-          existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+          # A failed lookup (not "found no match", but the `gh api` call
+          # itself erroring -- rate limit, transient API failure) must
+          # not fall through to the changed-status path below: with
+          # existing_id left empty, that path would then CREATE a new
+          # comment even though one may already exist, duplicating the
+          # report every time this step's API call happens to fail.
+          existing_id_err=$(mktemp)
+          if ! existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
             --jq '[.[] | select(.body | startswith("'"$marker"'"))] | (first.id // empty)' \
-            2>/dev/null)
+            2>"$existing_id_err"); then
+            echo "could not look up existing PR comment -- skipping to avoid posting a duplicate:" >&2
+            sed 's/^/  /' "$existing_id_err" >&2
+            rm -f "$existing_id_err"
+            exit 0
+          fi
+          rm -f "$existing_id_err"
 
           if [ "$STATUS" = "unchanged" ]; then
             if [ -n "$existing_id" ]; then

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -768,6 +768,222 @@ jobs:
             ./scripts/check-colmena-parity.sh
 
   # =====================================================================
+  # `nix store diff-closures` PR comment
+  #
+  # Audit item 6.2. The concrete motivation: a refactor asserted to be
+  # entirely behaviour-preserving merged with all 8 servers byte-identical
+  # (correct) but both desktops changed. Finding out *what* changed took a
+  # manual investigation across two commits -- comparing `system.path`,
+  # `environment.etc` names, `home.file` sources and text hashes by hand --
+  # and still did not fully resolve; the delta was somewhere inside the
+  # home-manager activation script. This job is the five-second read that
+  # investigation should have been: for every host find-systems flagged as
+  # impacted, diff its `system.build.toplevel` against the PR base and
+  # comment the result.
+  #
+  # NOT a required check. This is informational only -- see the "must never
+  # fail the PR" reasoning below -- and is deliberately NOT part of
+  # build-linux-summary's `needs`.
+  #
+  # WHY self-hosted, NOT ubuntu-latest
+  #
+  # Two independent reasons, either one sufficient on its own:
+  #
+  #   1. Reachability. The Attic substituter this job needs to check the
+  #      base commit's cached closure lives at http://192.168.31.14:8080/fred
+  #      -- a private LAN address. ubuntu-latest cannot reach it at all, so
+  #      this job could never usefully run there regardless of cost.
+  #   2. Cost class. colmena-parity's header measured 578s on ubuntu-latest
+  #      vs 103s on self-hosted for a full closure realisation, entirely due
+  #      to a cold eval cache and no LAN cache access. This job's substitute
+  #      step (see below) realises store paths the same way; it belongs
+  #      wherever build-servers/build-desktops already do.
+  #
+  # WHY THIS NEVER COSTS A BUILD -- read scripts/diff-closures-comment.sh's
+  # header before touching the substitution logic
+  #
+  # The AFTER closure is free: build-servers/build-desktops already realised
+  # it earlier in this same run and pushed it to Attic. The BEFORE closure
+  # (the PR base commit) is the one that could be expensive, and the script
+  # never pays that cost: it evaluates (never realises) the base commit's
+  # outPath via a `git+file://...?rev=<base_sha>` flake ref, and only
+  # attempts `nix build --max-jobs 0` (substitute-only; --max-jobs 0 makes a
+  # missing path a clean failure, never a real build) if that outPath
+  # actually differs from HEAD's.
+  #
+  # Whether that substitution succeeds depends on whether the base commit's
+  # closure is still cached. This repo's merge queue builds every commit
+  # that reaches `main`, and Attic retains what it serves for 30 days from
+  # last fetch (modules/services/attic/attic_server.nix), so the common
+  # case -- a PR based on a recent main commit -- substitutes cleanly. It is
+  # NOT guaranteed: a long-lived PR or GC pressure can make the base closure
+  # unavailable, and the honest answer in that case is "diff unavailable",
+  # not a silent fallback to a real build.
+  #
+  # NO-CHANGE / FORK-PR HANDLING
+  #
+  # - Every impacted host unchanged -> the script emits a single "no
+  #   closure changes" line rather than an empty table, and the comment
+  #   step only UPDATES an existing comment with it (never creates a new
+  #   one -- a clean PR should not get a fresh comment just to say so).
+  # - Fork PRs get a read-only GITHUB_TOKEN and cannot post comments even
+  #   with `pull-requests: write` declared below. The same fork guard every
+  #   other self-hosted job in this workflow carries (`if:` below) already
+  #   keeps fork PR code off self-hosted runners entirely, so this never
+  #   gets far enough to hit that limitation.
+  #
+  # `always()` is required in `if:` because build-servers/build-desktops use
+  # `fail-fast: false`: one matrix leg failing marks the whole job
+  # 'failure', and without `always()` this job would be skipped entirely --
+  # losing the diff for every host whose build DID succeed. Substitution
+  # failing for an unbuilt host is handled per-host inside the script
+  # (reported as "unavailable"), not by gating the whole job on build
+  # success.
+  diff-closures-comment:
+    name: Closure diff PR comment
+    runs-on: [self-hosted, Linux]
+    needs: [skip-if-clean, find-systems, build-servers, build-desktops]
+    if: |
+      always() &&
+      needs.skip-if-clean.outputs.skip != 'true' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (needs.find-systems.outputs.servers != '[]' || needs.find-systems.outputs.desktops != '[]')
+    # pull-requests: write is scoped to exactly this job -- nothing else in
+    # this workflow posts comments, so the top-level `permissions:` block
+    # stays read-only.
+    permissions:
+      id-token: "write"
+      contents: "read"
+      pull-requests: "write"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # fetch-depth: 0 -- the script evaluates the flake AT the PR base
+          # commit via `git+file://...?rev=<base_sha>`, which needs that
+          # commit's objects present locally, not just HEAD's.
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          trust-runner-user: true
+          extra-conf: |
+            access-tokens = github.com=${{ github.token }}
+            accept-flake-config = true
+            substituters = http://192.168.31.14:8080/fred https://catppuccin.cachix.org https://niri.cachix.org https://niri-epireyn.cachix.org https://cache.nixos.org/
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= fred:JjyhvRSvKfkk8r4HS0mS5r5I7dT4GociEFbrR9OgBZ0= niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964= niri-epireyn.cachix.org-1:tlVyFN7CtsDT+ZcLPS+ekFWeT1X6X4OqvWqbBMyIzFA= catppuccin.cachix.org-1:noG/4HkbhJb+lUAdKrph6LaozJvAeEEZj4N732IysmU=
+
+      # jq comes from `nix shell`, not the runner -- see the identical note
+      # on the colmena-parity job above.
+      - name: Combine impacted hosts
+        id: hosts
+        shell: bash
+        env:
+          SERVERS: ${{ needs.find-systems.outputs.servers }}
+          DESKTOPS: ${{ needs.find-systems.outputs.desktops }}
+        run: |
+          set -uo pipefail
+
+          # shellcheck disable=SC2016 # $servers/$desktops are jq --argjson
+          # bindings, not shell variables -- they must stay single-quoted.
+          hosts_json=$(nix shell --inputs-from . nixpkgs#jq --command jq -cn \
+            --argjson servers "$SERVERS" --argjson desktops "$DESKTOPS" \
+            '($servers + $desktops) | unique')
+
+          echo "Impacted hosts: $hosts_json"
+          echo "hosts_json=$hosts_json" >> "$GITHUB_OUTPUT"
+
+      # This step must never fail the job -- see the header block above.
+      # diff-closures-comment.sh already degrades every internal error to
+      # STATUS=nothing on stdout; the `status=$(...)` capture here plus the
+      # explicit rc/empty check is a second layer in case the script itself
+      # cannot even start (e.g. a shell parse error introduced by a future
+      # edit), so a bug in the script degrades to "nothing to report"
+      # instead of a red required-adjacent job.
+      - name: Compute closure diff
+        id: diff
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HOSTS_JSON: ${{ steps.hosts.outputs.hosts_json }}
+          OUT_FILE: body.md
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+
+          status="$(nix shell --inputs-from . nixpkgs#jq --command ./scripts/diff-closures-comment.sh)"
+          rc=$?
+
+          if [ "$rc" -ne 0 ] || [ -z "$status" ]; then
+            echo "diff-closures-comment.sh exited abnormally (rc=$rc) -- treating as nothing to report"
+            status="STATUS=nothing"
+            : > body.md
+          fi
+
+          echo "$status" >> "$GITHUB_OUTPUT"
+
+      # Find-then-edit-or-create, the same shape cve-scan.yaml's "Find or
+      # update CVE report issue" step uses for its rolling issue -- adapted
+      # here to a PR comment instead of an issue. The marker HTML comment at
+      # the top of body.md (written by the script) is what "find" searches
+      # for, so repeated pushes to the same PR update one comment instead of
+      # stacking a new one every run.
+      #
+      # gh/jq are added to PATH via `nix build --print-out-paths` rather
+      # than wrapping every call in `nix shell --command` -- both packages
+      # are common enough to substitute from cache.nixos.org in a couple of
+      # seconds, and prepending their `bin` dirs once keeps the rest of this
+      # step readable as plain `gh`/`jq` calls instead of deeply nested
+      # quoting.
+      #
+      # No `-e` and an explicit `exit 0` at the end: this step must never
+      # fail the job, per the "must never fail the PR" requirement -- a
+      # transient GitHub API error here is logged, not propagated.
+      - name: Find or update PR comment
+        if: steps.diff.outputs.STATUS != 'nothing'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STATUS: ${{ steps.diff.outputs.STATUS }}
+        run: |
+          set -uo pipefail
+
+          bin_paths=$(nix build --no-link --print-out-paths --inputs-from . nixpkgs#gh nixpkgs#jq)
+          while IFS= read -r p; do
+            [ -n "$p" ] && PATH="$p/bin:$PATH"
+          done <<<"$bin_paths"
+          export PATH
+
+          marker='<!-- diff-closures-report -->'
+
+          existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("'"$marker"'"))] | (first.id // empty)' \
+            2>/dev/null)
+
+          if [ "$STATUS" = "unchanged" ]; then
+            if [ -n "$existing_id" ]; then
+              echo "No closure changes -- updating existing comment #${existing_id}."
+              gh api --method PATCH "repos/${REPO}/issues/comments/${existing_id}" -f body=@body.md >/dev/null
+            else
+              echo "No closure changes and no existing comment -- nothing to do."
+            fi
+            exit 0
+          fi
+
+          if [ -n "$existing_id" ]; then
+            echo "Updating existing comment #${existing_id}."
+            gh api --method PATCH "repos/${REPO}/issues/comments/${existing_id}" -f body=@body.md >/dev/null
+          else
+            echo "Creating new PR comment."
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file body.md >/dev/null
+          fi
+
+          exit 0
+
+  # =====================================================================
   # Required summary check
   # =====================================================================
   build-linux-summary:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ dotfiles/fred/.config/nvim/lazy-lock.json
 *.pre-commit-config.yaml
 .DS_Store
 @girs
+
+# `nix build` output symlinks. Not ignoring these meant a stray `result` was
+# staged by `git add -A` and rejected by the check-symlinks hook as a broken
+# symlink once its target was garbage collected.
+result
+result-*

--- a/agent-docs/GRAFANA_SECRET_KEY_ROTATION.md
+++ b/agent-docs/GRAFANA_SECRET_KEY_ROTATION.md
@@ -1,0 +1,122 @@
+# Grafana secret_key rotation
+
+Runbook for rotating Grafana's `security.secret_key` on sdrhub, the only
+host running Grafana in this fleet.
+
+## Read this first
+
+`secret_key` is Grafana's envelope-encryption root key. It signs auth
+cookies and wraps the per-datasource secrets Grafana stores in its own
+`secrets` database table. The full safety analysis for rotating it --
+what is and is not protected by this key today -- lives in the comment
+block above `sops.secrets."monitoring/grafana_secret_key"` in
+`modules/monitoring/master/grafana.nix`. Read that before rotating; this
+runbook does not repeat it.
+
+Two consequences follow directly from that analysis, and both are
+expected, not failures:
+
+- **Every existing browser session is invalidated.** Cookies are signed
+  with the old key; Grafana rejects them once the new key is loaded, and
+  every logged-in user is sent back to the login page.
+- **The 42 rows in `data_keys` become permanently undecryptable.** They
+  protect nothing under the current datasource configuration (see the
+  nix-file comment for the verification), so this is expected. Grafana
+  logs decryption errors for them once after the restart and then moves
+  on -- do not treat that log line as a failure.
+
+The secret already carries `restartUnits = [ "grafana.service" ]`, so a
+normal deploy restarts Grafana automatically once the sops value
+changes. There is no separate restart step in this runbook.
+
+## Procedure: rotate the secret_key
+
+Use when the key may have leaked, or on a routine schedule. There is no
+partial/rolling state here -- a deploy either has restarted Grafana with
+the new key, or it has not.
+
+1. Generate a new random value on any machine with `nix`:
+
+   ```sh
+   nix run nixpkgs#openssl -- rand -base64 32
+   ```
+
+2. Put it in sops, replacing the existing value, on a machine that has
+   decrypt access (e.g. maranello):
+
+   ```sh
+   cd ~/GitHub/nixos
+   sops modules/secrets/secrets.yaml
+   # monitoring:
+   #   grafana_secret_key: <paste>
+   ```
+
+3. Deploy sdrhub. This is the moment every existing session is
+   invalidated and the `data_keys` rows above go stale:
+
+   ```sh
+   colmena apply --on sdrhub
+   ```
+
+4. Confirm Grafana actually restarted, the same way Procedure B in
+   `ATTIC_OPERATIONS.md` confirms atticd restarted -- `restartUnits`
+   handles this automatically, but a silent no-restart is exactly the
+   failure mode that runbook exists to catch:
+
+   ```sh
+   ssh sdrhub 'systemctl show grafana -p ActiveEnterTimestamp'
+   ```
+
+   The timestamp must be from this deploy. If it predates the deploy,
+   the unit did not restart and Grafana is still signing cookies with
+   the old key.
+
+5. Commit the sops change:
+
+   ```sh
+   git add modules/secrets/secrets.yaml && git commit
+   ```
+
+## Verifying a change
+
+```sh
+# Grafana is up and serving with the new process
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://grafana.int.fredsystems.org/login          # expect 200
+
+# an old session cookie is rejected -- the user-visible proof the key
+# actually rotated. Grab a cookie value from a browser session that
+# predates the deploy and confirm it no longer authenticates:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Cookie: grafana_session=<OLD_SESSION_COOKIE>" \
+  https://grafana.int.fredsystems.org/api/user       # expect 401
+
+# a fresh login still works
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST -H 'Content-Type: application/json' \
+  -d '{"user":"admin","password":"<current grafana_pw>"}' \
+  https://grafana.int.fredsystems.org/login          # expect 200
+```
+
+Then check the journal once for the expected, harmless `data_keys`
+decryption errors and confirm nothing else is logged as failing:
+
+```sh
+ssh sdrhub 'journalctl -u grafana --since "10 minutes ago" | grep -i error'
+```
+
+Expect only decryption failures naming the stale `data_keys` rows.
+Anything else (datasource provisioning errors, a crash loop) means the
+rotation surfaced a problem the nix-file's safety analysis did not
+anticipate -- stop and investigate before considering the rotation done.
+
+## Invariants
+
+- **`secret_key` lives only in sops**, never as a literal in
+  `grafana.nix`. The pre-sops history of this file is the reason this
+  invariant exists at all -- see the module comment.
+- **A deploy is the only rotation mechanism.** There is no live-reload
+  path; `restartUnits` is what makes the new value take effect.
+- **Every rotation logs out every user.** This is not survivable to
+  avoid -- do not schedule it during a live investigation that depends
+  on someone's Grafana session staying open.

--- a/agent-docs/GRAFANA_SECRET_KEY_ROTATION.md
+++ b/agent-docs/GRAFANA_SECRET_KEY_ROTATION.md
@@ -79,23 +79,41 @@ the new key, or it has not.
 
 ## Verifying a change
 
+Do this from a browser, not `curl` with credentials on the command line --
+both the session cookie and the admin password are secrets, and a shell
+command line is world-readable to anyone on the box via `/proc` or shell
+history for as long as it persists.
+
+1. **Grafana is up and serving with the new process.** Load
+   `https://grafana.int.fredsystems.org/login` -- expect the login page,
+   not a connection error.
+
+2. **An old session is rejected -- the user-visible proof the key
+   actually rotated.** In a browser tab that was logged in before the
+   deploy, reload any dashboard. Expect a redirect to the login page,
+   not the dashboard.
+
+3. **A fresh login still works.** Log in with the current admin
+   credentials in that same browser. Expect success.
+
+If you must script this (e.g. from an automation host with no browser),
+put the cookie and password in files with `chmod 600`, pass them via
+`curl`'s `-H @file` / `--data @file` forms, and delete the files
+immediately after:
+
 ```sh
-# Grafana is up and serving with the new process
-curl -s -o /dev/null -w '%{http_code}\n' \
-  https://grafana.int.fredsystems.org/login          # expect 200
+umask 077
+printf 'Cookie: grafana_session=%s\n' "$OLD_SESSION_COOKIE" >cookie.hdr
+printf '{"user":"admin","password":"%s"}\n' "$GRAFANA_PW" >login.json
 
-# an old session cookie is rejected -- the user-visible proof the key
-# actually rotated. Grab a cookie value from a browser session that
-# predates the deploy and confirm it no longer authenticates:
 curl -s -o /dev/null -w '%{http_code}\n' \
-  -H "Cookie: grafana_session=<OLD_SESSION_COOKIE>" \
-  https://grafana.int.fredsystems.org/api/user       # expect 401
+  -H @cookie.hdr https://grafana.int.fredsystems.org/api/user   # expect 401
 
-# a fresh login still works
 curl -s -o /dev/null -w '%{http_code}\n' \
-  -X POST -H 'Content-Type: application/json' \
-  -d '{"user":"admin","password":"<current grafana_pw>"}' \
-  https://grafana.int.fredsystems.org/login          # expect 200
+  -X POST -H 'Content-Type: application/json' --data @login.json \
+  https://grafana.int.fredsystems.org/login                     # expect 200
+
+rm -f cookie.hdr login.json
 ```
 
 Then check the journal once for the expected, harmless `data_keys`

--- a/agent-docs/SOPS_AGE_KEY_ROTATION.md
+++ b/agent-docs/SOPS_AGE_KEY_ROTATION.md
@@ -1,0 +1,269 @@
+# sops age-key rotation
+
+Runbook for adding, removing, and verifying age recipients for
+`modules/secrets/secrets.yaml`. This is the credential that gates every
+other secret in the fleet, so getting recipient changes wrong is worse
+than getting most other rotations wrong: a mistake here can either
+silently lock a host out of its own secrets at deploy time, or leave a
+removed recipient able to decrypt long after you believe they cannot.
+
+## Read this first
+
+`modules/secrets/.sops.yaml` declares 12 age recipients as YAML anchors
+under `keys:` and wires all 12 into a single `creation_rules` entry for
+`secrets.yaml$`. Every host that needs any secret from this file must be
+in that list -- there is no per-secret recipient scoping, only
+per-file.
+
+**Three sets have to agree, and `scripts/check-sops-recipients.sh`
+exists because nothing used to check that they did:**
+
+1. the anchors declared under `keys:` in `.sops.yaml`
+2. the age keys actually referenced by the `creation_rules` entry for
+   `secrets.yaml$`
+3. the recipients sops actually encrypted `secrets.yaml` for, per the
+   file's own (unencrypted) `sops.age[].recipient` metadata
+
+(1) and (2) can drift from each other by editing `.sops.yaml` alone.
+(2) and (3) drift when `.sops.yaml` is updated correctly but `sops
+updatekeys` is never run -- the file on disk still only decrypts for
+the old set. Every procedure below ends by running that script, and so
+does the `sops-recipients` flake check (`nix build
+.#checks.<system>.sops-recipients`), which runs the same script in CI
+and in the pre-commit hook whenever `.sops.yaml` or `secrets.yaml`
+changes.
+
+**`sops updatekeys` and `sops rotate` do different things, and only one
+of them actually revokes access.** This is the fact the inline comment
+in `sops.nix` did not capture, and it is the reason removing a
+recipient needs its own procedure instead of being the reverse of
+adding one:
+
+- `sops updatekeys` reconciles *who holds a wrapped copy of the current
+  data encryption key (DEK)*, against `creation_rules`. It adds a
+  wrapped DEK for a new recipient and drops the wrapped DEK entry for a
+  removed one. **It does not change the DEK itself.** Every value in
+  the file is still encrypted with the same DEK it was encrypted with
+  before.
+- `sops rotate` generates a **brand-new** DEK and re-encrypts every
+  value in the file with it, then wraps that new DEK for whoever is
+  currently a recipient.
+
+The distinction matters for revocation: a host that had legitimate
+decrypt access could have extracted the plaintext DEK before being
+removed (not just its own wrapped copy of it). Running `updatekeys`
+alone drops that host's entry from the file, but the surviving
+ciphertext is still encrypted with the same DEK that host already
+extracted -- so if it retained an old copy of the file, or the actual
+DEK value, `updatekeys` alone has not revoked anything. Only `sops
+rotate`, run *after* the recipient is removed from `.sops.yaml`, puts
+the remaining secrets behind a DEK that host was never given. This is
+the same "no partial revocation, only wholesale key replacement"
+property `ATTIC_OPERATIONS.md`'s Procedure B documents for the JWT
+signing key, except here sops gives you the tool to do it
+(`rotate`) instead of you having to regenerate and redeploy the whole
+service.
+
+**Editing `.sops.yaml` is destructive to itself if done in two steps.**
+The `creation_rules` age list references `keys:` anchors by YAML alias
+(`*name`). If you remove an anchor from `keys:` and commit that alone,
+without also removing its alias from `creation_rules`, the file no
+longer parses -- every `sops` invocation against it fails immediately,
+for every recipient, not just the one you touched. Add or remove the
+anchor and its `creation_rules` reference in the same edit.
+
+## Procedure A: add a new recipient (new host)
+
+Use when bringing up a new host that needs any secret from
+`secrets.yaml`.
+
+1. Generate an age keypair on the new host, if `add_new_system_sop.sh`
+   has not already been run there:
+
+   ```sh
+   nix shell nixpkgs#age -c age-keygen -o ~/.config/sops/age/keys.txt
+   ```
+
+   The command prints the public key (`age1...`) — copy it.
+
+2. On a machine that can already decrypt `secrets.yaml` (e.g.
+   maranello), add the new host as an anchor under `keys:` and add that
+   anchor to the `creation_rules` age list for `secrets.yaml$`, in the
+   same edit:
+
+   ```sh
+   cd ~/GitHub/nixos
+   "$EDITOR" modules/secrets/.sops.yaml
+   ```
+
+3. Re-encrypt `secrets.yaml` for the new recipient set. sops shows a
+   diff of who is being added/removed and asks for confirmation; `-y`
+   skips the prompt for non-interactive use:
+
+   ```sh
+   sops updatekeys modules/secrets/secrets.yaml
+   ```
+
+4. Verify all three sets agree:
+
+   ```sh
+   bash scripts/check-sops-recipients.sh
+   ```
+
+5. Commit `.sops.yaml` and `secrets.yaml` together — a commit touching
+   only one of the two is exactly the drift the check above exists to
+   catch:
+
+   ```sh
+   git add modules/secrets/.sops.yaml modules/secrets/secrets.yaml
+   git commit
+   ```
+
+6. Deploy the new host and confirm it actually decrypted (the metadata
+   check in step 4 proves sops *intends* the host to be able to
+   decrypt; it does not prove the host's own key file matches):
+
+   ```sh
+   ssh <newhost> 'test -s /run/secrets/fred-gpg && echo OK'
+   ```
+
+   Pick any secret the new host's config actually declares in its
+   `sops.secrets` block — `fred-gpg` is the one every Linux host with
+   `sops_secrets.enable_secrets.enable = true` gets via
+   `modules/secrets/sops.nix`.
+
+## Procedure B: remove a compromised recipient
+
+Use when a host's age private key is suspected leaked. This is the
+crisis response — the one to reach for, not the add-in-reverse.
+
+Everything currently in `secrets.yaml` must be treated as already seen
+by whoever has the compromised key. This procedure stops *future*
+exposure; it does not undo the past one. If any individual secret's
+own *value* (not just sops's ability to decrypt it) may have been
+read and copied out, that secret's own credential must be rotated too
+— see `GRAFANA_SECRET_KEY_ROTATION.md` and `ATTIC_OPERATIONS.md`'s
+Procedure B for the two that have their own runbooks; anything else in
+`secrets.yaml` needs the same treatment on a case-by-case basis.
+
+1. Remove the compromised host's anchor from `keys:` **and** its alias
+   from the `creation_rules` age list, in the same edit (see "Read this
+   first" — leaving these out of sync breaks the file for everyone):
+
+   ```sh
+   cd ~/GitHub/nixos
+   "$EDITOR" modules/secrets/.sops.yaml
+   ```
+
+2. Drop the compromised host's wrapped DEK entry from the file:
+
+   ```sh
+   sops updatekeys modules/secrets/secrets.yaml
+   ```
+
+3. **Rotate the DEK itself.** This is the step that actually revokes
+   access — skipping it leaves every value encrypted with a key the
+   compromised host may already have extracted:
+
+   ```sh
+   sops rotate --in-place modules/secrets/secrets.yaml
+   ```
+
+4. Verify the file is now wrapped for exactly the remaining recipients
+   and no more:
+
+   ```sh
+   bash scripts/check-sops-recipients.sh
+   ```
+
+5. Commit `.sops.yaml` and `secrets.yaml` together:
+
+   ```sh
+   git add modules/secrets/.sops.yaml modules/secrets/secrets.yaml
+   git commit
+   ```
+
+6. Redeploy every remaining host, not just one — `secrets.yaml` is
+   shared, and every host re-decrypts it on its next activation
+   regardless of whether that host's own secrets changed:
+
+   ```sh
+   colmena apply                                   # servers
+   sudo nixos-rebuild switch --flake .#maranello   # desktops, locally
+   sudo nixos-rebuild switch --flake .#Daytona
+   darwin-rebuild switch --flake .#Freds-MacBook-Pro   # Darwin, locally
+   darwin-rebuild switch --flake .#Freds-Mac-Studio
+   ```
+
+7. If the compromised host is being decommissioned rather than
+   re-keyed, that is a separate exercise (remove it from
+   `flake/hosts/servers.nix`, the colmena topology, monitoring targets,
+   etc.) — out of scope here.
+
+If you need to re-admit the same physical host later, treat it as a
+brand-new host: generate a fresh age keypair (Procedure A, step 1) and
+add it back under a fresh anchor. Never re-add the compromised public
+key.
+
+## Verifying every one of the 12 recipients can still decrypt
+
+The automated check only proves the *metadata* is internally
+consistent — that sops *intends* exactly these recipients to be able to
+decrypt. It cannot prove a given host's key file on disk still matches,
+so both steps below are required after any recipient change, not just
+one.
+
+1. Run the three-way check:
+
+   ```sh
+   bash scripts/check-sops-recipients.sh
+   ```
+
+   Expect:
+
+   ```text
+   sops recipient consistency OK (12 recipients, keys/creation_rules/secrets.yaml agree)
+   ```
+
+   A count other than the number of recipients you expect, or a
+   non-zero exit, means stop here — do not proceed to redeploying the
+   fleet with a `secrets.yaml` that does not match `.sops.yaml`.
+
+2. Confirm actual decryption on every host that should still have
+   access. Run this from each host, not against a copy of the repo
+   elsewhere — the whole point is testing that host's own key file:
+
+   ```sh
+   for host in maranello Daytona acarshub hfdlhub1 hfdlhub2 sdrhub \
+     vdlmhub fredhub nvrhub; do
+     echo "== $host =="
+     ssh "$host" 'cd ~/GitHub/nixos && sops -d modules/secrets/secrets.yaml >/dev/null && echo OK'
+   done
+
+   # fredvps uses a non-standard SSH port and a different target host --
+   # see flake/hosts/servers.nix
+   ssh -p 2269 fredclausen.com \
+     'cd ~/GitHub/nixos && sops -d modules/secrets/secrets.yaml >/dev/null && echo OK'
+   ```
+
+   The two Darwin hosts (`Freds-MacBook-Pro`, `Freds-Mac-Studio`) are
+   often offline or unreachable over SSH; run the same `sops -d ... &&
+   echo OK` check locally on each the next time it is available, rather
+   than skipping it. Do not consider a recipient-set change fully
+   verified until all 12 have reported `OK` at least once since the
+   change.
+
+## Invariants
+
+- **One file, one recipient list.** There is no per-secret scoping
+  inside `secrets.yaml` — anyone in the recipient list can decrypt
+  everything in it.
+- **`.sops.yaml` and `secrets.yaml` change together, in the same
+  commit.** A commit that edits one without the other is the exact
+  drift `check-sops-recipients.sh` exists to catch.
+- **Removing a recipient means rotating the DEK, not just editing the
+  recipient list.** `sops updatekeys` alone does not revoke anything —
+  see "Read this first".
+- **The three-way check is necessary but not sufficient.** It proves
+  the metadata is self-consistent; only an actual per-host decrypt
+  proves the corresponding private key still works.

--- a/agent-docs/SOPS_AGE_KEY_ROTATION.md
+++ b/agent-docs/SOPS_AGE_KEY_ROTATION.md
@@ -121,16 +121,33 @@ Use when bringing up a new host that needs any secret from
 
 6. Deploy the new host and confirm it actually decrypted (the metadata
    check in step 4 proves sops *intends* the host to be able to
-   decrypt; it does not prove the host's own key file matches):
+   decrypt; it does not prove the host's own key file matches). The
+   secret to check and how it lands on disk differ by platform — sops
+   secrets are not deployed the same way on Darwin as on NixOS:
 
-   ```sh
-   ssh <newhost> 'test -s /run/secrets/fred-gpg && echo OK'
-   ```
+   - **Linux**: `fred-gpg` is the one every host with
+     `sops_secrets.enable_secrets.enable = true` gets via
+     `modules/secrets/sops.nix`, decrypted by `sops-nix` into
+     `/run/secrets`:
 
-   Pick any secret the new host's config actually declares in its
-   `sops.secrets` block — `fred-gpg` is the one every Linux host with
-   `sops_secrets.enable_secrets.enable = true` gets via
-   `modules/secrets/sops.nix`.
+     ```sh
+     ssh <newhost> 'test -s /run/secrets/fred-gpg && echo OK'
+     ```
+
+   - **Darwin**: `sops-nix`'s NixOS module is not in play; verify with
+     the host's own darwin-rebuild/home-manager activation output
+     instead, or decrypt directly on the host to prove its key file
+     works:
+
+     ```sh
+     ssh <newdarwinhost> \
+       'sops -d --extract '"'"'["monitoring"]["grafana_pw"]'"'"' \
+         ~/GitHub/nixos/modules/secrets/secrets.yaml >/dev/null && echo OK'
+     ```
+
+     Substitute any key path the new host's own age recipient can
+     decrypt; `monitoring.grafana_pw` is just an example that exists in
+     the file today.
 
 ## Procedure B: remove a compromised recipient
 
@@ -205,13 +222,28 @@ brand-new host: generate a fresh age keypair (Procedure A, step 1) and
 add it back under a fresh anchor. Never re-add the compromised public
 key.
 
-## Verifying every one of the 12 recipients can still decrypt
+## Verifying every current recipient can still decrypt
 
 The automated check only proves the *metadata* is internally
-consistent — that sops *intends* exactly these recipients to be able to
-decrypt. It cannot prove a given host's key file on disk still matches,
-so both steps below are required after any recipient change, not just
-one.
+consistent — that sops *intends* exactly the current recipients to be
+able to decrypt. It cannot prove a given host's key file on disk still
+matches, so both steps below are required after any recipient change,
+not just one.
+
+**The expected recipient count and host list are whatever this
+procedure just changed them to, not a number fixed in this document.**
+After Procedure A (add) the list is one longer and includes the new
+host; after Procedure B (remove) it is one shorter and must NOT include
+the host you just revoked — that host succeeding here would mean the
+removal did not take effect. Read the current list from `.sops.yaml`
+itself rather than trusting a count written down in a runbook:
+
+```sh
+count=$(yq '.keys | length' modules/secrets/.sops.yaml)
+hosts=$(yq '.keys[] | anchor' modules/secrets/.sops.yaml)
+echo "expected recipients: $count"
+echo "$hosts"
+```
 
 1. Run the three-way check:
 
@@ -219,39 +251,57 @@ one.
    bash scripts/check-sops-recipients.sh
    ```
 
-   Expect:
+   Expect `sops recipient consistency OK (<count> recipients, ...)`
+   where `<count>` matches the `count` computed above. A different
+   count, or a non-zero exit, means stop here — do not proceed to
+   redeploying the fleet with a `secrets.yaml` that does not match
+   `.sops.yaml`.
 
-   ```text
-   sops recipient consistency OK (12 recipients, keys/creation_rules/secrets.yaml agree)
-   ```
-
-   A count other than the number of recipients you expect, or a
-   non-zero exit, means stop here — do not proceed to redeploying the
-   fleet with a `secrets.yaml` that does not match `.sops.yaml`.
-
-2. Confirm actual decryption on every host that should still have
-   access. Run this from each host, not against a copy of the repo
-   elsewhere — the whole point is testing that host's own key file:
+2. Confirm actual decryption on every host in `$hosts` above. Do this
+   against the **deployed** commit's ciphertext on each host, not a
+   possibly-stale local checkout of the repo elsewhere — the whole
+   point is testing that host's own key file against the sops file it
+   actually runs with. Set the age identity explicitly so this cannot
+   silently fall back to some other key on the runner's `$PATH`/env
+   (sops's own default identity resolution), and accumulate failures
+   instead of only printing them, so one bad host cannot hide behind
+   later successes:
 
    ```sh
+   fail=0
    for host in maranello Daytona acarshub hfdlhub1 hfdlhub2 sdrhub \
      vdlmhub fredhub nvrhub; do
      echo "== $host =="
-     ssh "$host" 'cd ~/GitHub/nixos && sops -d modules/secrets/secrets.yaml >/dev/null && echo OK'
+     if ! ssh fred@"$host" '
+       cd ~/GitHub/nixos && git fetch -q && git checkout -q origin/main &&
+       SOPS_AGE_KEY_FILE=/home/fred/.config/sops/age/keys.txt \
+         sops -d modules/secrets/secrets.yaml >/dev/null && echo OK'; then
+       echo "FAILED: $host"
+       fail=1
+     fi
    done
 
    # fredvps uses a non-standard SSH port and a different target host --
    # see flake/hosts/servers.nix
-   ssh -p 2269 fredclausen.com \
-     'cd ~/GitHub/nixos && sops -d modules/secrets/secrets.yaml >/dev/null && echo OK'
+   if ! ssh -p 2269 fred@fredclausen.com '
+     cd ~/GitHub/nixos && git fetch -q && git checkout -q origin/main &&
+     SOPS_AGE_KEY_FILE=/home/fred/.config/sops/age/keys.txt \
+       sops -d modules/secrets/secrets.yaml >/dev/null && echo OK'; then
+     echo "FAILED: fredvps"
+     fail=1
+   fi
+
+   [ "$fail" -eq 0 ] || { echo "one or more hosts failed to decrypt -- do not proceed"; exit 1; }
    ```
 
    The two Darwin hosts (`Freds-MacBook-Pro`, `Freds-Mac-Studio`) are
-   often offline or unreachable over SSH; run the same `sops -d ... &&
-   echo OK` check locally on each the next time it is available, rather
-   than skipping it. Do not consider a recipient-set change fully
-   verified until all 12 have reported `OK` at least once since the
-   change.
+   often offline or unreachable over SSH; run the same check locally on
+   each the next time it is available, using
+   `SOPS_AGE_KEY_FILE=/Users/fred/.config/sops/age/keys.txt` (Darwin's
+   age key path differs from Linux's), rather than skipping it. Do not
+   consider a recipient-set change fully verified until every current
+   recipient has reported `OK` at least once since the change, and any
+   host you just removed has been confirmed to FAIL.
 
 ## Invariants
 

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -138,6 +138,40 @@
         '';
       };
 
+      # Detects `.nix` files that are never imported anywhere and are not
+      # themselves a recognised entry point (flake.nix, flake/**, a host's
+      # configuration.nix/hardware-configuration.nix/home.nix, or a
+      # profiles/*.nix).
+      #
+      # `firmware.nix` used to sit in this repo imported by nothing, while CI
+      # still treated any change to it as a global rebuild trigger. It has
+      # since been deleted, so this check currently has no subject on the
+      # current tree -- that is fine and is the point: it is preventative,
+      # not remedial. See scripts/check-module-reachability.sh's header for
+      # the full design and its deliberate false-negative bias.
+      moduleReachabilityCheck = pkgs.writeShellApplication {
+        name = "check-module-reachability";
+        text = ''
+          bash scripts/check-module-reachability.sh
+        '';
+      };
+
+      # Asserts that every `mkOption { ... }` call declares both a `type`
+      # (so a bad value is an eval-time error, not a silent no-op) and a
+      # `description` (so the option is discoverable without reading the
+      # defining module). An audit found one option with no type at all and
+      # roughly seventeen with no description; both classes are now fixed,
+      # and this check is what keeps them from coming back. See
+      # scripts/check-option-schema.sh's header for the brace-matching
+      # parse strategy and its documented limitation.
+      optionSchemaCheck = pkgs.writeShellApplication {
+        name = "check-option-schema";
+        runtimeInputs = [ pkgs.python3 ];
+        text = ''
+          bash scripts/check-option-schema.sh
+        '';
+      };
+
       # Validates opencode.jsonc: a structural check (offline, default --
       # unknown top-level keys and command entries missing `template`,
       # wired into both the hook and the standalone check below via
@@ -231,6 +265,34 @@
                 # declared (module add/rename/removal), so it is the actual
                 # trigger for MODULES.md drift, not modules/*.nix directly.
                 files = "^(MODULES\\.md|flake\\.nix|flake/hosts/servers\\.nix|\\.github/workflows/ci-linux\\.yaml)$";
+                pass_filenames = false;
+              };
+
+              module-reachability = {
+                enable = true;
+                name = "no orphaned .nix modules (dead-file reachability)";
+                entry = "${pkgs.lib.getExe moduleReachabilityCheck}";
+
+                # Any .nix file change can create or resolve an orphan --
+                # adding a new file nobody imports yet, or deleting the last
+                # import of an existing one -- so this always re-scans the
+                # whole tree rather than reacting to a specific path.
+                # pass_filenames is off for the same reason: a single-file
+                # view cannot tell whether that file is reachable from
+                # anywhere else.
+                files = "\\.nix$";
+                pass_filenames = false;
+              };
+
+              option-schema = {
+                enable = true;
+                name = "mkOption type + description coverage";
+                entry = "${pkgs.lib.getExe optionSchemaCheck}";
+
+                # Same reasoning as module-reachability: an mkOption call can
+                # appear in any .nix file, so this re-scans the whole tree on
+                # any .nix change rather than reacting to a specific path.
+                files = "\\.nix$";
                 pass_filenames = false;
               };
 
@@ -420,6 +482,33 @@
           ''
             cd ${self}
             check-opencode-jsonc --offline
+            touch "$out"
+          '';
+
+      # Standalone check so `nix flake check` and CI catch an orphaned
+      # module even on a route that never ran pre-commit hooks.
+      module-reachability =
+        pkgs.runCommand "module-reachability-check"
+          {
+            nativeBuildInputs = [ moduleReachabilityCheck ];
+          }
+          ''
+            cd ${self}
+            check-module-reachability
+            touch "$out"
+          '';
+
+      # Standalone check so `nix flake check` and CI catch a schema
+      # regression (a new mkOption with no type/description) even on a
+      # route that never ran pre-commit hooks.
+      option-schema =
+        pkgs.runCommand "option-schema-check"
+          {
+            nativeBuildInputs = [ optionSchemaCheck ];
+          }
+          ''
+            cd ${self}
+            check-option-schema
             touch "$out"
           '';
 

--- a/modules/base/deployment-meta.nix
+++ b/modules/base/deployment-meta.nix
@@ -21,7 +21,10 @@ in
       default = null;
       description = ''
         Hostname or IP address Prometheus uses to scrape this node.
-        When null, defaults to <hostname>.local (suitable for LAN nodes).
+        When null, defaults to "<attr>.local", where <attr> is this host's
+        nixosConfigurations attribute name in flake.nix -- NOT
+        config.networking.hostName, which is not guaranteed to match (suitable
+        for LAN nodes).
         Set this to a Tailscale MagicDNS name for nodes not on the LAN.
       '';
     };
@@ -116,21 +119,27 @@ in
         # Unlike the assertion above, a missing scrapeAddress does not break
         # eval -- it just means flake.nix's agentScrapeMap/desktopScrapeMap
         # (see the "Monitoring topology" section of flake.nix) fall back to
-        # "<hostname>.local" for this node. That fallback is the right default
-        # for a LAN host with mDNS, and exactly wrong for one whose exporters
-        # were just rebound off the LAN by internetFacing itself: Prometheus
-        # would keep trying an address the host most likely does not answer
-        # on (a bare VPS in particular has no mDNS responder at all), so
-        # scrapes fail closed and silently rather than pointing at the
-        # Tailscale address this option's own doc comment says to use.
+        # "<attr>.local" for this node, where <attr> is the nixosConfigurations
+        # attribute name (flake.nix:319/334) -- NOT config.networking.hostName.
+        # The two are not guaranteed to match (a mismatch already caused a real
+        # bug in this repo: an alert rule excluded "daytona" while the actual
+        # identifier was "Daytona"). That fallback is the right default for a
+        # LAN host with mDNS, and exactly wrong for one whose exporters were
+        # just rebound off the LAN by internetFacing itself: Prometheus would
+        # keep trying an address the host most likely does not answer on (a
+        # bare VPS in particular has no mDNS responder at all), so scrapes
+        # fail closed and silently rather than pointing at the Tailscale
+        # address this option's own doc comment says to use.
         warnings = lib.optional (cfg.internetFacing && cfg.scrapeAddress == null) ''
           deployment.internetFacing is set on this host, but deployment.scrapeAddress is not.
 
-          Prometheus's target for this node falls back to "<hostname>.local", which is unlikely to
-          resolve for an internet-facing node (no LAN mDNS responder), while the exporters themselves
-          are now bound to deployment.tailscaleAddress instead of 0.0.0.0. Scraping this host will
-          most likely fail. Set deployment.scrapeAddress to this node's Tailscale MagicDNS name (see
-          fredvps's configuration.nix for the pattern).
+          Prometheus's target for this node falls back to "<attr>.local", where <attr> is this
+          host's nixosConfigurations attribute name in flake.nix (not necessarily
+          config.networking.hostName), which is unlikely to resolve for an internet-facing node (no
+          LAN mDNS responder), while the exporters themselves are now bound to
+          deployment.tailscaleAddress instead of 0.0.0.0. Scraping this host will most likely fail.
+          Set deployment.scrapeAddress to this node's Tailscale MagicDNS name (see fredvps's
+          configuration.nix for the pattern).
         '';
       }
     ]

--- a/modules/base/deployment-meta.nix
+++ b/modules/base/deployment-meta.nix
@@ -112,6 +112,26 @@ in
             message = "deployment.internetFacing requires deployment.tailscaleAddress to be set.";
           }
         ];
+
+        # Unlike the assertion above, a missing scrapeAddress does not break
+        # eval -- it just means flake.nix's agentScrapeMap/desktopScrapeMap
+        # (see the "Monitoring topology" section of flake.nix) fall back to
+        # "<hostname>.local" for this node. That fallback is the right default
+        # for a LAN host with mDNS, and exactly wrong for one whose exporters
+        # were just rebound off the LAN by internetFacing itself: Prometheus
+        # would keep trying an address the host most likely does not answer
+        # on (a bare VPS in particular has no mDNS responder at all), so
+        # scrapes fail closed and silently rather than pointing at the
+        # Tailscale address this option's own doc comment says to use.
+        warnings = lib.optional (cfg.internetFacing && cfg.scrapeAddress == null) ''
+          deployment.internetFacing is set on this host, but deployment.scrapeAddress is not.
+
+          Prometheus's target for this node falls back to "<hostname>.local", which is unlikely to
+          resolve for an internet-facing node (no LAN mDNS responder), while the exporters themselves
+          are now bound to deployment.tailscaleAddress instead of 0.0.0.0. Scraping this host will
+          most likely fail. Set deployment.scrapeAddress to this node's Tailscale MagicDNS name (see
+          fredvps's configuration.nix for the pattern).
+        '';
       }
     ]
     ++

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -518,6 +518,16 @@ in
           ExecStart = pkgs.writeShellScript "node-journal-metrics.sh" ''
             set -uo pipefail
 
+            # Forced C locale for the whole script, not just the commands
+            # below: the parsing here depends on journalctl emitting the
+            # literal English string "take up" and both journalctl and awk
+            # using "." as the decimal separator. Under any locale that
+            # translates that message or uses "," for decimals, every match
+            # below silently fails -- the collector would then report
+            # OK=0 on EVERY run, forever, rather than only when something
+            # is actually wrong. Raised in review on PR #2251.
+            export LC_ALL=C
+
             JOURNALCTL=${pkgs.systemd}/bin/journalctl
             AWK=${pkgs.gawk}/bin/awk
             HOST="${config.networking.hostName}"

--- a/modules/monitoring/agent/node_exporter.nix
+++ b/modules/monitoring/agent/node_exporter.nix
@@ -68,6 +68,76 @@ let
     "smb3"
     "fuse.sshfs"
   ];
+
+  # journald's configured SystemMaxUse, in bytes, for node_journal_max_bytes
+  # below (see the journal-retention producer near the bottom of this file).
+  #
+  # WHY THIS IS READ FROM THE NIXOS OPTION RATHER THAN PARSED AT RUNTIME
+  #
+  # modules/base/system.nix sets this via services.journald.extraConfig,
+  # which NixOS renders into /etc/systemd/journald.conf.d/. Two ways exist to
+  # recover the value: parse the rendered drop-in file at runtime, or read
+  # config.services.journald.extraConfig here at eval time. The rendered
+  # file's exact shape (drop-in filename, comment/whitespace placement,
+  # whether a future NixOS release changes how extraConfig is emitted) is an
+  # implementation detail of the module system, not a stable interface worth
+  # depending on from a shell script. config.services.journald.extraConfig is
+  # the actual value this repo sets, already resolved for whichever host is
+  # being built -- including any per-host mkForce/mkMerge override, though
+  # none exists today: modules/base/system.nix is the only place in this
+  # repo that touches services.journald.extraConfig.
+  #
+  # If the line is missing or its value doesn't parse, this evaluates to
+  # null and the systemd unit below simply omits node_journal_max_bytes
+  # rather than emitting a hardcoded/wrong constant.
+  journaldExtraConfigLines = lib.splitString "\n" config.services.journald.extraConfig;
+
+  systemMaxUseLine = lib.findFirst (
+    line: builtins.match "[[:space:]]*SystemMaxUse=.*" line != null
+  ) null journaldExtraConfigLines;
+
+  systemMaxUseMatch =
+    if systemMaxUseLine == null then
+      null
+    else
+      builtins.match "[[:space:]]*SystemMaxUse=([0-9]+)([KMGT]?)[[:space:]]*" systemMaxUseLine;
+
+  # journald's parse_size() treats these suffixes as IEC (1024-based), same
+  # as SystemMaxFileSize and the other size settings in modules/base/system.nix.
+  sizeSuffixMultiplier = {
+    "" = 1;
+    "K" = 1024;
+    "M" = 1024 * 1024;
+    "G" = 1024 * 1024 * 1024;
+    "T" = 1024 * 1024 * 1024 * 1024;
+  };
+
+  systemMaxUseBytes =
+    if systemMaxUseMatch == null then
+      null
+    else
+      let
+        number = lib.toInt (builtins.elemAt systemMaxUseMatch 0);
+        suffix = builtins.elemAt systemMaxUseMatch 1;
+        multiplier = sizeSuffixMultiplier.${suffix} or null;
+      in
+      if multiplier == null then null else number * multiplier;
+
+  # Emitted only when systemMaxUseBytes was determined above -- see the
+  # comment there. This is a build-time (Nix eval) determination shared by
+  # every host from the same module, not a per-scrape runtime concern, so it
+  # does not participate in the node_journal_metrics_ok liveness flag that
+  # the shell script below computes for its own, genuinely runtime, parse
+  # failures.
+  journalMaxBytesMetricLines =
+    if systemMaxUseBytes == null then
+      ""
+    else
+      ''
+        echo "# HELP node_journal_max_bytes Configured journald SystemMaxUse (the on-disk journal cap), in bytes."
+        echo "# TYPE node_journal_max_bytes gauge"
+        echo "node_journal_max_bytes{host=\"$HOST\"} ${toString systemMaxUseBytes}"
+      '';
 in
 {
   systemd = {
@@ -432,6 +502,131 @@ in
           '';
         };
       };
+
+      # Audit item 6.11 (reshaped): is the journald retention policy in
+      # modules/base/system.nix actually being achieved, or is the 1G
+      # SystemMaxUse cap evicting entries before MaxRetentionSec=30day gets
+      # a chance to? Measured on this host (maranello): 966.2M used, oldest
+      # entry 8 days old -- size is binding ~3.7x before time, so the
+      # 30-day policy is currently fiction here and nothing reported it.
+      # This unit makes that observable instead of asserting a threshold on
+      # it; see node_journal_max_bytes above for why no alert ships yet.
+      node-journal-metrics = {
+        description = "Emit journald disk-usage and oldest-entry metrics for Prometheus";
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = pkgs.writeShellScript "node-journal-metrics.sh" ''
+            set -uo pipefail
+
+            JOURNALCTL=${pkgs.systemd}/bin/journalctl
+            AWK=${pkgs.gawk}/bin/awk
+            HOST="${config.networking.hostName}"
+            TEXTFILE_DIR=/var/lib/node_exporter/textfiles
+            OUT="$TEXTFILE_DIR/node_journal.prom"
+            TMP="$OUT.tmp"
+
+            mkdir -p "$TEXTFILE_DIR"
+
+            # Tracks whether every value below was actually parsed, as
+            # opposed to falling back to 0 because journalctl's human-
+            # readable output didn't match what this script expects. See
+            # node_journal_metrics_ok below for why this has to be its own
+            # exported series rather than a silent fallback.
+            OK=1
+
+            # --- On-disk usage -------------------------------------------
+            #
+            # `journalctl --disk-usage` is the cheap (~2ms), verified route:
+            # it already accounts for archived + active journals across
+            # every file, sparse or not. Output is one line, e.g.
+            # "Archived and active journals take up 966.2M in the file
+            # system." -- parsed carefully because it emits B/K/M/G/T
+            # suffixes depending on size.
+            disk_usage_re='take up ([0-9.]+)([BKMGT]) in'
+            DISK_BYTES=0
+            DISK_LINE=$("$JOURNALCTL" --disk-usage 2>/dev/null) || OK=0
+            if [[ "$DISK_LINE" =~ $disk_usage_re ]]; then
+              disk_num="''${BASH_REMATCH[1]}"
+              disk_unit="''${BASH_REMATCH[2]}"
+              case "$disk_unit" in
+                B) disk_mult=1 ;;
+                K) disk_mult=1024 ;;
+                M) disk_mult=1048576 ;;
+                G) disk_mult=1073741824 ;;
+                T) disk_mult=1099511627776 ;;
+                *) disk_mult=0 ;;
+              esac
+              if [[ "$disk_mult" -gt 0 ]]; then
+                DISK_BYTES=$("$AWK" -v n="$disk_num" -v m="$disk_mult" 'BEGIN { printf "%.0f", n * m }')
+              else
+                OK=0
+              fi
+            else
+              OK=0
+            fi
+
+            # --- Oldest retained entry ------------------------------------
+            #
+            # `journalctl --header` prints one block per journal file
+            # (~25 on this fleet); the minimum "Head realtime timestamp"
+            # across all of them is the oldest entry actually still on
+            # disk. Deliberately NOT `journalctl -o json -n1[--reverse]`:
+            # verified on this host that both forms return the NEWEST
+            # entry, which would silently report retention as "0 days" on
+            # every scrape. The parenthesised value is microseconds since
+            # the epoch, in hex.
+            head_ts_re='Head realtime timestamp:.*\(([0-9a-fA-F]+)\)'
+            OLDEST_US=""
+            HEADER=$("$JOURNALCTL" --header 2>/dev/null) || OK=0
+            while IFS= read -r line; do
+              if [[ "$line" =~ $head_ts_re ]]; then
+                hex="''${BASH_REMATCH[1]}"
+                us=$((16#$hex))
+                if [[ -z "$OLDEST_US" || "$us" -lt "$OLDEST_US" ]]; then
+                  OLDEST_US=$us
+                fi
+              fi
+            done <<< "$HEADER"
+
+            if [[ -z "$OLDEST_US" ]]; then
+              OK=0
+              OLDEST_SEC=0
+            else
+              OLDEST_SEC=$(( OLDEST_US / 1000000 ))
+            fi
+
+            # One invalid sample makes the textfile collector reject the
+            # ENTIRE file (see nixos-deploy-state-metric's comment above for
+            # the demonstrated case), so this is written to a temp file and
+            # renamed into place atomically -- a failure partway through
+            # never leaves a half-written .prom for the collector to trip
+            # over.
+            {
+              echo "# HELP node_journal_disk_bytes Current on-disk size of the systemd journal (journalctl --disk-usage)."
+              echo "# TYPE node_journal_disk_bytes gauge"
+              echo "node_journal_disk_bytes{host=\"$HOST\"} $DISK_BYTES"
+
+              ${journalMaxBytesMetricLines}
+              echo "# HELP node_journal_oldest_entry_timestamp_seconds Unix timestamp of the oldest journal entry still retained (min Head realtime timestamp across all journal files)."
+              echo "# TYPE node_journal_oldest_entry_timestamp_seconds gauge"
+              echo "node_journal_oldest_entry_timestamp_seconds{host=\"$HOST\"} $OLDEST_SEC"
+
+              # journalctl --header's output is human-readable, not a
+              # stable API: if systemd rewords a field, the regexes above
+              # silently match nothing and a naive collector would just
+              # emit no metric, leaving the host looking healthy while
+              # retention drifted unnoticed underneath it. This flag turns
+              # that failure mode into a first-class, alertable series
+              # instead -- 0 means the two metrics above are stale/wrong for
+              # this scrape, not "no data".
+              echo "# HELP node_journal_metrics_ok Whether this collector run successfully parsed journalctl's output (0 = parse failure; node_journal_disk_bytes / node_journal_oldest_entry_timestamp_seconds are unreliable for this scrape)."
+              echo "# TYPE node_journal_metrics_ok gauge"
+              echo "node_journal_metrics_ok{host=\"$HOST\"} $OK"
+            } > "$TMP"
+            mv "$TMP" "$OUT"
+          '';
+        };
+      };
     }
     // lib.optionalAttrs config.services.fwupd.enable {
       fwupd-updates-metric = {
@@ -515,6 +710,17 @@ in
           Persistent = true;
           # Without this the whole fleet fetches on the same wall-clock minute.
           RandomizedDelaySec = "120";
+        };
+      };
+
+      node-journal-metrics = {
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          # Every 15 minutes; both journalctl calls run in ~2ms so cost isn't
+          # a reason to go coarser, and retention drift is a slow-moving
+          # signal that doesn't need finer resolution than that.
+          OnCalendar = "*:0/15";
+          Persistent = true;
         };
       };
     }

--- a/modules/monitoring/master/grafana.nix
+++ b/modules/monitoring/master/grafana.nix
@@ -53,6 +53,9 @@
     # The 42 rows in `data_keys` are wrapped with the old key and become
     # undecryptable. They protect nothing per the above; expect Grafana to log
     # decryption errors for them once and then move on.
+    #
+    # For the executable rotation procedure (generate, deploy, verify), see
+    # agent-docs/GRAFANA_SECRET_KEY_ROTATION.md.
     "monitoring/grafana_secret_key" = {
       owner = "grafana";
       restartUnits = [ "grafana.service" ];

--- a/modules/secrets/sops.nix
+++ b/modules/secrets/sops.nix
@@ -17,10 +17,7 @@ let
 in
 {
   options.sops_secrets.enable_secrets = {
-    enable = lib.mkOption {
-      description = "Enable SOPS Secrets.";
-      default = false;
-    };
+    enable = lib.mkEnableOption "SOPS-encrypted secrets (SSH keys, GPG key, sops-nix module wiring)";
   };
 
   imports =

--- a/modules/secrets/sops.nix
+++ b/modules/secrets/sops.nix
@@ -141,3 +141,8 @@ in
 # 7. On the new system, pull the latest changes from the repository.
 # 8. On the new system pamu2fcfg -u fred | tee ~/test.txt, copy the key to sops secrets.yaml....this is if you want yubikey
 # 8. Rebuild the NixOS configuration to apply the changes and decrypt the secrets.
+#
+# For the full runbook -- adding a recipient, revoking a compromised one
+# (including why `sops updatekeys` alone does not revoke access and
+# `sops rotate` is also required), and verifying all recipients can still
+# decrypt -- see agent-docs/SOPS_AGE_KEY_ROTATION.md.

--- a/modules/services/adsb-docker-units.nix
+++ b/modules/services/adsb-docker-units.nix
@@ -8,6 +8,32 @@
 let
   cfg = config.services.adsb;
 
+  # A `ports` entry with fewer than 3 `:`-separated fields has no explicit
+  # bind address ("HOSTPORT:CONTAINERPORT", or a range like
+  # "9273-9274:9273-9274"), so Docker's `-p` falls back to its own default
+  # of 0.0.0.0 -- reachable from anywhere the host itself is. That is fine
+  # on every LAN-only host in this fleet, where "reachable from anywhere"
+  # means "reachable from the LAN". On an internet-facing host it means
+  # reachable from the internet, which is exactly the failure class
+  # `deployment.internetFacing` exists to close for the exporters (see
+  # modules/base/deployment-meta.nix) -- but that option only rebinds the
+  # exporters it directly owns; a container port mapping written by hand in
+  # a host config is not touched by it at all. fredvps had this exact
+  # incident with dozzle-agent's default 0.0.0.0:7007 (see
+  # modules/services/mk-dozzle-agent.nix's header) and every one of its
+  # container ports is now bound to an explicit address, which is why this
+  # warns rather than asserts: unlike internetFacing/tailscaleAddress, an
+  # unbound port is not necessarily wrong (a deliberately public web UI would
+  # look identical), so a human has to make the call.
+  unboundPortsByContainer = lib.filterAttrs (_: bad: bad != [ ]) (
+    lib.listToAttrs (
+      map (c: {
+        inherit (c) name;
+        value = lib.filter (p: lib.length (lib.splitString ":" p) < 3) (c.ports or [ ]);
+      }) cfg.containers
+    )
+  );
+
   # Convert attrset → "-e KEY=value"
   mkEnvFlags = env: lib.concatStringsSep " " (lib.mapAttrsToList (k: v: ''-e "${k}=${v}"'') env);
 
@@ -241,5 +267,15 @@ in
     systemd.services = lib.foldl' (
       acc: c: acc // { "docker-${c.name}" = mkUnit c; }
     ) { } cfg.containers;
+
+    warnings = lib.optionals config.deployment.internetFacing (
+      lib.mapAttrsToList (
+        name: bad:
+        "services.adsb.containers: '${name}' publishes ${toString bad} with no explicit bind address "
+        + "on an internet-facing host (deployment.internetFacing = true), so Docker binds 0.0.0.0 and "
+        + "the port is reachable from the public internet. Bind it to an explicit address (e.g. "
+        + "\${config.deployment.tailscaleAddress} or 127.0.0.1) unless it is meant to be public."
+      ) unboundPortsByContainer
+    );
   };
 }

--- a/modules/services/nas-home.nix
+++ b/modules/services/nas-home.nix
@@ -22,6 +22,7 @@ in
     mounts = mkOption {
       type = types.listOf nasMountType;
       default = [ ];
+      description = "NAS shares to create GNOME/gvfs bookmarks for, mirroring the system-level mounts declared in nas-system.nix.";
     };
 
     wifiDetectionCmd = mkOption {
@@ -29,6 +30,7 @@ in
       default = ''
         nmcli -t -f active,ssid dev wifi | ${pkgs.gawk}/bin/awk -F: '$1=="yes"{print $2}'
       '';
+      description = "Shell command that prints the currently-associated WiFi SSID, used to gate WiFi-scoped bookmarks.";
     };
   };
 

--- a/modules/services/nas-mount-type.nix
+++ b/modules/services/nas-mount-type.nix
@@ -2,14 +2,24 @@
 { lib }:
 lib.types.submodule {
   options = {
-    path = lib.mkOption { type = lib.types.str; };
-    host = lib.mkOption { type = lib.types.str; };
-    share = lib.mkOption { type = lib.types.str; };
+    path = lib.mkOption {
+      type = lib.types.str;
+      description = "Local mount point, as an absolute path with no leading slash (e.g. \"mnt/nas\").";
+    };
+    host = lib.mkOption {
+      type = lib.types.str;
+      description = "Hostname or IP address of the NAS exporting this share.";
+    };
+    share = lib.mkOption {
+      type = lib.types.str;
+      description = "Name of the exported NFS share or SMB share on the NAS.";
+    };
     type = lib.mkOption {
       type = lib.types.enum [
         "nfs"
         "smb"
       ];
+      description = "Protocol used to mount the share; selects the fstab/gio mount options.";
     };
     wifi = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
@@ -24,6 +34,7 @@ lib.types.submodule {
     extraOptions = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
+      description = "Additional mount options appended after the type-specific defaults.";
     };
   };
 }

--- a/modules/services/nas-mount-type.nix
+++ b/modules/services/nas-mount-type.nix
@@ -4,7 +4,7 @@ lib.types.submodule {
   options = {
     path = lib.mkOption {
       type = lib.types.str;
-      description = "Local mount point, as an absolute path with no leading slash (e.g. \"mnt/nas\").";
+      description = "Local mount point, as an absolute path (e.g. \"/mnt/nas/fred\").";
     };
     host = lib.mkOption {
       type = lib.types.str;

--- a/modules/services/nas-system.nix
+++ b/modules/services/nas-system.nix
@@ -22,6 +22,7 @@ in
     mounts = mkOption {
       type = types.listOf nasMountType;
       default = [ ];
+      description = "NAS shares to mount as systemd automounts, optionally gated to a specific WiFi SSID.";
     };
 
     wifiDetectionCmd = mkOption {
@@ -29,6 +30,7 @@ in
       default = ''
         nmcli -t -f active,ssid dev wifi | ${pkgs.gawk}/bin/awk -F: '$1=="yes"{print $2}'
       '';
+      description = "Shell command that prints the currently-associated WiFi SSID, used to gate WiFi-scoped mounts.";
     };
   };
 

--- a/modules/services/sync-compose.nix
+++ b/modules/services/sync-compose.nix
@@ -40,15 +40,18 @@ in
             port = lib.mkOption {
               type = lib.types.str;
               default = "22";
+              description = "SSH port to connect to on the remote host.";
             };
             legacyScp = lib.mkOption {
               type = lib.types.bool;
               default = false;
+              description = "Use the legacy SCP protocol (-O) instead of the SFTP-based default, for hosts running an OpenSSH version too old to speak SFTP-based scp.";
             };
           };
         }
       );
       default = [ ];
+      description = "Remote hosts to sync docker-compose.yaml and .env with, keyed by name for use as sync-compose's target argument.";
     };
   };
 

--- a/modules/terminal/common.nix
+++ b/modules/terminal/common.nix
@@ -19,32 +19,38 @@ in
     font.size = lib.mkOption {
       type = lib.types.number;
       default = 12;
+      description = "Default terminal font size, in points.";
     };
 
     opacity = lib.mkOption {
       type = lib.types.float;
       default = 0.95;
+      description = "Background opacity for terminal emulators that support it, from 0.0 (fully transparent) to 1.0 (opaque).";
     };
 
     theme = lib.mkOption {
       type = lib.types.str;
       default = "Catppuccin Mocha";
+      description = "Colour scheme name shared across terminal emulators that support named Catppuccin themes.";
     };
 
     enableWayland = lib.mkOption {
       type = lib.types.bool;
       default = !isDarwin;
+      description = "Whether terminal emulators should prefer their native Wayland backend instead of XWayland. Defaults to off on Darwin, where Wayland does not apply.";
     };
 
     # Terminal-specific overrides
     wezterm.extraLua = lib.mkOption {
       type = lib.types.lines;
       default = "";
+      description = "Extra Lua snippet appended to the generated WezTerm config, for settings not covered by the shared terminal options.";
     };
 
     alacritty.extraSettings = lib.mkOption {
       type = lib.types.attrs;
       default = { };
+      description = "Extra settings merged into the generated Alacritty TOML config, for options not covered by the shared terminal options.";
     };
   };
 }

--- a/scripts/check-module-reachability.sh
+++ b/scripts/check-module-reachability.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# check-module-reachability.sh -- detect `.nix` files that are never
+# imported anywhere and are not themselves a recognised entry point.
+#
+# WHY THIS EXISTS
+#
+# `firmware.nix` used to sit in this repo, imported by nothing, while CI
+# still treated any change to it as a global rebuild trigger (matching the
+# broad `modules/` path pattern). It has since been deleted, so this check
+# currently has no subject on the current tree -- that is fine and is the
+# point: it is preventative, not remedial. A file that stops being
+# imported (a rename that missed one call site, a module folded into
+# another and the old file left behind) previously had no signal at all
+# short of a human noticing the file never comes up in `rg` output.
+#
+# ENTRY POINTS (files that are live without being imported by name)
+#
+#   - flake.nix and everything under flake/           -- read by Nix
+#     itself via the flake's own outputs, never `import`ed by a sibling
+#     module.
+#   - hosts/*/*/configuration.nix and
+#     hosts/*/*/hardware-configuration.nix             -- wired in
+#     per-host by flake/lib/mk-system.nix /
+#     flake/lib/mk-darwin-system.nix via a host-name lookup, not a
+#     textual import from another module.
+#   - hosts/*/*/home.nix                               -- referenced the
+#     same way, from the home-manager side of the same host-name lookup.
+#   - profiles/*.nix                                    -- selected by
+#     name from flake/hosts/servers.nix / the host's own module list, not
+#     imported by basename from inside modules/.
+#   - any `default.nix` reached by directory import (`import ./foo` picks
+#     up `foo/default.nix` without ever spelling out the filename) -- see
+#     below for how this is handled; it is not a blanket exemption.
+#
+# Everything else must show up, verbatim, as a substring of some OTHER
+# file in the tree, or it is reported as unreachable.
+#
+# WHY BASENAME SUBSTRING MATCHING, NOT AN AST
+#
+# Nix import expressions show up in several shapes in this repo:
+# `./foo.nix`, `./foo` (directory), `../../modules/x.nix`, and inside
+# `lib.optional` / `lib.optionals` / `imports = [ ... ]` lists. Building a
+# real Nix parser to resolve every one of these precisely is a lot of
+# machinery for a check whose entire job is "does this filename appear
+# anywhere else". Nix does not auto-append `.nix` to a path (unlike some
+# other languages' module resolution), so a direct-file import of
+# `foo.nix` must always spell the extension out literally somewhere --
+# which means a plain substring search for the basename is a sound MOSTLY
+# COMPLETE test for "is this file imported by name", not a heuristic
+# approximation of one.
+#
+# `default.nix` is the one case that breaks that argument: a directory
+# import spells out the DIRECTORY's name, not the literal string
+# "default.nix" (see `./modules` in
+# features/desktop/environments/default.nix, which resolves to
+# features/desktop/environments/modules/default.nix without "default.nix"
+# appearing anywhere in the importing file). So for a `default.nix`, the
+# search token is its PARENT directory's basename instead of its own
+# filename -- matching how every directory import in this repo is
+# actually written (relative to the importing file's own directory, one
+# path component at a time, never a multi-segment path pieced together
+# from the repo root).
+#
+# FALSE-NEGATIVE / FALSE-POSITIVE TRADEOFF (chosen deliberately)
+#
+# This check is heavily biased toward false negatives (missing a dead
+# file) over false positives (flagging a live one), for two independent
+# reasons:
+#
+#   1. Some files are imported as plain functions rather than modules --
+#      `import ../lib/home-dir.nix { ... }`, `import
+#      ../lib/gitconfig-template.nix` -- which is still a literal
+#      basename-with-extension reference and is picked up by the same
+#      substring search with no special-casing needed.
+#   2. Several `default.nix` parent-directory names are short, common
+#      English words that could in principle appear elsewhere in the
+#      tree by coincidence (comments, unrelated option names) even if the
+#      directory itself were dead. This check accepts that risk
+#      willingly: a missed dead file costs nothing (it is preventative,
+#      not the thing currently broken), while a false CI failure on a
+#      live module costs a wasted investigation on every affected commit.
+#      "Report a file as dead only when its basename appears in no
+#      import expression anywhere in the tree" is the brief this script
+#      was written against, and it is interpreted literally: presence
+#      anywhere, not presence in a syntactically-valid import position.
+#
+# Given that bias, a clean run of this script is NOT proof that every
+# file is genuinely wired into a host's module tree -- only that its
+# name shows up somewhere plausible. It is a tripwire for the
+# `firmware.nix` failure mode (renamed/orphaned/never-added file with an
+# uncommon name), not a full reachability graph.
+set -euo pipefail
+
+# Located by BASH_SOURCE, not `git rev-parse`, so this also works from
+# inside the standalone flake check's sandboxed build (no .git there).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+for tool in grep find; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: required tool not on PATH: $tool" >&2
+    echo "hint: run inside 'nix develop', or via 'nix build .#checks.\${system}.module-reachability'" >&2
+    exit 1
+  }
+done
+
+mapfile -t all_files < <(
+  find . -name '*.nix' -not -path './.git/*' -print \
+    | sed 's#^\./##' \
+    | sort
+)
+
+if [[ ${#all_files[@]} -eq 0 ]]; then
+  echo "error: no .nix files found (run from the repository root)" >&2
+  exit 1
+fi
+
+is_entry_point() {
+  case "$1" in
+    flake.nix) return 0 ;;
+    flake/*) return 0 ;;
+    hosts/*/*/configuration.nix) return 0 ;;
+    hosts/*/*/hardware-configuration.nix) return 0 ;;
+    hosts/*/*/home.nix) return 0 ;;
+    profiles/*.nix) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+dead=()
+
+for f in "${all_files[@]}"; do
+  if is_entry_point "$f"; then
+    continue
+  fi
+
+  base="$(basename "$f")"
+  if [[ $base == "default.nix" ]]; then
+    # Directory import: the importer spells out the directory name, not
+    # "default.nix" itself. See the header comment for why this is one
+    # path component, not the full path from the repo root.
+    token="$(basename "$(dirname "$f")")"
+    reason="directory '$(dirname "$f")' (via its basename '${token}')"
+  else
+    token="$base"
+    reason="filename '${token}'"
+  fi
+
+  mapfile -t hits < <(
+    grep -rlF --include='*.nix' --exclude-dir=.git -- "$token" . \
+      | sed 's#^\./##' \
+      || true
+  )
+
+  found_elsewhere=0
+  for h in "${hits[@]:-}"; do
+    [[ -z $h ]] && continue
+    if [[ $h != "$f" ]]; then
+      found_elsewhere=1
+      break
+    fi
+  done
+
+  if [[ $found_elsewhere -eq 0 ]]; then
+    dead+=("${f}: ${reason} does not appear in any other .nix file")
+  fi
+done
+
+if [[ ${#dead[@]} -gt 0 ]]; then
+  echo "module reachability check FAILED:" >&2
+  echo "" >&2
+  for d in "${dead[@]}"; do
+    echo "  - ${d}" >&2
+  done
+  echo "" >&2
+  echo "Each of the above is not a recognised entry point (flake.nix, flake/**," >&2
+  echo "a host's configuration.nix/hardware-configuration.nix/home.nix, or a" >&2
+  echo "profiles/*.nix) and its name does not appear in any other .nix file in" >&2
+  echo "the tree. Either wire it into an imports list / lib.optional, delete it" >&2
+  echo "if it is genuinely orphaned, or -- if it is a new kind of entry point --" >&2
+  echo "extend is_entry_point() in $(basename "$0") to recognise it." >&2
+  exit 1
+fi
+
+echo "module reachability OK (${#all_files[@]} .nix files, none unreachable)"

--- a/scripts/check-option-schema.sh
+++ b/scripts/check-option-schema.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+#
+# check-option-schema.sh -- assert that every `mkOption { ... }` call in the
+# tree declares both a `type` and a `description`.
+#
+# WHY THIS EXISTS
+#
+# An audit of the 86-ish `mkOption` sites in this repo found one option
+# with no `type` at all (modules/secrets/sops.nix's
+# `sops_secrets.enable_secrets.enable`, since converted to
+# `lib.mkEnableOption`) and roughly seventeen with no `description`,
+# concentrated in modules/terminal/common.nix, modules/services/nas-*.nix
+# and modules/services/sync-compose.nix. Neither omission fails the build:
+# an untyped option silently accepts whatever nonsense is assigned to it
+# with no coercion/merge behaviour and no eval-time type error, and an
+# undocumented option is just as functional as a documented one until
+# someone tries to use it and has to go read the defining module instead
+# of `nixos-option`/generated docs. Nothing previously stopped a new
+# option from being added the same way.
+#
+# `lib.mkEnableOption "foo"` is intentionally NOT flagged: it expands to an
+# option that already carries both a `types.bool` type and a generated
+# description ("Whether to enable foo."), so requiring a second explicit
+# `type`/`description` on top of it would be busywork, not safety.
+#
+# PARSING STRATEGY
+#
+# Regexing `mkOption { ... }` line-by-line breaks the moment a value spans
+# multiple lines (every multi-line `description`, every `submodule`, every
+# `enum [ ... ]`) or a nested option block reuses the same field names one
+# level down. This script instead:
+#
+#   1. Masks out comments (`#`, `/* */`) and string bodies (`"..."`,
+#      `''...''`) to spaces, character-for-character (newlines preserved),
+#      so brace-matching below is never confused by a `{`/`}`/`;` that
+#      only exists inside a comment or a string. This is safe because Nix
+#      string/comment bodies cannot contribute an UNbalanced brace to the
+#      surrounding code: any `${...}` antiquotation inside a string is
+#      itself brace-balanced, so blanking the whole string only removes
+#      balanced pairs.
+#   2. Finds every standalone `mkOption` token (word-bounded, so this
+#      correctly skips `mkEnableOption` and `mkOptionDefault`, neither of
+#      which contains "mkOption" as a bounded substring).
+#   3. Requires the next non-whitespace character to be `{`. A bare
+#      `mkOption` mention that is NOT immediately followed by an attrset
+#      literal (e.g. appearing in an `inherit (lib) mkOption ...;` import
+#      list, which this repo has twice) is not a call site at all and is
+#      silently skipped -- it is not ambiguous, it is simply not a call.
+#   4. Brace-matches from that `{` to find the call's own closing `}`,
+#      tracking only `{`/`}` depth (not parens/brackets): Nix has no other
+#      use of curly braces, so any `{`/`}` encountered anywhere inside --
+#      nested submodule, list-of-attrsets, function call taking an
+#      attrset -- still balances correctly against this same counter.
+#   5. Within that body, splits on `;` at brace-depth 0 (relative to the
+#      body) to recover the body's own top-level `key = value;`
+#      assignments, and checks whether `type` and `description` are among
+#      them.
+#
+# KNOWN LIMITATION (documented, not silently swallowed)
+#
+# Step 5's depth counter tracks only `{`/`}`, so a bare `let x = ...; in
+# ...;` used as a value (no enclosing braces) introduces a `;` at
+# apparent depth 0 that does not really terminate the enclosing
+# assignment. This repo has exactly one such case today
+# (modules/data/home-network.nix's `type = let octet = "..."; in
+# lib.types.strMatching ...;`), and it happens to still classify
+# correctly: the spurious early split still starts with the real `type =`
+# token (the first `=` in the mis-split segment), so `type` is still
+# recorded; the "orphan" continuation segment (` in lib.types.strMatching
+# ...`) contains no top-level `=` and is discarded rather than
+# misread as a second, bogus key. This has been verified empirically
+# against the current tree. The failure mode this construct COULD in
+# theory cause is a false negative -- a `let`-bound local variable that
+# happens to be named `type` or `description` could make a genuinely
+# undocumented option look documented -- never a false positive. That
+# tradeoff (miss a violation vs. block an unrelated commit on a parser
+# artifact) is the intended one; see the reachability checker for the
+# same philosophy applied to a different check.
+#
+# `default`/`example`/`apply`/`readOnly`/`internal` and any other
+# recognised or unrecognised mkOption field are not inspected; this check
+# only asserts presence of `type` and `description`, not their content.
+set -euo pipefail
+
+# Located by BASH_SOURCE, not `git rev-parse`, so this also works from
+# inside the standalone flake check's sandboxed build (no .git there).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Fail on a missing dependency with an actionable message, kept separate
+# from the actual content check below: reporting "python3 is missing" as
+# an option-schema violation would invent a bug that does not exist. See
+# check-opencode-jsonc.sh for the precedent and the incident that made
+# this its own paragraph.
+command -v python3 >/dev/null 2>&1 || {
+  echo "error: required tool not on PATH: python3" >&2
+  echo "hint: run inside 'nix develop', or via 'nix build .#checks.\${system}.option-schema'" >&2
+  exit 1
+}
+
+python3 - "$REPO_ROOT" <<'PY'
+import re
+import subprocess
+import sys
+
+repo_root = sys.argv[1]
+
+result = subprocess.run(
+    ["find", ".", "-name", "*.nix", "-not", "-path", "./.git/*"],
+    capture_output=True,
+    text=True,
+    cwd=repo_root,
+    check=True,
+)
+files = sorted(f for f in result.stdout.split() if f)
+
+if not files:
+    print("error: no .nix files found (run from the repository root)", file=sys.stderr)
+    sys.exit(1)
+
+
+def mask(text):
+    """Blank out comment and string bodies, preserving length and newlines."""
+    out = list(text)
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if text[i : i + 2] == "/*":
+            j = text.find("*/", i + 2)
+            end = j + 2 if j != -1 else n
+            for k in range(i, end):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = end
+            continue
+        if c == "#":
+            j = text.find("\n", i)
+            end = j if j != -1 else n
+            for k in range(i, end):
+                out[k] = " "
+            i = end
+            continue
+        if text[i : i + 2] == "''":
+            j = text.find("''", i + 2)
+            end = j + 2 if j != -1 else n
+            for k in range(i, end):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = end
+            continue
+        if c == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                if text[j] == "\\":
+                    j += 1
+                j += 1
+            end = j + 1 if j < n else n
+            for k in range(i, end):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = end
+            continue
+        i += 1
+    return "".join(out)
+
+
+def find_matching_close(masked, open_pos):
+    depth = 1
+    i = open_pos + 1
+    n = len(masked)
+    while i < n and depth > 0:
+        if masked[i] == "{":
+            depth += 1
+        elif masked[i] == "}":
+            depth -= 1
+        i += 1
+    return (i - 1) if depth == 0 else None
+
+
+_ASSIGN_TARGET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_'-]*$")
+
+
+def parse_key(segment):
+    """Return the leading attrpath's first component, or None if this
+    segment is not (or does not start with) a `key = value` assignment."""
+    stripped = segment.strip()
+    if not stripped:
+        return None
+    idx = None
+    for m in re.finditer(r"=", stripped):
+        pos = m.start()
+        prevc = stripped[pos - 1] if pos > 0 else ""
+        nextc = stripped[pos + 1] if pos + 1 < len(stripped) else ""
+        if nextc == "=" or prevc in "!<>=":
+            continue
+        idx = pos
+        break
+    if idx is None:
+        return None
+    left = stripped[:idx].strip()
+    first = left.split(".")[0].strip().strip('"')
+    return first if _ASSIGN_TARGET_RE.match(first) else None
+
+
+def extract_top_level_keys(masked_body):
+    keys = []
+    depth = 0
+    seg_start = 0
+    for i, c in enumerate(masked_body):
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        elif c == ";" and depth == 0:
+            key = parse_key(masked_body[seg_start:i])
+            if key:
+                keys.append(key)
+            seg_start = i + 1
+    return keys
+
+
+MKOPTION_RE = re.compile(r"\bmkOption\b")
+
+violations = []
+unbalanced = []
+total_calls = 0
+
+for relpath in files:
+    with open(f"{repo_root}/{relpath}", encoding="utf-8") as fh:
+        text = fh.read()
+    masked = mask(text)
+
+    for m in MKOPTION_RE.finditer(masked):
+        rest = masked[m.end() :]
+        skip = len(rest) - len(rest.lstrip())
+        brace_pos = m.end() + skip
+        if brace_pos >= len(masked) or masked[brace_pos] != "{":
+            # Not a call site (e.g. `inherit (lib) mkOption ...;`).
+            continue
+
+        total_calls += 1
+        line_no = text[: m.start()].count("\n") + 1
+        close_pos = find_matching_close(masked, brace_pos)
+        if close_pos is None:
+            unbalanced.append(f"{relpath}:{line_no}: mkOption {{ ... }} has no matching closing brace (unbalanced braces, or a construct this script cannot classify)")
+            continue
+
+        body = masked[brace_pos + 1 : close_pos]
+        keys = extract_top_level_keys(body)
+
+        missing = [f for f in ("type", "description") if f not in keys]
+        if missing:
+            violations.append(f"{relpath}:{line_no}: mkOption is missing {', '.join(missing)}")
+
+if unbalanced:
+    print("option schema check FAILED (could not parse):", file=sys.stderr)
+    print("", file=sys.stderr)
+    for u in unbalanced:
+        print(f"  - {u}", file=sys.stderr)
+    sys.exit(1)
+
+if violations:
+    print("option schema check FAILED:", file=sys.stderr)
+    print("", file=sys.stderr)
+    for v in sorted(violations):
+        print(f"  - {v}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Every mkOption { ... } needs a `type` (so a bad value is an eval error,", file=sys.stderr)
+    print("not a silent no-op) and a `description` (so the option is discoverable", file=sys.stderr)
+    print("without reading the defining module). `lib.mkEnableOption \"foo\"` already", file=sys.stderr)
+    print("supplies both and does not need either field added.", file=sys.stderr)
+    sys.exit(1)
+
+print(f"option schema OK ({total_calls} mkOption call sites, all with type + description)")
+PY

--- a/scripts/check-option-schema.sh
+++ b/scripts/check-option-schema.sh
@@ -142,8 +142,30 @@ def mask(text):
             i = end
             continue
         if text[i : i + 2] == "''":
-            j = text.find("''", i + 2)
-            end = j + 2 if j != -1 else n
+            # Indented strings have three escape forms that each contain
+            # a literal "''" but do NOT close the string: "''$" (escaped
+            # antiquotation, as in "''${...}" for a literal "${"), "'''"
+            # (an escaped literal "''"), and "''\\X" (an escaped char,
+            # e.g. "''\\n"). A naive `text.find("''", i + 2)` treats any
+            # of these as the closing delimiter, ending the mask early
+            # and exposing real string content -- including a `type`- or
+            # `description`-shaped key -- as if it were code.
+            j = i + 2
+            while j < n:
+                if text[j : j + 2] == "''":
+                    nxt = text[j + 2 : j + 3]
+                    if nxt == "$":
+                        j += 3
+                        continue
+                    if nxt == "'":
+                        j += 3
+                        continue
+                    if nxt == "\\":
+                        j += 4
+                        continue
+                    break
+                j += 1
+            end = j + 2 if j < n else n
             for k in range(i, end):
                 if out[k] != "\n":
                     out[k] = " "

--- a/scripts/diff-closures-comment.sh
+++ b/scripts/diff-closures-comment.sh
@@ -100,7 +100,11 @@ SAMPLE_LIMIT=15
 
 fail_nothing() {
   echo "error: $*" >&2
-  : >"$OUT_FILE"
+  # Per the OUTPUT CONTRACT above: STATUS=nothing means nothing written
+  # to $OUT_FILE. Deliberately do not touch/truncate it here -- a caller
+  # relying on the documented contract should never need to look at the
+  # file when STATUS=nothing, but leaving a stale or unexpectedly-empty
+  # file behind would be a silent contract violation if one ever did.
   echo "STATUS=nothing"
   exit 0
 }
@@ -108,7 +112,7 @@ fail_nothing() {
 [ -n "${BASE_SHA:-}" ] || fail_nothing "BASE_SHA env var required"
 [ -n "${HOSTS_JSON:-}" ] || fail_nothing "HOSTS_JSON env var required"
 
-for tool in nix nix-store jq comm sort git; do
+for tool in nix nix-store jq comm sort git sed head mktemp grep; do
   command -v "$tool" >/dev/null 2>&1 || fail_nothing "required tool not on PATH: $tool"
 done
 
@@ -127,6 +131,7 @@ if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
 fi
 
 declare -A STATUS
+declare -A ERROR_SIDE
 declare -A UNAVAILABLE_REASON
 declare -A DIFF_OUTPUT
 declare -A ADDED_SAMPLE
@@ -135,6 +140,32 @@ declare -A ADDED_COUNT
 declare -A REMOVED_COUNT
 declare -A HEAD_PATH
 declare -A BASE_PATH
+
+# A host absent from the base commit's own nixosConfigurations (added by
+# this PR) is not an error -- there is nothing to diff against. A host
+# PRESENT at base whose toplevel eval nonetheless fails there IS a
+# genuine eval error and must be reported as one, not silently folded
+# into "new". Distinguishing the two requires knowing the base commit's
+# attribute set up front, once, rather than inferring it from a single
+# per-host eval failure (which cannot tell "absent" from "broken").
+declare -A BASE_HOST_EXISTS
+base_hosts_err="$(mktemp)"
+if base_hosts_json="$(nix eval --json "git+file://${REPO_ROOT}?rev=${BASE_SHA}#nixosConfigurations" --apply builtins.attrNames 2>"$base_hosts_err")"; then
+  while IFS= read -r bh; do
+    [ -n "$bh" ] && BASE_HOST_EXISTS[$bh]=1
+  done < <(jq -r '.[]' <<<"$base_hosts_json" 2>/dev/null)
+  base_hosts_known=1
+else
+  # Could not even enumerate the base commit's hosts (e.g. the whole
+  # base flake fails to evaluate). Do NOT default to "new" here -- that
+  # would misreport a genuine base-wide breakage as a set of harmless
+  # new hosts. Fall through to the per-host eval below, which will fail
+  # the same way and be correctly reported as "error".
+  echo "warning: could not enumerate base commit's nixosConfigurations:" >&2
+  sed 's/^/  /' "$base_hosts_err" >&2
+  base_hosts_known=0
+fi
+rm -f "$base_hosts_err"
 
 for host in "${HOSTS[@]}"; do
   echo "== $host ==" >&2
@@ -149,24 +180,37 @@ for host in "${HOSTS[@]}"; do
     echo "  HEAD eval failed:" >&2
     sed 's/^/    /' "$head_err" >&2
     STATUS[$host]="error"
+    ERROR_SIDE[$host]="head"
     rm -f "$head_err" "$base_err"
+    continue
+  fi
+
+  rm -f "$head_err"
+
+  if [ "$base_hosts_known" -eq 1 ] && [ -z "${BASE_HOST_EXISTS[$host]:-}" ]; then
+    echo "  host not present in nixosConfigurations at base commit -- new host, nothing to diff" >&2
+    STATUS[$host]="new"
+    rm -f "$base_err"
     continue
   fi
 
   base_path="$(nix eval --raw "git+file://${REPO_ROOT}?rev=${BASE_SHA}#nixosConfigurations.${host}.config.system.build.toplevel.outPath" 2>"$base_err")"
   base_rc=$?
-  rm -f "$head_err" "$base_err"
 
   if [ "$base_rc" -ne 0 ] || [ -z "$base_path" ]; then
-    # Most common real cause: the host did not exist in
-    # nixosConfigurations at the base commit (a host added by this PR).
-    # Anything else is a genuine eval error at the base rev -- and this
-    # job must degrade on that exactly like every other failure mode,
-    # not propagate it.
-    echo "  BASE eval failed (new host, or base-rev eval error)" >&2
-    STATUS[$host]="new"
+    # The host IS present in the base commit's nixosConfigurations (or
+    # we could not tell either way) yet its toplevel still fails to
+    # evaluate there -- a genuine eval error at the base rev, not a new
+    # host. Degrade like every other failure mode, but report it as
+    # what it is.
+    echo "  BASE eval failed (genuine eval error at base rev):" >&2
+    sed 's/^/    /' "$base_err" >&2
+    STATUS[$host]="error"
+    ERROR_SIDE[$host]="base"
+    rm -f "$base_err"
     continue
   fi
+  rm -f "$base_err"
 
   HEAD_PATH[$host]="$head_path"
   BASE_PATH[$host]="$base_path"
@@ -345,7 +389,10 @@ fi
       error)
         echo "#### \`${host}\` -- eval error"
         echo
-        echo "Evaluating this host's toplevel failed at HEAD; see the workflow run logs."
+        case "${ERROR_SIDE[$host]:-}" in
+          base) echo "Evaluating this host's toplevel failed at the PR base commit \`${BASE_SHA:0:12}\`; see the workflow run logs." ;;
+          *) echo "Evaluating this host's toplevel failed at HEAD; see the workflow run logs." ;;
+        esac
         echo
         ;;
     esac

--- a/scripts/diff-closures-comment.sh
+++ b/scripts/diff-closures-comment.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+#
+# diff-closures-comment.sh
+#
+# Computes, for every host ci-linux.yaml's find-systems job flagged as
+# impacted by a PR, what `nixosConfigurations.<host>.config.system.
+# build.toplevel` actually changed between the PR base and HEAD, and
+# renders a single markdown report body suitable for a PR comment.
+#
+# WHY THIS EXISTS
+#
+# A refactor asserted to be entirely behaviour-preserving can still be
+# wrong in a way that only shows up on some hosts. The incident that
+# motivated this script: all 8 servers came out byte-identical (correct),
+# both desktops did not, and finding out *what* changed took a manual
+# investigation across two commits -- comparing `system.path`,
+# `environment.etc` names, `home.file` sources and text hashes by hand --
+# and still did not fully resolve; the delta was somewhere inside the
+# home-manager activation script.
+#
+# `nix store diff-closures` alone would not have caught it either: it
+# groups by package name with the version stripped out, and a changed
+# activation-script derivation keeps the same name and an empty
+# ("epsilon") version on both sides, so a real content difference renders
+# as literally nothing. Confirmed directly against the pair of maranello
+# toplevels from that incident -- `nix store diff-closures <before>
+# <after>` prints EMPTY for them despite the closures differing. This
+# script therefore also computes a raw closure diff
+# (`nix-store -qR`, sorted, `comm`'d) alongside `diff-closures`'s
+# package/version view, specifically to surface that class of change.
+#
+# COST MODEL -- READ BEFORE CHANGING THE SUBSTITUTION LOGIC
+#
+# The AFTER side is cheap: build-servers/build-desktops already realised
+# it earlier in the same workflow run and pushed it to the Attic cache at
+# 192.168.31.14, so it substitutes.
+#
+# The BEFORE side (the PR base commit) is the one that could be
+# expensive, and this script deliberately never pays that cost. Exactly
+# two nix operations are used to get there:
+#
+#   1. `nix eval --raw` against a `git+file://...?rev=<base_sha>` flake
+#      ref, to learn the base commit's toplevel outPath. This is a pure
+#      evaluation -- no realisation is requested -- and costs only eval
+#      time (observed ~12s warm against this repo's eval cache).
+#   2. If, and only if, that outPath differs from HEAD's: attempt
+#      `nix build --max-jobs 0 --no-link <path>`. `--max-jobs 0`
+#      disables ALL local building, so this either substitutes from a
+#      configured cache (Attic, cache.nixos.org, ...) or fails cleanly
+#      with "local builds are disabled" / "no substituter can build it"
+#      -- it can never silently fall back to a real build.
+#
+# Whether step 2 succeeds for the base commit depends entirely on
+# whether that commit's closure is still cached. In practice this repo's
+# merge queue builds every commit that reaches `main` before it merges,
+# and Attic's default-retention-period is 30 days from last fetch (see
+# modules/services/attic/attic_server.nix), so the common case -- a PR
+# based on a recent `main` commit -- substitutes cleanly. It is NOT
+# guaranteed: a long-lived PR, a base commit whose relevant host was
+# never rebuilt by CI, or ordinary GC pressure can all make the base
+# closure unavailable. When that happens this script reports the host as
+# "unavailable" and moves on. It will never trigger a real closure
+# realisation (the kind of build ci-linux.yaml's colmena-parity job
+# comment measures at 578s/103s) just to populate a comment.
+#
+# OUTPUT CONTRACT
+#
+# All diagnostics go to stderr. On any successful run, stdout carries
+# exactly one line:
+#
+#   STATUS=changed     body written to $OUT_FILE; something to report
+#                       (a real diff, a new host, or a coverage gap)
+#   STATUS=unchanged    body written to $OUT_FILE with a single "no
+#                       changes" line -- the caller should update an
+#                       existing PR comment if one exists, but must NOT
+#                       create a new one (avoid noise on every PR)
+#   STATUS=nothing      nothing written to $OUT_FILE; the caller should
+#                       not post anything at all
+#
+# This script never fails the job it runs in: every error path degrades
+# to STATUS=nothing (or drops just the one affected host into the
+# "unavailable"/"eval error" bucket) rather than a non-zero exit, per
+# ci-linux.yaml's "must never fail the PR" contract for this job.
+#
+# Usage:
+#   BASE_SHA=<sha> HOSTS_JSON='["a","b"]' [RUN_URL=<url>] \
+#     scripts/diff-closures-comment.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || {
+  echo "error: cannot cd to repo root $REPO_ROOT" >&2
+  echo "STATUS=nothing"
+  exit 0
+}
+
+OUT_FILE="${OUT_FILE:-body.md}"
+RUN_URL="${RUN_URL:-}"
+SAMPLE_LIMIT=15
+
+fail_nothing() {
+  echo "error: $*" >&2
+  : >"$OUT_FILE"
+  echo "STATUS=nothing"
+  exit 0
+}
+
+[ -n "${BASE_SHA:-}" ] || fail_nothing "BASE_SHA env var required"
+[ -n "${HOSTS_JSON:-}" ] || fail_nothing "HOSTS_JSON env var required"
+
+for tool in nix nix-store jq comm sort git; do
+  command -v "$tool" >/dev/null 2>&1 || fail_nothing "required tool not on PATH: $tool"
+done
+
+mapfile -t HOSTS < <(jq -r '.[]' <<<"$HOSTS_JSON" 2>/dev/null)
+if [ "${#HOSTS[@]}" -eq 0 ]; then
+  fail_nothing "HOSTS_JSON produced no hosts"
+fi
+
+echo "Diffing closures for: ${HOSTS[*]}" >&2
+echo "Base: $BASE_SHA" >&2
+
+# Must be reachable in this checkout (the workflow uses fetch-depth: 0,
+# but a misconfigured checkout must degrade, not hard-fail).
+if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+  fail_nothing "base commit $BASE_SHA not present locally (shallow checkout?)"
+fi
+
+declare -A STATUS
+declare -A UNAVAILABLE_REASON
+declare -A DIFF_OUTPUT
+declare -A ADDED_SAMPLE
+declare -A REMOVED_SAMPLE
+declare -A ADDED_COUNT
+declare -A REMOVED_COUNT
+declare -A HEAD_PATH
+declare -A BASE_PATH
+
+for host in "${HOSTS[@]}"; do
+  echo "== $host ==" >&2
+
+  head_err="$(mktemp)"
+  base_err="$(mktemp)"
+
+  head_path="$(nix eval --raw ".#nixosConfigurations.${host}.config.system.build.toplevel.outPath" 2>"$head_err")"
+  head_rc=$?
+
+  if [ "$head_rc" -ne 0 ] || [ -z "$head_path" ]; then
+    echo "  HEAD eval failed:" >&2
+    sed 's/^/    /' "$head_err" >&2
+    STATUS[$host]="error"
+    rm -f "$head_err" "$base_err"
+    continue
+  fi
+
+  base_path="$(nix eval --raw "git+file://${REPO_ROOT}?rev=${BASE_SHA}#nixosConfigurations.${host}.config.system.build.toplevel.outPath" 2>"$base_err")"
+  base_rc=$?
+  rm -f "$head_err" "$base_err"
+
+  if [ "$base_rc" -ne 0 ] || [ -z "$base_path" ]; then
+    # Most common real cause: the host did not exist in
+    # nixosConfigurations at the base commit (a host added by this PR).
+    # Anything else is a genuine eval error at the base rev -- and this
+    # job must degrade on that exactly like every other failure mode,
+    # not propagate it.
+    echo "  BASE eval failed (new host, or base-rev eval error)" >&2
+    STATUS[$host]="new"
+    continue
+  fi
+
+  HEAD_PATH[$host]="$head_path"
+  BASE_PATH[$host]="$base_path"
+
+  if [ "$head_path" = "$base_path" ]; then
+    echo "  unchanged: $head_path" >&2
+    STATUS[$host]="unchanged"
+    continue
+  fi
+
+  echo "  before: $base_path" >&2
+  echo "  after:  $head_path" >&2
+
+  # Substitute-only. --max-jobs 0 disables all local building, so each
+  # of these either pulls from a configured cache or fails cleanly --
+  # see the cost-model note at the top of this file.
+  if ! nix build --max-jobs 0 --no-link "$head_path" >/dev/null 2>"$head_err"; then
+    echo "  AFTER closure not substitutable:" >&2
+    sed 's/^/    /' "$head_err" >&2
+    rm -f "$head_err"
+    STATUS[$host]="unavailable"
+    UNAVAILABLE_REASON[$host]="the after-closure is not in the cache yet (its build may still be running, or failed)"
+    continue
+  fi
+  rm -f "$head_err"
+
+  if ! nix build --max-jobs 0 --no-link "$base_path" >/dev/null 2>"$base_err"; then
+    echo "  BEFORE closure not substitutable:" >&2
+    sed 's/^/    /' "$base_err" >&2
+    rm -f "$base_err"
+    STATUS[$host]="unavailable"
+    UNAVAILABLE_REASON[$host]="the base commit's closure is no longer cached (retention window, or it was never built) -- diffing it here would require a real rebuild, which this job intentionally will not do"
+    continue
+  fi
+  rm -f "$base_err"
+
+  # Both closures are locally present now (substituted, never built).
+  #
+  # `nix store diff-closures` emits ANSI colour codes for size deltas
+  # unconditionally -- it ignores both a non-tty stdout and NO_COLOR in
+  # this nix version -- so strip them before embedding the output in a
+  # markdown code block, or GitHub renders the raw escape bytes.
+  DIFF_OUTPUT[$host]="$(nix store diff-closures "$base_path" "$head_path" 2>/dev/null | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g')"
+
+  # Raw closure diff: catches what diff-closures structurally cannot --
+  # same package name, no version bump, size delta under its 8 KiB
+  # threshold, but a genuinely different store path. This is the
+  # home-manager-activation-script case this script exists for.
+  before_req="$(nix-store -qR "$base_path" 2>/dev/null | sort -u)"
+  after_req="$(nix-store -qR "$head_path" 2>/dev/null | sort -u)"
+
+  removed="$(comm -23 <(printf '%s\n' "$before_req") <(printf '%s\n' "$after_req"))"
+  added="$(comm -13 <(printf '%s\n' "$before_req") <(printf '%s\n' "$after_req"))"
+
+  ADDED_COUNT[$host]="$(printf '%s\n' "$added" | grep -c . || true)"
+  REMOVED_COUNT[$host]="$(printf '%s\n' "$removed" | grep -c . || true)"
+  ADDED_SAMPLE[$host]="$(printf '%s\n' "$added" | head -n "$SAMPLE_LIMIT")"
+  REMOVED_SAMPLE[$host]="$(printf '%s\n' "$removed" | head -n "$SAMPLE_LIMIT")"
+
+  STATUS[$host]="changed"
+done
+
+# =============================================================================
+# Decide whether there is anything worth posting at all.
+#
+# "unchanged" for every host is the common, boring, correct case -- do
+# not manufacture a table for it. Anything else (a real diff, a new
+# host, an eval error, or a coverage gap where we simply could not tell)
+# is worth a line in the report so a reviewer knows what this check did
+# and did not confirm.
+# =============================================================================
+show_report=0
+for host in "${HOSTS[@]}"; do
+  if [ "${STATUS[$host]}" != "unchanged" ]; then
+    show_report=1
+    break
+  fi
+done
+
+if [ "$show_report" -eq 0 ]; then
+  {
+    echo "<!-- diff-closures-report -->"
+    echo "### Closure diff"
+    echo
+    echo "No closure changes for any impacted host between \`${BASE_SHA:0:12}\` and this PR's HEAD: ${HOSTS[*]}."
+  } >"$OUT_FILE"
+  echo "STATUS=unchanged"
+  exit 0
+fi
+
+{
+  echo "<!-- diff-closures-report -->"
+  echo "### Closure diff (base \`${BASE_SHA:0:12}\` -> HEAD)"
+  echo
+  if [ -n "$RUN_URL" ]; then
+    echo "_Compares each impacted host's \`system.build.toplevel\` against the PR base. The before-closure is only ever substituted, never built -- see the header of \`scripts/diff-closures-comment.sh\` for the cost model. [Run]($RUN_URL)._"
+  else
+    echo "_Compares each impacted host's \`system.build.toplevel\` against the PR base. The before-closure is only ever substituted, never built -- see the header of \`scripts/diff-closures-comment.sh\` for the cost model._"
+  fi
+  echo
+  echo "| Host | Status |"
+  echo "| --- | --- |"
+  for host in "${HOSTS[@]}"; do
+    case "${STATUS[$host]}" in
+      unchanged) label="unchanged" ;;
+      changed) label="**changed**" ;;
+      new) label="new host (no prior closure)" ;;
+      unavailable) label="_diff unavailable_" ;;
+      error) label="_eval error_" ;;
+      *) label="${STATUS[$host]}" ;;
+    esac
+    echo "| \`${host}\` | ${label} |"
+  done
+  echo
+
+  for host in "${HOSTS[@]}"; do
+    case "${STATUS[$host]}" in
+      changed)
+        echo "#### \`${host}\`"
+        echo
+        echo "before: \`${BASE_PATH[$host]}\`"
+        echo
+        echo "after:  \`${HEAD_PATH[$host]}\`"
+        echo
+
+        if [ -n "${DIFF_OUTPUT[$host]}" ]; then
+          echo "Package/version changes (\`nix store diff-closures\`):"
+          echo
+          echo '```'
+          printf '%s\n' "${DIFF_OUTPUT[$host]}"
+          echo '```'
+          echo
+        fi
+
+        added_count="${ADDED_COUNT[$host]:-0}"
+        removed_count="${REMOVED_COUNT[$host]:-0}"
+
+        if [ -z "${DIFF_OUTPUT[$host]}" ] && { [ "$added_count" -gt 0 ] || [ "$removed_count" -gt 0 ]; }; then
+          echo "> [!NOTE]"
+          echo "> \`nix store diff-closures\` reported no package/version differences, but the two closures are not the same: ${added_count} store path(s) added, ${removed_count} removed. This is the case diff-closures cannot see (same package name, no version bump) -- for example, a changed home-manager activation script."
+          echo
+        fi
+
+        if [ "$added_count" -gt 0 ]; then
+          echo "<details><summary>${added_count} store path(s) added (showing up to ${SAMPLE_LIMIT})</summary>"
+          echo
+          echo '```'
+          printf '%s\n' "${ADDED_SAMPLE[$host]}"
+          echo '```'
+          echo "</details>"
+          echo
+        fi
+
+        if [ "$removed_count" -gt 0 ]; then
+          echo "<details><summary>${removed_count} store path(s) removed (showing up to ${SAMPLE_LIMIT})</summary>"
+          echo
+          echo '```'
+          printf '%s\n' "${REMOVED_SAMPLE[$host]}"
+          echo '```'
+          echo "</details>"
+          echo
+        fi
+        ;;
+      unavailable)
+        echo "#### \`${host}\` -- diff unavailable"
+        echo
+        echo "${UNAVAILABLE_REASON[$host]}"
+        echo
+        ;;
+      new)
+        echo "#### \`${host}\` -- new host"
+        echo
+        echo "This host has no closure at the PR base to compare against."
+        echo
+        ;;
+      error)
+        echo "#### \`${host}\` -- eval error"
+        echo
+        echo "Evaluating this host's toplevel failed at HEAD; see the workflow run logs."
+        echo
+        ;;
+    esac
+  done
+} >"$OUT_FILE"
+
+echo "STATUS=changed"


### PR DESCRIPTION
Implements batch 6 of `AUDIT-2026-08-04.md` Part 9, plus item 4.9 which was
blocked on batch 5. Four parallel worktrees on disjoint file sets, merged
sequentially with verification after each.

## The item that immediately paid for itself: 6.2 closure-diff comments

Two days ago a refactor asserted to be behaviour-preserving left all 8 servers
byte-identical but changed both desktops. Working out *what* moved took a long
manual comparison of `system.path`, `environment.etc`, `home.file` sources and
text hashes across two commits — and I gave up without resolving it.

**`nix store diff-closures` alone would not have resolved it either.** For that
pair it prints *nothing*, because no package version changed. So this job also
computes a raw closure diff over `nix-store -qR` and surfaces it whenever
`diff-closures` is empty but the closures still differ. Run against the real
pair, it answers the question instantly:

```text
ADDED/REMOVED (same names, different hashes):
  hm_skills
  home-manager-files
  home-manager-generation
  unit-home-manager-fred.service
  system-units
  etc
```

Root cause, now confirmed: `features/ai/opencode/default.nix:18` takes
`skillsSource = ../../../.opencode/skills`, so `hm_skills` is derived from the
flake source path and its hash moves whenever **any** file in the repo changes.
`sdrhub` was a misleading control earlier — it has no opencode skills module at
all, which is why its home-manager activation stayed identical.

Consequence worth knowing separately from this PR: **both desktops rebuild on
every commit**, regardless of relevance. A filtered source would fix that; not
done here.

Cost: the after-closure is already built and pushed to Attic by the build jobs
in the same run. The before-closure is evaluated as a flake ref at the base
commit then fetched with `nix build --max-jobs 0`, which substitutes or fails
and can **never** escalate to a local build. A host whose base closure is
unavailable is reported as such rather than silently costing a rebuild.
Self-hosted for two independent reasons: the Attic substituter is a LAN address
`ubuntu-latest` cannot reach at all, and realising closures there measured 578s
versus 103s.

## The rest

| Item | Outcome |
| --- | --- |
| 4.9 | Dead-module reachability check. Deliberately biased toward false negatives — missing a dead file costs nothing, failing CI on a live one costs an investigation every commit. |
| 6.4 | Review dates on every grype suppression, dated from git history (all six trace to `2455c95b`), as YAML comments. |
| 6.5 | Option schema lint. Fixed the 1 missing `type` and 17 missing `description` — **and found an 18th the audit missed**. |
| 6.7 | Grafana `secret_key` and sops age-key rotation runbooks. |
| 6.9 | Two `warnings`, where there were previously zero against three assertions. |
| 6.11 | Journal retention metrics as a node_exporter textfile collector. |

## Three findings worth your attention

**`sops updatekeys` does not revoke.** Surfaced while writing the 6.7 runbook.
It only reconciles who holds a wrapped copy of the *existing* data key; the DEK
itself is unchanged. A host removed from the recipient list that already
extracted the DEK is **not** cut off until `sops rotate` generates a fresh one.
Procedure B sequences remove → `updatekeys` → `rotate` → verify and explains
why the order matters. It also flags the dangling-anchor failure, where removing
a `keys:` entry without its `creation_rules` alias stops the file parsing for
everyone.

**grype silently accepts unknown keys** inside an ignore rule — verified
empirically against a real SBOM on 0.116.1, same five suppressions, exit 0. The
review dates went in as *comments* anyway, because that is undefined behaviour a
future release could start validating, and because the file's header
deliberately rejects CVSS/EPSS/age-based filtering. The dates are scheduling
metadata and must never gate suppression.

**The journal metric confirms the policy is fiction on at least one host.**
maranello: 966.2M against `SystemMaxUse=1G`, oldest entry 8 days old against
`MaxRetentionSec=30day`. Size binds ~3.7x before time. `SystemMaxUse` is parsed
at Nix eval time from the real option rather than hardcoded, and omitted
entirely when undeterminable, so it is never a confidently wrong constant.
`node_journal_metrics_ok` accompanies the values because `journalctl --header`
is not a stable API and the textfile collector has no concept of expiry —
without it a collector broken by a systemd reword leaves a stale `.prom` and the
host looks healthy.

**No alert rule**, deliberately: thresholds should come from observed fleet data,
and `check-alert-metrics.sh` would fail CI for an alert whose metric has no
series yet.

## On the two new warnings

CI fails on **any** `evaluation warning:`, so a warning that fires breaks every
build. Both are proven silent across all 12 hosts, and each was proven *capable*
of firing by temporarily breaking the invariant on fredvps then confirming the
store path returned to its original hash.

- `internetFacing` with no `scrapeAddress` — the Prometheus target falls back to
  `<hostname>.local`, which a VPS with no LAN mDNS responder cannot answer.
- a container port on an `internetFacing` host with no explicit bind IP, which
  Docker publishes on `0.0.0.0`. `deployment.internetFacing` only rebinds the
  exporters it owns, not hand-written container ports — the exact shape of the
  incident recorded in `mk-dozzle-agent.nix`'s header.

Two further candidates were investigated and **rejected rather than padding the
count**: the RTL-SDR one fires fleet-wide because that feature is unconditional,
and an SDR-container device-access warning would misclassify network-only
decoders.

## Verification

- All 10 Linux + both Darwin hosts evaluate, **zero** `evaluation warning:`
- All **7** flake checks green, including the two new ones and the full
  pre-commit suite
- `statix`, `deadnix`, `shellcheck` clean; actionlint unchanged at 10
  pre-existing findings
- colmena parity holds (8 servers)
- Negative tests for every new check: dead standalone file, dead `default.nix`
  directory, missing `type`, missing `description`, and both warnings

Also fixes a gap found during verification: `result` / `result-*` were not
gitignored, so a stray `nix build` symlink got staged and failed
`check-symlinks` with every other hook passing.

## Not included

- **6.3** (`osv-scanner` trial) — rejected by owner decision.
- **6.6** (Renovate for `.opencode/package-lock.json`) — **invalid as written**.
  Those files were untracked and gitignored, so Renovate could never have
  managed them, and nothing referenced `@opencode-ai/plugin`. Removed locally as
  dead cruft (58M); no repo change was possible or needed.
- **6.1** (`nixosTest`s) — prerequisite now confirmed (`/dev/kvm` is `0666`), but
  this is a large new capability and deserves its own change.
- **6.8** (`mk-simple-package-module` install path) and **6.10** (post-deploy
  smoke test) — both need a decision before implementation; 6.8 is a real
  user-visible behaviour change across 13 modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added journal monitoring metrics for disk usage, retention age, configured limits, and collection status.
  * Pull requests can receive automated reports summarizing system closure changes.
  * Added warnings for unsafe network bindings and missing scrape addresses.

* **Documentation**
  * Added runbooks for Grafana secret-key and SOPS/age key rotation.
  * Expanded configuration descriptions and operational guidance.

* **Tests**
  * Added automated module reachability and option-schema validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->